### PR TITLE
#8: Improve test coverage from 44% to 93%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = src/clauditor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
       - run: uv run pytest --cov=clauditor --cov-report=xml
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.13'
         with:
           files: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 .env
 .ruff_cache/
 .pytest_cache/
+.coverage
+htmlcov/
+coverage.xml
 .mypy_cache/
 *.so
 
@@ -31,6 +34,4 @@ build/
 .dolt/
 *.db
 .beads-credential-key
-work-ss5.3/
-work-ss5.5/
-work-ss5.7/
+work-*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,18 +52,28 @@ bd close <id>         # Complete work
 
 ## Build & Test
 
-_Add your build and test commands here_
-
 ```bash
-# Example:
-# npm install
-# npm test
+uv sync --dev               # Install dependencies
+uv run ruff check src/ tests/  # Lint
+uv run pytest --cov=clauditor --cov-report=term-missing  # Test with coverage (80% gate enforced)
 ```
 
 ## Architecture Overview
 
-_Add a brief overview of your project architecture_
+Three-layer skill evaluation framework:
+- **Layer 1** (`assertions.py`): Deterministic checks (regex, string matching, counting)
+- **Layer 2** (`grader.py`): LLM-graded schema extraction via Haiku
+- **Layer 3** (`quality_grader.py`, `triggers.py`): LLM-graded quality and trigger precision via Sonnet
+
+Supporting modules: `runner.py` (subprocess execution), `spec.py` (orchestrator), `schemas.py` (data models), `cli.py` (CLI entry point), `comparator.py` (A/B testing), `pytest_plugin.py` (pytest integration).
 
 ## Conventions & Patterns
 
-_Add your project-specific conventions here_
+### Testing
+- Tests in `tests/`, one file per source module (`test_<module>.py`)
+- Class-based test organization (`TestFromFile`, `TestEvaluate`, etc.)
+- `asyncio_mode = "strict"` — async tests require `@pytest.mark.asyncio`
+- Mock external calls with `unittest.mock` (MagicMock, AsyncMock, patch)
+- Modules imported by the pytest plugin before coverage starts need `importlib.reload()` at the top of their test file (see `test_schemas.py` for pattern)
+- `tests/conftest.py` has shared fixtures; must NOT shadow plugin fixture names (`clauditor_runner`, `clauditor_spec`, `clauditor_grader`, `clauditor_triggers`)
+- Use `tmp_path` for file-based tests, not `tempfile` directly

--- a/plans/super/8-improve-test-coverage.md
+++ b/plans/super/8-improve-test-coverage.md
@@ -6,7 +6,7 @@
 |--------------|-------|
 | Ticket       | [#8](https://github.com/wjduenow/clauditor/issues/8) |
 | Branch       | `feature/8-improve-test-coverage` |
-| Phase        | `detailing` |
+| Phase        | `devolved` |
 | Sessions     | 1 |
 | Last session | 2026-04-08 |
 
@@ -530,4 +530,21 @@ _Rationale: cli.py is the main entry point; broad coverage catches regressions i
 
 ## Beads Manifest
 
-_Pending Phase 7._
+| Story | Bead ID | Title |
+|-------|---------|-------|
+| Epic | clauditor-n75 | #8: Improve test coverage from 44% to 80%+ |
+| US-001 | clauditor-n75.1 | Fix coverage config + test __init__.py |
+| US-002 | clauditor-n75.2 | Create shared conftest.py |
+| US-003 | clauditor-n75.3 | Test SkillResult methods + SkillRunner.run() |
+| US-004 | clauditor-n75.4 | Test schemas.py from_file, to_dict, edge cases |
+| US-005 | clauditor-n75.5 | Test assertions.py coverage gaps |
+| US-006 | clauditor-n75.6 | Test spec.py from_file, run, evaluate |
+| US-007 | clauditor-n75.7 | Test grader.py + fix dead branch |
+| US-008 | clauditor-n75.8 | Test comparator.py compare_ab async flow |
+| US-009 | clauditor-n75.9 | Test cli.py all 5 subcommands |
+| US-010 | clauditor-n75.10 | Test pytest_plugin.py with pytester |
+| US-011 | clauditor-n75.11 | Add CI coverage gate |
+| QG | clauditor-n75.12 | Quality Gate — code review x4 + validation |
+| P&M | clauditor-n75.13 | Patterns & Memory — update conventions and docs |
+
+**Worktree:** `/home/wesd/Projects/clauditor` (branch: `feature/8-improve-test-coverage`)

--- a/plans/super/8-improve-test-coverage.md
+++ b/plans/super/8-improve-test-coverage.md
@@ -1,0 +1,80 @@
+# Super Plan: #8 — Improve Test Coverage from 44% to 80%+
+
+## Meta
+
+| Field        | Value |
+|--------------|-------|
+| Ticket       | [#8](https://github.com/wjduenow/clauditor/issues/8) |
+| Branch       | `feature/8-improve-test-coverage` |
+| Phase        | `discovery` |
+| Sessions     | 1 |
+| Last session | 2026-04-08 |
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+Raise overall test coverage from 44% (116 tests) to 80%+, with no individual module below 60%. Layer 3 modules (triggers.py, quality_grader.py) are already well-covered (94-97%). The gap is concentrated in older modules: cli.py (0%), spec.py (0%), __init__.py (0%), runner.py (18%), pytest_plugin.py (11%), and partially-covered modules like grader.py (46%), schemas.py (38%), assertions.py (57%), comparator.py (68%).
+
+### Codebase Findings
+
+**Source modules:** All 11 modules live in `src/clauditor/`
+
+**Existing tests:** 8 test files in `tests/`, no conftest.py. 116 tests passing.
+
+**Test patterns:**
+- Class-based test organization (`TestContains`, `TestGradeQuality`)
+- Factory helpers (`_make_spec()`, `_make_results()`, `_make_report()`)
+- `unittest.mock` with `MagicMock`, `AsyncMock`, `patch`
+- `@pytest.mark.asyncio` with `asyncio_mode = "strict"`
+- Plain `assert` statements, `pytest.approx()` for floats
+
+**Config:**
+- pytest 8.0+, pytest-asyncio 1.3.0+, pytest-cov 5.0+
+- Ruff linting (line length 88, rules E/F/I/N/W/UP) applies to tests
+- CI runs on Python 3.11, 3.12, 3.13 with coverage uploaded to CodeCov
+
+**No `.claude/rules/` files, no workflow-project.md, no ARCHITECTURE.md.**
+
+### Proposed Scope
+
+Three tiers matching the issue:
+1. **Easy wins** — cli.py, spec.py, __init__.py (0% → 60%+)
+2. **Mock-heavy** — runner.py, grader.py, pytest_plugin.py (need subprocess/API mocking)
+3. **Gap filling** — assertions.py, schemas.py, comparator.py (raise to 60%+)
+
+### Scoping Questions
+
+_See below — awaiting user answers._
+
+---
+
+## Architecture Review
+
+_Pending Phase 2._
+
+---
+
+## Refinement Log
+
+### Sessions
+
+_Pending Phase 3._
+
+### Decisions
+
+_Pending Phase 3._
+
+---
+
+## Detailed Breakdown
+
+_Pending Phase 4._
+
+---
+
+## Beads Manifest
+
+_Pending Phase 7._

--- a/plans/super/8-improve-test-coverage.md
+++ b/plans/super/8-improve-test-coverage.md
@@ -6,7 +6,7 @@
 |--------------|-------|
 | Ticket       | [#8](https://github.com/wjduenow/clauditor/issues/8) |
 | Branch       | `feature/8-improve-test-coverage` |
-| Phase        | `discovery` |
+| Phase        | `detailing` |
 | Sessions     | 1 |
 | Last session | 2026-04-08 |
 
@@ -45,33 +45,486 @@ Three tiers matching the issue:
 2. **Mock-heavy** — runner.py, grader.py, pytest_plugin.py (need subprocess/API mocking)
 3. **Gap filling** — assertions.py, schemas.py, comparator.py (raise to 60%+)
 
-### Scoping Questions
+### Scoping Answers
 
-_See below — awaiting user answers._
+- **Q1: CI Coverage Gate** → A) Add `--cov-fail-under=80` to CI
+- **Q2: pytest_plugin.py Testing** → A) Use `pytester` for realistic plugin integration tests
+- **Q3: spec.py Scope** → A) Test the full `evaluate()` flow with mocked runner/grader
+- **Q4: conftest.py** → A) Create a `tests/conftest.py` with shared fixtures
+- **Q5: Coverage Measurement** → A) Run coverage first to get current baseline
+
+### Verified Baseline (2026-04-08)
+
+| Module | Stmts | Miss | Cover |
+|--------|-------|------|-------|
+| __init__.py | 13 | 13 | 0% |
+| assertions.py | 82 | 35 | 57% |
+| cli.py | 177 | 177 | 0% |
+| comparator.py | 53 | 17 | 68% |
+| grader.py | 61 | 33 | 46% |
+| pytest_plugin.py | 54 | 48 | 11% |
+| quality_grader.py | 126 | 7 | 94% |
+| runner.py | 78 | 64 | 18% |
+| schemas.py | 58 | 36 | 38% |
+| spec.py | 38 | 38 | 0% |
+| triggers.py | 103 | 3 | 97% |
+| **TOTAL** | **843** | **471** | **44%** |
 
 ---
 
 ## Architecture Review
 
-_Pending Phase 2._
+| Area | Rating | Key Finding |
+|------|--------|-------------|
+| Security | concern | Mock `clauditor.runner.subprocess.run` (not global `subprocess.run`) to prevent accidental live CLI calls. Use `tmp_path` for all file-based test fixtures. |
+| Performance | concern | Pytester tests add ~0.2-0.5s each — keep to 3-5 max. Use `runpytest_inprocess()` when possible for speed and coverage measurement. |
+| Testing Strategy | concern | `__init__.py` at 0% is a **coverage config issue** (module imported before measurement starts), not a testing gap. `schemas.py` may also benefit from the same fix. Dead branch bug found in `grader.py` line 145. |
+| Data Model | pass | No schema changes needed. |
+| API Design | pass | No API changes — pure test additions. |
+| Observability | pass | Coverage reporting already configured via CodeCov. Adding `--cov-fail-under=80` is the only change. |
+
+### Key Architectural Findings
+
+1. **Coverage config fix needed first:** `__init__.py` shows 0% because the clauditor plugin imports the package before `pytest-cov` starts measuring. Fix with `--import-mode=importlib` or `.coveragerc` source config. This may also raise `schemas.py` for free.
+
+2. **Dead branch bug in `grader.py:145`:** `elif "```" in json_str` can never execute because the identical `if` condition on line 142 already matched. Tests will expose this — fix or remove the dead branch.
+
+3. **`SkillResult` assertion methods (runner.py:3-89) entirely untested:** These are load-bearing (`spec.evaluate()` and `cli.py` depend on `succeeded`). Zero mocking needed — pure functions.
+
+4. **conftest.py must not shadow plugin fixtures:** Don't redeclare `clauditor_runner`, `clauditor_spec`, `clauditor_grader`, `clauditor_triggers`. Only add new shared test helpers.
+
+5. **Pytester + coverage:** Use `runpytest_inprocess()` instead of `runpytest()` so the outer coverage session measures plugin code without needing `--cov-append`.
+
+6. **`cli.py` inner async functions:** `cmd_grade` defines `_run_grade()` inside the function body — cannot be patched directly. Patch `clauditor.quality_grader.grade_quality` and `clauditor.comparator.compare_ab` at module level instead.
 
 ---
 
 ## Refinement Log
 
-### Sessions
+### Session 1 — 2026-04-08
 
-_Pending Phase 3._
+Resolved all architecture concerns and scoping questions. No blockers remain.
 
 ### Decisions
 
-_Pending Phase 3._
+**DEC-001: CI coverage gate**
+Add `--cov-fail-under=80` to CI pipeline.
+_Rationale: Hard gate ensures coverage never regresses below target._
+
+**DEC-002: Pytester for plugin tests**
+Use `pytester` with `runpytest_inprocess()` for realistic integration tests.
+_Rationale: Accurate plugin testing; inprocess avoids subprocess overhead and coverage gaps._
+
+**DEC-003: Full spec.py evaluate flow**
+Test `from_file()`, `run()`, and `evaluate()` with mocked runner/grader.
+_Rationale: spec.py is the main orchestrator — all paths matter._
+
+**DEC-004: Shared conftest.py**
+Create `tests/conftest.py` with shared fixtures. Must not shadow plugin fixture names.
+_Rationale: Multiple new test files will share sample specs, mock runners, tmp files._
+
+**DEC-005: Baseline first**
+Verified baseline: 44% overall, 843 stmts, 471 missed. (Confirmed 2026-04-08.)
+
+**DEC-006: Coverage config fix (both)**
+Add both `--import-mode=importlib` and `.coveragerc` with `source = clauditor`.
+_Rationale: Belt and suspenders — fixes __init__.py 0% measurement bug and may raise schemas.py for free._
+
+**DEC-007: Fix dead branch in grader.py**
+Remove the unreachable `elif` on grader.py:145 as part of this PR.
+_Rationale: It's a bug discovered by testing; small fix, in scope._
+
+**DEC-008: Pytester — 5 tests**
+5 pytester tests: marker registration + skip logic, fixture creation, CLI option passing, grade marker skip, full integration with mock skill.
+_Rationale: Thorough plugin validation without going overboard._
+
+**DEC-009: Test all SkillResult methods exhaustively**
+Test all 7 assertion helpers + `succeeded` with happy path and failure path each.
+_Rationale: Pure functions, trivial to write, load-bearing for spec.evaluate() and cli.py._
+
+**DEC-010: cli.py — cover all 5 subcommands**
+Cover all 5 subcommands (validate, run, init, grade, triggers) with at least one happy path each, plus key error paths.
+_Rationale: cli.py is the main entry point; broad coverage catches regressions in all commands._
 
 ---
 
 ## Detailed Breakdown
 
-_Pending Phase 4._
+### US-001: Fix coverage config + test __init__.py
+
+**Description:** Fix the `module-not-measured` coverage warning by adding `--import-mode=importlib` to pytest config and a `.coveragerc` file (DEC-006). Add tests for `__getattr__` lazy imports and `AttributeError` fallback.
+
+**Traces to:** DEC-005, DEC-006
+
+**Acceptance Criteria:**
+- `__init__.py` shows >60% coverage
+- No `module-not-measured` warning in pytest output
+- Lazy imports (`GradingReport`, `ABResult`, `TriggerReport`) resolve correctly
+- `AttributeError` raised for invalid attribute names
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** `__init__.py` coverage ≥60%, no measurement warnings.
+
+**Files:**
+- `pyproject.toml` — add `addopts = "--import-mode=importlib"` to `[tool.pytest.ini_options]`
+- `.coveragerc` — new file, `[run] source = clauditor`
+- `tests/test_init.py` — new file with `TestLazyImports`, `TestAttributeError`
+
+**Depends on:** none
+
+**TDD:**
+- `test_lazy_import_grading_report` — `from clauditor import GradingReport` resolves
+- `test_lazy_import_ab_result` — `from clauditor import ABResult` resolves
+- `test_lazy_import_trigger_report` — `from clauditor import TriggerReport` resolves
+- `test_invalid_attribute_raises` — `clauditor.Nonexistent` raises `AttributeError`
+- `test_all_exports_importable` — every name in `__all__` is importable
+
+---
+
+### US-002: Create shared conftest.py
+
+**Description:** Create `tests/conftest.py` with shared fixtures used by 3+ upcoming test files: sample eval spec data, temp skill files, and mock runner factory. Must NOT shadow plugin fixture names (DEC-004).
+
+**Traces to:** DEC-004
+
+**Acceptance Criteria:**
+- `tests/conftest.py` exists with shared fixtures
+- No fixtures named `clauditor_runner`, `clauditor_spec`, `clauditor_grader`, or `clauditor_triggers`
+- Existing tests still pass unchanged
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** conftest.py created, existing 116 tests still pass.
+
+**Files:**
+- `tests/conftest.py` — new file with `sample_eval_data`, `make_eval_spec`, `tmp_skill_file`, `mock_runner` fixtures
+
+**Depends on:** US-001
+
+---
+
+### US-003: Test SkillResult methods + SkillRunner.run()
+
+**Description:** Test all 7 assertion helper methods on `SkillResult` (lines 39-83) plus the `succeeded` property (line 34) with happy path and failure path each (DEC-009). Also test `SkillRunner.run()` (lines 99-150) — success, timeout, FileNotFoundError — mirroring existing `run_raw` tests.
+
+**Traces to:** DEC-009
+
+**Acceptance Criteria:**
+- `runner.py` coverage ≥60%
+- All 7 assertion methods tested (pass + fail)
+- `succeeded` property tested: `exit_code=0, output="text"` → True; `exit_code=0, output=""` → False; `exit_code=1` → False
+- `SkillRunner.run()` tested with mocked `subprocess.run` for success, timeout, not-found
+- Mock target is `clauditor.runner.subprocess.run` (not global)
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** runner.py ≥60% coverage.
+
+**Files:**
+- `tests/test_runner.py` — extend with `TestSkillResultSucceeded`, `TestSkillResultAssertions`, `TestSkillRunnerRun`
+
+**Depends on:** US-002
+
+**TDD:**
+- `test_succeeded_true` — exit_code=0, non-empty output → True
+- `test_succeeded_false_empty_output` — exit_code=0, output="" → False
+- `test_succeeded_false_whitespace` — exit_code=0, output="  \n" → False
+- `test_succeeded_false_nonzero_exit` — exit_code=1 → False
+- `test_assert_contains_pass` / `test_assert_contains_fail`
+- `test_assert_not_contains_pass` / `test_assert_not_contains_fail`
+- `test_assert_matches_pass` / `test_assert_matches_fail`
+- `test_assert_min_count_pass` / `test_assert_min_count_fail`
+- `test_assert_min_length_pass` / `test_assert_min_length_fail`
+- `test_assert_has_urls_pass` / `test_assert_has_urls_fail`
+- `test_assert_has_entries_pass` / `test_assert_has_entries_fail`
+- `test_run_assertions_delegates`
+- `test_runner_run_success` / `test_runner_run_timeout` / `test_runner_run_not_found`
+
+---
+
+### US-004: Test schemas.py — from_file, to_dict, edge cases
+
+**Description:** Extend `test_schemas.py` to cover `EvalSpec.from_file()` with full data, missing file, malformed JSON, partial fields. Test `to_dict()` round-trip. Test `TriggerTests` and `VarianceConfig` loading.
+
+**Traces to:** DEC-005
+
+**Acceptance Criteria:**
+- `schemas.py` coverage ≥60%
+- `from_file` tested: valid file, missing file raises, malformed JSON raises, partial fields use defaults
+- `to_dict` tested: round-trip `from_file → to_dict` produces equivalent data
+- `TriggerTests` and `VarianceConfig` optional loading tested
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** schemas.py ≥60% coverage.
+
+**Files:**
+- `tests/test_schemas.py` — extend with `TestFromFile`, `TestToDict`, `TestOptionalFields`
+
+**Depends on:** US-002
+
+**TDD:**
+- `test_from_file_full` — loads a complete eval.json with all fields
+- `test_from_file_minimal` — loads with only `skill_name`
+- `test_from_file_missing` — raises on nonexistent file
+- `test_from_file_malformed_json` — raises `json.JSONDecodeError`
+- `test_to_dict_roundtrip` — `from_file → to_dict` matches original data
+- `test_trigger_tests_loaded` — `trigger_tests` field populated correctly
+- `test_variance_config_loaded` — `variance` field populated correctly
+- `test_no_trigger_tests` — `trigger_tests` is None when absent
+- `test_no_variance` — `variance` is None when absent
+
+---
+
+### US-005: Test assertions.py — fill coverage gaps
+
+**Description:** Add tests for `assert_max_length`, `assert_has_urls`, `assert_has_entries`, and edge cases in `run_assertions` (unknown type, empty assertions list). Target the uncovered lines: 6-32, 35-36, 39-40, 45, 54, 64, 74, 85, 96, 106-116, 128, 139, 156, 158, 162.
+
+**Traces to:** DEC-005
+
+**Acceptance Criteria:**
+- `assertions.py` coverage ≥60%
+- `assert_max_length` tested (pass and fail)
+- `run_assertions` tested with unknown type (returns failed result)
+- `run_assertions` tested with empty list (returns empty AssertionSet)
+- `AssertionSet.summary()`, `.pass_rate`, `.failed` tested
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** assertions.py ≥60% coverage.
+
+**Files:**
+- `tests/test_assertions.py` — extend with `TestMaxLength`, `TestRunAssertionsEdgeCases`, `TestAssertionSetProperties`
+
+**Depends on:** US-002
+
+**TDD:**
+- `test_max_length_pass` / `test_max_length_fail`
+- `test_run_assertions_unknown_type` — returns `AssertionResult(passed=False)`
+- `test_run_assertions_empty` — returns empty `AssertionSet`
+- `test_assertionset_pass_rate` / `test_assertionset_failed` / `test_assertionset_summary`
+- `test_assertionresult_bool` — `bool(result)` matches `result.passed`
+
+---
+
+### US-006: Test spec.py — from_file, run, evaluate
+
+**Description:** Full test coverage for `SkillSpec`: `from_file()` with auto-discovery and explicit eval path, `run()` with and without args, `evaluate()` happy path, failed run path, no eval spec, and explicit output (DEC-003).
+
+**Traces to:** DEC-003
+
+**Acceptance Criteria:**
+- `spec.py` coverage ≥60%
+- `from_file` tested: file not found, auto-discover eval, explicit eval, no eval
+- `run` tested: uses eval_spec.test_args when args=None, passes explicit args
+- `evaluate` tested: happy path, failed run returns error AssertionSet, no eval raises ValueError, explicit output skips run
+- `_failed_run_result` tested via the evaluate failed-run branch
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** spec.py ≥60% coverage.
+
+**Files:**
+- `tests/test_spec.py` — new file with `TestFromFile`, `TestRun`, `TestEvaluate`
+
+**Depends on:** US-002, US-003
+
+**TDD:**
+- `test_from_file_with_eval` — auto-discovers sibling .eval.json
+- `test_from_file_explicit_eval` — uses provided eval_path
+- `test_from_file_no_eval` — spec has eval_spec=None
+- `test_from_file_missing_skill` — raises FileNotFoundError
+- `test_run_uses_eval_args` — when args=None, uses eval_spec.test_args
+- `test_run_explicit_args` — passes explicit args to runner
+- `test_evaluate_happy_path` — mock runner returns good output, assertions pass
+- `test_evaluate_failed_run` — mock runner returns failed result, get error AssertionSet
+- `test_evaluate_no_eval_spec` — raises ValueError
+- `test_evaluate_with_explicit_output` — skips running, uses provided output
+
+---
+
+### US-007: Test grader.py — build_extraction_prompt + extract_and_grade
+
+**Description:** Test `build_extraction_prompt()` (pure function, lines 34-64) and `extract_and_grade()` (async, lines 109-168) with mocked `AsyncAnthropic`. Fix the dead branch bug on line 144-145 (DEC-007).
+
+**Traces to:** DEC-007
+
+**Acceptance Criteria:**
+- `grader.py` coverage ≥60%
+- `build_extraction_prompt` tested with sections and fields
+- `extract_and_grade` tested: success path, JSON parse failure, markdown-wrapped JSON
+- Dead `elif` on line 144-145 removed
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** grader.py ≥60%, dead branch removed.
+
+**Files:**
+- `src/clauditor/grader.py` — remove dead `elif` on line 144-145
+- `tests/test_grader.py` — extend with `TestBuildExtractionPrompt`, `TestExtractAndGrade`
+
+**Depends on:** US-002, US-004
+
+**TDD:**
+- `test_build_prompt_includes_fields` — output contains field names from eval spec
+- `test_build_prompt_includes_section_names` — output contains section names
+- `test_extract_and_grade_success` — mock API returns valid JSON, grading succeeds
+- `test_extract_and_grade_markdown_json` — mock API returns ```json-wrapped response
+- `test_extract_and_grade_parse_failure` — mock API returns garbage, get error AssertionSet
+- `test_extract_and_grade_import_error` — when anthropic not importable, raises ImportError
+
+---
+
+### US-008: Test comparator.py — compare_ab async flow
+
+**Description:** Test the `compare_ab()` async function (lines 62-126) with mocked `grade_quality` and mocked spec runner. Cover: success path, no eval spec, empty test_args, baseline with fewer criteria than skill.
+
+**Traces to:** DEC-005
+
+**Acceptance Criteria:**
+- `comparator.py` coverage ≥60%
+- `compare_ab` tested: success (no regression), regression detected, no eval spec raises, empty test_args raises, baseline shorter than skill criteria
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** comparator.py ≥60% coverage.
+
+**Files:**
+- `tests/test_comparator.py` — extend with `TestCompareAB`
+
+**Depends on:** US-002, US-003
+
+**TDD:**
+- `test_compare_ab_no_regression` — both pass, no regression
+- `test_compare_ab_regression` — baseline passes, skill fails → regression
+- `test_compare_ab_no_eval_spec` — raises ValueError
+- `test_compare_ab_empty_test_args` — raises ValueError
+- `test_compare_ab_baseline_fewer_criteria` — padding with synthetic failing result
+
+---
+
+### US-009: Test cli.py — all 5 subcommands
+
+**Description:** Test all 5 CLI commands via `main(argv=[...])` with mocked `SkillSpec.from_file`, mocked runners, and mocked async functions (DEC-010). Cover happy paths and key error paths for each command.
+
+**Traces to:** DEC-010
+
+**Acceptance Criteria:**
+- `cli.py` coverage ≥60%
+- All 5 subcommands tested: validate, run, grade, triggers, init
+- `cmd_validate`: happy path (with --output), no eval spec error, --json output
+- `cmd_run`: happy path, error output
+- `cmd_grade`: happy path (with --output), no eval spec, no grading_criteria, --dry-run, --json
+- `cmd_triggers`: happy path (with --output), --dry-run, --json
+- `cmd_init`: creates file, existing file without --force returns 1, --force overwrites
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** cli.py ≥60% coverage.
+
+**Files:**
+- `tests/test_cli.py` — new file with `TestCmdValidate`, `TestCmdRun`, `TestCmdGrade`, `TestCmdTriggers`, `TestCmdInit`
+
+**Depends on:** US-002, US-006
+
+**TDD:**
+- `test_validate_with_output_file` — reads file, runs assertions, returns 0
+- `test_validate_no_eval_spec` — returns 1
+- `test_validate_json_output` — --json flag produces valid JSON
+- `test_run_happy_path` — runs skill, prints output
+- `test_grade_with_output` — grades pre-captured output
+- `test_grade_no_eval_spec` — returns 1
+- `test_grade_no_grading_criteria` — returns 1
+- `test_grade_dry_run` — prints prompt, returns 0
+- `test_grade_json_output` — --json produces valid JSON
+- `test_triggers_happy_path` — runs trigger testing
+- `test_triggers_dry_run` — prints prompts, returns 0
+- `test_init_creates_file` — creates eval.json
+- `test_init_existing_no_force` — returns 1
+- `test_init_force_overwrites` — --force creates file
+
+---
+
+### US-010: Test pytest_plugin.py with pytester
+
+**Description:** Use pytester (with `runpytest_inprocess()`) to test plugin registration, marker skip logic, fixture creation, CLI option passing, and grade marker skip (DEC-002, DEC-008). 5 tests total.
+
+**Traces to:** DEC-002, DEC-008
+
+**Acceptance Criteria:**
+- `pytest_plugin.py` coverage ≥60%
+- 5 pytester tests: marker registration, skip without --clauditor-grade, fixture available, CLI options passed through, grade marker enables with flag
+- Uses `runpytest_inprocess()` for coverage measurement
+- `uv run pytest --cov=clauditor` passes
+
+**Done when:** pytest_plugin.py ≥60% coverage.
+
+**Files:**
+- `tests/test_pytest_plugin.py` — rewrite with pytester-based tests
+
+**Depends on:** US-002
+
+**TDD:**
+- `test_marker_registered` — `clauditor_grade` marker registered in help output
+- `test_grade_marker_skipped_by_default` — test with marker is skipped
+- `test_grade_marker_runs_with_flag` — test with marker runs with --clauditor-grade
+- `test_runner_fixture_available` — `clauditor_runner` fixture resolves
+- `test_cli_options_passed` — --clauditor-timeout value reaches fixture
+
+---
+
+### US-011: Add CI coverage gate
+
+**Description:** Add `--cov-fail-under=80` to the CI pipeline and pytest config (DEC-001). Verify the full test suite achieves 80%+ overall with no module below 60%.
+
+**Traces to:** DEC-001
+
+**Acceptance Criteria:**
+- `--cov-fail-under=80` in pytest addopts or CI command
+- Full test suite passes with 80%+ coverage
+- No module below 60%
+- CI pipeline updated
+- `uv run pytest --cov=clauditor --cov-fail-under=80` passes
+
+**Done when:** CI enforces 80% coverage floor.
+
+**Files:**
+- `pyproject.toml` — add `--cov-fail-under=80` to addopts
+- `.github/workflows/ci.yml` — ensure coverage command includes fail-under
+
+**Depends on:** US-001 through US-010
+
+---
+
+### US-012: Quality Gate — code review x4
+
+**Description:** Run code reviewer 4 times across the full changeset, fixing all real bugs found each pass. Run project validation after all fixes.
+
+**Traces to:** all decisions
+
+**Acceptance Criteria:**
+- 4 code review passes completed
+- All real bugs fixed
+- `uv run pytest --cov=clauditor --cov-fail-under=80` passes
+- `uv run ruff check src/ tests/` passes
+- No module below 60% coverage
+
+**Done when:** All review passes clean, validation green.
+
+**Files:** Any files touched by bug fixes from review.
+
+**Depends on:** US-011
+
+---
+
+### US-013: Patterns & Memory — update conventions and docs
+
+**Description:** Update project conventions with new patterns learned during this work (test patterns, coverage config, pytester usage). Update CLAUDE.md build/test commands.
+
+**Traces to:** all decisions
+
+**Acceptance Criteria:**
+- CLAUDE.md updated with actual build/test commands
+- Any new conventions documented
+- `bd remember` called for persistent insights
+
+**Done when:** Docs updated, memories saved.
+
+**Files:** `CLAUDE.md`, possibly `.claude/rules/` files.
+
+**Depends on:** US-012
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ select = ["E", "F", "I", "N", "W", "UP"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "strict"
+addopts = "--import-mode=importlib"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ select = ["E", "F", "I", "N", "W", "UP"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "strict"
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib --cov-fail-under=80"
 
 [dependency-groups]
 dev = [

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -141,8 +141,6 @@ async def extract_and_grade(
         json_str = response_text
         if "```" in json_str:
             json_str = json_str.split("```json")[-1].split("```")[0]
-        elif "```" in json_str:
-            json_str = json_str.split("```")[-2]
 
         raw = json.loads(json_str.strip())
     except (json.JSONDecodeError, IndexError):

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -139,8 +139,14 @@ async def extract_and_grade(
     try:
         # Extract JSON from response (may be wrapped in markdown code block)
         json_str = response_text
-        if "```" in json_str:
+        if "```json" in json_str:
             json_str = json_str.split("```json")[-1].split("```")[0]
+        elif "```" in json_str:
+            # Generic fence without language tag
+            parts = json_str.split("```")
+            # Take the content between the first pair of fences
+            if len(parts) >= 3:
+                json_str = parts[1]
 
         raw = json.loads(json_str.strip())
     except (json.JSONDecodeError, IndexError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,186 @@
+"""Shared test fixtures for clauditor tests.
+
+Provides reusable fixtures for eval data, specs, temp skill files, and mock runners.
+IMPORTANT: Do NOT define fixtures named clauditor_runner, clauditor_spec,
+clauditor_grader, or clauditor_triggers -- those are defined by the pytest plugin.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from clauditor.runner import SkillResult, SkillRunner
+from clauditor.schemas import (
+    EvalSpec,
+    FieldRequirement,
+    SectionRequirement,
+)
+
+
+@pytest.fixture
+def sample_eval_data() -> dict:
+    """Return a dict matching eval.json format with all fields populated."""
+    return {
+        "skill_name": "find-kid-activities",
+        "description": "Eval for /find-kid-activities",
+        "test_args": '"Cupertino, CA" --dates today --cost Free --depth quick',
+        "assertions": [
+            {"type": "contains", "value": "Venues"},
+            {"type": "has_entries", "value": "3"},
+            {"type": "has_urls", "value": "2"},
+            {"type": "not_contains", "value": "ERROR"},
+            {"type": "min_length", "value": "500"},
+        ],
+        "sections": [
+            {
+                "name": "Venues",
+                "min_entries": 3,
+                "fields": [
+                    {"name": "name", "required": True},
+                    {"name": "address", "required": True},
+                    {"name": "hours", "required": True},
+                    {"name": "website", "required": True},
+                    {"name": "phone", "required": False},
+                ],
+            },
+            {
+                "name": "Events",
+                "min_entries": 0,
+                "fields": [
+                    {"name": "name", "required": True},
+                    {"name": "date", "required": True},
+                    {"name": "event_url", "required": True},
+                ],
+            },
+        ],
+        "grading_criteria": [
+            "Are venues within the specified distance?",
+            "Are hours accurate for the requested dates?",
+        ],
+        "grading_model": "claude-sonnet-4-6",
+        "trigger_tests": {
+            "should_trigger": [
+                "find kid activities in Cupertino",
+                "things to do with kids near me",
+            ],
+            "should_not_trigger": [
+                "what is the weather today",
+                "write me a poem",
+            ],
+        },
+        "variance": {
+            "n_runs": 5,
+            "min_stability": 0.8,
+        },
+    }
+
+
+@pytest.fixture
+def make_eval_spec():
+    """Factory fixture that creates EvalSpec instances from optional overrides.
+
+    Usage:
+        def test_something(make_eval_spec):
+            spec = make_eval_spec(skill_name="my-skill")
+    """
+
+    def _factory(**overrides) -> EvalSpec:
+        defaults = {
+            "skill_name": "test-skill",
+            "description": "A test eval spec",
+            "test_args": "--depth quick",
+            "assertions": [{"type": "contains", "value": "test"}],
+            "sections": [
+                SectionRequirement(
+                    name="Results",
+                    min_entries=1,
+                    fields=[
+                        FieldRequirement(name="name", required=True),
+                        FieldRequirement(name="url", required=False),
+                    ],
+                )
+            ],
+            "grading_criteria": ["Is the output relevant?"],
+            "grading_model": "claude-sonnet-4-6",
+            "trigger_tests": None,
+            "variance": None,
+        }
+        defaults.update(overrides)
+        return EvalSpec(**defaults)
+
+    return _factory
+
+
+@pytest.fixture
+def tmp_skill_file(tmp_path):
+    """Factory fixture that creates a temporary .md skill file.
+
+    Optionally creates a sibling .eval.json file.
+
+    Usage:
+        def test_something(tmp_skill_file):
+            skill_path = tmp_skill_file("my-skill", content="# My Skill")
+            skill_path, eval_path = tmp_skill_file(
+                "my-skill",
+                content="# My Skill",
+                eval_data={"skill_name": "my-skill", "assertions": []},
+            )
+    """
+
+    def _factory(
+        name: str = "test-skill",
+        content: str = "# Test Skill\n\nA test skill for unit tests.",
+        eval_data: dict | None = None,
+    ) -> Path | tuple[Path, Path]:
+        skill_path = tmp_path / f"{name}.md"
+        skill_path.write_text(content)
+
+        if eval_data is not None:
+            eval_path = tmp_path / f"{name}.eval.json"
+            eval_path.write_text(json.dumps(eval_data, indent=2))
+            return skill_path, eval_path
+
+        return skill_path
+
+    return _factory
+
+
+@pytest.fixture
+def mock_runner():
+    """Factory fixture returning a MagicMock SkillRunner.
+
+    The mock's .run() returns a configurable SkillResult.
+
+    Usage:
+        def test_something(mock_runner):
+            runner = mock_runner(output="some output", exit_code=0)
+            result = runner.run("my-skill")
+            assert result.output == "some output"
+    """
+
+    def _factory(
+        output: str = "mock output",
+        exit_code: int = 0,
+        skill_name: str = "test-skill",
+        args: str = "",
+        duration_seconds: float = 1.0,
+        error: str | None = None,
+    ) -> MagicMock:
+        mock = MagicMock(spec=SkillRunner)
+        result = SkillResult(
+            output=output,
+            exit_code=exit_code,
+            skill_name=skill_name,
+            args=args,
+            duration_seconds=duration_seconds,
+            error=error,
+        )
+        mock.run.return_value = result
+        mock.run_raw.return_value = result
+        return mock
+
+    return _factory

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,6 +1,12 @@
 """Tests for Layer 1 deterministic assertions."""
 
-from clauditor.assertions import (
+import importlib
+
+import clauditor.assertions as _assertions_mod
+
+importlib.reload(_assertions_mod)
+
+from clauditor.assertions import (  # noqa: E402
     AssertionResult,
     AssertionSet,
     assert_contains,

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,10 +1,12 @@
 """Tests for Layer 1 deterministic assertions."""
 
 from clauditor.assertions import (
+    AssertionResult,
     AssertionSet,
     assert_contains,
     assert_has_entries,
     assert_has_urls,
+    assert_max_length,
     assert_min_count,
     assert_min_length,
     assert_not_contains,
@@ -176,3 +178,105 @@ class TestAssertionSet:
         assert s.passed
         assert s.pass_rate == 1.0
         assert len(s.failed) == 0
+
+    def test_pass_rate_mixed(self):
+        s = AssertionSet(
+            results=[
+                assert_contains("hello", "hello"),
+                assert_contains("hello", "missing"),
+                assert_contains("hello", "also_missing"),
+            ]
+        )
+        assert not s.passed
+        assert abs(s.pass_rate - 1 / 3) < 0.01
+
+    def test_failed_returns_only_failures(self):
+        s = AssertionSet(
+            results=[
+                assert_contains("hello", "hello"),
+                assert_contains("hello", "nope"),
+            ]
+        )
+        failed = s.failed
+        assert len(failed) == 1
+        assert not failed[0].passed
+
+    def test_summary_format(self):
+        s = AssertionSet(
+            results=[
+                assert_contains("hello", "hello"),
+                assert_contains("hello", "nope"),
+            ]
+        )
+        summary = s.summary()
+        assert "1/2" in summary
+        assert "50%" in summary
+        assert "FAIL" in summary
+        assert "nope" in summary
+
+
+class TestMaxLength:
+    def test_pass(self):
+        result = assert_max_length("short", 100)
+        assert result.passed
+        assert "5" in result.message
+
+    def test_fail(self):
+        result = assert_max_length("this is too long", 5)
+        assert not result.passed
+
+    def test_exact(self):
+        result = assert_max_length("12345", 5)
+        assert result.passed
+
+
+class TestAssertionResultBool:
+    def test_bool_true(self):
+        r = AssertionResult(name="test", passed=True, message="ok")
+        assert bool(r) is True
+
+    def test_bool_false(self):
+        r = AssertionResult(name="test", passed=False, message="fail")
+        assert bool(r) is False
+
+
+class TestRunAssertionsEdgeCases:
+    def test_empty_assertions(self):
+        result = run_assertions("anything", [])
+        assert isinstance(result, AssertionSet)
+        assert result.passed  # vacuous truth
+        assert len(result.results) == 0
+
+    def test_unknown_type_message(self):
+        result = run_assertions("text", [{"type": "bogus", "value": "x"}])
+        assert not result.passed
+        assert len(result.results) == 1
+        assert "Unknown assertion type" in result.results[0].message
+        assert result.results[0].name == "unknown:bogus"
+
+    def test_max_length_via_run(self):
+        result = run_assertions("short", [{"type": "max_length", "value": "100"}])
+        assert result.passed
+
+    def test_regex_via_run(self):
+        result = run_assertions("hello 123", [{"type": "regex", "value": r"\d+"}])
+        assert result.passed
+
+    def test_min_count_via_run(self):
+        assertion = {"type": "min_count", "value": "a", "minimum": 3}
+        result = run_assertions("aaa", [assertion])
+        assert result.passed
+
+    def test_has_urls_via_run(self):
+        result = run_assertions(
+            "visit https://example.com",
+            [{"type": "has_urls", "value": "1"}],
+        )
+        assert result.passed
+
+    def test_has_entries_via_run(self):
+        result = run_assertions(
+            "**1. Item** **2. Item**",
+            [{"type": "has_entries", "value": "2"}],
+        )
+        assert result.passed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,371 @@
+"""Tests for clauditor CLI commands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from clauditor.cli import main
+from clauditor.quality_grader import GradingReport, GradingResult
+from clauditor.runner import SkillResult
+from clauditor.schemas import EvalSpec, TriggerTests
+from clauditor.spec import SkillSpec
+from clauditor.triggers import TriggerReport, TriggerResult
+
+
+def _make_spec(eval_spec=None, skill_name="test-skill"):
+    """Create a mock SkillSpec with the given eval_spec."""
+    spec = MagicMock(spec=SkillSpec)
+    spec.skill_name = skill_name
+    spec.eval_spec = eval_spec
+    return spec
+
+
+def _make_eval_spec(**overrides):
+    """Create a minimal EvalSpec for testing."""
+    defaults = dict(
+        skill_name="test-skill",
+        description="A test skill",
+        test_args="--depth quick",
+        assertions=[{"type": "contains", "value": "hello"}],
+        sections=[],
+        grading_criteria=["Is the output relevant?"],
+        grading_model="claude-sonnet-4-6",
+        trigger_tests=None,
+        variance=None,
+    )
+    defaults.update(overrides)
+    return EvalSpec(**defaults)
+
+
+class TestCmdValidate:
+    """Tests for the validate subcommand."""
+
+    def test_validate_with_output_file(self, tmp_path):
+        """Validate reads output file, runs assertions, returns 0."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hello world with some content")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+    def test_validate_no_eval_spec(self, capsys):
+        """Returns 1 when no eval spec is found."""
+        spec = _make_spec(eval_spec=None)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 1
+        assert "No eval spec" in capsys.readouterr().err
+
+    def test_validate_json_output(self, tmp_path):
+        """--json flag produces valid JSON output."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hello world with some content")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(
+                ["validate", "skill.md", "--output", str(output_file), "--json"]
+            )
+
+        # rc may be 0 or 1 depending on assertion pass, but JSON should be valid
+        # (contains assertion should pass since output has "hello")
+        assert rc == 0
+
+    def test_validate_run_skill(self):
+        """Without --output, runs the skill to get output."""
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output="hello world output",
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=1.5,
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        spec.run.assert_called_once()
+
+    def test_validate_run_skill_fails(self, capsys):
+        """Returns 1 when skill run fails."""
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output="",
+            exit_code=1,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=0.5,
+            error="timeout",
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 1
+        assert "Skill failed" in capsys.readouterr().err
+
+
+class TestCmdRun:
+    """Tests for the run subcommand."""
+
+    def test_run_happy_path(self, capsys):
+        """Runs skill and prints output."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = SkillResult(
+            output="skill output here",
+            exit_code=0,
+            skill_name="my-skill",
+            args="",
+            duration_seconds=2.0,
+        )
+
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill"])
+
+        assert rc == 0
+        assert "skill output here" in capsys.readouterr().out
+
+    def test_run_with_error(self, capsys):
+        """Prints error to stderr and returns non-zero exit code."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = SkillResult(
+            output="",
+            exit_code=1,
+            skill_name="my-skill",
+            args="",
+            duration_seconds=0.5,
+            error="command not found",
+        )
+
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill"])
+
+        assert rc == 1
+        assert "command not found" in capsys.readouterr().err
+
+
+class TestCmdGrade:
+    """Tests for the grade subcommand."""
+
+    def _make_grading_report(self, passed=True):
+        return GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="Is the output relevant?",
+                    passed=passed,
+                    score=0.9 if passed else 0.3,
+                    evidence="Found relevant content",
+                    reasoning="Output addresses the query",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+    def test_grade_with_output(self, tmp_path):
+        """Grades pre-captured output, returns 0 when passed."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_grading_report(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+    def test_grade_no_eval_spec(self, capsys):
+        """Returns 1 when no eval spec is found."""
+        spec = _make_spec(eval_spec=None)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 1
+        assert "No eval spec" in capsys.readouterr().err
+
+    def test_grade_no_grading_criteria(self, capsys):
+        """Returns 1 when no grading_criteria defined."""
+        eval_spec = _make_eval_spec(grading_criteria=[])
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 1
+        assert "No grading_criteria" in capsys.readouterr().err
+
+    def test_grade_dry_run(self, capsys):
+        """--dry-run prints prompt and returns 0 without API calls."""
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["grade", "skill.md", "--dry-run"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Model:" in out
+        assert "Prompt:" in out
+
+    def test_grade_failed(self, tmp_path):
+        """Returns 1 when grading fails."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("bad output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_grading_report(passed=False)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 1
+
+
+class TestCmdTriggers:
+    """Tests for the triggers subcommand."""
+
+    def _make_trigger_report(self, passed=True):
+        return TriggerReport(
+            skill_name="test-skill",
+            skill_description="A test skill",
+            model="claude-sonnet-4-6",
+            results=[
+                TriggerResult(
+                    query="test query",
+                    expected_trigger=True,
+                    predicted_trigger=True if passed else False,
+                    passed=passed,
+                    confidence=0.95,
+                    reasoning="Matches skill intent",
+                ),
+            ],
+        )
+
+    def test_triggers_happy_path(self, capsys):
+        """Runs trigger testing and prints report."""
+        eval_spec = _make_eval_spec(
+            trigger_tests=TriggerTests(
+                should_trigger=["find activities"],
+                should_not_trigger=["weather today"],
+            )
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_trigger_report(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.triggers.test_triggers",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["triggers", "skill.md"])
+
+        assert rc == 0
+
+    def test_triggers_dry_run(self, capsys):
+        """--dry-run prints prompts and returns 0."""
+        eval_spec = _make_eval_spec(
+            trigger_tests=TriggerTests(
+                should_trigger=["find activities"],
+                should_not_trigger=["weather today"],
+            )
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["triggers", "skill.md", "--dry-run"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Model:" in out
+        assert "should_trigger" in out
+        assert "should_not_trigger" in out
+
+    def test_triggers_no_eval_spec(self, capsys):
+        """Returns 1 when no eval spec is found."""
+        spec = _make_spec(eval_spec=None)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["triggers", "skill.md"])
+
+        assert rc == 1
+        assert "No eval spec" in capsys.readouterr().err
+
+
+class TestCmdInit:
+    """Tests for the init subcommand."""
+
+    def test_init_creates_file(self, tmp_path):
+        """Creates eval.json with starter content."""
+        skill_path = tmp_path / "my-skill.md"
+        skill_path.write_text("# My Skill")
+
+        rc = main(["init", str(skill_path)])
+
+        assert rc == 0
+        eval_path = tmp_path / "my-skill.eval.json"
+        assert eval_path.exists()
+        data = json.loads(eval_path.read_text())
+        assert data["skill_name"] == "my-skill"
+        assert "assertions" in data
+        assert "grading_criteria" in data
+
+    def test_init_existing_no_force(self, tmp_path, capsys):
+        """Returns 1 when eval.json already exists without --force."""
+        skill_path = tmp_path / "my-skill.md"
+        skill_path.write_text("# My Skill")
+        eval_path = tmp_path / "my-skill.eval.json"
+        eval_path.write_text("{}")
+
+        rc = main(["init", str(skill_path)])
+
+        assert rc == 1
+        assert "already exists" in capsys.readouterr().err
+
+    def test_init_force_overwrites(self, tmp_path):
+        """--force overwrites existing eval.json."""
+        skill_path = tmp_path / "my-skill.md"
+        skill_path.write_text("# My Skill")
+        eval_path = tmp_path / "my-skill.eval.json"
+        eval_path.write_text("{}")
+
+        rc = main(["init", str(skill_path), "--force"])
+
+        assert rc == 0
+        data = json.loads(eval_path.read_text())
+        assert data["skill_name"] == "my-skill"

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,7 +1,12 @@
 """Tests for the A/B baseline comparator."""
 
-from clauditor.comparator import ABReport, ABResult
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clauditor.comparator import ABReport, ABResult, compare_ab
 from clauditor.quality_grader import GradingReport, GradingResult
+from clauditor.runner import SkillResult
 
 
 def _make_grade(criterion: str, passed: bool, score: float = 0.8) -> GradingResult:
@@ -174,3 +179,160 @@ class TestABReport:
         summary = report.summary()
         assert "PASS" in summary
         assert "REGRESSION" not in summary
+
+
+def _mock_eval_spec(test_args="find kid activities near me"):
+    """Create a mock eval spec with test_args and grading criteria."""
+    es = MagicMock()
+    es.test_args = test_args
+    return es
+
+
+def _mock_spec(
+    eval_spec=None,
+    skill_output="skill output",
+    baseline_output="baseline output",
+):
+    """Create a mock SkillSpec with a mock runner."""
+    spec = MagicMock()
+    spec.skill_name = "test-skill"
+    spec.eval_spec = eval_spec
+    spec.run.return_value = SkillResult(
+        output=skill_output, exit_code=0, skill_name="test-skill", args="test"
+    )
+    spec.runner.run_raw.return_value = SkillResult(
+        output=baseline_output, exit_code=0, skill_name="__baseline__", args="test"
+    )
+    return spec
+
+
+class TestCompareAB:
+    """Tests for the compare_ab async function."""
+
+    @pytest.mark.asyncio
+    async def test_success_no_regressions(self):
+        eval_spec = _mock_eval_spec()
+        spec = _mock_spec(eval_spec=eval_spec)
+
+        skill_grades = [
+            _make_grade("clarity", True, 0.9),
+            _make_grade("accuracy", True, 0.85),
+        ]
+        baseline_grades = [
+            _make_grade("clarity", True, 0.8),
+            _make_grade("accuracy", True, 0.75),
+        ]
+
+        skill_report = _make_report(skill_grades)
+        baseline_report = _make_report(baseline_grades)
+
+        mock_grade = AsyncMock(side_effect=[skill_report, baseline_report])
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+            report = await compare_ab(spec)
+
+        assert report.passed is True
+        assert len(report.results) == 2
+        assert report.regressions == []
+        assert report.skill_name == "test-skill"
+        assert mock_grade.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_regression_detected(self):
+        eval_spec = _mock_eval_spec()
+        spec = _mock_spec(eval_spec=eval_spec)
+
+        skill_grades = [
+            _make_grade("clarity", False, 0.3),
+            _make_grade("accuracy", True, 0.9),
+        ]
+        baseline_grades = [
+            _make_grade("clarity", True, 0.9),
+            _make_grade("accuracy", True, 0.8),
+        ]
+
+        skill_report = _make_report(skill_grades)
+        baseline_report = _make_report(baseline_grades)
+
+        mock_grade = AsyncMock(side_effect=[skill_report, baseline_report])
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+            report = await compare_ab(spec)
+
+        assert report.passed is False
+        assert len(report.regressions) == 1
+        assert report.regressions[0].criterion == "clarity"
+
+    @pytest.mark.asyncio
+    async def test_no_eval_spec_raises(self):
+        spec = _mock_spec(eval_spec=None)
+
+        with pytest.raises(ValueError, match="No eval spec found"):
+            await compare_ab(spec)
+
+    @pytest.mark.asyncio
+    async def test_empty_test_args_raises(self):
+        eval_spec = _mock_eval_spec(test_args="")
+        spec = _mock_spec(eval_spec=eval_spec)
+
+        with pytest.raises(ValueError, match="non-empty test_args"):
+            await compare_ab(spec)
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_test_args_raises(self):
+        eval_spec = _mock_eval_spec(test_args="   ")
+        spec = _mock_spec(eval_spec=eval_spec)
+
+        with pytest.raises(ValueError, match="non-empty test_args"):
+            await compare_ab(spec)
+
+    @pytest.mark.asyncio
+    async def test_baseline_fewer_criteria_pads_with_synthetic(self):
+        eval_spec = _mock_eval_spec()
+        spec = _mock_spec(eval_spec=eval_spec)
+
+        skill_grades = [
+            _make_grade("clarity", True, 0.9),
+            _make_grade("accuracy", True, 0.8),
+            _make_grade("format", False, 0.4),
+        ]
+        baseline_grades = [
+            _make_grade("clarity", True, 0.85),
+        ]
+
+        skill_report = _make_report(skill_grades)
+        baseline_report = _make_report(baseline_grades)
+
+        mock_grade = AsyncMock(side_effect=[skill_report, baseline_report])
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+            report = await compare_ab(spec)
+
+        assert len(report.results) == 3
+        assert report.results[0].baseline_grade.passed is True
+        assert report.results[1].baseline_grade.passed is False
+        assert report.results[1].baseline_grade.score == 0.0
+        assert "not evaluated" in report.results[1].baseline_grade.reasoning
+        assert report.results[2].baseline_grade.passed is False
+        assert report.results[1].regression is False
+        assert report.results[2].regression is False
+
+    @pytest.mark.asyncio
+    async def test_custom_model_passed_through(self):
+        eval_spec = _mock_eval_spec()
+        spec = _mock_spec(eval_spec=eval_spec)
+
+        grades = [_make_grade("clarity", True, 0.9)]
+        report_obj = _make_report(grades)
+        mock_grade = AsyncMock(side_effect=[report_obj, report_obj])
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+            report = await compare_ab(spec, model="claude-haiku-4-5")
+
+        assert report.model == "claude-haiku-4-5"
+        for call in mock_grade.call_args_list:
+            assert call.kwargs.get("model") == "claude-haiku-4-5"

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,6 +1,6 @@
 """Tests for the A/B baseline comparator."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -228,8 +228,7 @@ class TestCompareAB:
 
         mock_grade = AsyncMock(side_effect=[skill_report, baseline_report])
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+        with patch("clauditor.comparator.grade_quality", mock_grade):
             report = await compare_ab(spec)
 
         assert report.passed is True
@@ -257,8 +256,7 @@ class TestCompareAB:
 
         mock_grade = AsyncMock(side_effect=[skill_report, baseline_report])
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+        with patch("clauditor.comparator.grade_quality", mock_grade):
             report = await compare_ab(spec)
 
         assert report.passed is False
@@ -307,8 +305,7 @@ class TestCompareAB:
 
         mock_grade = AsyncMock(side_effect=[skill_report, baseline_report])
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+        with patch("clauditor.comparator.grade_quality", mock_grade):
             report = await compare_ab(spec)
 
         assert len(report.results) == 3
@@ -329,8 +326,7 @@ class TestCompareAB:
         report_obj = _make_report(grades)
         mock_grade = AsyncMock(side_effect=[report_obj, report_obj])
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr("clauditor.comparator.grade_quality", mock_grade)
+        with patch("clauditor.comparator.grade_quality", mock_grade):
             report = await compare_ab(spec, model="claude-haiku-4-5")
 
         assert report.model == "claude-haiku-4-5"

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -236,6 +236,14 @@ class TestExtractAndGrade:
 
     @pytest.mark.asyncio
     async def test_import_error_when_no_anthropic(self):
-        with patch.dict("sys.modules", {"anthropic": None}):
-            with pytest.raises(ImportError, match="anthropic SDK"):
-                await extract_and_grade("output", _make_spec())
+        # Remove anthropic from sys.modules and block re-import
+        import sys
+
+        real_anthropic = sys.modules.pop("anthropic", None)
+        try:
+            with patch.dict("sys.modules", {"anthropic": None}):
+                with pytest.raises(ImportError, match="anthropic SDK"):
+                    await extract_and_grade("output", _make_spec())
+        finally:
+            if real_anthropic is not None:
+                sys.modules["anthropic"] = real_anthropic

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -208,6 +208,23 @@ class TestExtractAndGrade:
         assert result.passed
 
     @pytest.mark.asyncio
+    async def test_generic_code_block_stripped(self):
+        data = {
+            "Venues": [
+                {"name": "A", "address": "B", "website": "C"},
+                {"name": "D", "address": "E", "website": "F"},
+            ]
+        }
+        wrapped = f"```\n{json.dumps(data)}\n```"
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=wrapped)]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert result.passed
+
+    @pytest.mark.asyncio
     async def test_json_parse_failure(self):
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="not valid json at all")]

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1,6 +1,17 @@
 """Tests for Layer 2 grading (extraction validation, not LLM calls)."""
 
-from clauditor.grader import ExtractedEntry, ExtractedOutput, grade_extraction
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clauditor.grader import (
+    ExtractedEntry,
+    ExtractedOutput,
+    build_extraction_prompt,
+    extract_and_grade,
+    grade_extraction,
+)
 from clauditor.schemas import EvalSpec, FieldRequirement, SectionRequirement
 
 
@@ -110,3 +121,121 @@ class TestGradeExtraction:
         # phone is optional, should still pass
         results = grade_extraction(extracted, _make_spec())
         assert results.passed
+
+
+class TestBuildExtractionPrompt:
+    def test_contains_section_and_fields(self):
+        spec = _make_spec()
+        prompt = build_extraction_prompt(spec)
+        assert "Venues" in prompt
+        assert "name" in prompt
+        assert "address" in prompt
+        assert "website" in prompt
+        assert "phone" in prompt
+
+    def test_includes_json_schema_block(self):
+        spec = _make_spec()
+        prompt = build_extraction_prompt(spec)
+        assert '"Venues"' in prompt
+        assert '"name": "value or null"' in prompt
+
+    def test_multiple_sections(self):
+        spec = EvalSpec(
+            skill_name="multi",
+            sections=[
+                SectionRequirement(
+                    name="Hotels",
+                    min_entries=1,
+                    fields=[FieldRequirement(name="name", required=True)],
+                ),
+                SectionRequirement(
+                    name="Restaurants",
+                    min_entries=1,
+                    fields=[
+                        FieldRequirement(name="name", required=True),
+                        FieldRequirement(name="cuisine", required=False),
+                    ],
+                ),
+            ],
+        )
+        prompt = build_extraction_prompt(spec)
+        assert "Hotels" in prompt
+        assert "Restaurants" in prompt
+        assert "cuisine" in prompt
+
+    def test_returns_string(self):
+        prompt = build_extraction_prompt(_make_spec())
+        assert isinstance(prompt, str)
+        assert prompt.startswith("Extract structured data")
+
+
+class TestExtractAndGrade:
+    @pytest.mark.asyncio
+    async def test_successful_extraction(self):
+        data = {
+            "Venues": [
+                {"name": "CDM", "address": "180 Woz Way", "website": "https://cdm.org"},
+                {
+                    "name": "Deer Hollow",
+                    "address": "22500 Cristo Rey Dr",
+                    "website": "https://deerhollowfarm.org",
+                },
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert result.passed
+
+    @pytest.mark.asyncio
+    async def test_markdown_code_block_stripped(self):
+        data = {
+            "Venues": [
+                {"name": "A", "address": "B", "website": "C"},
+                {"name": "D", "address": "E", "website": "F"},
+            ]
+        }
+        wrapped = f"```json\n{json.dumps(data)}\n```"
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=wrapped)]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert result.passed
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure(self):
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="not valid json at all")]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert not result.passed
+        assert any("parse" in r.name for r in result.results)
+
+    @pytest.mark.asyncio
+    async def test_missing_required_field_in_response(self):
+        data = {
+            "Venues": [
+                {"name": "CDM", "address": None, "website": "https://cdm.org"},
+                {"name": "Deer Hollow", "address": "addr", "website": "https://dh.org"},
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert not result.passed
+
+    @pytest.mark.asyncio
+    async def test_import_error_when_no_anthropic(self):
+        with patch.dict("sys.modules", {"anthropic": None}):
+            with pytest.raises(ImportError, match="anthropic SDK"):
+                await extract_and_grade("output", _make_spec())

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,69 @@
+"""Tests for clauditor package __init__.py."""
+
+import importlib
+
+import pytest
+
+
+def test_version_exists():
+    """__version__ is defined and non-empty."""
+    import clauditor
+
+    assert hasattr(clauditor, "__version__")
+    assert isinstance(clauditor.__version__, str)
+    assert len(clauditor.__version__) > 0
+
+
+def test_reload_executes_module_level_code():
+    """Reloading the module re-executes top-level imports under coverage."""
+    import clauditor
+
+    reloaded = importlib.reload(clauditor)
+    assert reloaded.__version__ == "0.1.0"
+    assert hasattr(reloaded, "SkillRunner")
+    assert hasattr(reloaded, "EvalSpec")
+    assert hasattr(reloaded, "AssertionResult")
+
+
+def test_lazy_import_grading_report():
+    """__getattr__ lazily imports GradingReport from quality_grader."""
+    import clauditor
+
+    GradingReport = clauditor.GradingReport  # noqa: N806
+    assert GradingReport is not None
+    assert GradingReport.__name__ == "GradingReport"
+
+
+def test_lazy_import_ab_result():
+    """__getattr__ lazily imports ABResult from comparator."""
+    import clauditor
+
+    ABResult = clauditor.ABResult  # noqa: N806
+    assert ABResult is not None
+    assert ABResult.__name__ == "ABResult"
+
+
+def test_lazy_import_trigger_report():
+    """__getattr__ lazily imports TriggerReport from triggers."""
+    import clauditor
+
+    TriggerReport = clauditor.TriggerReport  # noqa: N806
+    assert TriggerReport is not None
+    assert TriggerReport.__name__ == "TriggerReport"
+
+
+def test_invalid_attribute_raises():
+    """Accessing a nonexistent attribute raises AttributeError."""
+    import clauditor
+
+    with pytest.raises(AttributeError, match="has no attribute 'no_such_thing'"):
+        _ = clauditor.no_such_thing
+
+
+def test_all_names_importable():
+    """Every name listed in __all__ is importable from the package."""
+    import clauditor
+
+    for name in clauditor.__all__:
+        obj = getattr(clauditor, name)
+        assert obj is not None, f"{name} resolved to None"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,7 +19,7 @@ def test_reload_executes_module_level_code():
     import clauditor
 
     reloaded = importlib.reload(clauditor)
-    assert reloaded.__version__ == "0.1.0"
+    assert isinstance(reloaded.__version__, str) and len(reloaded.__version__) > 0
     assert hasattr(reloaded, "SkillRunner")
     assert hasattr(reloaded, "EvalSpec")
     assert hasattr(reloaded, "AssertionResult")

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,51 +1,185 @@
-"""Tests for the clauditor pytest plugin (marker registration, skip logic)."""
+"""Tests for the clauditor pytest plugin using pytester."""
 
 from __future__ import annotations
 
-import pytest
+import importlib
+from unittest.mock import MagicMock
+
+import clauditor.pytest_plugin as _plugin_mod
+from clauditor.pytest_plugin import (
+    clauditor_runner,
+    clauditor_spec,
+    pytest_addoption,
+    pytest_collection_modifyitems,
+    pytest_configure,
+)
+
+# Re-import to ensure coverage sees the module code
+importlib.reload(_plugin_mod)
+
+pytest_plugins = ["pytester"]
 
 
-def test_clauditor_grade_marker_registered(pytestconfig):
-    """Verify the clauditor_grade marker is registered via pytest_configure."""
-    markers = pytestconfig.getini("markers")
-    assert any("clauditor_grade" in m for m in markers)
+class TestPytestPlugin:
+    def test_marker_registered(self, pytester):
+        """Check that clauditor_grade marker appears in help."""
+        result = pytester.runpytest_inprocess("--markers")
+        result.stdout.fnmatch_lines(["*clauditor_grade*"])
+
+    def test_grade_marker_skipped_by_default(self, pytester):
+        """Grade-marked tests are skipped without --clauditor-grade."""
+        pytester.makepyfile("""
+            import pytest
+            @pytest.mark.clauditor_grade
+            def test_graded():
+                pass
+            def test_normal():
+                pass
+        """)
+        result = pytester.runpytest_inprocess("-v")
+        result.assert_outcomes(passed=1, skipped=1)
+
+    def test_grade_marker_runs_with_flag(self, pytester):
+        """Grade-marked tests run when --clauditor-grade is passed."""
+        pytester.makepyfile("""
+            import pytest
+            @pytest.mark.clauditor_grade
+            def test_graded():
+                pass
+        """)
+        result = pytester.runpytest_inprocess("--clauditor-grade", "-v")
+        result.assert_outcomes(passed=1)
+
+    def test_runner_fixture_available(self, pytester):
+        """The clauditor_runner fixture is available and non-None."""
+        pytester.makepyfile("""
+            def test_runner(clauditor_runner):
+                assert clauditor_runner is not None
+        """)
+        result = pytester.runpytest_inprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_cli_options_passed(self, pytester):
+        """CLI options are forwarded to fixture-created objects."""
+        pytester.makepyfile("""
+            def test_timeout(clauditor_runner):
+                assert clauditor_runner.timeout == 42
+        """)
+        result = pytester.runpytest_inprocess("--clauditor-timeout=42")
+        result.assert_outcomes(passed=1)
+
+    def test_spec_fixture_available(self, pytester):
+        """The clauditor_spec fixture is available and callable."""
+        pytester.makepyfile("""
+            def test_spec(clauditor_spec):
+                assert callable(clauditor_spec)
+        """)
+        result = pytester.runpytest_inprocess()
+        result.assert_outcomes(passed=1)
 
 
-@pytest.mark.clauditor_grade
-def test_marked_test_is_skipped_without_flag():
-    """This test should be skipped when --clauditor-grade is not passed."""
-    pytest.fail("This test should have been skipped")
+class TestPluginFunctionsDirect:
+    """Direct unit tests for plugin functions to ensure coverage."""
 
+    def test_pytest_addoption_registers_options(self):
+        """pytest_addoption adds the expected CLI options."""
+        parser = MagicMock()
+        group = MagicMock()
+        parser.getgroup.return_value = group
+        pytest_addoption(parser)
+        parser.getgroup.assert_called_once_with(
+            "clauditor", "Claude Code skill testing"
+        )
+        assert group.addoption.call_count == 5
+        # Verify option names
+        option_names = [call.args[0] for call in group.addoption.call_args_list]
+        assert "--clauditor-project-dir" in option_names
+        assert "--clauditor-timeout" in option_names
+        assert "--clauditor-claude-bin" in option_names
+        assert "--clauditor-grade" in option_names
+        assert "--clauditor-model" in option_names
 
-def test_skip_logic_via_subprocess(tmp_path):
-    """Verify skip behaviour end-to-end using a subprocess pytest run."""
-    import subprocess
-    import sys
+    def test_pytest_configure_adds_marker(self):
+        """pytest_configure registers the clauditor_grade marker."""
+        config = MagicMock()
+        pytest_configure(config)
+        config.addinivalue_line.assert_called_once()
+        args = config.addinivalue_line.call_args
+        assert args[0][0] == "markers"
+        assert "clauditor_grade" in args[0][1]
 
-    test_file = tmp_path / "test_grade_check.py"
-    test_file.write_text(
-        "import pytest\n\n"
-        "@pytest.mark.clauditor_grade\n"
-        "def test_graded():\n"
-        "    pass\n\n"
-        "def test_normal():\n"
-        "    pass\n"
-    )
+    def test_collection_modifyitems_skips_grade_tests(self):
+        """Grade-marked items are skipped when flag is not set."""
+        config = MagicMock()
+        config.getoption.return_value = False
+        item = MagicMock()
+        item.keywords = {"clauditor_grade": True}
+        pytest_collection_modifyitems(config, [item])
+        item.add_marker.assert_called_once()
 
-    # Run WITHOUT --clauditor-grade: graded test should be skipped
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", str(test_file), "-v"],
-        capture_output=True,
-        text=True,
-    )
-    assert "test_graded SKIPPED" in result.stdout
-    assert "test_normal PASSED" in result.stdout
+    def test_collection_modifyitems_no_skip_with_flag(self):
+        """Grade-marked items are NOT skipped when flag is set."""
+        config = MagicMock()
+        config.getoption.return_value = True
+        item = MagicMock()
+        item.keywords = {"clauditor_grade": True}
+        pytest_collection_modifyitems(config, [item])
+        item.add_marker.assert_not_called()
 
-    # Run WITH --clauditor-grade: graded test should pass
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", str(test_file), "-v", "--clauditor-grade"],
-        capture_output=True,
-        text=True,
-    )
-    assert "test_graded PASSED" in result.stdout
-    assert "test_normal PASSED" in result.stdout
+    def test_collection_modifyitems_ignores_normal_tests(self):
+        """Non-grade items are never skipped."""
+        config = MagicMock()
+        config.getoption.return_value = False
+        item = MagicMock()
+        item.keywords = {}
+        pytest_collection_modifyitems(config, [item])
+        item.add_marker.assert_not_called()
+
+    def test_runner_fixture_returns_skill_runner(self):
+        """clauditor_runner fixture returns a configured SkillRunner."""
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 60,
+                "--clauditor-claude-bin": "claude",
+            }[opt]
+        )
+        # Access the underlying function, bypassing the fixture decorator
+        runner = clauditor_runner.__wrapped__(request)
+        assert runner.timeout == 60
+        assert runner.claude_bin == "claude"
+
+    def test_spec_fixture_returns_callable(self):
+        """clauditor_spec fixture returns a callable factory."""
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 180,
+                "--clauditor-claude-bin": "claude",
+            }[opt]
+        )
+        factory = clauditor_spec.__wrapped__(request)
+        assert callable(factory)
+
+    def test_spec_factory_calls_from_file(self):
+        """clauditor_spec factory delegates to SkillSpec.from_file."""
+        from unittest.mock import patch
+
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 180,
+                "--clauditor-claude-bin": "claude",
+            }[opt]
+        )
+        factory = clauditor_spec.__wrapped__(request)
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file"
+        ) as mock_from_file:
+            mock_from_file.return_value = MagicMock()
+            result = factory("some/skill.md")
+            mock_from_file.assert_called_once()
+            assert result is mock_from_file.return_value

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -145,7 +145,6 @@ class TestPluginFunctionsDirect:
                 "--clauditor-claude-bin": "claude",
             }[opt]
         )
-        # Access the underlying function, bypassing the fixture decorator
         runner = clauditor_runner.__wrapped__(request)
         assert runner.timeout == 60
         assert runner.claude_bin == "claude"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,11 +1,16 @@
 """Tests for SkillRunner."""
 
+import importlib
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from clauditor.runner import SkillResult, SkillRunner
+import clauditor.runner as _runner_mod
+
+importlib.reload(_runner_mod)
+
+from clauditor.runner import SkillResult, SkillRunner  # noqa: E402
 
 
 class TestRunRaw:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -161,7 +161,7 @@ class TestSkillResultAssertions:
         assertion_set = result.run_assertions(
             [{"type": "contains", "value": "hello"}]
         )
-        assert assertion_set.passed > 0
+        assert assertion_set.passed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,11 @@
 """Tests for SkillRunner."""
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
-from clauditor.runner import SkillRunner
+import pytest
+
+from clauditor.runner import SkillResult, SkillRunner
 
 
 class TestRunRaw:
@@ -32,8 +35,6 @@ class TestRunRaw:
             assert result.output == "some output"
 
     def test_run_raw_handles_timeout(self):
-        import subprocess
-
         runner = SkillRunner(project_dir="/tmp", timeout=1, claude_bin="claude")
         with patch(
             "subprocess.run",
@@ -51,3 +52,164 @@ class TestRunRaw:
             assert result.exit_code == -1
             assert result.skill_name == "__baseline__"
             assert "not found" in result.error
+
+
+# ---------------------------------------------------------------------------
+# SkillResult.succeeded
+# ---------------------------------------------------------------------------
+
+
+class TestSkillResultSucceeded:
+    def _make(self, exit_code: int = 0, output: str = "some output") -> SkillResult:
+        return SkillResult(
+            output=output,
+            exit_code=exit_code,
+            skill_name="test",
+            args="",
+        )
+
+    def test_succeeded_true(self):
+        assert self._make(exit_code=0, output="hello").succeeded is True
+
+    def test_succeeded_false_empty_output(self):
+        assert self._make(exit_code=0, output="").succeeded is False
+
+    def test_succeeded_false_whitespace(self):
+        assert self._make(exit_code=0, output="  \n").succeeded is False
+
+    def test_succeeded_false_nonzero_exit(self):
+        assert self._make(exit_code=1, output="hello").succeeded is False
+
+
+# ---------------------------------------------------------------------------
+# SkillResult assertion helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSkillResultAssertions:
+    """Each assertion method should pass or raise AssertionError."""
+
+    def _make(self, output: str) -> SkillResult:
+        return SkillResult(
+            output=output, exit_code=0, skill_name="test", args=""
+        )
+
+    # assert_contains
+    def test_assert_contains_pass(self):
+        self._make("hello world").assert_contains("world")
+
+    def test_assert_contains_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("hello world").assert_contains("missing")
+
+    # assert_not_contains
+    def test_assert_not_contains_pass(self):
+        self._make("hello world").assert_not_contains("missing")
+
+    def test_assert_not_contains_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("hello world").assert_not_contains("hello")
+
+    # assert_matches
+    def test_assert_matches_pass(self):
+        self._make("order 12345 confirmed").assert_matches(r"\d{5}")
+
+    def test_assert_matches_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("no digits here").assert_matches(r"\d{5}")
+
+    # assert_min_count
+    def test_assert_min_count_pass(self):
+        self._make("a a a").assert_min_count("a", 3)
+
+    def test_assert_min_count_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("a a").assert_min_count("a", 5)
+
+    # assert_min_length
+    def test_assert_min_length_pass(self):
+        self._make("x" * 100).assert_min_length(100)
+
+    def test_assert_min_length_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("short").assert_min_length(1000)
+
+    # assert_has_urls
+    def test_assert_has_urls_pass(self):
+        self._make("Visit https://example.com today").assert_has_urls(1)
+
+    def test_assert_has_urls_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("no urls here").assert_has_urls(1)
+
+    # assert_has_entries
+    def test_assert_has_entries_pass(self):
+        self._make("**1. First**\n**2. Second**\n**3. Third**").assert_has_entries(3)
+
+    def test_assert_has_entries_fail(self):
+        with pytest.raises(AssertionError):
+            self._make("no numbered entries").assert_has_entries(3)
+
+    # run_assertions delegates
+    def test_run_assertions_delegates(self):
+        result = self._make("hello world")
+        assertion_set = result.run_assertions(
+            [{"type": "contains", "value": "hello"}]
+        )
+        assert assertion_set.passed > 0
+
+
+# ---------------------------------------------------------------------------
+# SkillRunner.run()
+# ---------------------------------------------------------------------------
+
+
+class TestSkillRunnerRun:
+    def test_runner_run_success(self):
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="skill output", stderr="", returncode=0
+            )
+            result = runner.run("my-skill", "some args")
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["claude", "-p", "/my-skill some args", "--no-input"]
+            assert result.output == "skill output"
+            assert result.exit_code == 0
+            assert result.skill_name == "my-skill"
+            assert result.args == "some args"
+            assert result.error is None
+
+    def test_runner_run_success_no_args(self):
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                stdout="output", stderr="", returncode=0
+            )
+            runner.run("my-skill")
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["claude", "-p", "/my-skill", "--no-input"]
+
+    def test_runner_run_timeout(self):
+        runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("claude", 5),
+        ):
+            result = runner.run("my-skill")
+            assert result.exit_code == -1
+            assert "Timed out" in result.error
+            assert result.output == ""
+
+    def test_runner_run_not_found(self):
+        runner = SkillRunner(project_dir="/tmp", claude_bin="missing-bin")
+        with patch(
+            "clauditor.runner.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            result = runner.run("my-skill")
+            assert result.exit_code == -1
+            assert "not found" in result.error
+            assert result.output == ""

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,11 +1,16 @@
 """Tests for eval spec loading and schema definitions."""
 
+import importlib
 import json
 import tempfile
 
 import pytest
 
-from clauditor.schemas import (
+import clauditor.schemas as _schemas_mod
+
+importlib.reload(_schemas_mod)
+
+from clauditor.schemas import (  # noqa: E402
     EvalSpec,
     FieldRequirement,
     SectionRequirement,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -3,6 +3,8 @@
 import json
 import tempfile
 
+import pytest
+
 from clauditor.schemas import (
     EvalSpec,
     FieldRequirement,
@@ -207,3 +209,243 @@ class TestEvalSpecNewFields:
         assert "trigger_tests" not in d
         assert "variance" not in d
         assert d["grading_model"] == "claude-sonnet-4-6"
+
+
+# --- New test classes for from_file, to_dict, and edge cases ---
+
+FULL_EVAL_DATA = {
+    "skill_name": "full-skill",
+    "description": "A fully populated eval spec",
+    "test_args": "--location NYC --depth full",
+    "assertions": [
+        {"type": "contains", "value": "Results"},
+        {"type": "min_length", "value": "200"},
+    ],
+    "sections": [
+        {
+            "name": "Places",
+            "min_entries": 2,
+            "fields": [
+                {"name": "name", "required": True},
+                {"name": "address", "required": True},
+                {"name": "zip", "required": False, "pattern": r"^\d{5}$"},
+            ],
+        },
+    ],
+    "grading_criteria": ["Are results relevant?", "Is formatting correct?"],
+    "grading_model": "claude-opus-4-6",
+    "trigger_tests": {
+        "should_trigger": ["find places in NYC", "places near me"],
+        "should_not_trigger": ["tell me a joke"],
+    },
+    "variance": {"n_runs": 8, "min_stability": 0.85},
+}
+
+
+def _write_json(tmp_path, data, name="eval.json"):
+    """Helper to write JSON data to a temp file and return its path."""
+    p = tmp_path / name
+    p.write_text(json.dumps(data))
+    return p
+
+
+class TestFromFile:
+    """Tests for EvalSpec.from_file() covering full data, minimal, errors."""
+
+    def test_from_file_full(self, tmp_path):
+        """Load a complete eval.json with every field populated."""
+        path = _write_json(tmp_path, FULL_EVAL_DATA)
+        spec = EvalSpec.from_file(path)
+
+        assert spec.skill_name == "full-skill"
+        assert spec.description == "A fully populated eval spec"
+        assert spec.test_args == "--location NYC --depth full"
+        assert len(spec.assertions) == 2
+        assert len(spec.sections) == 1
+        assert spec.sections[0].name == "Places"
+        assert spec.sections[0].min_entries == 2
+        assert len(spec.sections[0].fields) == 3
+        assert spec.sections[0].fields[2].pattern == r"^\d{5}$"
+        assert spec.sections[0].fields[2].required is False
+        assert spec.grading_criteria == [
+            "Are results relevant?",
+            "Is formatting correct?",
+        ]
+        assert spec.grading_model == "claude-opus-4-6"
+        assert spec.trigger_tests is not None
+        assert spec.variance is not None
+
+    def test_from_file_minimal(self, tmp_path):
+        """Load with only skill_name; everything else uses defaults."""
+        path = _write_json(tmp_path, {"skill_name": "bare"})
+        spec = EvalSpec.from_file(path)
+
+        assert spec.skill_name == "bare"
+        assert spec.description == ""
+        assert spec.test_args == ""
+        assert spec.assertions == []
+        assert spec.sections == []
+        assert spec.grading_criteria == []
+        assert spec.grading_model == "claude-sonnet-4-6"
+        assert spec.trigger_tests is None
+        assert spec.variance is None
+
+    def test_from_file_empty_dict_defaults_skill_name_to_stem(self, tmp_path):
+        """When skill_name is missing, defaults to the file stem."""
+        path = _write_json(tmp_path, {}, name="my-skill.eval.json")
+        spec = EvalSpec.from_file(path)
+
+        assert spec.skill_name == "my-skill.eval"
+
+    def test_from_file_missing(self, tmp_path):
+        """Raises FileNotFoundError for a nonexistent file."""
+        missing = tmp_path / "nonexistent.json"
+        with pytest.raises(FileNotFoundError):
+            EvalSpec.from_file(missing)
+
+    def test_from_file_malformed_json(self, tmp_path):
+        """Raises json.JSONDecodeError for invalid JSON content."""
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not valid json!!!")
+        with pytest.raises(json.JSONDecodeError):
+            EvalSpec.from_file(bad)
+
+    def test_from_file_field_pattern_none_when_absent(self, tmp_path):
+        """Fields without a pattern key have pattern=None."""
+        data = {
+            "skill_name": "test",
+            "sections": [
+                {"name": "S", "fields": [{"name": "f1", "required": True}]}
+            ],
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.sections[0].fields[0].pattern is None
+
+
+class TestToDict:
+    """Tests for EvalSpec.to_dict() serialization and round-trip."""
+
+    def test_to_dict_roundtrip(self, tmp_path):
+        """from_file -> to_dict produces data equivalent to the input."""
+        path = _write_json(tmp_path, FULL_EVAL_DATA)
+        spec = EvalSpec.from_file(path)
+        d = spec.to_dict()
+
+        assert d["skill_name"] == FULL_EVAL_DATA["skill_name"]
+        assert d["description"] == FULL_EVAL_DATA["description"]
+        assert d["test_args"] == FULL_EVAL_DATA["test_args"]
+        assert d["assertions"] == FULL_EVAL_DATA["assertions"]
+        assert d["grading_criteria"] == FULL_EVAL_DATA["grading_criteria"]
+        assert d["grading_model"] == FULL_EVAL_DATA["grading_model"]
+        # Sections structure matches
+        assert len(d["sections"]) == 1
+        assert d["sections"][0]["name"] == "Places"
+        assert d["sections"][0]["min_entries"] == 2
+        assert len(d["sections"][0]["fields"]) == 3
+        # Pattern included only where present
+        assert d["sections"][0]["fields"][2]["pattern"] == r"^\d{5}$"
+        assert "pattern" not in d["sections"][0]["fields"][0]
+        # Trigger tests
+        assert d["trigger_tests"] == FULL_EVAL_DATA["trigger_tests"]
+        # Variance
+        assert d["variance"] == FULL_EVAL_DATA["variance"]
+
+    def test_to_dict_reload_produces_equal_spec(self, tmp_path):
+        """to_dict output can be written and re-loaded to get an equal spec."""
+        path1 = _write_json(tmp_path, FULL_EVAL_DATA, name="first.json")
+        spec1 = EvalSpec.from_file(path1)
+        d = spec1.to_dict()
+        path2 = _write_json(tmp_path, d, name="second.json")
+        spec2 = EvalSpec.from_file(path2)
+
+        assert spec1.skill_name == spec2.skill_name
+        assert spec1.description == spec2.description
+        assert spec1.test_args == spec2.test_args
+        assert spec1.assertions == spec2.assertions
+        assert spec1.grading_model == spec2.grading_model
+        assert spec1.grading_criteria == spec2.grading_criteria
+        assert spec1.trigger_tests.should_trigger == spec2.trigger_tests.should_trigger
+        assert (
+            spec1.trigger_tests.should_not_trigger
+            == spec2.trigger_tests.should_not_trigger
+        )
+        assert spec1.variance.n_runs == spec2.variance.n_runs
+        assert spec1.variance.min_stability == spec2.variance.min_stability
+
+    def test_to_dict_omits_trigger_tests_when_none(self):
+        """trigger_tests key absent when field is None."""
+        spec = EvalSpec(skill_name="x")
+        d = spec.to_dict()
+        assert "trigger_tests" not in d
+
+    def test_to_dict_omits_variance_when_none(self):
+        """variance key absent when field is None."""
+        spec = EvalSpec(skill_name="x")
+        d = spec.to_dict()
+        assert "variance" not in d
+
+
+class TestOptionalFields:
+    """Tests for trigger_tests and variance loading from files."""
+
+    def test_trigger_tests_loaded(self, tmp_path):
+        """trigger_tests section is correctly parsed into TriggerTests."""
+        data = {
+            "skill_name": "t",
+            "trigger_tests": {
+                "should_trigger": ["a", "b"],
+                "should_not_trigger": ["c"],
+            },
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        assert isinstance(spec.trigger_tests, TriggerTests)
+        assert spec.trigger_tests.should_trigger == ["a", "b"]
+        assert spec.trigger_tests.should_not_trigger == ["c"]
+
+    def test_variance_config_loaded(self, tmp_path):
+        """variance section is correctly parsed into VarianceConfig."""
+        data = {
+            "skill_name": "v",
+            "variance": {"n_runs": 12, "min_stability": 0.95},
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        assert isinstance(spec.variance, VarianceConfig)
+        assert spec.variance.n_runs == 12
+        assert spec.variance.min_stability == 0.95
+
+    def test_no_trigger_tests(self, tmp_path):
+        """trigger_tests is None when key absent from JSON."""
+        path = _write_json(tmp_path, {"skill_name": "no-tt"})
+        spec = EvalSpec.from_file(path)
+        assert spec.trigger_tests is None
+
+    def test_no_variance(self, tmp_path):
+        """variance is None when key absent from JSON."""
+        path = _write_json(tmp_path, {"skill_name": "no-var"})
+        spec = EvalSpec.from_file(path)
+        assert spec.variance is None
+
+    def test_trigger_tests_defaults_empty_lists(self, tmp_path):
+        """trigger_tests with empty dict gets default empty lists."""
+        data = {"skill_name": "t", "trigger_tests": {}}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        assert spec.trigger_tests is not None
+        assert spec.trigger_tests.should_trigger == []
+        assert spec.trigger_tests.should_not_trigger == []
+
+    def test_variance_defaults(self, tmp_path):
+        """variance with empty dict gets default values."""
+        data = {"skill_name": "v", "variance": {}}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        assert spec.variance is not None
+        assert spec.variance.n_runs == 5
+        assert spec.variance.min_stability == 0.8

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 
 import pytest
 
-from clauditor.spec import SkillSpec, _failed_run_result
+import clauditor.spec as _spec_mod
+
+importlib.reload(_spec_mod)
+
+from clauditor.spec import SkillSpec, _failed_run_result  # noqa: E402
 
 # ── Minimal eval data for fixture ──────────────────────────────────────────
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,138 @@
+"""Tests for SkillSpec: from_file, run, evaluate."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clauditor.spec import SkillSpec, _failed_run_result
+
+# ── Minimal eval data for fixture ──────────────────────────────────────────
+
+MINIMAL_EVAL = {
+    "skill_name": "test-skill",
+    "description": "test eval",
+    "test_args": "--depth quick",
+    "assertions": [{"type": "contains", "value": "hello"}],
+}
+
+
+class TestFromFile:
+    """SkillSpec.from_file factory method."""
+
+    def test_missing_skill_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="Skill file not found"):
+            SkillSpec.from_file(tmp_path / "nonexistent.md")
+
+    def test_loads_skill_without_eval(self, tmp_skill_file, mock_runner):
+        skill_path = tmp_skill_file("bare-skill")
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_path == skill_path
+        assert spec.skill_name == "bare-skill"
+        assert spec.eval_spec is None
+
+    def test_auto_discovers_sibling_eval(self, tmp_skill_file, mock_runner):
+        skill_path, eval_path = tmp_skill_file("my-skill", eval_data=MINIMAL_EVAL)
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.eval_spec is not None
+        assert spec.eval_spec.skill_name == "test-skill"
+
+    def test_explicit_eval_path(self, tmp_skill_file, tmp_path, mock_runner):
+        skill_path = tmp_skill_file("a-skill")
+        # Write eval json at a non-sibling location
+        custom_eval = tmp_path / "custom.eval.json"
+        custom_eval.write_text(json.dumps(MINIMAL_EVAL))
+        spec = SkillSpec.from_file(
+            skill_path, eval_path=custom_eval, runner=mock_runner()
+        )
+        assert spec.eval_spec is not None
+        assert spec.eval_spec.test_args == "--depth quick"
+
+
+class TestRun:
+    """SkillSpec.run method."""
+
+    def test_run_with_explicit_args(self, tmp_skill_file, mock_runner):
+        skill_path = tmp_skill_file("run-skill")
+        runner = mock_runner(output="explicit output")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.run(args="--custom flag")
+        runner.run.assert_called_once_with("run-skill", "--custom flag")
+        assert result.output == "explicit output"
+
+    def test_run_uses_eval_test_args_when_no_args(self, tmp_skill_file, mock_runner):
+        skill_path, _ = tmp_skill_file("run-skill", eval_data=MINIMAL_EVAL)
+        runner = mock_runner(output="eval args output")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run()
+        runner.run.assert_called_once_with("run-skill", "--depth quick")
+
+    def test_run_uses_empty_string_when_no_eval_no_args(
+        self, tmp_skill_file, mock_runner
+    ):
+        skill_path = tmp_skill_file("run-skill")
+        runner = mock_runner(output="empty args output")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run()
+        runner.run.assert_called_once_with("run-skill", "")
+
+
+class TestEvaluate:
+    """SkillSpec.evaluate method."""
+
+    def test_raises_when_no_eval_spec(self, tmp_skill_file, mock_runner):
+        skill_path = tmp_skill_file("no-eval")
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        with pytest.raises(ValueError, match="No eval spec found"):
+            spec.evaluate()
+
+    def test_happy_path_with_explicit_output(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "eval-skill",
+            "assertions": [{"type": "contains", "value": "hello"}],
+        }
+        skill_path, _ = tmp_skill_file("eval-skill", eval_data=eval_data)
+        runner = mock_runner()
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.evaluate(output="hello world")
+        assert result.passed
+        # Runner should NOT have been called since we provided output
+        runner.run.assert_not_called()
+
+    def test_evaluate_runs_skill_when_no_output(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "auto-skill",
+            "assertions": [{"type": "contains", "value": "mock"}],
+        }
+        skill_path, _ = tmp_skill_file("auto-skill", eval_data=eval_data)
+        runner = mock_runner(output="mock output")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.evaluate()
+        assert result.passed
+        runner.run.assert_called_once()
+
+    def test_evaluate_returns_error_on_failed_run(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "fail-skill",
+            "assertions": [{"type": "contains", "value": "anything"}],
+        }
+        skill_path, _ = tmp_skill_file("fail-skill", eval_data=eval_data)
+        runner = mock_runner(output="", exit_code=1, error="boom")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.evaluate()
+        assert not result.passed
+        assert len(result.results) == 1
+        assert "failed to run" in result.results[0].message
+        assert "boom" in result.results[0].message
+
+
+class TestFailedRunResult:
+    """_failed_run_result helper."""
+
+    def test_returns_failed_assertion_result(self):
+        r = _failed_run_result("my-skill", "timeout")
+        assert r.passed is False
+        assert "my-skill" in r.message
+        assert "timeout" in r.message
+        assert r.name == "skill_execution"


### PR DESCRIPTION
## Summary
- Super plan for #8 — raise test coverage from 44% to 80%+, no module below 60%
- Discovery phase complete: codebase researched, 5 scoping questions identified
- Awaiting answers on CI gate, plugin testing approach, spec.py scope, conftest strategy, and baseline measurement

## Plan document
See `plans/super/8-improve-test-coverage.md` for the full plan.

## Next steps
- Answer scoping questions in Claude Code
- Architecture review, refinement, story breakdown to follow
- Approve plan to devolve into beads tasks for execution

Generated with [Claude Code](https://claude.com/claude-code)