### PR TITLE
#11: First Pass Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,13 @@ clauditor init <skill.md>              # Generate starter eval.json
 clauditor validate <skill.md>          # Run Layer 1 assertions
 clauditor validate <skill.md> --json   # JSON output for CI
 clauditor run <skill-name> --args "…"  # Run skill, print output
+clauditor extract <skill.md>           # Layer 2 schema extraction
+clauditor extract <skill.md> --dry-run # Print extraction prompt only
 clauditor grade <skill.md>             # Layer 3 quality grading
 clauditor grade <skill.md> --compare   # A/B comparison
 clauditor grade <skill.md> --variance 3  # Variance measurement
+clauditor grade <skill.md> --save      # Persist results to .clauditor/
+clauditor grade <skill.md> --diff      # Compare against prior results
 clauditor triggers <skill.md>          # Trigger precision testing
 ```
 
@@ -350,12 +354,19 @@ A complete eval spec with all three layers:
     }
   ],
 
+  "output_file": "research/results.md",
+  "output_files": ["research/*.md", "research/*.json"],
+
   "grading_criteria": [
     "Are all venues within the specified distance?",
     "Are venues appropriate for the specified age range?",
     "Do cost tiers match the budget filter?"
   ],
   "grading_model": "claude-sonnet-4-6",
+  "grade_thresholds": {
+    "min_pass_rate": 0.7,
+    "min_mean_score": 0.5
+  },
 
   "trigger_tests": {
     "should_trigger": [

--- a/README.md
+++ b/README.md
@@ -179,17 +179,25 @@ Define rubric criteria in your eval spec:
     "Are all venues within the specified distance?",
     "Are events actually happening on the target date?",
     "Do cost tiers match the budget filter?"
-  ]
+  ],
+  "grade_thresholds": {
+    "min_pass_rate": 0.7,
+    "min_mean_score": 0.5
+  }
 }
 ```
+
+`grade_thresholds` controls when grading passes overall. `min_pass_rate` (default 0.7) is the fraction of criteria that must pass. `min_mean_score` (default 0.5) is the minimum average score across all criteria. Both must be met. This differs from `variance.min_stability`, which measures consistency across multiple runs rather than quality of a single run.
 
 ```bash
 clauditor grade .claude/commands/my-skill.md
 clauditor grade .claude/commands/my-skill.md --json
 clauditor grade .claude/commands/my-skill.md --dry-run   # Print prompt, no API call
+clauditor grade .claude/commands/my-skill.md --save       # Persist results to .clauditor/
+clauditor grade .claude/commands/my-skill.md --diff       # Compare against prior saved results
 ```
 
-Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning.
+Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--save` to persist results for regression tracking, and `--diff` to compare against a prior run (flags regressions where a criterion's score drops by more than 0.1).
 
 #### A/B Comparison
 
@@ -325,6 +333,8 @@ Place `<skill-name>.eval.json` alongside your `.claude/commands/<skill-name>.md`
 ├── find-restaurants.md
 └── find-restaurants.eval.json
 ```
+
+**File-based output:** Many skills save results to files instead of printing to stdout. Use `output_file` for skills that write to one known path (e.g., `research/results.md`). Use `output_files` with glob patterns for skills that produce multiple files (e.g., `["research/*.md"]`). If both are set, `output_file` takes precedence. When set, clauditor reads the file(s) after running the skill instead of capturing stdout.
 
 A complete eval spec with all three layers:
 

--- a/plans/super/11-first-pass-improvements.md
+++ b/plans/super/11-first-pass-improvements.md
@@ -1,0 +1,392 @@
+# Super Plan: #11 — First Pass Improvements
+
+## Meta
+
+| Field        | Value |
+|--------------|-------|
+| Ticket       | [#11](https://github.com/wjduenow/clauditor/issues/11) |
+| Branch       | `feature/11-first-pass-improvements` |
+| Phase        | `detailing` |
+| Sessions     | 1 |
+| Last session | 2026-04-09 |
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+Seven improvements identified from the first real-world eval run against my_claude_agent's `/find-restaurants` skill. The issue bundles infrastructure fixes, new features, and developer experience improvements into one tracking ticket.
+
+**Stories from the ticket:**
+1. Support file-based skill output (output_path/output_glob in eval specs)
+2. ~~Add `--live` mode to validate command~~ → Dropped (DEC-001)
+3. Fix `--no-input` flag in runner (broken with current Claude CLI)
+4. Support multi-file skill output
+5. Add score thresholds for Layer 3 (min_mean_score instead of all-or-nothing)
+6. Add diff mode for A/B regression (compare against prior runs)
+7. Publish extraction prompt for debugging (--dry-run for Layer 2)
+
+### Codebase Findings
+
+**Core files that will be touched across multiple stories:**
+
+| File | Stories | Current Role |
+|------|---------|-------------|
+| `schemas.py` (62 lines) | 1, 4, 5, 6 | EvalSpec dataclass, all config fields |
+| `runner.py` (198 lines) | 1, 3, 4 | SkillRunner subprocess execution |
+| `cli.py` (418 lines) | 5, 6, 7 | All CLI commands (validate, grade, etc.) |
+| `quality_grader.py` (229 lines) | 5, 6 | GradingReport pass/fail logic |
+| `spec.py` (76 lines) | 1, 4 | SkillSpec orchestrator |
+| `comparator.py` (126 lines) | 6 | A/B comparison |
+| `grader.py` (172 lines) | 4 | Layer 2 extraction |
+
+**Key patterns to preserve:**
+- All dataclasses use `@dataclass` with optional fields defaulting to `None` or `field(default_factory=list)`
+- New EvalSpec fields must be backward-compatible (old JSON files without the field still load)
+- Result types expose `.passed` property + `.summary()` method
+- Layer 3 types use lazy imports in `__init__.py` to avoid requiring `anthropic` at import time
+- Tests use `unittest.mock` with `MagicMock`/`AsyncMock`/`patch`
+- Coverage gate: 80% overall, enforced in CI
+
+**The `--no-input` bug (Story 3):**
+- `runner.py` lines 118 and 166 pass `--no-input` to `claude` CLI
+- Current Claude CLI uses `-p`/`--print` for non-interactive mode; `--no-input` doesn't exist
+- Both `run()` and `run_raw()` already pass `-p` as the first flag, making `--no-input` both broken and redundant
+- Fix: simply remove `--no-input` from the command array
+
+**GradingReport.passed (Story 5):**
+```python
+@property
+def passed(self) -> bool:
+    return all(r.passed for r in self.results)
+```
+Currently all-or-nothing. VarianceReport already has configurable `min_stability` threshold — extend this pattern.
+
+**Dry-run pattern (Story 7):**
+- `cmd_grade` already has `--dry-run` that calls `build_grading_prompt()` and prints without API call
+- `grader.py` has `build_extraction_prompt()` but no CLI surface for it
+- Pattern is identical: build prompt, print, exit
+
+### Scoping Answers
+
+- **Q1: Story ordering** → B) Plan all 7 as one cohesive release
+- **Q2: Multi-file output** → A) Yes, include now — `/market-research` produces 5+ files
+- **Q3: Diff mode storage** → Alongside eval.json in `.clauditor/` directory
+- **Q4: Score thresholds** → B) Ship with lenient default — no one is using this yet
+- **Q5: --live mode** → ~~B) Add to both~~ → Dropped per DEC-001
+
+---
+
+## Architecture Review
+
+| Area | Rating | Findings |
+|------|--------|----------|
+| **Data Model** | pass | All new EvalSpec fields have safe defaults (`None`, `field(default_factory=list)`). Old JSON files load without changes. `to_dict()` already skips `None` fields. |
+| **API Design** | pass | `--live` dropped (redundant). New `extract` subcommand mirrors 3-layer architecture. Thresholds in EvalSpec keeps function signatures clean. |
+| **Backward Compat** | pass | All changes additive. No breaking changes to existing CLI flags, Python API, or eval spec format. |
+| **Testing Strategy** | pass | ~38 new tests, mostly unit. Existing conftest fixtures reusable. No coverage risk. |
+
+### Concerns Resolved
+
+- **C1 (--live redundancy):** Dropped entirely → DEC-001
+- **C2 (flag naming):** `--save` and `--diff` adopted → DEC-002
+- **C3 (thresholds location):** In EvalSpec, not function params → DEC-003
+
+---
+
+## Refinement Log
+
+### Decisions
+
+**DEC-001: Drop --live flag**
+- Commands already run the skill when `--output` is not provided
+- Adding `--live` is redundant and confusing
+- Instead: document existing behavior in CLI help text
+- Rationale: API reviewer found validate and grade both default to running the skill
+
+**DEC-002: Use --save and --diff for grade persistence**
+- `--save` writes the GradingReport to `.clauditor/<skill_name>.grade.json`
+- `--diff` loads prior results from the same path and compares
+- Naming is short, clear, and doesn't collide with `--compare` (A/B baseline)
+- Rationale: `--save-results` and `--compare-prior` were vague
+
+**DEC-003: Thresholds live in EvalSpec**
+- New field: `grade_thresholds: GradeThresholds | None` on EvalSpec
+- `GradeThresholds` dataclass with `min_pass_rate: float = 0.7`, `min_mean_score: float = 0.5`
+- When `None`, default GradeThresholds values apply (lenient)
+- `GradingReport.passed` checks thresholds instead of `all(r.passed)`
+- Rationale: Follows VarianceConfig/min_stability pattern. Keeps grade_quality() signature clean.
+
+**DEC-004: Prior results storage structure**
+- Directory: `.clauditor/` at project root
+- File: `.clauditor/<skill_name>.grade.json` (latest report only)
+- Format: JSON with skill_name, model, timestamp, results array
+- `--save` overwrites latest; no history tracking in v1
+- Rationale: Simple, no history management complexity. Can add timestamped history later.
+
+**DEC-005: New `extract` CLI subcommand for Layer 2**
+- Mirrors three-layer architecture: `validate` (L1), `extract` (L2), `grade` (L3)
+- Supports `--dry-run` (print prompt), `--output` (pre-captured), `--json`, `--model`
+- Default behavior: run skill, then extract
+- Rationale: Cleaner than adding flags to validate. Discoverable. Consistent.
+
+**DEC-006: SkillResult multi-file via `outputs` dict**
+- Add `outputs: dict[str, str] = field(default_factory=dict)` to SkillResult
+- `output: str` stays as the primary output (first/main file)
+- When runner detects multi-file output via `output_files` in EvalSpec, populates both
+- All existing code using `result.output` continues working
+- Rationale: Backward compatible, simple, clear semantics
+
+---
+
+## Detailed Breakdown
+
+### US-001: Fix --no-input flag in runner
+
+**Description:** Remove the broken `--no-input` flag from `SkillRunner.run()` and `run_raw()`. The flag doesn't exist in the current Claude CLI and `-p` already provides non-interactive mode.
+
+**Traces to:** DEC-001 (simplify, don't add flags)
+
+**Acceptance Criteria:**
+- `--no-input` removed from subprocess command in both `run()` and `run_raw()`
+- Command array is `[claude_bin, "-p", prompt]` with no extra flags
+- Existing tests updated to match new command structure
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** `--no-input` string appears nowhere in `runner.py`
+
+**Files:**
+- `src/clauditor/runner.py` — remove `"--no-input"` from lines 118 and 166
+- `tests/test_runner.py` — update mock expectations (3 tests)
+
+**Depends on:** none
+
+---
+
+### US-002: Add output_file and output_files to EvalSpec
+
+**Description:** Add `output_file: str | None` and `output_files: list[str]` fields to EvalSpec so eval specs can declare where skills write their output files. This is the schema foundation for Stories 1 and 4.
+
+**Traces to:** DEC-006 (multi-file support)
+
+**Acceptance Criteria:**
+- `output_file` (single path) and `output_files` (list of paths/globs) added to EvalSpec
+- `from_file()` loads both fields from JSON; missing fields default to `None` / `[]`
+- `to_dict()` includes them when non-default
+- Old eval.json files without these fields still load correctly
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** EvalSpec can round-trip `output_file` and `output_files` through JSON
+
+**Files:**
+- `src/clauditor/schemas.py` — add fields to EvalSpec, update `from_file()` and `to_dict()`
+- `tests/test_schemas.py` — add TestEvalSpecOutputFields (5-6 tests)
+
+**Depends on:** none
+
+---
+
+### US-003: Add outputs dict to SkillResult
+
+**Description:** Add `outputs: dict[str, str]` to SkillResult for multi-file skill output. Keep `output: str` as primary output for backward compatibility.
+
+**Traces to:** DEC-006
+
+**Acceptance Criteria:**
+- `outputs` field added with `field(default_factory=dict)`
+- Existing code using `result.output` unaffected
+- `succeeded` property still works (considers both `output` and `outputs`)
+- All assertion methods (`assert_contains`, etc.) operate on `output` string
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** SkillResult has `outputs` dict and all existing tests pass
+
+**Files:**
+- `src/clauditor/runner.py` — add `outputs` field to SkillResult
+- `tests/test_runner.py` — add TestSkillResultOutputs (5 tests)
+
+**Depends on:** none
+
+---
+
+### US-004: Wire file-based output through SkillSpec and runner
+
+**Description:** When `eval_spec.output_file` or `output_files` is set, SkillSpec.run() reads the output from files after skill execution instead of relying on stdout capture. Runner populates `outputs` dict.
+
+**Traces to:** DEC-006
+
+**Acceptance Criteria:**
+- `SkillSpec.run()` checks `eval_spec.output_file` / `output_files` after skill execution
+- If `output_file` set: reads that file into `result.output`
+- If `output_files` set: globs/reads all matching files into `result.outputs`, sets `output` to first match
+- Falls back to stdout capture if neither field is set
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** `SkillSpec.run()` returns file content when eval spec declares output paths
+
+**Files:**
+- `src/clauditor/spec.py` — update `run()` to read output files
+- `src/clauditor/runner.py` — pass `outputs` dict population through
+- `tests/test_spec.py` — add file-based output tests (3-4 tests, mock filesystem)
+
+**Depends on:** US-002, US-003
+
+**TDD:**
+- Test: eval spec with `output_file`, mock runner, assert `result.output` is file content
+- Test: eval spec with `output_files` glob, mock filesystem with 3 files, assert `result.outputs` has all 3
+- Test: eval spec with neither field, assert stdout capture behavior unchanged
+
+---
+
+### US-005: Add GradeThresholds to EvalSpec
+
+**Description:** Add `GradeThresholds` dataclass and `grade_thresholds` field to EvalSpec. Default: `min_pass_rate=0.7`, `min_mean_score=0.5`. Update `GradingReport.passed` to use thresholds.
+
+**Traces to:** DEC-003
+
+**Acceptance Criteria:**
+- `GradeThresholds` dataclass with `min_pass_rate` (default 0.7) and `min_mean_score` (default 0.5)
+- `EvalSpec.grade_thresholds` field, defaults to `None` (which means use GradeThresholds defaults)
+- `GradingReport` accepts thresholds, `passed` property evaluates against them
+- When `grade_thresholds` is `None` in EvalSpec, `GradingReport` uses default `GradeThresholds()`
+- Old eval specs without `grade_thresholds` still work
+- `grade_quality()` passes thresholds from eval spec to report
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** `GradingReport.passed` respects configurable thresholds
+
+**Files:**
+- `src/clauditor/schemas.py` — add GradeThresholds dataclass, add field to EvalSpec
+- `src/clauditor/quality_grader.py` — update GradingReport.passed, update grade_quality()
+- `src/clauditor/cli.py` — pass thresholds from spec to grade_quality()
+- `tests/test_schemas.py` — GradeThresholds loading/roundtrip (3 tests)
+- `tests/test_quality_grader.py` — threshold logic (4-6 tests)
+
+**Depends on:** none
+
+**TDD:**
+- Test: all criteria pass with scores above thresholds → `passed=True`
+- Test: pass_rate 60% but min_pass_rate is 0.5 → `passed=True`
+- Test: pass_rate 60% but min_pass_rate is 0.8 → `passed=False`
+- Test: mean_score 0.45 with min_mean_score 0.5 → `passed=False`
+- Test: no thresholds in eval spec → uses defaults (0.7/0.5)
+
+---
+
+### US-006: Add GradingReport JSON serialization
+
+**Description:** Add `to_json()` and `from_json()` methods to GradingReport for persisting results to `.clauditor/`. Required for diff mode (US-008).
+
+**Traces to:** DEC-004
+
+**Acceptance Criteria:**
+- `GradingReport.to_json() -> str` serializes to JSON with timestamp
+- `GradingReport.from_json(data: str) -> GradingReport` round-trips correctly
+- All fields preserved: skill_name, model, duration, results (criterion, passed, score, evidence, reasoning)
+- Float scores round-trip accurately
+- Missing optional fields handled gracefully in `from_json()`
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** `GradingReport.from_json(report.to_json())` produces equivalent report
+
+**Files:**
+- `src/clauditor/quality_grader.py` — add `to_json()` and `from_json()` to GradingReport
+- `tests/test_quality_grader.py` — serialization roundtrip tests (5 tests)
+
+**Depends on:** none
+
+---
+
+### US-007: Add `extract` CLI subcommand
+
+**Description:** New CLI command `clauditor extract <skill.md>` for Layer 2 schema extraction with `--dry-run` support. Mirrors the three-layer architecture: validate (L1), extract (L2), grade (L3).
+
+**Traces to:** DEC-005
+
+**Acceptance Criteria:**
+- `clauditor extract <skill.md>` runs skill and extracts structured data
+- `--dry-run` prints the extraction prompt without API calls
+- `--output <file>` uses pre-captured output
+- `--json` outputs structured JSON
+- `--model` overrides extraction model
+- Exits 0 on pass, 1 on failure
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** `clauditor extract --help` shows all flags and `--dry-run` prints the prompt
+
+**Files:**
+- `src/clauditor/cli.py` — add `cmd_extract()` function, add argparse subparser
+- `tests/test_cli.py` — extract command tests (4-6 tests: dry-run, output file, json, error cases)
+
+**Depends on:** none (reuses existing `build_extraction_prompt()` and `extract_and_grade()`)
+
+---
+
+### US-008: Add --save and --diff to grade command
+
+**Description:** Add `--save` flag to persist GradingReport to `.clauditor/<skill>.grade.json`, and `--diff` flag to load prior results and compare for regressions.
+
+**Traces to:** DEC-002, DEC-004
+
+**Acceptance Criteria:**
+- `--save` writes GradingReport JSON to `.clauditor/<skill_name>.grade.json`
+- Creates `.clauditor/` directory if it doesn't exist
+- `--diff` loads prior report from same path, compares scores, shows regressions
+- `--save --diff` together: load prior, run grading, compare, then save new results
+- If `--diff` and no prior results exist, warns and continues (no error)
+- Regression = criterion score dropped by > 0.1 or went from pass to fail
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80%
+
+**Done when:** `clauditor grade skill.md --save --diff` shows regression table and persists results
+
+**Files:**
+- `src/clauditor/cli.py` — add `--save` and `--diff` flags to grade argparser, add comparison logic
+- `tests/test_cli.py` — file I/O tests (4-5 tests: save, diff, both, missing prior, regression detection)
+
+**Depends on:** US-006 (GradingReport serialization)
+
+---
+
+### US-009: Quality Gate
+
+**Description:** Run code review across the full changeset. Validate all tests pass, linting clean, coverage maintained.
+
+**Acceptance Criteria:**
+- `uv run ruff check src/ tests/` — zero errors
+- `uv run pytest --cov=clauditor --cov-report=term-missing` — all pass, >=80% coverage
+- No regressions in existing test suite
+- All new features have test coverage
+
+**Done when:** CI-equivalent checks pass locally
+
+**Files:** All changed files
+
+**Depends on:** US-001 through US-008
+
+---
+
+### US-010: Patterns & Memory
+
+**Description:** Update documentation and conventions with patterns learned during implementation.
+
+**Acceptance Criteria:**
+- README updated with `extract` command in CLI reference
+- README updated with `--save` and `--diff` flags on grade command
+- README updated with `grade_thresholds` in eval spec format
+- README updated with `output_file`/`output_files` in eval spec format
+
+**Done when:** README reflects all new features
+
+**Files:**
+- `README.md`
+
+**Depends on:** US-009

--- a/plans/super/11-first-pass-improvements.md
+++ b/plans/super/11-first-pass-improvements.md
@@ -6,7 +6,7 @@
 |--------------|-------|
 | Ticket       | [#11](https://github.com/wjduenow/clauditor/issues/11) |
 | Branch       | `feature/11-first-pass-improvements` |
-| Phase        | `detailing` |
+| Phase        | `devolved` |
 | Sessions     | 1 |
 | Last session | 2026-04-09 |
 

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -197,6 +197,54 @@ def cmd_grade(args: argparse.Namespace) -> int:
         if variance_report:
             print(f"\n{variance_report.summary()}")
 
+    # --diff: compare against prior results
+    save_dir = Path(".clauditor")
+    save_path = save_dir / f"{spec.skill_name}.grade.json"
+
+    if args.diff:
+        if save_path.exists():
+            from clauditor.quality_grader import GradingReport
+
+            prior = GradingReport.from_json(save_path.read_text())
+            prior_by_name = {r.criterion: r for r in prior.results}
+            current_by_name = {r.criterion: r for r in report.results}
+            common = set(prior_by_name) & set(current_by_name)
+            regressions = []
+            print("\nDiff vs prior results:")
+            print(f"  {'Criterion':<40} {'Prior':>6} {'Current':>8} {'Delta':>6}")
+            print(f"  {'-'*40} {'-'*6} {'-'*8} {'-'*6}")
+            for name in sorted(common):
+                p_score = prior_by_name[name].score
+                c_score = current_by_name[name].score
+                delta = c_score - p_score
+                is_regression = (
+                    delta < -0.1
+                    or (prior_by_name[name].passed and not current_by_name[name].passed)
+                )
+                marker = " REGRESSION" if is_regression else ""
+                line = (
+                    f"  {name:<40} {p_score:>6.2f}"
+                    f" {c_score:>8.2f} {delta:>+6.2f}{marker}"
+                )
+                print(line)
+                if is_regression:
+                    regressions.append(name)
+            if regressions:
+                print(f"\n  {len(regressions)} regression(s) detected.")
+            else:
+                print("\n  No regressions detected.")
+        else:
+            print(
+                f"\nWARNING: No prior results at {save_path}. "
+                "Run with --save first to establish a baseline.",
+                file=sys.stderr,
+            )
+
+    if args.save:
+        save_dir.mkdir(parents=True, exist_ok=True)
+        save_path.write_text(report.to_json())
+        print(f"\nGrade report saved to {save_path}")
+
     # Determine exit code
     passed = report.passed
     if ab_report:
@@ -378,6 +426,12 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         metavar="N",
         help="Run N times with variance measurement",
+    )
+    p_grade.add_argument(
+        "--save", action="store_true", help="Save grade report to .clauditor/"
+    )
+    p_grade.add_argument(
+        "--diff", action="store_true", help="Compare against prior grade results"
     )
 
     # triggers

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -198,8 +198,10 @@ def cmd_grade(args: argparse.Namespace) -> int:
             print(f"\n{variance_report.summary()}")
 
     # --diff: compare against prior results
+    # Use stderr for human output when --json is set to keep stdout valid JSON
     save_dir = Path(".clauditor")
     save_path = save_dir / f"{spec.skill_name}.grade.json"
+    diff_out = sys.stderr if args.json else sys.stdout
 
     if args.diff:
         if save_path.exists():
@@ -210,9 +212,14 @@ def cmd_grade(args: argparse.Namespace) -> int:
             current_by_name = {r.criterion: r for r in report.results}
             common = set(prior_by_name) & set(current_by_name)
             regressions = []
-            print("\nDiff vs prior results:")
-            print(f"  {'Criterion':<40} {'Prior':>6} {'Current':>8} {'Delta':>6}")
-            print(f"  {'-'*40} {'-'*6} {'-'*8} {'-'*6}")
+            print("\nDiff vs prior results:", file=diff_out)
+            print(
+                f"  {'Criterion':<40} {'Prior':>6} {'Current':>8} {'Delta':>6}",
+                file=diff_out,
+            )
+            print(
+                f"  {'-'*40} {'-'*6} {'-'*8} {'-'*6}", file=diff_out
+            )
             for name in sorted(common):
                 p_score = prior_by_name[name].score
                 c_score = current_by_name[name].score
@@ -226,13 +233,15 @@ def cmd_grade(args: argparse.Namespace) -> int:
                     f"  {name:<40} {p_score:>6.2f}"
                     f" {c_score:>8.2f} {delta:>+6.2f}{marker}"
                 )
-                print(line)
+                print(line, file=diff_out)
                 if is_regression:
                     regressions.append(name)
             if regressions:
-                print(f"\n  {len(regressions)} regression(s) detected.")
+                print(
+                    f"\n  {len(regressions)} regression(s) detected.", file=diff_out
+                )
             else:
-                print("\n  No regressions detected.")
+                print("\n  No regressions detected.", file=diff_out)
         else:
             print(
                 f"\nWARNING: No prior results at {save_path}. "
@@ -243,7 +252,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
     if args.save:
         save_dir.mkdir(parents=True, exist_ok=True)
         save_path.write_text(report.to_json())
-        print(f"\nGrade report saved to {save_path}")
+        print(f"\nGrade report saved to {save_path}", file=diff_out)
 
     # Determine exit code
     passed = report.passed

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -123,7 +123,10 @@ def cmd_grade(args: argparse.Namespace) -> int:
     from clauditor.quality_grader import grade_quality
 
     async def _run_grade():
-        report = await grade_quality(output, spec.eval_spec, model)
+        report = await grade_quality(
+            output, spec.eval_spec, model,
+            thresholds=spec.eval_spec.grade_thresholds,
+        )
         ab_report = None
         if args.compare:
             from clauditor.comparator import compare_ab

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -270,6 +270,75 @@ def cmd_triggers(args: argparse.Namespace) -> int:
     return 0 if report.passed else 1
 
 
+def cmd_extract(args: argparse.Namespace) -> int:
+    """Run Layer 2 schema extraction against a skill's output."""
+    import asyncio
+
+    spec = SkillSpec.from_file(args.skill, eval_path=args.eval)
+
+    if not spec.eval_spec:
+        print(f"ERROR: No eval spec found for {args.skill}", file=sys.stderr)
+        return 1
+
+    if not spec.eval_spec.sections:
+        print("ERROR: No sections defined in eval spec", file=sys.stderr)
+        return 1
+
+    model = args.model or "claude-haiku-4-5-20251001"
+
+    # --dry-run: print prompt and exit
+    if args.dry_run:
+        from clauditor.grader import build_extraction_prompt
+
+        prompt = build_extraction_prompt(spec.eval_spec)
+        print(f"Model: {model}")
+        print(f"Prompt:\n{prompt}")
+        return 0
+
+    # Get output
+    if args.output:
+        output = Path(args.output).read_text()
+    else:
+        print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
+        result = spec.run()
+        if not result.succeeded:
+            print(f"ERROR: Skill failed: {result.error}", file=sys.stderr)
+            return 1
+        output = result.output
+
+    # Extract and grade
+    from clauditor.grader import extract_and_grade
+
+    results = asyncio.run(extract_and_grade(output, spec.eval_spec, model))
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "skill": spec.skill_name,
+                    "model": model,
+                    "pass_rate": results.pass_rate,
+                    "passed": results.passed,
+                    "results": [
+                        {
+                            "name": r.name,
+                            "passed": r.passed,
+                            "message": r.message,
+                            **({"evidence": r.evidence} if r.evidence else {}),
+                        }
+                        for r in results.results
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"Schema Extraction: {spec.skill_name} ({model})")
+        print(results.summary())
+
+    return 0 if results.passed else 1
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Generate a starter eval.json for a skill."""
     skill_path = Path(args.skill)
@@ -396,6 +465,25 @@ def main(argv: list[str] | None = None) -> int:
         "--dry-run", action="store_true", help="Print sample trigger prompts"
     )
 
+    # extract
+    p_extract = subparsers.add_parser(
+        "extract", help="Layer 2: LLM schema extraction"
+    )
+    p_extract.add_argument("skill", help="Path to skill .md file")
+    p_extract.add_argument(
+        "--eval", help="Path to eval.json (auto-discovered if omitted)"
+    )
+    p_extract.add_argument(
+        "--output", help="Path to pre-captured output file (skips running the skill)"
+    )
+    p_extract.add_argument("--model", help="Override extraction model")
+    p_extract.add_argument(
+        "--json", action="store_true", help="Output results as JSON"
+    )
+    p_extract.add_argument(
+        "--dry-run", action="store_true", help="Print prompt without making API calls"
+    )
+
     # init
     p_init = subparsers.add_parser(
         "init", help="Generate a starter eval.json for a skill"
@@ -415,6 +503,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_grade(parsed)
     elif parsed.command == "triggers":
         return cmd_triggers(parsed)
+    elif parsed.command == "extract":
+        return cmd_extract(parsed)
     elif parsed.command == "init":
         return cmd_init(parsed)
 

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -6,6 +6,7 @@ eval spec. Each criterion is scored independently with evidence and reasoning.
 
 from __future__ import annotations
 
+import datetime
 import json
 import math
 import time
@@ -56,6 +57,47 @@ class GradingReport:
         if not self.results:
             return 0.0
         return sum(r.score for r in self.results) / len(self.results)
+
+    def to_json(self) -> str:
+        """Serialize the report to a JSON string."""
+        data = {
+            "skill_name": self.skill_name,
+            "model": self.model,
+            "duration_seconds": self.duration_seconds,
+            "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+            "results": [
+                {
+                    "criterion": r.criterion,
+                    "passed": r.passed,
+                    "score": r.score,
+                    "evidence": r.evidence,
+                    "reasoning": r.reasoning,
+                }
+                for r in self.results
+            ],
+        }
+        return json.dumps(data, indent=2)
+
+    @classmethod
+    def from_json(cls, data: str) -> GradingReport:
+        """Deserialize a GradingReport from a JSON string."""
+        parsed = json.loads(data)
+        results = [
+            GradingResult(
+                criterion=item.get("criterion", ""),
+                passed=bool(item.get("passed", False)),
+                score=float(item.get("score", 0.0)),
+                evidence=item.get("evidence", ""),
+                reasoning=item.get("reasoning", ""),
+            )
+            for item in parsed.get("results", [])
+        ]
+        return cls(
+            skill_name=parsed.get("skill_name", ""),
+            results=results,
+            model=parsed.get("model", ""),
+            duration_seconds=float(parsed.get("duration_seconds", 0.0)),
+        )
 
     def summary(self) -> str:
         """Format a human-readable summary of grading results."""

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -12,7 +12,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from clauditor.schemas import EvalSpec
+from clauditor.schemas import EvalSpec, GradeThresholds
 
 if TYPE_CHECKING:
     from clauditor.spec import SkillSpec
@@ -37,11 +37,20 @@ class GradingReport:
     results: list[GradingResult]
     model: str
     duration_seconds: float = 0.0
+    thresholds: GradeThresholds | None = None
 
     @property
     def passed(self) -> bool:
-        """Whether all criteria passed."""
-        return all(r.passed for r in self.results)
+        """Whether grading meets threshold requirements.
+
+        Uses provided thresholds or defaults (min_pass_rate=0.7,
+        min_mean_score=0.5) when no thresholds are set.
+        """
+        t = self.thresholds if self.thresholds is not None else GradeThresholds()
+        return (
+            self.pass_rate >= t.min_pass_rate
+            and self.mean_score >= t.min_mean_score
+        )
 
     @property
     def pass_rate(self) -> float:
@@ -152,6 +161,7 @@ async def grade_quality(
     output: str,
     eval_spec: EvalSpec,
     model: str = "claude-sonnet-4-6",
+    thresholds: GradeThresholds | None = None,
 ) -> GradingReport:
     """Layer 3: Grade skill output against rubric criteria using an LLM.
 
@@ -197,6 +207,7 @@ async def grade_quality(
             ],
             model=model,
             duration_seconds=duration,
+            thresholds=thresholds,
         )
 
     response_text = response.content[0].text
@@ -219,6 +230,7 @@ async def grade_quality(
             ],
             model=model,
             duration_seconds=duration,
+            thresholds=thresholds,
         )
 
     return GradingReport(
@@ -226,6 +238,7 @@ async def grade_quality(
         results=results,
         model=model,
         duration_seconds=duration,
+        thresholds=thresholds,
     )
 
 

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -85,6 +85,11 @@ class GradingReport:
                 for r in self.results
             ],
         }
+        if self.thresholds is not None:
+            data["thresholds"] = {
+                "min_pass_rate": self.thresholds.min_pass_rate,
+                "min_mean_score": self.thresholds.min_mean_score,
+            }
         return json.dumps(data, indent=2)
 
     @classmethod
@@ -101,11 +106,19 @@ class GradingReport:
             )
             for item in parsed.get("results", [])
         ]
+        thresholds = None
+        if "thresholds" in parsed:
+            t = parsed["thresholds"]
+            thresholds = GradeThresholds(
+                min_pass_rate=float(t.get("min_pass_rate", 0.7)),
+                min_mean_score=float(t.get("min_mean_score", 0.5)),
+            )
         return cls(
             skill_name=parsed.get("skill_name", ""),
             results=results,
             model=parsed.get("model", ""),
             duration_seconds=float(parsed.get("duration_seconds", 0.0)),
+            thresholds=thresholds,
         )
 
     def summary(self) -> str:

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -101,8 +101,8 @@ class GradingReport:
                 criterion=item.get("criterion", ""),
                 passed=bool(item.get("passed", False)),
                 score=float(item.get("score", 0.0)),
-                evidence=item.get("evidence", ""),
-                reasoning=item.get("reasoning", ""),
+                evidence=item.get("evidence") or "",
+                reasoning=item.get("reasoning") or "",
             )
             for item in parsed.get("results", [])
         ]

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from clauditor.assertions import (
@@ -29,6 +29,7 @@ class SkillResult:
     args: str
     duration_seconds: float = 0.0
     error: str | None = None
+    outputs: dict[str, str] = field(default_factory=dict)
 
     @property
     def succeeded(self) -> bool:

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -115,7 +115,7 @@ class SkillRunner:
         start = time.monotonic()
         try:
             result = subprocess.run(
-                [self.claude_bin, "-p", prompt, "--no-input"],
+                [self.claude_bin, "-p", prompt],
                 capture_output=True,
                 text=True,
                 timeout=self.timeout,
@@ -163,7 +163,7 @@ class SkillRunner:
         start = time.monotonic()
         try:
             result = subprocess.run(
-                [self.claude_bin, "-p", prompt, "--no-input"],
+                [self.claude_bin, "-p", prompt],
                 capture_output=True,
                 text=True,
                 timeout=self.timeout,

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -58,6 +58,8 @@ class EvalSpec:
     sections: list[SectionRequirement] = field(default_factory=list)  # Layer 2 schema
     grading_criteria: list[str] = field(default_factory=list)  # Layer 3 rubric
     grading_model: str = "claude-sonnet-4-6"
+    output_file: str | None = None  # Single output file path
+    output_files: list[str] = field(default_factory=list)  # Multiple file paths/globs
     trigger_tests: TriggerTests | None = None
     variance: VarianceConfig | None = None
 
@@ -110,6 +112,8 @@ class EvalSpec:
             sections=sections,
             grading_criteria=data.get("grading_criteria", []),
             grading_model=data.get("grading_model", "claude-sonnet-4-6"),
+            output_file=data.get("output_file"),
+            output_files=data.get("output_files", []),
             trigger_tests=trigger_tests,
             variance=variance,
         )
@@ -139,6 +143,10 @@ class EvalSpec:
             "grading_criteria": self.grading_criteria,
             "grading_model": self.grading_model,
         }
+        if self.output_file is not None:
+            result["output_file"] = self.output_file
+        if self.output_files:
+            result["output_files"] = self.output_files
         if self.trigger_tests is not None:
             result["trigger_tests"] = {
                 "should_trigger": self.trigger_tests.should_trigger,

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -37,6 +37,14 @@ class TriggerTests:
 
 
 @dataclass
+class GradeThresholds:
+    """Thresholds for pass/fail determination in quality grading."""
+
+    min_pass_rate: float = 0.7
+    min_mean_score: float = 0.5
+
+
+@dataclass
 class VarianceConfig:
     """Configuration for variance measurement."""
 
@@ -62,6 +70,7 @@ class EvalSpec:
     output_files: list[str] = field(default_factory=list)  # Multiple file paths/globs
     trigger_tests: TriggerTests | None = None
     variance: VarianceConfig | None = None
+    grade_thresholds: GradeThresholds | None = None
 
     @classmethod
     def from_file(cls, path: str | Path) -> EvalSpec:
@@ -104,6 +113,14 @@ class EvalSpec:
                 min_stability=v.get("min_stability", 0.8),
             )
 
+        grade_thresholds = None
+        if "grade_thresholds" in data:
+            gt = data["grade_thresholds"]
+            grade_thresholds = GradeThresholds(
+                min_pass_rate=gt.get("min_pass_rate", 0.7),
+                min_mean_score=gt.get("min_mean_score", 0.5),
+            )
+
         return cls(
             skill_name=data.get("skill_name", path.stem),
             description=data.get("description", ""),
@@ -116,6 +133,7 @@ class EvalSpec:
             output_files=data.get("output_files", []),
             trigger_tests=trigger_tests,
             variance=variance,
+            grade_thresholds=grade_thresholds,
         )
 
     def to_dict(self) -> dict:
@@ -156,5 +174,10 @@ class EvalSpec:
             result["variance"] = {
                 "n_runs": self.variance.n_runs,
                 "min_stability": self.variance.min_stability,
+            }
+        if self.grade_thresholds is not None:
+            result["grade_thresholds"] = {
+                "min_pass_rate": self.grade_thresholds.min_pass_rate,
+                "min_mean_score": self.grade_thresholds.min_mean_score,
             }
         return result

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -77,22 +77,27 @@ class SkillSpec:
         result = self.runner.run(self.skill_name, run_args)
 
         # Read output from files if eval spec specifies file-based output
-        if self.eval_spec:
+        # Only read files on successful runs to avoid stale output
+        if self.eval_spec and result.succeeded:
             base_dir = self.runner.project_dir
             if self.eval_spec.output_file:
                 file_path = base_dir / self.eval_spec.output_file
                 if file_path.exists():
                     result.output = file_path.read_text()
             elif self.eval_spec.output_files:
+                first_output = None
                 for pattern in self.eval_spec.output_files:
                     full_pattern = str(base_dir / pattern)
                     for match in sorted(glob.glob(full_pattern)):
                         match_path = Path(match)
                         if match_path.is_file():
-                            result.outputs[match_path.name] = match_path.read_text()
-                if result.outputs:
-                    first_key = sorted(result.outputs)[0]
-                    result.output = result.outputs[first_key]
+                            output_text = match_path.read_text()
+                            key = match_path.relative_to(base_dir).as_posix()
+                            result.outputs[key] = output_text
+                            if first_output is None:
+                                first_output = output_text
+                if first_output is not None:
+                    result.output = first_output
 
         return result
 

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -5,6 +5,7 @@ Combines the skill file, eval spec, and runner into a single interface.
 
 from __future__ import annotations
 
+import glob
 from pathlib import Path
 
 from clauditor.assertions import AssertionSet, run_assertions
@@ -73,7 +74,27 @@ class SkillSpec:
             if args is not None
             else (self.eval_spec.test_args if self.eval_spec else "")
         )
-        return self.runner.run(self.skill_name, run_args)
+        result = self.runner.run(self.skill_name, run_args)
+
+        # Read output from files if eval spec specifies file-based output
+        if self.eval_spec:
+            base_dir = self.runner.project_dir
+            if self.eval_spec.output_file:
+                file_path = base_dir / self.eval_spec.output_file
+                if file_path.exists():
+                    result.output = file_path.read_text()
+            elif self.eval_spec.output_files:
+                for pattern in self.eval_spec.output_files:
+                    full_pattern = str(base_dir / pattern)
+                    for match in glob.glob(full_pattern):
+                        match_path = Path(match)
+                        if match_path.is_file():
+                            result.outputs[match_path.name] = match_path.read_text()
+                if result.outputs:
+                    first_key = next(iter(result.outputs))
+                    result.output = result.outputs[first_key]
+
+        return result
 
     def evaluate(self, output: str | None = None) -> AssertionSet:
         """Run Layer 1 assertions from the eval spec against output.

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -86,12 +86,12 @@ class SkillSpec:
             elif self.eval_spec.output_files:
                 for pattern in self.eval_spec.output_files:
                     full_pattern = str(base_dir / pattern)
-                    for match in glob.glob(full_pattern):
+                    for match in sorted(glob.glob(full_pattern)):
                         match_path = Path(match)
                         if match_path.is_file():
                             result.outputs[match_path.name] = match_path.read_text()
                 if result.outputs:
-                    first_key = next(iter(result.outputs))
+                    first_key = sorted(result.outputs)[0]
                     result.output = result.outputs[first_key]
 
         return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,7 @@ def mock_runner():
         error: str | None = None,
     ) -> MagicMock:
         mock = MagicMock(spec=SkillRunner)
+        mock.project_dir = Path.cwd()
         result = SkillResult(
             output=output,
             exit_code=exit_code,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,6 +254,213 @@ class TestCmdGrade:
         assert rc == 1
 
 
+class TestCmdGradeSaveDiff:
+    """Tests for --save and --diff flags on the grade subcommand."""
+
+    def _make_grading_report(self, skill_name="test-skill", passed=True, score=0.9):
+        return GradingReport(
+            skill_name=skill_name,
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="Is the output relevant?",
+                    passed=passed,
+                    score=score,
+                    evidence="Found relevant content",
+                    reasoning="Output addresses the query",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+    def test_save_creates_file(self, tmp_path):
+        """--save writes JSON to .clauditor/."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_grading_report()
+
+        import os
+
+        orig_dir = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            with (
+                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+                patch(
+                    "clauditor.quality_grader.grade_quality",
+                    new_callable=AsyncMock,
+                    return_value=report,
+                ),
+            ):
+                rc = main(
+                    ["grade", "skill.md", "--output", str(output_file), "--save"]
+                )
+
+            assert rc == 0
+            save_path = tmp_path / ".clauditor" / "test-skill.grade.json"
+            assert save_path.exists()
+            data = json.loads(save_path.read_text())
+            assert data["skill_name"] == "test-skill"
+        finally:
+            os.chdir(orig_dir)
+
+    def test_save_creates_directory(self, tmp_path):
+        """.clauditor/ is created if missing."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_grading_report()
+
+        import os
+
+        orig_dir = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            assert not (tmp_path / ".clauditor").exists()
+            with (
+                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+                patch(
+                    "clauditor.quality_grader.grade_quality",
+                    new_callable=AsyncMock,
+                    return_value=report,
+                ),
+            ):
+                main(["grade", "skill.md", "--output", str(output_file), "--save"])
+
+            assert (tmp_path / ".clauditor").is_dir()
+        finally:
+            os.chdir(orig_dir)
+
+    def test_diff_shows_regressions(self, tmp_path, capsys):
+        """--diff with prior results shows regression table."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        # Prior report: high score
+        prior_report = self._make_grading_report(score=0.9, passed=True)
+        # Current report: low score (regression)
+        current_report = self._make_grading_report(score=0.5, passed=False)
+
+        import os
+
+        orig_dir = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            # Write prior results
+            save_dir = tmp_path / ".clauditor"
+            save_dir.mkdir()
+            (save_dir / "test-skill.grade.json").write_text(prior_report.to_json())
+
+            with (
+                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+                patch(
+                    "clauditor.quality_grader.grade_quality",
+                    new_callable=AsyncMock,
+                    return_value=current_report,
+                ),
+            ):
+                main(["grade", "skill.md", "--output", str(output_file), "--diff"])
+
+            out = capsys.readouterr().out
+            assert "REGRESSION" in out
+            assert "1 regression(s) detected" in out
+        finally:
+            os.chdir(orig_dir)
+
+    def test_diff_no_prior_warns(self, tmp_path, capsys):
+        """--diff without prior results warns, doesn't error."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_grading_report()
+
+        import os
+
+        orig_dir = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            with (
+                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+                patch(
+                    "clauditor.quality_grader.grade_quality",
+                    new_callable=AsyncMock,
+                    return_value=report,
+                ),
+            ):
+                rc = main(
+                    ["grade", "skill.md", "--output", str(output_file), "--diff"]
+                )
+
+            assert rc == 0
+            err = capsys.readouterr().err
+            assert "WARNING" in err
+            assert "No prior results" in err
+        finally:
+            os.chdir(orig_dir)
+
+    def test_save_and_diff_together(self, tmp_path, capsys):
+        """Both --save and --diff work in sequence."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        prior_report = self._make_grading_report(score=0.8, passed=True)
+        current_report = self._make_grading_report(score=0.85, passed=True)
+
+        import os
+
+        orig_dir = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            # Write prior results
+            save_dir = tmp_path / ".clauditor"
+            save_dir.mkdir()
+            (save_dir / "test-skill.grade.json").write_text(prior_report.to_json())
+
+            with (
+                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+                patch(
+                    "clauditor.quality_grader.grade_quality",
+                    new_callable=AsyncMock,
+                    return_value=current_report,
+                ),
+            ):
+                rc = main(
+                    [
+                        "grade",
+                        "skill.md",
+                        "--output",
+                        str(output_file),
+                        "--diff",
+                        "--save",
+                    ]
+                )
+
+            assert rc == 0
+            out = capsys.readouterr().out
+            # Diff ran (no regressions since score improved)
+            assert "No regressions detected" in out
+            # Save ran — file updated with current results
+            saved = json.loads(
+                (save_dir / "test-skill.grade.json").read_text()
+            )
+            assert saved["results"][0]["score"] == 0.85
+        finally:
+            os.chdir(orig_dir)
+
+
 class TestCmdTriggers:
     """Tests for the triggers subcommand."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from clauditor.assertions import AssertionResult, AssertionSet
 from clauditor.cli import main
 from clauditor.quality_grader import GradingReport, GradingResult
 from clauditor.runner import SkillResult
-from clauditor.schemas import EvalSpec, TriggerTests
+from clauditor.schemas import (
+    EvalSpec,
+    FieldRequirement,
+    SectionRequirement,
+    TriggerTests,
+)
 from clauditor.spec import SkillSpec
 from clauditor.triggers import TriggerReport, TriggerResult
 
@@ -369,3 +375,148 @@ class TestCmdInit:
         assert rc == 0
         data = json.loads(eval_path.read_text())
         assert data["skill_name"] == "my-skill"
+
+
+def _make_sections():
+    """Create sample sections for Layer 2 testing."""
+    return [
+        SectionRequirement(
+            name="Results",
+            min_entries=2,
+            fields=[
+                FieldRequirement(name="name", required=True),
+                FieldRequirement(name="address", required=True),
+            ],
+        )
+    ]
+
+
+class TestCmdExtract:
+    """Tests for the extract subcommand."""
+
+    def _make_extraction_results(self, passed=True):
+        return AssertionSet(
+            results=[
+                AssertionResult(
+                    name="section:Results:count",
+                    passed=passed,
+                    message="Section 'Results' has 3 entries (need >=2)",
+                ),
+                AssertionResult(
+                    name="section:Results[0].name",
+                    passed=passed,
+                    message=(
+                        "Field present"
+                        if passed
+                        else "Missing required field 'name'"
+                    ),
+                    evidence="Test Place" if passed else None,
+                ),
+            ]
+        )
+
+    def test_extract_dry_run(self, capsys):
+        """--dry-run prints prompt and returns 0 without API calls."""
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["extract", "skill.md", "--dry-run"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Model:" in out
+        assert "Prompt:" in out
+        assert "Results" in out
+
+    def test_extract_no_sections_error(self, capsys):
+        """Returns 1 when no sections defined in eval spec."""
+        eval_spec = _make_eval_spec(sections=[])
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["extract", "skill.md"])
+
+        assert rc == 1
+        assert "No sections defined" in capsys.readouterr().err
+
+    def test_extract_no_eval_spec(self, capsys):
+        """Returns 1 when no eval spec is found."""
+        spec = _make_spec(eval_spec=None)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["extract", "skill.md"])
+
+        assert rc == 1
+        assert "No eval spec" in capsys.readouterr().err
+
+    def test_extract_with_output_file(self, tmp_path):
+        """Reads output file, calls extract_and_grade, returns 0 on pass."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output with results")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_results(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+    def test_extract_json_output(self, tmp_path, capsys):
+        """--json flag produces valid JSON output."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output with results")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_results(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(
+                ["extract", "skill.md", "--output", str(output_file), "--json"]
+            )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["skill"] == "test-skill"
+        assert data["passed"] is True
+        assert "results" in data
+        assert len(data["results"]) == 2
+
+    def test_extract_failed(self, tmp_path):
+        """Returns 1 when extraction grading fails."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("bad output")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_results(passed=False)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 1

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -214,6 +214,40 @@ class TestGradingReportSerialization:
         # ISO 8601 timestamp should contain a 'T' separator
         assert "T" in data["timestamp"]
 
+    def test_thresholds_roundtrip(self):
+        """Thresholds survive JSON round-trip."""
+        thresholds = GradeThresholds(min_pass_rate=0.8, min_mean_score=0.6)
+        original = GradingReport(
+            skill_name="threshold-test",
+            results=_make_results([True, False]),
+            model="claude-sonnet-4-6",
+            thresholds=thresholds,
+        )
+        raw = original.to_json()
+        data = json.loads(raw)
+        assert data["thresholds"]["min_pass_rate"] == 0.8
+        assert data["thresholds"]["min_mean_score"] == 0.6
+
+        restored = GradingReport.from_json(raw)
+        assert restored.thresholds is not None
+        assert restored.thresholds.min_pass_rate == pytest.approx(0.8)
+        assert restored.thresholds.min_mean_score == pytest.approx(0.6)
+        assert restored.passed == original.passed
+
+    def test_no_thresholds_roundtrip(self):
+        """Report without thresholds omits them from JSON."""
+        original = GradingReport(
+            skill_name="no-thresh",
+            results=_make_results([True]),
+            model="claude-sonnet-4-6",
+        )
+        raw = original.to_json()
+        data = json.loads(raw)
+        assert "thresholds" not in data
+
+        restored = GradingReport.from_json(raw)
+        assert restored.thresholds is None
+
 
 class TestParseGradingResponse:
     def test_valid_json(self):

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -126,6 +126,95 @@ class TestGradingReport:
         assert "FAIL: Tone is professional" in s
 
 
+class TestGradingReportSerialization:
+    def test_to_json_basic(self):
+        report = GradingReport(
+            skill_name="test-skill",
+            results=_make_results([True, False, True]),
+            model="claude-sonnet-4-6",
+            duration_seconds=1.5,
+        )
+        raw = report.to_json()
+        data = json.loads(raw)
+        assert data["skill_name"] == "test-skill"
+        assert data["model"] == "claude-sonnet-4-6"
+        assert data["duration_seconds"] == 1.5
+        assert len(data["results"]) == 3
+        assert (
+            data["results"][0]["criterion"]
+            == "Output contains actionable recommendations"
+        )
+        assert data["results"][0]["passed"] is True
+        assert "timestamp" in data
+
+    def test_from_json_roundtrip(self):
+        original = GradingReport(
+            skill_name="roundtrip-skill",
+            results=_make_results([True, False, True]),
+            model="claude-sonnet-4-6",
+            duration_seconds=2.3,
+        )
+        raw = original.to_json()
+        restored = GradingReport.from_json(raw)
+        assert restored.skill_name == original.skill_name
+        assert restored.model == original.model
+        assert restored.duration_seconds == pytest.approx(original.duration_seconds)
+        assert len(restored.results) == len(original.results)
+        for orig_r, rest_r in zip(original.results, restored.results):
+            assert rest_r.criterion == orig_r.criterion
+            assert rest_r.passed == orig_r.passed
+            assert rest_r.score == pytest.approx(orig_r.score)
+            assert rest_r.evidence == orig_r.evidence
+            assert rest_r.reasoning == orig_r.reasoning
+
+    def test_from_json_preserves_floats(self):
+        report = GradingReport(
+            skill_name="float-test",
+            results=[
+                GradingResult(
+                    criterion="precision",
+                    passed=True,
+                    score=0.8765,
+                    evidence="e",
+                    reasoning="r",
+                )
+            ],
+            model="claude-sonnet-4-6",
+            duration_seconds=3.14159,
+        )
+        restored = GradingReport.from_json(report.to_json())
+        assert restored.results[0].score == pytest.approx(0.8765)
+        assert restored.duration_seconds == pytest.approx(3.14159)
+
+    def test_from_json_handles_missing_duration(self):
+        data = json.dumps({
+            "skill_name": "no-duration",
+            "model": "claude-sonnet-4-6",
+            "results": [
+                {
+                    "criterion": "c1",
+                    "passed": True,
+                    "score": 0.9,
+                    "evidence": "e",
+                    "reasoning": "r",
+                }
+            ],
+        })
+        restored = GradingReport.from_json(data)
+        assert restored.duration_seconds == 0.0
+
+    def test_to_json_includes_timestamp(self):
+        report = GradingReport(
+            skill_name="ts-test",
+            results=[],
+            model="claude-sonnet-4-6",
+        )
+        raw = report.to_json()
+        data = json.loads(raw)
+        # ISO 8601 timestamp should contain a 'T' separator
+        assert "T" in data["timestamp"]
+
+
 class TestParseGradingResponse:
     def test_valid_json(self):
         data = [

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -16,7 +16,7 @@ from clauditor.quality_grader import (
     measure_variance,
     parse_grading_response,
 )
-from clauditor.schemas import EvalSpec, VarianceConfig
+from clauditor.schemas import EvalSpec, GradeThresholds, VarianceConfig
 
 
 def _make_spec() -> EvalSpec:
@@ -640,3 +640,93 @@ class TestMeasureVariance:
 
         with pytest.raises(ValueError, match="No eval spec found"):
             await measure_variance(mock_spec, n_runs=3)
+
+
+class TestGradeThresholdsOnReport:
+    """Tests for GradeThresholds logic in GradingReport.passed."""
+
+    def _make_report(
+        self,
+        passed_flags: list[bool],
+        scores: list[float],
+        thresholds: GradeThresholds | None = None,
+    ) -> GradingReport:
+        results = [
+            GradingResult(
+                criterion=f"c{i}",
+                passed=p,
+                score=s,
+                evidence="e",
+                reasoning="r",
+            )
+            for i, (p, s) in enumerate(zip(passed_flags, scores))
+        ]
+        return GradingReport(
+            skill_name="test",
+            results=results,
+            model="claude-sonnet-4-6",
+            thresholds=thresholds,
+        )
+
+    def test_all_above_threshold_passes(self):
+        """All criteria pass and scores are above threshold -> passed=True."""
+        report = self._make_report(
+            [True, True, True], [0.8, 0.9, 0.7],
+            thresholds=GradeThresholds(min_pass_rate=0.7, min_mean_score=0.5),
+        )
+        assert report.pass_rate == pytest.approx(1.0)
+        assert report.mean_score == pytest.approx(0.8)
+        assert report.passed is True
+
+    def test_pass_rate_below_threshold_fails(self):
+        """pass_rate below min_pass_rate -> passed=False."""
+        # 1 of 3 pass -> pass_rate = 0.333
+        report = self._make_report(
+            [True, False, False], [0.9, 0.6, 0.6],
+            thresholds=GradeThresholds(min_pass_rate=0.7, min_mean_score=0.5),
+        )
+        assert report.pass_rate == pytest.approx(1 / 3)
+        assert report.mean_score == pytest.approx(0.7)
+        assert report.passed is False
+
+    def test_mean_score_below_threshold_fails(self):
+        """mean_score below min_mean_score -> passed=False."""
+        # All pass but scores are low
+        report = self._make_report(
+            [True, True, True], [0.3, 0.4, 0.2],
+            thresholds=GradeThresholds(min_pass_rate=0.7, min_mean_score=0.5),
+        )
+        assert report.pass_rate == pytest.approx(1.0)
+        assert report.mean_score == pytest.approx(0.3)
+        assert report.passed is False
+
+    def test_no_thresholds_uses_defaults(self):
+        """When thresholds is None, uses defaults (0.7/0.5)."""
+        # 3/4 pass -> pass_rate = 0.75 >= 0.7, mean_score = 0.6 >= 0.5
+        report = self._make_report(
+            [True, True, True, False], [0.7, 0.7, 0.6, 0.4],
+            thresholds=None,
+        )
+        assert report.pass_rate == pytest.approx(0.75)
+        assert report.mean_score == pytest.approx(0.6)
+        assert report.passed is True
+
+    def test_custom_thresholds_from_eval_spec(self):
+        """Custom strict thresholds cause failure even when defaults would pass."""
+        # pass_rate=0.75, mean_score=0.6 — passes with defaults, fails with strict
+        report = self._make_report(
+            [True, True, True, False], [0.7, 0.7, 0.6, 0.4],
+            thresholds=GradeThresholds(min_pass_rate=0.9, min_mean_score=0.8),
+        )
+        assert report.passed is False
+
+    def test_at_exact_threshold_boundary(self):
+        """Values exactly at thresholds should pass."""
+        report = self._make_report(
+            [True, True, True, False, False, False, True, True, True, True],
+            [0.5] * 10,
+            thresholds=GradeThresholds(min_pass_rate=0.7, min_mean_score=0.5),
+        )
+        assert report.pass_rate == pytest.approx(0.7)
+        assert report.mean_score == pytest.approx(0.5)
+        assert report.passed is True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -218,3 +218,47 @@ class TestSkillRunnerRun:
             assert result.exit_code == -1
             assert "not found" in result.error
             assert result.output == ""
+
+
+# ---------------------------------------------------------------------------
+# SkillResult.outputs dict
+# ---------------------------------------------------------------------------
+
+
+class TestSkillResultOutputs:
+    def _make(self, **kwargs) -> SkillResult:
+        defaults = dict(output="some output", exit_code=0, skill_name="test", args="")
+        defaults.update(kwargs)
+        return SkillResult(**defaults)
+
+    def test_outputs_defaults_to_empty_dict(self):
+        result = self._make()
+        assert result.outputs == {}
+
+    def test_outputs_can_be_populated_with_multiple_files(self):
+        files = {"report.md": "# Report", "data.csv": "a,b\n1,2"}
+        result = self._make(outputs=files)
+        assert result.outputs == files
+        assert result.outputs["report.md"] == "# Report"
+        assert result.outputs["data.csv"] == "a,b\n1,2"
+
+    def test_succeeded_works_when_outputs_populated(self):
+        result = self._make(
+            output="primary output",
+            exit_code=0,
+            outputs={"file.txt": "content"},
+        )
+        assert result.succeeded is True
+
+    def test_succeeded_works_with_empty_outputs(self):
+        result = self._make(output="primary output", exit_code=0)
+        assert result.outputs == {}
+        assert result.succeeded is True
+
+    def test_assertion_methods_use_output_not_outputs(self):
+        result = self._make(
+            output="hello world",
+            outputs={"other.txt": "completely different text"},
+        )
+        result.assert_contains("hello world")
+        result.assert_not_contains("completely different text")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -33,7 +33,6 @@ class TestRunRaw:
                 "claude",
                 "-p",
                 "find me activities in Seattle",
-                "--no-input",
             ]
             assert result.skill_name == "__baseline__"
             assert result.args == "find me activities in Seattle"
@@ -180,7 +179,7 @@ class TestSkillRunnerRun:
 
             mock_run.assert_called_once()
             cmd = mock_run.call_args[0][0]
-            assert cmd == ["claude", "-p", "/my-skill some args", "--no-input"]
+            assert cmd == ["claude", "-p", "/my-skill some args"]
             assert result.output == "skill output"
             assert result.exit_code == 0
             assert result.skill_name == "my-skill"
@@ -195,7 +194,7 @@ class TestSkillRunnerRun:
             )
             runner.run("my-skill")
             cmd = mock_run.call_args[0][0]
-            assert cmd == ["claude", "-p", "/my-skill", "--no-input"]
+            assert cmd == ["claude", "-p", "/my-skill"]
 
     def test_runner_run_timeout(self):
         runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -13,6 +13,7 @@ importlib.reload(_schemas_mod)
 from clauditor.schemas import (  # noqa: E402
     EvalSpec,
     FieldRequirement,
+    GradeThresholds,
     SectionRequirement,
     TriggerTests,
     VarianceConfig,
@@ -512,3 +513,70 @@ class TestEvalSpecOutputFields:
         d = spec.to_dict()
         assert "output_file" not in d
         assert "output_files" not in d
+
+
+class TestGradeThresholds:
+    """Tests for GradeThresholds loading, defaults, and round-trip."""
+
+    def test_defaults(self):
+        gt = GradeThresholds()
+        assert gt.min_pass_rate == 0.7
+        assert gt.min_mean_score == 0.5
+
+    def test_from_file_with_grade_thresholds(self, tmp_path):
+        """grade_thresholds section is correctly parsed from JSON."""
+        data = {
+            "skill_name": "gt-test",
+            "grade_thresholds": {
+                "min_pass_rate": 0.9,
+                "min_mean_score": 0.8,
+            },
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        assert spec.grade_thresholds is not None
+        assert spec.grade_thresholds.min_pass_rate == 0.9
+        assert spec.grade_thresholds.min_mean_score == 0.8
+
+    def test_from_file_without_grade_thresholds(self, tmp_path):
+        """grade_thresholds is None when absent from JSON."""
+        path = _write_json(tmp_path, {"skill_name": "no-gt"})
+        spec = EvalSpec.from_file(path)
+        assert spec.grade_thresholds is None
+
+    def test_roundtrip(self, tmp_path):
+        """from_file -> to_dict -> from_file preserves grade_thresholds."""
+        data = {
+            "skill_name": "rt",
+            "grade_thresholds": {
+                "min_pass_rate": 0.85,
+                "min_mean_score": 0.6,
+            },
+        }
+        path1 = _write_json(tmp_path, data, name="first.json")
+        spec1 = EvalSpec.from_file(path1)
+        d = spec1.to_dict()
+        assert d["grade_thresholds"]["min_pass_rate"] == 0.85
+        assert d["grade_thresholds"]["min_mean_score"] == 0.6
+
+        path2 = _write_json(tmp_path, d, name="second.json")
+        spec2 = EvalSpec.from_file(path2)
+        assert spec2.grade_thresholds.min_pass_rate == 0.85
+        assert spec2.grade_thresholds.min_mean_score == 0.6
+
+    def test_to_dict_omits_when_none(self):
+        """grade_thresholds key absent from to_dict when field is None."""
+        spec = EvalSpec(skill_name="x")
+        d = spec.to_dict()
+        assert "grade_thresholds" not in d
+
+    def test_from_file_empty_dict_uses_defaults(self, tmp_path):
+        """grade_thresholds with empty dict gets default values."""
+        data = {"skill_name": "gt", "grade_thresholds": {}}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        assert spec.grade_thresholds is not None
+        assert spec.grade_thresholds.min_pass_rate == 0.7
+        assert spec.grade_thresholds.min_mean_score == 0.5

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -454,3 +454,61 @@ class TestOptionalFields:
         assert spec.variance is not None
         assert spec.variance.n_runs == 5
         assert spec.variance.min_stability == 0.8
+
+
+class TestEvalSpecOutputFields:
+    """Tests for output_file and output_files fields on EvalSpec."""
+
+    def test_load_with_output_file(self, tmp_path):
+        """output_file is loaded from JSON when present."""
+        data = {"skill_name": "s", "output_file": "report.md"}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.output_file == "report.md"
+
+    def test_load_with_output_files(self, tmp_path):
+        """output_files list is loaded from JSON when present."""
+        data = {"skill_name": "s", "output_files": ["out/*.md", "summary.txt"]}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.output_files == ["out/*.md", "summary.txt"]
+
+    def test_to_dict_roundtrip(self, tmp_path):
+        """from_file -> to_dict preserves both output fields."""
+        data = {
+            "skill_name": "s",
+            "output_file": "result.json",
+            "output_files": ["a.txt", "b.txt"],
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        d = spec.to_dict()
+        assert d["output_file"] == "result.json"
+        assert d["output_files"] == ["a.txt", "b.txt"]
+
+    def test_defaults_when_missing(self, tmp_path):
+        """output_file defaults to None, output_files to [] when absent."""
+        path = _write_json(tmp_path, {"skill_name": "bare"})
+        spec = EvalSpec.from_file(path)
+        assert spec.output_file is None
+        assert spec.output_files == []
+
+    def test_backward_compat_old_eval_json(self, tmp_path):
+        """Old eval.json without output fields loads without error."""
+        old_data = {
+            "skill_name": "legacy",
+            "description": "An old spec",
+            "assertions": [{"type": "contains", "value": "hello"}],
+        }
+        path = _write_json(tmp_path, old_data)
+        spec = EvalSpec.from_file(path)
+        assert spec.skill_name == "legacy"
+        assert spec.output_file is None
+        assert spec.output_files == []
+
+    def test_to_dict_omits_defaults(self):
+        """to_dict omits output_file and output_files when at defaults."""
+        spec = EvalSpec(skill_name="x")
+        d = spec.to_dict()
+        assert "output_file" not in d
+        assert "output_files" not in d

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -132,6 +132,82 @@ class TestEvaluate:
         assert "boom" in result.results[0].message
 
 
+class TestFileBasedOutput:
+    """SkillSpec.run with file-based output (output_file / output_files)."""
+
+    def test_output_file_reads_file_content(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "file-skill",
+            "test_args": "",
+            "assertions": [],
+            "output_file": "results/output.txt",
+        }
+        skill_path, _ = tmp_skill_file("file-skill", eval_data=eval_data)
+        runner = mock_runner(output="stdout content")
+        # runner.project_dir must point to tmp_path so we can create the file
+        project_dir = skill_path.parent
+        runner.project_dir = project_dir
+        # Create the output file
+        (project_dir / "results").mkdir()
+        (project_dir / "results" / "output.txt").write_text("file content here")
+
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.run()
+        assert result.output == "file content here"
+
+    def test_output_file_missing_keeps_stdout(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "file-skill",
+            "test_args": "",
+            "assertions": [],
+            "output_file": "nonexistent.txt",
+        }
+        skill_path, _ = tmp_skill_file("file-skill", eval_data=eval_data)
+        runner = mock_runner(output="stdout fallback")
+        runner.project_dir = skill_path.parent
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.run()
+        assert result.output == "stdout fallback"
+
+    def test_output_files_glob_populates_outputs(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "glob-skill",
+            "test_args": "",
+            "assertions": [],
+            "output_files": ["out/*.txt"],
+        }
+        skill_path, _ = tmp_skill_file("glob-skill", eval_data=eval_data)
+        runner = mock_runner(output="stdout content")
+        project_dir = skill_path.parent
+        runner.project_dir = project_dir
+        # Create matching files
+        (project_dir / "out").mkdir()
+        (project_dir / "out" / "a.txt").write_text("alpha")
+        (project_dir / "out" / "b.txt").write_text("beta")
+
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.run()
+        assert len(result.outputs) == 2
+        assert result.outputs["a.txt"] == "alpha"
+        assert result.outputs["b.txt"] == "beta"
+        # result.output should be set to the first match
+        assert result.output in ("alpha", "beta")
+
+    def test_no_output_file_fields_keeps_stdout(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "plain-skill",
+            "test_args": "",
+            "assertions": [],
+        }
+        skill_path, _ = tmp_skill_file("plain-skill", eval_data=eval_data)
+        runner = mock_runner(output="just stdout")
+        runner.project_dir = skill_path.parent
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.run()
+        assert result.output == "just stdout"
+        assert result.outputs == {}
+
+
 class TestFailedRunResult:
     """_failed_run_result helper."""
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -188,10 +188,10 @@ class TestFileBasedOutput:
         spec = SkillSpec.from_file(skill_path, runner=runner)
         result = spec.run()
         assert len(result.outputs) == 2
-        assert result.outputs["a.txt"] == "alpha"
-        assert result.outputs["b.txt"] == "beta"
-        # result.output should be set to the first match
-        assert result.output in ("alpha", "beta")
+        assert result.outputs["out/a.txt"] == "alpha"
+        assert result.outputs["out/b.txt"] == "beta"
+        # result.output should be set to the first file read
+        assert result.output == "alpha"
 
     def test_no_output_file_fields_keeps_stdout(self, tmp_skill_file, mock_runner):
         eval_data = {


### PR DESCRIPTION
## Summary
Implementation of 7 improvements from first real-world eval run against my_claude_agent.

**8 implementation stories** completed:
- Fix --no-input flag in runner
- Add output_file/output_files to EvalSpec
- Add outputs dict to SkillResult
- Wire file-based output through SkillSpec
- Add GradeThresholds to EvalSpec (lenient defaults: 0.7 pass rate, 0.5 mean score)
- Add GradingReport JSON serialization
- Add `extract` CLI subcommand (Layer 2 with --dry-run)
- Add --save and --diff to grade command

**6 decisions** captured in plan. **281 tests**, 94% coverage.

## Test plan
- [x] `uv run ruff check src/ tests/` — lint clean
- [x] `uv run pytest --cov=clauditor --cov-report=term-missing` — 281 passed, 94% coverage
- [x] CodeRabbit review — all findings addressed
- [x] Copilot review — all findings addressed

## Plan document
See `plans/super/11-first-pass-improvements.md` for architecture decisions and story breakdown.

Generated with [Claude Code](https://claude.com/claude-code)