### PR TITLE
#12: Tiered Section Validation (plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ uv run pytest --cov=clauditor --cov-report=term-missing  # Test with coverage (8
 
 Three-layer skill evaluation framework:
 - **Layer 1** (`assertions.py`): Deterministic checks (regex, string matching, counting)
-- **Layer 2** (`grader.py`): LLM-graded schema extraction via Haiku
+- **Layer 2** (`grader.py`): LLM-graded schema extraction via Haiku (supports tiered sections with per-tier field requirements)
 - **Layer 3** (`quality_grader.py`, `triggers.py`): LLM-graded quality and trigger precision via Sonnet
 
 Supporting modules: `runner.py` (subprocess execution), `spec.py` (orchestrator), `schemas.py` (data models), `cli.py` (CLI entry point), `comparator.py` (A/B testing), `pytest_plugin.py` (pytest integration).

--- a/examples/.claude/commands/example-skill.eval.json
+++ b/examples/.claude/commands/example-skill.eval.json
@@ -39,61 +39,71 @@
   "sections": [
     {
       "name": "Venues",
-      "min_entries": 2,
-      "fields": [
+      "tiers": [
         {
-          "name": "name",
-          "required": true
-        },
-        {
-          "name": "address",
-          "required": true
-        },
-        {
-          "name": "hours",
-          "required": true
-        },
-        {
-          "name": "website",
-          "required": true
-        },
-        {
-          "name": "phone",
-          "required": false
-        },
-        {
-          "name": "cost",
-          "required": true
-        },
-        {
-          "name": "ages",
-          "required": true
+          "label": "default",
+          "min_entries": 2,
+          "fields": [
+            {
+              "name": "name",
+              "required": true
+            },
+            {
+              "name": "address",
+              "required": true
+            },
+            {
+              "name": "hours",
+              "required": true
+            },
+            {
+              "name": "website",
+              "required": true
+            },
+            {
+              "name": "phone",
+              "required": false
+            },
+            {
+              "name": "cost",
+              "required": true
+            },
+            {
+              "name": "ages",
+              "required": true
+            }
+          ]
         }
       ]
     },
     {
       "name": "Events",
-      "min_entries": 0,
-      "fields": [
+      "tiers": [
         {
-          "name": "name",
-          "required": true
-        },
-        {
-          "name": "date",
-          "required": true
-        },
-        {
-          "name": "time",
-          "required": true
-        },
-        {
-          "name": "event_url",
-          "required": true
-        },
-        {
-          "name": "ages",
-          "required": true
+          "label": "default",
+          "min_entries": 0,
+          "fields": [
+            {
+              "name": "name",
+              "required": true
+            },
+            {
+              "name": "date",
+              "required": true
+            },
+            {
+              "name": "time",
+              "required": true
+            },
+            {
+              "name": "event_url",
+              "required": true
+            },
+            {
+              "name": "ages",
+              "required": true
+            }
+          ]
         }
       ]
     }

--- a/plans/super/12-tiered-section-validation.md
+++ b/plans/super/12-tiered-section-validation.md
@@ -7,7 +7,7 @@
 | Ticket        | wjduenow/clauditor#12                      |
 | Branch        | `feature/12-tiered-section-validation`     |
 | Worktree      | TBD                                        |
-| Phase         | detailing                                  |
+| Phase         | devolved                                   |
 | Created       | 2026-04-10                                 |
 | Sessions      | 1                                          |
 
@@ -252,16 +252,16 @@ Each tier gets an optional `description` injected into the extraction prompt. Th
 
 ## Beads Manifest
 
-| Field       | Value |
-|-------------|-------|
-| Epic        | TBD   |
-| Worktree    | TBD   |
+| Field       | Value                                          |
+|-------------|------------------------------------------------|
+| Epic        | clauditor-cr1                                  |
+| Worktree    | feature/12-tiered-section-validation           |
 
-| Story  | Bead ID | Status |
-|--------|---------|--------|
-| US-001 | TBD     | —      |
-| US-002 | TBD     | —      |
-| US-003 | TBD     | —      |
-| US-004 | TBD     | —      |
-| US-005 | TBD     | —      |
+| Story  | Bead ID          | Status | Depends on       |
+|--------|------------------|--------|------------------|
+| US-001 | clauditor-cr1.1  | open   | none             |
+| US-002 | clauditor-cr1.2  | open   | cr1.1            |
+| US-003 | clauditor-cr1.3  | open   | cr1.1            |
+| US-004 | clauditor-cr1.4  | open   | cr1.1, cr1.2, cr1.3 |
+| US-005 | clauditor-cr1.5  | open   | cr1.4            |
 

--- a/plans/super/12-tiered-section-validation.md
+++ b/plans/super/12-tiered-section-validation.md
@@ -1,0 +1,267 @@
+# Super Plan: Issue #12 — Tiered Section Validation
+
+## Meta
+
+| Field         | Value                                      |
+|---------------|--------------------------------------------|
+| Ticket        | wjduenow/clauditor#12                      |
+| Branch        | `feature/12-tiered-section-validation`     |
+| Worktree      | TBD                                        |
+| Phase         | detailing                                  |
+| Created       | 2026-04-10                                 |
+| Sessions      | 1                                          |
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+Support primary and secondary entry tiers within a section schema, with different required field sets per tier. Originated from `/find-restaurants` eval where 3 honorable mentions (abbreviated one-liners) failed 7 field checks, dropping score to 84% despite perfect main results. Current workaround: making fields globally optional, which weakens validation for main entries.
+
+### User Concern
+
+**The ticket may be too specific to the restaurant test case.** The proposed JSON schema (with `"main"` and `"honorable_mentions"` tier labels, LLM classification, per-tier field requirements) is heavy machinery for what may be a narrow problem.
+
+### Codebase Findings
+
+**Current schema flow:**
+- `SectionRequirement` has a flat `fields: list[FieldRequirement]` — all entries validated identically
+- `FieldRequirement` has `required: bool` — binary, no nuance
+- `grade_extraction()` iterates entries uniformly, checking required fields on each
+- `build_extraction_prompt()` generates a single JSON schema per section, no tier awareness
+- `min_entries` is per-section, not per-tier
+
+**Key files:**
+- `src/clauditor/schemas.py` — `SectionRequirement`, `FieldRequirement`, `EvalSpec`
+- `src/clauditor/grader.py` — `grade_extraction()`, `build_extraction_prompt()`, `extract_and_grade()`
+- `tests/test_grader.py` — Grader tests (267 lines)
+- `tests/test_schemas.py` — Schema roundtrip tests (583 lines)
+
+**The core tension:** Entries beyond `min_entries` are "bonus" results the LLM found, but they're validated with the same strictness as the primary entries. This creates a perverse incentive: the more results the LLM finds, the more likely it is to fail.
+
+---
+
+## Scoping Answers
+
+- **Q1 (B) Emerging pattern** — Other evals will produce mixed-quality entries. Worth a general solution.
+- **Q2 (B) Full tiers** — Named tiers with independent field sets and `min_entries`. LLM classifies entries into tiers.
+- **Q3 (A) Critical** — Eval report must clearly distinguish "main entry passed" from "bonus entry passed" in output.
+- **Q4 (A) Build first** — The weakened schema (globally optional fields) is unacceptable. Build the real solution before shipping.
+
+---
+
+## Architecture Review
+
+| Area                   | Rating  | Notes |
+|------------------------|---------|-------|
+| Security               | pass    | No new user input vectors. Tier labels come from eval spec (author-controlled), not user input. |
+| Performance            | pass    | Same single Haiku call. Slightly more complex prompt but no additional API calls. |
+| Data Model             | concern | `to_dict()` must emit either `tiers` or `fields`, never both. Round-trip needs care. Tier label uniqueness should be validated. |
+| API Design             | pass    | CLI commands unchanged. Tier info appears in grading output/assertion names. |
+| Observability          | pass    | Assertion names will include tier: `section:Venues/main[0].address`. Clear in reports. |
+| Testing                | concern | Need assertion name format tests, unknown-tier handling, zero-min_entries tier edge case. |
+| LLM Classification     | concern | Haiku must interpret prose to classify entries into tiers — contradicts current "do not interpret" prompt rule. Accuracy risk with varied phrasing. |
+| Extraction Parsing     | blocker | Current parser (`isinstance(entries_data, list)`) silently drops dict values. Tiered output is `{"Section": {"tier": [...]}}` — would produce zero entries with no error. Must handle both shapes. |
+| Extraction Prompt      | blocker | `build_extraction_prompt()` generates flat JSON schema. Must be redesigned for tiered output. Conflicting instructions (extract raw vs classify into tiers). |
+| Backward Compatibility | concern | `fields` without `tiers` must still work. `from_file()` must detect and normalize. `to_dict()` must match source shape. |
+
+### Blocker Resolution Required
+
+**B1: Extraction parsing** — Parser must handle both flat (`[entries]`) and tiered (`{"tier": [entries]}`) shapes. Flat = legacy/no-tiers sections. Tiered = sections with tiers defined.
+
+**B2: Extraction prompt** — Tiered sections need a different prompt structure. The "do not interpret" rule must be relaxed for tier classification while keeping it for field values. Prompt must include tier definitions and expected JSON shape.
+
+---
+
+## Refinement Log
+
+### Decisions
+
+**DEC-001: No backward compatibility required**
+Module is not in production. All changes can be breaking. No dual-path serialization, no legacy format preservation.
+
+**DEC-002: `fields` is sugar for a single default tier**
+If a section has `fields` but no `tiers`, `from_file()` normalizes it into a single tier with label `"default"`, inheriting the section's `min_entries` and `fields`. Internally, `SectionRequirement` always has `tiers: list[TierRequirement]`. `to_dict()` always emits the `tiers` form.
+*Rationale:* One code path in the grader, not two. Breaking changes are acceptable.
+
+**DEC-003: Assertion names always include tier**
+Format: `section:{Section}/{tier}[{i}].{field}` and `section:{Section}:count/{tier}`. Legacy sections use tier label `"default"`. No branching on tier presence.
+*Rationale:* One format everywhere. Clean, predictable, parseable.
+
+**DEC-004: Fail on shape mismatch, no silent fallback**
+If the section defines tiers but the LLM returns a flat list, emit `grader:parse:{SectionName}` failure. Don't silently degrade — the eval spec author needs to know their tier descriptions aren't working.
+*Rationale:* Silent fallback hides broken prompts. Explicit failure is debuggable.
+
+**DEC-005: Tier `description` field for extraction hints**
+Each tier gets an optional `description` injected into the extraction prompt. The label is the machine name, the description is the human instruction to the LLM. If omitted, the label is used as-is.
+*Rationale:* Makes Haiku's job pattern-matching rather than interpretation. Addresses LLM classification accuracy concern.
+
+**DEC-006: Extraction JSON shape is nested by tier**
+```json
+{
+  "Restaurants": {
+    "main": [{"name": "...", "phone": "..."}],
+    "honorable_mentions": [{"name": "..."}]
+  }
+}
+```
+*Rationale:* Clean separation. Parser checks `isinstance(entries_data, dict)` for tiered sections.
+
+### Blocker Resolutions
+
+**B1 (Extraction parsing):** Resolved by DEC-006. Parser expects dict-of-lists for all sections (since all sections are tiered internally via DEC-002). Flat list = parse error per DEC-004.
+
+**B2 (Extraction prompt):** Resolved by DEC-005. Tier descriptions guide the LLM. Prompt redesign includes tier-aware JSON schema example and per-tier extraction instructions.
+
+---
+
+## Detailed Breakdown
+
+### US-001: Schema — Add TierRequirement and refactor SectionRequirement
+
+**Description:** Add a `TierRequirement` dataclass and refactor `SectionRequirement` so that `tiers: list[TierRequirement]` is the canonical representation. `from_file()` normalizes legacy `fields`-style sections into a single `"default"` tier. `to_dict()` always emits the `tiers` form.
+
+**Traces to:** DEC-001, DEC-002
+
+**Acceptance criteria:**
+- `TierRequirement` has `label: str`, `description: str = ""`, `min_entries: int = 0`, `fields: list[FieldRequirement]`
+- `SectionRequirement` has `name: str`, `tiers: list[TierRequirement]` (no more top-level `fields` or `min_entries`)
+- `from_file()` with a `tiers`-style JSON loads correctly
+- `from_file()` with a legacy `fields`-style JSON normalizes to single `"default"` tier
+- `to_dict()` always emits `tiers` array (never `fields` at section level)
+- Roundtrip: `from_file() -> to_dict() -> from_file()` produces equivalent objects for both styles
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80% coverage
+
+**Done when:** `EvalSpec` loads both legacy and tiered JSON, serializes consistently, and all schema tests pass.
+
+**Files:**
+- `src/clauditor/schemas.py` — Add `TierRequirement`, refactor `SectionRequirement`, update `from_file()` and `to_dict()`
+- `tests/test_schemas.py` — Update `SAMPLE_EVAL` to use tiers, add tier-specific tests, update existing assertions for new structure
+
+**Depends on:** none
+
+**TDD:**
+1. Test `from_file()` loads a tiered JSON with two tiers, correct labels/fields/min_entries
+2. Test `from_file()` normalizes legacy `fields`-style section into `tiers: [{label: "default", ...}]`
+3. Test `to_dict()` always emits `tiers` (never top-level `fields`)
+4. Roundtrip test for tiered JSON
+5. Roundtrip test for legacy JSON (loads as tiers, serializes as tiers)
+6. Test tier `description` field is preserved through roundtrip
+
+---
+
+### US-002: Grader — Tier-aware extraction prompt, parsing, and validation
+
+**Description:** Update `build_extraction_prompt()` to generate a tier-nested JSON schema with tier descriptions. Update `grade_extraction()` to validate per-tier field requirements and entry counts with new assertion name format. Update the `extract_and_grade()` parser to handle dict-of-lists (tiered) JSON shape and fail on flat-list responses.
+
+**Traces to:** DEC-003, DEC-004, DEC-005, DEC-006
+
+**Acceptance criteria:**
+- `build_extraction_prompt()` generates nested JSON schema: `{"Section": {"tier_label": [{fields}]}}`
+- Prompt includes tier descriptions when provided
+- `grade_extraction()` validates per-tier: entry count as `section:{Name}:count/{tier}`, fields as `section:{Name}/{tier}[{i}].{field}`
+- `extract_and_grade()` parser expects `dict` values per section (not `list`), maps entries by tier label
+- Flat list response for a tiered section produces `grader:parse:{SectionName}` failure
+- All existing `extract_and_grade()` async tests updated for new JSON shape
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80% coverage
+
+**Done when:** Extraction prompt asks for tiered JSON, parser handles it, grading validates per-tier, and all grader tests pass.
+
+**Files:**
+- `src/clauditor/grader.py` — Update `build_extraction_prompt()`, `grade_extraction()`, and the parser in `extract_and_grade()`
+- `tests/test_grader.py` — Update `_make_spec()` for tier structure, update all test data to tiered JSON shape, add tier-specific tests
+
+**Depends on:** US-001
+
+**TDD:**
+1. Test `grade_extraction()` with two tiers, all fields present — passes
+2. Test `grade_extraction()` with missing required field in main tier — fails with `section:Venues/main[0].address`
+3. Test `grade_extraction()` with optional field missing in secondary tier — passes
+4. Test `grade_extraction()` with too few entries in a tier — fails with `section:Venues:count/main`
+5. Test `grade_extraction()` with zero-min_entries tier having no entries — passes
+6. Test `grade_extraction()` with missing section — fails
+7. Test `build_extraction_prompt()` includes tier labels and descriptions in output
+8. Test `extract_and_grade()` with tiered JSON response — parses correctly
+9. Test `extract_and_grade()` with flat list response — fails with `grader:parse:SectionName`
+10. Test `extract_and_grade()` with unknown tier label in response — entries ignored (only defined tiers validated)
+
+---
+
+### US-003: CLI and example — Update init template and example spec
+
+**Description:** Update `cmd_init()` starter JSON to use `tiers` format. Update the example eval spec to demonstrate tiered sections.
+
+**Traces to:** DEC-002
+
+**Acceptance criteria:**
+- `cmd_init()` generates a starter spec with `tiers` (single default tier) instead of top-level `fields`
+- Example `example-skill.eval.json` updated to use `tiers` format
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80% coverage
+
+**Done when:** Init and example both demonstrate the new tiers format.
+
+**Files:**
+- `src/clauditor/cli.py` — Update `cmd_init()` starter JSON (lines 411-444)
+- `examples/.claude/commands/example-skill.eval.json` — Convert to `tiers` format
+
+**Depends on:** US-001
+
+---
+
+### US-004: Quality Gate — code review x4
+
+**Description:** Run code reviewer 4 times across the full changeset, fixing all real bugs found each pass. Lint and tests must pass after all fixes.
+
+**Traces to:** all decisions
+
+**Acceptance criteria:**
+- 4 review passes completed
+- All real bugs fixed
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with >=80% coverage
+
+**Done when:** All review passes clean, all tests green.
+
+**Files:** Any files touched by US-001 through US-003
+
+**Depends on:** US-001, US-002, US-003
+
+---
+
+### US-005: Patterns & Memory — update conventions and docs
+
+**Description:** Update CLAUDE.md architecture overview to mention tiered validation. Record any new patterns learned during implementation.
+
+**Traces to:** all decisions
+
+**Acceptance criteria:**
+- CLAUDE.md architecture section updated if tier pattern warrants it
+- Any useful memories captured via `bd remember`
+
+**Done when:** Documentation reflects the new tier capability.
+
+**Files:** `CLAUDE.md` (if applicable)
+
+**Depends on:** US-004
+
+---
+
+## Beads Manifest
+
+| Field       | Value |
+|-------------|-------|
+| Epic        | TBD   |
+| Worktree    | TBD   |
+
+| Story  | Bead ID | Status |
+|--------|---------|--------|
+| US-001 | TBD     | —      |
+| US-002 | TBD     | —      |
+| US-003 | TBD     | —      |
+| US-004 | TBD     | —      |
+| US-005 | TBD     | —      |
+

--- a/src/clauditor/__init__.py
+++ b/src/clauditor/__init__.py
@@ -6,6 +6,7 @@ from clauditor.schemas import (
     EvalSpec,
     FieldRequirement,
     SectionRequirement,
+    TierRequirement,
     TriggerTests,
     VarianceConfig,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "GradingReport",
     "GradingResult",
     "SectionRequirement",
+    "TierRequirement",
     "SkillResult",
     "SkillRunner",
     "SkillSpec",

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -421,10 +421,15 @@ def cmd_init(args: argparse.Namespace) -> int:
         "sections": [
             {
                 "name": "Results",
-                "min_entries": 3,
-                "fields": [
-                    {"name": "name", "required": True},
-                    {"name": "address", "required": True},
+                "tiers": [
+                    {
+                        "label": "default",
+                        "min_entries": 3,
+                        "fields": [
+                            {"name": "name", "required": True},
+                            {"name": "address", "required": True},
+                        ],
+                    }
                 ],
             }
         ],

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -184,6 +184,7 @@ async def extract_and_grade(
     # Convert raw JSON to ExtractedOutput
     extracted = ExtractedOutput(raw_json=raw)
     parse_errors: list[AssertionResult] = []
+    expected_sections = {s.name for s in eval_spec.sections}
 
     for section_name, section_data in raw.items():
         if isinstance(section_data, dict):
@@ -197,8 +198,11 @@ async def extract_and_grade(
                         if isinstance(e, dict)
                     ]
             extracted.sections[section_name] = tier_map
-        elif isinstance(section_data, list):
-            # Flat list = shape mismatch error
+        elif (
+            isinstance(section_data, list)
+            and section_name in expected_sections
+        ):
+            # Flat list for an expected section = shape mismatch error
             parse_errors.append(
                 AssertionResult(
                     name=f"grader:parse:{section_name}",

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -27,7 +27,7 @@ class ExtractedEntry:
 class ExtractedOutput:
     """Structured data extracted from skill output."""
 
-    sections: dict[str, list[ExtractedEntry]] = field(default_factory=dict)
+    sections: dict[str, dict[str, list[ExtractedEntry]]] = field(default_factory=dict)
     raw_json: dict | None = None
 
 
@@ -35,17 +35,30 @@ def build_extraction_prompt(eval_spec: EvalSpec) -> str:
     """Build a prompt that asks the LLM to extract structured data."""
     sections_desc = []
     for section in eval_spec.sections:
-        field_names = [f.name for f in section.fields]
+        tier_descs = []
+        for tier in section.tiers:
+            field_names = [f.name for f in tier.fields]
+            desc_part = f' ({tier.description})' if tier.description else ''
+            tier_descs.append(
+                f'  - Tier "{tier.label}"{desc_part}: '
+                f'fields [{", ".join(field_names)}]'
+            )
         sections_desc.append(
-            f'- Section "{section.name}": extract fields [{", ".join(field_names)}] '
-            f"for each entry"
+            f'- Section "{section.name}":\n' + "\n".join(tier_descs)
         )
 
     # Build schema example lines
     schema_lines = []
     for s in eval_spec.sections:
-        field_pairs = ", ".join(f'"{f.name}": "value or null"' for f in s.fields)
-        schema_lines.append(f'  "{s.name}": [{{ {field_pairs} }}]')
+        tier_lines = []
+        for t in s.tiers:
+            field_pairs = ", ".join(
+                f'"{f.name}": "value or null"' for f in t.fields
+            )
+            tier_lines.append(f'    "{t.label}": [{{ {field_pairs} }}]')
+        schema_lines.append(
+            f'  "{s.name}": {{\n' + ",\n".join(tier_lines) + "\n  }"
+        )
     schema_block = ",\n".join(schema_lines)
     sections_block = "\n".join(sections_desc)
 
@@ -61,6 +74,7 @@ def build_extraction_prompt(eval_spec: EvalSpec) -> str:
         "- Return null for fields that are missing or unclear\n"
         "- Extract the raw value as a string, do not interpret or reformat\n"
         "- Include ALL entries found in each section\n"
+        "- Group entries by tier within each section\n"
     )
 
 
@@ -69,39 +83,45 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
     results = AssertionSet()
 
     for section_req in eval_spec.sections:
-        entries = extracted.sections.get(section_req.name, [])
+        section_data = extracted.sections.get(section_req.name, {})
 
-        # Check minimum entry count
-        results.results.append(
-            AssertionResult(
-                name=f"section:{section_req.name}:count",
-                passed=len(entries) >= section_req.min_entries,
-                message=(
-                    f"Section '{section_req.name}' has {len(entries)} entries "
-                    f"(need ≥{section_req.min_entries})"
-                ),
-            )
-        )
+        for tier in section_req.tiers:
+            entries = section_data.get(tier.label, [])
 
-        # Check required fields on each entry
-        for i, entry in enumerate(entries):
-            for field_req in section_req.fields:
-                if not field_req.required:
-                    continue
-                has_value = entry.has_field(field_req.name)
-                results.results.append(
-                    AssertionResult(
-                        name=f"section:{section_req.name}[{i}].{field_req.name}",
-                        passed=has_value,
-                        message=(
-                            "Field present"
-                            if has_value
-                            else f"Missing required field '{field_req.name}' "
-                            f"in {section_req.name} entry {i + 1}"
-                        ),
-                        evidence=entry.fields.get(field_req.name),
-                    )
+            # Check minimum entry count
+            results.results.append(
+                AssertionResult(
+                    name=f"section:{section_req.name}:count/{tier.label}",
+                    passed=len(entries) >= tier.min_entries,
+                    message=(
+                        f"Section '{section_req.name}' tier '{tier.label}' "
+                        f"has {len(entries)} entries "
+                        f"(need \u2265{tier.min_entries})"
+                    ),
                 )
+            )
+
+            # Check required fields on each entry
+            for i, entry in enumerate(entries):
+                for field_req in tier.fields:
+                    if not field_req.required:
+                        continue
+                    has_value = entry.has_field(field_req.name)
+                    results.results.append(
+                        AssertionResult(
+                            name=f"section:{section_req.name}/{tier.label}[{i}].{field_req.name}",
+                            passed=has_value,
+                            message=(
+                                "Field present"
+                                if has_value
+                                else f"Missing required field "
+                                f"'{field_req.name}' in "
+                                f"{section_req.name} tier "
+                                f"'{tier.label}' entry {i + 1}"
+                            ),
+                            evidence=entry.fields.get(field_req.name),
+                        )
+                    )
 
     return results
 
@@ -163,10 +183,34 @@ async def extract_and_grade(
 
     # Convert raw JSON to ExtractedOutput
     extracted = ExtractedOutput(raw_json=raw)
-    for section_name, entries_data in raw.items():
-        if isinstance(entries_data, list):
-            extracted.sections[section_name] = [
-                ExtractedEntry(fields=e) for e in entries_data if isinstance(e, dict)
-            ]
+    parse_errors: list[AssertionResult] = []
+
+    for section_name, section_data in raw.items():
+        if isinstance(section_data, dict):
+            # Tiered format: {"tier_label": [entries]}
+            tier_map: dict[str, list[ExtractedEntry]] = {}
+            for tier_label, entries_data in section_data.items():
+                if isinstance(entries_data, list):
+                    tier_map[tier_label] = [
+                        ExtractedEntry(fields=e)
+                        for e in entries_data
+                        if isinstance(e, dict)
+                    ]
+            extracted.sections[section_name] = tier_map
+        elif isinstance(section_data, list):
+            # Flat list = shape mismatch error
+            parse_errors.append(
+                AssertionResult(
+                    name=f"grader:parse:{section_name}",
+                    passed=False,
+                    message=(
+                        f"Section '{section_name}' returned flat list "
+                        f"instead of tier-grouped dict"
+                    ),
+                )
+            )
+
+    if parse_errors:
+        return AssertionSet(results=parse_errors)
 
     return grade_extraction(extracted, eval_spec)

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -20,12 +20,21 @@ class FieldRequirement:
 
 
 @dataclass
+class TierRequirement:
+    """A tier within a section, grouping fields with a label and threshold."""
+
+    label: str
+    description: str = ""
+    min_entries: int = 0
+    fields: list[FieldRequirement] = field(default_factory=list)
+
+
+@dataclass
 class SectionRequirement:
     """A required section in the output (e.g., 'Venues', 'Events')."""
 
     name: str
-    min_entries: int = 1
-    fields: list[FieldRequirement] = field(default_factory=list)
+    tiers: list[TierRequirement] = field(default_factory=list)
 
 
 @dataclass
@@ -81,19 +90,47 @@ class EvalSpec:
 
         sections = []
         for s in data.get("sections", []):
-            fields = [
-                FieldRequirement(
-                    name=f["name"],
-                    required=f.get("required", True),
-                    pattern=f.get("pattern"),
-                )
-                for f in s.get("fields", [])
-            ]
+            if "tiers" in s:
+                # New tiered format
+                tiers = []
+                for t in s["tiers"]:
+                    tier_fields = [
+                        FieldRequirement(
+                            name=f["name"],
+                            required=f.get("required", True),
+                            pattern=f.get("pattern"),
+                        )
+                        for f in t.get("fields", [])
+                    ]
+                    tiers.append(
+                        TierRequirement(
+                            label=t["label"],
+                            description=t.get("description", ""),
+                            min_entries=t.get("min_entries", 0),
+                            fields=tier_fields,
+                        )
+                    )
+            else:
+                # Legacy fields-style: normalize to single default tier
+                legacy_fields = [
+                    FieldRequirement(
+                        name=f["name"],
+                        required=f.get("required", True),
+                        pattern=f.get("pattern"),
+                    )
+                    for f in s.get("fields", [])
+                ]
+                tiers = [
+                    TierRequirement(
+                        label="default",
+                        min_entries=s.get("min_entries", 1),
+                        fields=legacy_fields,
+                    )
+                ]
             sections.append(
                 SectionRequirement(
                     name=s["name"],
-                    min_entries=s.get("min_entries", 1),
-                    fields=fields,
+                    tiers=tiers,
                 )
             )
 
@@ -146,14 +183,25 @@ class EvalSpec:
             "sections": [
                 {
                     "name": s.name,
-                    "min_entries": s.min_entries,
-                    "fields": [
+                    "tiers": [
                         {
-                            "name": f.name,
-                            "required": f.required,
-                            **({"pattern": f.pattern} if f.pattern else {}),
+                            "label": t.label,
+                            "description": t.description,
+                            "min_entries": t.min_entries,
+                            "fields": [
+                                {
+                                    "name": f.name,
+                                    "required": f.required,
+                                    **(
+                                        {"pattern": f.pattern}
+                                        if f.pattern
+                                        else {}
+                                    ),
+                                }
+                                for f in t.fields
+                            ],
                         }
-                        for f in s.fields
+                        for t in s.tiers
                     ],
                 }
                 for s in self.sections

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -186,7 +186,11 @@ class EvalSpec:
                     "tiers": [
                         {
                             "label": t.label,
-                            "description": t.description,
+                            **(
+                                {"description": t.description}
+                                if t.description
+                                else {}
+                            ),
                             "min_entries": t.min_entries,
                             "fields": [
                                 {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from clauditor.schemas import (
     EvalSpec,
     FieldRequirement,
     SectionRequirement,
+    TierRequirement,
     TriggerTests,
 )
 from clauditor.spec import SkillSpec
@@ -589,10 +590,15 @@ def _make_sections():
     return [
         SectionRequirement(
             name="Results",
-            min_entries=2,
-            fields=[
-                FieldRequirement(name="name", required=True),
-                FieldRequirement(name="address", required=True),
+            tiers=[
+                TierRequirement(
+                    label="default",
+                    min_entries=2,
+                    fields=[
+                        FieldRequirement(name="name", required=True),
+                        FieldRequirement(name="address", required=True),
+                    ],
+                )
             ],
         )
     ]

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -12,7 +12,12 @@ from clauditor.grader import (
     extract_and_grade,
     grade_extraction,
 )
-from clauditor.schemas import EvalSpec, FieldRequirement, SectionRequirement
+from clauditor.schemas import (
+    EvalSpec,
+    FieldRequirement,
+    SectionRequirement,
+    TierRequirement,
+)
 
 
 def _make_spec() -> EvalSpec:
@@ -21,12 +26,49 @@ def _make_spec() -> EvalSpec:
         sections=[
             SectionRequirement(
                 name="Venues",
-                min_entries=2,
-                fields=[
-                    FieldRequirement(name="name", required=True),
-                    FieldRequirement(name="address", required=True),
-                    FieldRequirement(name="website", required=True),
-                    FieldRequirement(name="phone", required=False),
+                tiers=[
+                    TierRequirement(
+                        label="default",
+                        min_entries=2,
+                        fields=[
+                            FieldRequirement(name="name", required=True),
+                            FieldRequirement(name="address", required=True),
+                            FieldRequirement(name="website", required=True),
+                            FieldRequirement(name="phone", required=False),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def _make_two_tier_spec() -> EvalSpec:
+    return EvalSpec(
+        skill_name="test-skill",
+        sections=[
+            SectionRequirement(
+                name="Venues",
+                tiers=[
+                    TierRequirement(
+                        label="main",
+                        description="Primary venues with full details",
+                        min_entries=1,
+                        fields=[
+                            FieldRequirement(name="name", required=True),
+                            FieldRequirement(name="address", required=True),
+                            FieldRequirement(name="website", required=True),
+                        ],
+                    ),
+                    TierRequirement(
+                        label="honorable_mention",
+                        description="Brief mentions worth noting",
+                        min_entries=0,
+                        fields=[
+                            FieldRequirement(name="name", required=True),
+                            FieldRequirement(name="reason", required=False),
+                        ],
+                    ),
                 ],
             ),
         ],
@@ -37,24 +79,26 @@ class TestGradeExtraction:
     def test_all_fields_present(self):
         extracted = ExtractedOutput(
             sections={
-                "Venues": [
-                    ExtractedEntry(
-                        fields={
-                            "name": "CDM",
-                            "address": "180 Woz Way",
-                            "website": "https://cdm.org",
-                            "phone": "(408) 298-5437",
-                        }
-                    ),
-                    ExtractedEntry(
-                        fields={
-                            "name": "Deer Hollow",
-                            "address": "22500 Cristo Rey Dr",
-                            "website": "https://deerhollowfarm.org",
-                            "phone": None,
-                        }
-                    ),
-                ]
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "CDM",
+                                "address": "180 Woz Way",
+                                "website": "https://cdm.org",
+                                "phone": "(408) 298-5437",
+                            }
+                        ),
+                        ExtractedEntry(
+                            fields={
+                                "name": "Deer Hollow",
+                                "address": "22500 Cristo Rey Dr",
+                                "website": "https://deerhollowfarm.org",
+                                "phone": None,
+                            }
+                        ),
+                    ]
+                }
             }
         )
         results = grade_extraction(extracted, _make_spec())
@@ -63,37 +107,41 @@ class TestGradeExtraction:
     def test_missing_required_field(self):
         extracted = ExtractedOutput(
             sections={
-                "Venues": [
-                    ExtractedEntry(
-                        fields={
-                            "name": "CDM",
-                            "address": None,  # missing required
-                            "website": "https://cdm.org",
-                        }
-                    ),
-                    ExtractedEntry(
-                        fields={
-                            "name": "Deer Hollow",
-                            "address": "22500 Cristo Rey Dr",
-                            "website": "https://deerhollowfarm.org",
-                        }
-                    ),
-                ]
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "CDM",
+                                "address": None,  # missing required
+                                "website": "https://cdm.org",
+                            }
+                        ),
+                        ExtractedEntry(
+                            fields={
+                                "name": "Deer Hollow",
+                                "address": "22500 Cristo Rey Dr",
+                                "website": "https://deerhollowfarm.org",
+                            }
+                        ),
+                    ]
+                }
             }
         )
         results = grade_extraction(extracted, _make_spec())
         assert not results.passed
         failed_names = [r.name for r in results.failed]
-        assert "section:Venues[0].address" in failed_names
+        assert "section:Venues/default[0].address" in failed_names
 
     def test_not_enough_entries(self):
         extracted = ExtractedOutput(
             sections={
-                "Venues": [
-                    ExtractedEntry(
-                        fields={"name": "Only One", "address": "x", "website": "x"}
-                    ),
-                ]
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={"name": "Only One", "address": "x", "website": "x"}
+                        ),
+                    ]
+                }
             }
         )
         results = grade_extraction(extracted, _make_spec())
@@ -108,19 +156,189 @@ class TestGradeExtraction:
     def test_optional_field_missing_ok(self):
         extracted = ExtractedOutput(
             sections={
-                "Venues": [
-                    ExtractedEntry(
-                        fields={"name": "A", "address": "B", "website": "C"}
-                    ),
-                    ExtractedEntry(
-                        fields={"name": "D", "address": "E", "website": "F"}
-                    ),
-                ]
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={"name": "A", "address": "B", "website": "C"}
+                        ),
+                        ExtractedEntry(
+                            fields={"name": "D", "address": "E", "website": "F"}
+                        ),
+                    ]
+                }
             }
         )
         # phone is optional, should still pass
         results = grade_extraction(extracted, _make_spec())
         assert results.passed
+
+    def test_two_tier_all_present(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "main": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "CDM",
+                                "address": "180 Woz Way",
+                                "website": "https://cdm.org",
+                            }
+                        ),
+                    ],
+                    "honorable_mention": [
+                        ExtractedEntry(
+                            fields={"name": "Deer Hollow", "reason": "scenic"}
+                        ),
+                    ],
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_two_tier_spec())
+        assert results.passed
+
+    def test_two_tier_missing_required_in_main(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "main": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "CDM",
+                                "address": None,  # missing required
+                                "website": "https://cdm.org",
+                            }
+                        ),
+                    ],
+                    "honorable_mention": [],
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_two_tier_spec())
+        assert not results.passed
+        failed_names = [r.name for r in results.failed]
+        assert "section:Venues/main[0].address" in failed_names
+
+    def test_two_tier_optional_field_missing_in_secondary(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "main": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "CDM",
+                                "address": "180 Woz Way",
+                                "website": "https://cdm.org",
+                            }
+                        ),
+                    ],
+                    "honorable_mention": [
+                        ExtractedEntry(
+                            fields={"name": "Deer Hollow"}
+                            # reason is optional, missing is fine
+                        ),
+                    ],
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_two_tier_spec())
+        assert results.passed
+
+    def test_two_tier_too_few_entries(self):
+        # main requires min_entries=1, but we provide 0
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "main": [],
+                    "honorable_mention": [],
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_two_tier_spec())
+        assert not results.passed
+        failed_names = [r.name for r in results.failed]
+        assert "section:Venues:count/main" in failed_names
+
+    def test_zero_min_entries_tier_with_no_entries_passes(self):
+        # honorable_mention has min_entries=0
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "main": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "CDM",
+                                "address": "x",
+                                "website": "x",
+                            }
+                        ),
+                    ],
+                    "honorable_mention": [],
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_two_tier_spec())
+        assert results.passed
+
+    def test_unknown_tier_label_ignored(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={"name": "A", "address": "B", "website": "C"}
+                        ),
+                        ExtractedEntry(
+                            fields={"name": "D", "address": "E", "website": "F"}
+                        ),
+                    ],
+                    "unknown_tier": [
+                        ExtractedEntry(fields={"name": "X"}),
+                    ],
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_spec())
+        # unknown_tier is silently ignored, only "default" is validated
+        assert results.passed
+
+    def test_assertion_name_format_count(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={"name": "A", "address": "B", "website": "C"}
+                        ),
+                        ExtractedEntry(
+                            fields={"name": "D", "address": "E", "website": "F"}
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_spec())
+        names = [r.name for r in results.results]
+        assert "section:Venues:count/default" in names
+
+    def test_assertion_name_format_field(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Venues": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={"name": "A", "address": "B", "website": "C"}
+                        ),
+                        ExtractedEntry(
+                            fields={"name": "D", "address": "E", "website": "F"}
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_spec())
+        names = [r.name for r in results.results]
+        assert "section:Venues/default[0].name" in names
+        assert "section:Venues/default[1].address" in names
 
 
 class TestBuildExtractionPrompt:
@@ -137,6 +355,7 @@ class TestBuildExtractionPrompt:
         spec = _make_spec()
         prompt = build_extraction_prompt(spec)
         assert '"Venues"' in prompt
+        assert '"default"' in prompt
         assert '"name": "value or null"' in prompt
 
     def test_multiple_sections(self):
@@ -145,15 +364,25 @@ class TestBuildExtractionPrompt:
             sections=[
                 SectionRequirement(
                     name="Hotels",
-                    min_entries=1,
-                    fields=[FieldRequirement(name="name", required=True)],
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[FieldRequirement(name="name", required=True)],
+                        ),
+                    ],
                 ),
                 SectionRequirement(
                     name="Restaurants",
-                    min_entries=1,
-                    fields=[
-                        FieldRequirement(name="name", required=True),
-                        FieldRequirement(name="cuisine", required=False),
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(name="name", required=True),
+                                FieldRequirement(name="cuisine", required=False),
+                            ],
+                        ),
                     ],
                 ),
             ],
@@ -168,19 +397,40 @@ class TestBuildExtractionPrompt:
         assert isinstance(prompt, str)
         assert prompt.startswith("Extract structured data")
 
+    def test_includes_tier_labels_and_descriptions(self):
+        spec = _make_two_tier_spec()
+        prompt = build_extraction_prompt(spec)
+        assert '"main"' in prompt
+        assert '"honorable_mention"' in prompt
+        assert "Primary venues with full details" in prompt
+        assert "Brief mentions worth noting" in prompt
+
+    def test_nested_json_schema(self):
+        spec = _make_two_tier_spec()
+        prompt = build_extraction_prompt(spec)
+        # Should show nested structure: "Venues": { "main": [...], ... }
+        assert '"Venues": {' in prompt
+        assert '"main": [{' in prompt or '"main": [{ ' in prompt
+
 
 class TestExtractAndGrade:
     @pytest.mark.asyncio
     async def test_successful_extraction(self):
         data = {
-            "Venues": [
-                {"name": "CDM", "address": "180 Woz Way", "website": "https://cdm.org"},
-                {
-                    "name": "Deer Hollow",
-                    "address": "22500 Cristo Rey Dr",
-                    "website": "https://deerhollowfarm.org",
-                },
-            ]
+            "Venues": {
+                "default": [
+                    {
+                        "name": "CDM",
+                        "address": "180 Woz Way",
+                        "website": "https://cdm.org",
+                    },
+                    {
+                        "name": "Deer Hollow",
+                        "address": "22500 Cristo Rey Dr",
+                        "website": "https://deerhollowfarm.org",
+                    },
+                ]
+            }
         }
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text=json.dumps(data))]
@@ -193,10 +443,12 @@ class TestExtractAndGrade:
     @pytest.mark.asyncio
     async def test_markdown_code_block_stripped(self):
         data = {
-            "Venues": [
-                {"name": "A", "address": "B", "website": "C"},
-                {"name": "D", "address": "E", "website": "F"},
-            ]
+            "Venues": {
+                "default": [
+                    {"name": "A", "address": "B", "website": "C"},
+                    {"name": "D", "address": "E", "website": "F"},
+                ]
+            }
         }
         wrapped = f"```json\n{json.dumps(data)}\n```"
         mock_response = MagicMock()
@@ -210,10 +462,12 @@ class TestExtractAndGrade:
     @pytest.mark.asyncio
     async def test_generic_code_block_stripped(self):
         data = {
-            "Venues": [
-                {"name": "A", "address": "B", "website": "C"},
-                {"name": "D", "address": "E", "website": "F"},
-            ]
+            "Venues": {
+                "default": [
+                    {"name": "A", "address": "B", "website": "C"},
+                    {"name": "D", "address": "E", "website": "F"},
+                ]
+            }
         }
         wrapped = f"```\n{json.dumps(data)}\n```"
         mock_response = MagicMock()
@@ -238,10 +492,20 @@ class TestExtractAndGrade:
     @pytest.mark.asyncio
     async def test_missing_required_field_in_response(self):
         data = {
-            "Venues": [
-                {"name": "CDM", "address": None, "website": "https://cdm.org"},
-                {"name": "Deer Hollow", "address": "addr", "website": "https://dh.org"},
-            ]
+            "Venues": {
+                "default": [
+                    {
+                        "name": "CDM",
+                        "address": None,
+                        "website": "https://cdm.org",
+                    },
+                    {
+                        "name": "Deer Hollow",
+                        "address": "addr",
+                        "website": "https://dh.org",
+                    },
+                ]
+            }
         }
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text=json.dumps(data))]
@@ -264,3 +528,48 @@ class TestExtractAndGrade:
         finally:
             if real_anthropic is not None:
                 sys.modules["anthropic"] = real_anthropic
+
+    @pytest.mark.asyncio
+    async def test_flat_list_response_produces_parse_error(self):
+        """Flat list instead of tier-grouped dict = grader:parse:{Section} failure."""
+        data = {
+            "Venues": [
+                {"name": "CDM", "address": "180 Woz Way", "website": "https://cdm.org"},
+                {
+                    "name": "Deer Hollow",
+                    "address": "22500 Cristo Rey Dr",
+                    "website": "https://deerhollowfarm.org",
+                },
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert not result.passed
+        failed_names = [r.name for r in result.failed]
+        assert "grader:parse:Venues" in failed_names
+
+    @pytest.mark.asyncio
+    async def test_unknown_tier_in_response_ignored(self):
+        """Entries under undefined tier labels are silently ignored."""
+        data = {
+            "Venues": {
+                "default": [
+                    {"name": "A", "address": "B", "website": "C"},
+                    {"name": "D", "address": "E", "website": "F"},
+                ],
+                "bonus": [
+                    {"name": "X"},
+                ],
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert result.passed

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -534,7 +534,11 @@ class TestExtractAndGrade:
         """Flat list instead of tier-grouped dict = grader:parse:{Section} failure."""
         data = {
             "Venues": [
-                {"name": "CDM", "address": "180 Woz Way", "website": "https://cdm.org"},
+                {
+                    "name": "CDM",
+                    "address": "180 Woz Way",
+                    "website": "https://cdm.org",
+                },
                 {
                     "name": "Deer Hollow",
                     "address": "22500 Cristo Rey Dr",
@@ -551,6 +555,29 @@ class TestExtractAndGrade:
         assert not result.passed
         failed_names = [r.name for r in result.failed]
         assert "grader:parse:Venues" in failed_names
+
+    @pytest.mark.asyncio
+    async def test_extra_section_flat_list_ignored(self):
+        """Extra sections not in eval_spec with flat lists are ignored."""
+        data = {
+            "Venues": {
+                "default": [
+                    {"name": "A", "address": "B", "website": "C"},
+                    {"name": "D", "address": "E", "website": "F"},
+                ],
+            },
+            "ExtraStuff": [
+                {"note": "LLM added this unsolicited"},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        # Extra flat-list section is not in spec, so no parse error
+        assert result.passed
 
     @pytest.mark.asyncio
     async def test_unknown_tier_in_response_ignored(self):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -15,6 +15,7 @@ from clauditor.schemas import (  # noqa: E402
     FieldRequirement,
     GradeThresholds,
     SectionRequirement,
+    TierRequirement,
     TriggerTests,
     VarianceConfig,
 )
@@ -67,11 +68,15 @@ class TestEvalSpecFromFile:
         assert len(spec.assertions) == 2
         assert len(spec.sections) == 2
         assert spec.sections[0].name == "Venues"
-        assert spec.sections[0].min_entries == 3
-        assert len(spec.sections[0].fields) == 5
-        assert spec.sections[0].fields[0].name == "name"
-        assert spec.sections[0].fields[0].required is True
-        assert spec.sections[0].fields[4].required is False
+        # Legacy fields normalized to single default tier
+        assert len(spec.sections[0].tiers) == 1
+        tier = spec.sections[0].tiers[0]
+        assert tier.label == "default"
+        assert tier.min_entries == 3
+        assert len(tier.fields) == 5
+        assert tier.fields[0].name == "name"
+        assert tier.fields[0].required is True
+        assert tier.fields[4].required is False
 
     def test_missing_optional_fields(self):
         minimal = {"skill_name": "test"}
@@ -99,7 +104,7 @@ class TestEvalSpecFromFile:
         d = spec.to_dict()
         assert d["skill_name"] == "find-kid-activities"
         assert len(d["sections"]) == 2
-        assert d["sections"][0]["fields"][0]["name"] == "name"
+        assert d["sections"][0]["tiers"][0]["fields"][0]["name"] == "name"
 
 
 class TestFieldRequirement:
@@ -116,8 +121,7 @@ class TestFieldRequirement:
 class TestSectionRequirement:
     def test_defaults(self):
         s = SectionRequirement(name="Results")
-        assert s.min_entries == 1
-        assert s.fields == []
+        assert s.tiers == []
 
 
 class TestTriggerTests:
@@ -269,10 +273,12 @@ class TestFromFile:
         assert len(spec.assertions) == 2
         assert len(spec.sections) == 1
         assert spec.sections[0].name == "Places"
-        assert spec.sections[0].min_entries == 2
-        assert len(spec.sections[0].fields) == 3
-        assert spec.sections[0].fields[2].pattern == r"^\d{5}$"
-        assert spec.sections[0].fields[2].required is False
+        tier = spec.sections[0].tiers[0]
+        assert tier.label == "default"
+        assert tier.min_entries == 2
+        assert len(tier.fields) == 3
+        assert tier.fields[2].pattern == r"^\d{5}$"
+        assert tier.fields[2].required is False
         assert spec.grading_criteria == [
             "Are results relevant?",
             "Is formatting correct?",
@@ -326,7 +332,7 @@ class TestFromFile:
         }
         path = _write_json(tmp_path, data)
         spec = EvalSpec.from_file(path)
-        assert spec.sections[0].fields[0].pattern is None
+        assert spec.sections[0].tiers[0].fields[0].pattern is None
 
 
 class TestToDict:
@@ -344,14 +350,16 @@ class TestToDict:
         assert d["assertions"] == FULL_EVAL_DATA["assertions"]
         assert d["grading_criteria"] == FULL_EVAL_DATA["grading_criteria"]
         assert d["grading_model"] == FULL_EVAL_DATA["grading_model"]
-        # Sections structure matches
+        # Sections structure matches (legacy normalized to tiers)
         assert len(d["sections"]) == 1
         assert d["sections"][0]["name"] == "Places"
-        assert d["sections"][0]["min_entries"] == 2
-        assert len(d["sections"][0]["fields"]) == 3
+        tier = d["sections"][0]["tiers"][0]
+        assert tier["label"] == "default"
+        assert tier["min_entries"] == 2
+        assert len(tier["fields"]) == 3
         # Pattern included only where present
-        assert d["sections"][0]["fields"][2]["pattern"] == r"^\d{5}$"
-        assert "pattern" not in d["sections"][0]["fields"][0]
+        assert tier["fields"][2]["pattern"] == r"^\d{5}$"
+        assert "pattern" not in tier["fields"][0]
         # Trigger tests
         assert d["trigger_tests"] == FULL_EVAL_DATA["trigger_tests"]
         # Variance
@@ -580,3 +588,193 @@ class TestGradeThresholds:
         assert spec.grade_thresholds is not None
         assert spec.grade_thresholds.min_pass_rate == 0.7
         assert spec.grade_thresholds.min_mean_score == 0.5
+
+
+class TestTierRequirement:
+    """Tests for TierRequirement dataclass."""
+
+    def test_defaults(self):
+        t = TierRequirement(label="basic")
+        assert t.label == "basic"
+        assert t.description == ""
+        assert t.min_entries == 0
+        assert t.fields == []
+
+    def test_with_all_fields(self):
+        t = TierRequirement(
+            label="premium",
+            description="High quality entries",
+            min_entries=5,
+            fields=[FieldRequirement(name="url")],
+        )
+        assert t.label == "premium"
+        assert t.description == "High quality entries"
+        assert t.min_entries == 5
+        assert len(t.fields) == 1
+
+
+TIERED_SECTION_DATA = {
+    "skill_name": "tiered-skill",
+    "sections": [
+        {
+            "name": "Venues",
+            "tiers": [
+                {
+                    "label": "basic",
+                    "description": "Minimum viable info",
+                    "min_entries": 3,
+                    "fields": [
+                        {"name": "name", "required": True},
+                        {"name": "address", "required": True},
+                    ],
+                },
+                {
+                    "label": "detailed",
+                    "description": "Rich venue data",
+                    "min_entries": 1,
+                    "fields": [
+                        {"name": "name", "required": True},
+                        {"name": "address", "required": True},
+                        {"name": "hours", "required": True},
+                        {"name": "website", "required": False},
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
+
+class TestTieredSections:
+    """Tests for tiered section loading, normalization, and roundtrip."""
+
+    def test_load_tiered_json(self, tmp_path):
+        """Load JSON with explicit tiers array."""
+        path = _write_json(tmp_path, TIERED_SECTION_DATA)
+        spec = EvalSpec.from_file(path)
+
+        assert len(spec.sections) == 1
+        section = spec.sections[0]
+        assert section.name == "Venues"
+        assert len(section.tiers) == 2
+
+        assert section.tiers[0].label == "basic"
+        assert section.tiers[0].description == "Minimum viable info"
+        assert section.tiers[0].min_entries == 3
+        assert len(section.tiers[0].fields) == 2
+
+        assert section.tiers[1].label == "detailed"
+        assert section.tiers[1].description == "Rich venue data"
+        assert section.tiers[1].min_entries == 1
+        assert len(section.tiers[1].fields) == 4
+
+    def test_legacy_fields_normalized_to_default_tier(self, tmp_path):
+        """Legacy fields-style JSON is normalized to a single default tier."""
+        legacy_data = {
+            "skill_name": "legacy",
+            "sections": [
+                {
+                    "name": "Results",
+                    "min_entries": 5,
+                    "fields": [
+                        {"name": "title", "required": True},
+                        {"name": "url", "required": False},
+                    ],
+                }
+            ],
+        }
+        path = _write_json(tmp_path, legacy_data)
+        spec = EvalSpec.from_file(path)
+
+        section = spec.sections[0]
+        assert len(section.tiers) == 1
+        tier = section.tiers[0]
+        assert tier.label == "default"
+        assert tier.description == ""
+        assert tier.min_entries == 5
+        assert len(tier.fields) == 2
+        assert tier.fields[0].name == "title"
+        assert tier.fields[1].required is False
+
+    def test_tiered_roundtrip(self, tmp_path):
+        """from_file -> to_dict -> from_file preserves tiered structure."""
+        path1 = _write_json(tmp_path, TIERED_SECTION_DATA, name="first.json")
+        spec1 = EvalSpec.from_file(path1)
+        d = spec1.to_dict()
+
+        # Verify dict structure
+        assert len(d["sections"]) == 1
+        assert len(d["sections"][0]["tiers"]) == 2
+        assert d["sections"][0]["tiers"][0]["label"] == "basic"
+        assert d["sections"][0]["tiers"][1]["label"] == "detailed"
+
+        # Reload and verify equality
+        path2 = _write_json(tmp_path, d, name="second.json")
+        spec2 = EvalSpec.from_file(path2)
+
+        assert len(spec2.sections[0].tiers) == 2
+        assert spec2.sections[0].tiers[0].label == "basic"
+        assert spec2.sections[0].tiers[0].min_entries == 3
+        assert spec2.sections[0].tiers[1].label == "detailed"
+        assert len(spec2.sections[0].tiers[1].fields) == 4
+
+    def test_legacy_roundtrip(self, tmp_path):
+        """Legacy format -> load -> to_dict -> reload produces consistent tiers."""
+        legacy_data = {
+            "skill_name": "legacy-rt",
+            "sections": [
+                {
+                    "name": "Items",
+                    "min_entries": 2,
+                    "fields": [{"name": "name", "required": True}],
+                }
+            ],
+        }
+        path1 = _write_json(tmp_path, legacy_data, name="first.json")
+        spec1 = EvalSpec.from_file(path1)
+        d = spec1.to_dict()
+
+        # Output always uses tiers form
+        assert "tiers" in d["sections"][0]
+        assert d["sections"][0]["tiers"][0]["label"] == "default"
+
+        # Reload produces same structure
+        path2 = _write_json(tmp_path, d, name="second.json")
+        spec2 = EvalSpec.from_file(path2)
+        assert spec2.sections[0].tiers[0].label == "default"
+        assert spec2.sections[0].tiers[0].min_entries == 2
+        assert len(spec2.sections[0].tiers[0].fields) == 1
+
+    def test_tier_description_preserved_through_roundtrip(self, tmp_path):
+        """Tier description field survives from_file -> to_dict -> from_file."""
+        path1 = _write_json(tmp_path, TIERED_SECTION_DATA, name="first.json")
+        spec1 = EvalSpec.from_file(path1)
+
+        d = spec1.to_dict()
+        assert d["sections"][0]["tiers"][0]["description"] == "Minimum viable info"
+        assert d["sections"][0]["tiers"][1]["description"] == "Rich venue data"
+
+        path2 = _write_json(tmp_path, d, name="second.json")
+        spec2 = EvalSpec.from_file(path2)
+        assert spec2.sections[0].tiers[0].description == "Minimum viable info"
+        assert spec2.sections[0].tiers[1].description == "Rich venue data"
+
+    def test_tier_defaults_for_optional_fields(self, tmp_path):
+        """Tiers with missing optional fields get defaults."""
+        data = {
+            "skill_name": "sparse",
+            "sections": [
+                {
+                    "name": "S",
+                    "tiers": [{"label": "minimal"}],
+                }
+            ],
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+
+        tier = spec.sections[0].tiers[0]
+        assert tier.label == "minimal"
+        assert tier.description == ""
+        assert tier.min_entries == 0
+        assert tier.fields == []


### PR DESCRIPTION
## Summary
Super plan for #12 — Tiered Section Validation.

**Phase:** devolved (all stories implemented and closed)
**Stories:** 3 implementation stories + Quality Gate + Patterns & Memory
**Decisions:** 6 decisions captured (DEC-001 through DEC-006)

## Key Decisions
- **DEC-001:** No backward compatibility required — all changes can be breaking
- **DEC-002:** `fields` is sugar for a single `"default"` tier — one code path everywhere
- **DEC-003:** Assertion names always include tier: `section:Venues/main[0].address`
- **DEC-004:** Fail on shape mismatch, no silent fallback
- **DEC-005:** Tier `description` field guides LLM classification
- **DEC-006:** Extraction JSON is nested by tier

## Changes
- **schemas.py** — Added `TierRequirement` dataclass, refactored `SectionRequirement` to use `tiers`
- **grader.py** — Tier-aware extraction prompt, tier-grouped JSON parsing, per-tier field validation
- **cli.py** — Updated `init` template to use `tiers` format
- **example-skill.eval.json** — Converted to `tiers` format
- **tests** — 301 tests passing, 93.73% coverage