### PR TITLE
#13: Field-Level Validation Assertions (plan)

### DIFF
--- a/plans/super/13-field-validation.md
+++ b/plans/super/13-field-validation.md
@@ -1,0 +1,396 @@
+# Super Plan: #13 — Field-Level Validation Assertions
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/13
+- **Branch:** `feature/13-field-validation`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-10
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Add field-level validation capabilities to strengthen output validation without LLM costs. The ticket specifically requests:
+1. A `urls_reachable` assertion (Layer 1) — HTTP HEAD check that extracted URLs resolve
+2. Field pattern enforcement (Layer 2) — validate each extracted field value against `FieldRequirement.pattern` regex
+
+**Why:** Current validation has a gap between Layer 1 (whole-output string matching) and Layer 3 (expensive LLM grading). URLs can be syntactically valid but 404; phone fields can contain garbage that passes whole-output regex checks. These are cheap, deterministic checks that belong in Layers 1-2.
+
+**User extension:** The user wants a **generalized data-type validation system** — not just phone/URL but a broad set of recognizable output formats (email, date, currency, etc.) that can be validated cheaply.
+
+### Codebase Findings
+
+**Layer 1 — assertions.py (179 lines)**
+- 8 assertion types: `contains`, `not_contains`, `regex`, `min_count`, `min_length`, `max_length`, `has_urls`, `has_entries`
+- Pattern: each type is a standalone function returning `AssertionResult`, dispatched via if-elif chain in `run_assertions()` (line 139)
+- `has_urls` already extracts URLs via regex (line 118: `r"https?://[^\s\)\"'>]+"`) but only counts them — no reachability check
+- Zero external dependencies (no `requests`, no `httpx`, no `aiohttp`)
+
+**Layer 2 — grader.py (221 lines)**
+- `grade_extraction()` (line 81) validates extracted data against schema
+- Currently only checks field presence via `entry.has_field()` (line 109)
+- `FieldRequirement.pattern` exists in schemas.py (line 19) but is **never enforced** — the field is loaded from JSON and serialized back, but grader.py ignores it entirely
+- Pattern enforcement insertion point: lines 104-124, after the `has_value` check
+
+**schemas.py (236 lines)**
+- `FieldRequirement` (line 14): `name`, `required`, `pattern` (optional regex string)
+- No `type` or `format` field exists yet — pattern is the only validation mechanism
+
+**Dependencies (pyproject.toml)**
+- Zero runtime dependencies; `anthropic` is optional (grader extra)
+- No HTTP client library in deps — `urls_reachable` needs one
+
+### Proposed Scope
+
+The ticket asks for two things; the user asks us to think broader. I propose three work streams:
+
+1. **URL reachability** — New Layer 1 assertion `urls_reachable` that HTTP-HEAD-checks URLs
+2. **Field pattern enforcement** — Wire up the existing `FieldRequirement.pattern` in `grade_extraction()`
+3. **Data format validators** — A registry of named format patterns (email, phone, date, currency, URL, etc.) that can be referenced from `FieldRequirement` by name instead of inline regex, usable in both Layer 1 (whole-output format scanning) and Layer 2 (per-field validation)
+
+### Scoping Questions
+
+**Q1: HTTP client for URL reachability**
+The project currently has zero runtime dependencies. Adding `httpx` or `aiohttp` would be the first.
+
+- **(A)** Use stdlib `urllib.request` — no new dependency, synchronous, limited but sufficient for HEAD requests
+- **(B)** Add `httpx` as an optional dependency (like anthropic) — async-native, production-grade, but adds a dep
+- **(C)** Add `aiohttp` as optional — async, lighter than httpx, but less ergonomic
+- **(D)** Use `urllib` as default, with optional `httpx` if installed — best of both
+
+**Q2: Scope of format validators**
+How broad should the built-in format registry be?
+
+- **(A)** Minimal — just the formats mentioned in the ticket: `phone_us`, `url` (4-5 formats)
+- **(B)** Moderate — common structured data types: `phone_us`, `email`, `url`, `date_iso`, `currency_usd`, `zip_us`, `time_24h`, `percentage` (~8-10 formats)
+- **(C)** Broad — everything in (B) plus international variants and domain patterns: `phone_intl`, `date_various`, `currency_intl`, `ipv4`, `ipv6`, `uuid`, `hex_color`, `latitude`, `longitude`, `ssn_masked` (~15-20 formats)
+- **(D)** Extensible — ship (B) as built-ins plus let eval specs register custom named patterns
+
+**Q3: How should named formats integrate with FieldRequirement?**
+
+- **(A)** New `format` field on `FieldRequirement` — `{"name": "phone", "format": "phone_us"}` — separate from `pattern` (regex). `format` is a named preset; `pattern` is custom regex. If both set, both must match.
+- **(B)** Overload `pattern` — allow `pattern` to accept either a regex string or a format name like `"phone_us"`. Detect by prefix or registry lookup.
+- **(C)** Replace `pattern` with `format` entirely — `format` accepts either a named preset or an inline regex (auto-detected by trying registry first, falling back to regex)
+
+**Q4: Layer 1 format-scanning assertions**
+Beyond `has_urls` and `urls_reachable`, should we add format-aware counting assertions?
+
+- **(A)** Yes — add `has_emails`, `has_phones`, `has_dates`, etc. as distinct assertion types
+- **(B)** Yes, but generalized — add a single `has_format` assertion type: `{"type": "has_format", "format": "email", "value": "3"}` that uses the format registry
+- **(C)** No — keep Layer 1 for raw string checks, let Layer 2 handle format validation per-field
+
+**Q5: URL reachability — failure semantics**
+When a URL returns non-2xx or times out:
+
+- **(A)** Binary pass/fail — count reachable URLs, fail if below threshold
+- **(B)** Graded — report per-URL status (2xx, 3xx redirect, 4xx, 5xx, timeout) in evidence, let user set which codes count as "reachable"
+- **(C)** Start with (A), make (B) a follow-up issue
+
+### Scoping Answers
+
+| Q | Answer | Decision |
+|---|--------|----------|
+| Q1 | **(D)** | `urllib.request` default, optional `httpx` if installed |
+| Q2 | **(C)** | Broad format registry (~15-20 built-in formats) |
+| Q3 | **(A)** | New `format` field on `FieldRequirement`, separate from `pattern` |
+| Q4 | **(B)** | Generalized `has_format` assertion: `{"type": "has_format", "format": "email", "value": "3"}` |
+| Q5 | **(C)** | Binary pass/fail now, graded per-URL status as follow-up |
+
+---
+
+## Architecture Review
+
+### DEC-001: Zero-dep HTTP with optional upgrade
+`urls_reachable` uses `urllib.request.urlopen` (HEAD) by default. If `httpx` is installed, uses `httpx.head()` instead. No new required dependency added to pyproject.toml. `httpx` could optionally be added to `[project.optional-dependencies]` for discoverability.
+
+### DEC-002: Format registry as module
+New `formats.py` module containing a `FORMAT_REGISTRY: dict[str, FormatDef]` mapping format names to `FormatDef(name, pattern, description)`. ~15-20 built-in entries. Pure data + one lookup function. No classes needed beyond the dataclass.
+
+### DEC-003: FieldRequirement gains `format` field
+`format: str | None = None` added alongside existing `pattern`. `format` references a registry name; `pattern` is inline regex. If both set, both must match. Schema loading and serialization updated.
+
+### DEC-004: Generalized `has_format` assertion
+Single new assertion type in Layer 1: `{"type": "has_format", "format": "email", "value": "3"}`. Looks up format in registry, runs its regex against full output, counts matches. Replaces the need for individual `has_emails`, `has_phones`, etc.
+
+### DEC-005: Pattern enforcement in grade_extraction
+After the existing `has_value` check (grader.py:109), add pattern/format validation. If `field_req.format` is set, resolve to regex from registry. If `field_req.pattern` is set, use it directly. Apply `re.fullmatch()` against the extracted field value. Failed matches produce an AssertionResult with the value as evidence.
+
+### Review Ratings
+
+| Area | Rating | Key Finding |
+|------|--------|-------------|
+| Security | **CONCERN** | SSRF risk in `urls_reachable` (private IPs, metadata endpoints); ReDoS risk from user-supplied regex in `pattern` field |
+| Performance | **PASS** | HTTP HEAD with timeout is lightweight; regex on short field values is negligible |
+| Data Model | **PASS** | `format` field is backward compatible; must update `to_dict()` serialization |
+| API Design | **PASS** | New assertion formats consistent with existing style |
+| Observability | **PASS** | AssertionResult evidence field already carries diagnostic data |
+| Testing | **CONCERN** | `urls_reachable` needs HTTP mocking; no mocking lib in deps (stdlib `unittest.mock` sufficient) |
+
+### Security Mitigations Required
+
+1. **SSRF protection for `urls_reachable`:**
+   - Block private IP ranges (RFC1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+   - Block loopback (127.0.0.0/8) and link-local (169.254.0.0/16)
+   - Reject `file://` scheme — only allow `http://` and `https://`
+   - Limit redirects (max 3, same-scheme only)
+   - Set socket timeout (5s)
+
+2. **ReDoS protection for `pattern` field:**
+   - Use `re.fullmatch()` with a compilation-time check
+   - Set a reasonable timeout via signal or thread-based guard for pathological patterns
+   - Named `format` patterns in registry are pre-validated (safe by construction)
+
+### Serialization Fix
+
+`schemas.py` `to_dict()` must serialize the new `format` field alongside `pattern`:
+```python
+**({"format": f.format} if f.format else {}),
+```
+
+---
+
+## Refinement Log
+
+### Session 1 — 2026-04-10
+
+**DEC-006: ReDoS mitigation — pragmatic approach**
+Pre-compile patterns at load time; let `re.error` surface invalid regex. No timeout wrapper. Named `format` patterns are safe by construction (pre-validated in registry). Inline `pattern` is the eval author's responsibility. Rationale: eval specs are developer-authored, not untrusted input.
+
+**DEC-007: SSRF mitigation for `urls_reachable`**
+Block private IPs (RFC1918, loopback, link-local, metadata endpoints), reject non-HTTP(S) schemes, 5s timeout, max 3 redirects. This is defensive because skill output *is* LLM-generated and could contain internal URLs via hallucination or prompt injection.
+
+**Resolved concerns:**
+- Security (ReDoS): resolved via DEC-006 — pragmatic, no timeout
+- Security (SSRF): resolved via DEC-007 — denylist + timeout
+- Testing (HTTP mocking): use stdlib `unittest.mock.patch` on `urllib.request.urlopen`
+- Data model (serialization): add `format` to `to_dict()` alongside `pattern`
+
+## Detailed Breakdown
+
+### US-001: Format Registry Module
+
+**Description:** Create `formats.py` with a `FORMAT_REGISTRY` mapping ~15-20 named format patterns. Each entry is a `FormatDef` dataclass with `name`, `pattern` (compiled regex), `description`, and an `extract_pattern` (for Layer 1 scanning, may differ from the strict `pattern` used for fullmatch validation).
+
+**Traces to:** DEC-002, DEC-006
+
+**Built-in formats:**
+- `phone_us` — `\(\d{3}\) \d{3}-\d{4}`
+- `phone_intl` — `\+\d{1,3}[\s-]?\d{4,14}`
+- `email` — `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`
+- `url` — `https?://[^\s\)\"'>]+`
+- `date_iso` — `\d{4}-\d{2}-\d{2}`
+- `date_us` — `\d{1,2}/\d{1,2}/\d{2,4}`
+- `time_24h` — `\d{1,2}:\d{2}(:\d{2})?`
+- `time_12h` — `\d{1,2}:\d{2}\s?[AaPp][Mm]`
+- `currency_usd` — `\$[\d,]+(\.\d{2})?`
+- `currency_eur` — `€[\d.,]+`
+- `zip_us` — `\d{5}(-\d{4})?`
+- `zip_uk` — `[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}`
+- `percentage` — `\d+(\.\d+)?%`
+- `ipv4` — `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`
+- `uuid` — `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`
+- `hex_color` — `#[0-9a-fA-F]{6}`
+- `latitude` — `-?\d{1,2}\.\d+`
+- `longitude` — `-?\d{1,3}\.\d+`
+- `star_rating` — `\d(\.\d)?\s?(stars?|★|⭐)`
+
+Public API: `get_format(name) -> FormatDef | None`, `list_formats() -> list[str]`, `validate_value(value, format_name) -> bool`.
+
+**Acceptance Criteria:**
+- [ ] `FormatDef` dataclass with `name`, `pattern`, `description`, `extract_pattern`
+- [ ] `FORMAT_REGISTRY` dict with ~15-20 entries
+- [ ] `get_format()`, `list_formats()`, `validate_value()` functions
+- [ ] All patterns pre-compiled at import time; invalid patterns raise immediately
+- [ ] `uv run ruff check src/ tests/` passes
+- [ ] `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+
+**Done when:** `from clauditor.formats import get_format; get_format("email")` returns a valid `FormatDef` and `validate_value("test@example.com", "email")` returns `True`.
+
+**Files:**
+- `src/clauditor/formats.py` (new)
+- `tests/test_formats.py` (new)
+
+**Depends on:** none
+
+**TDD:**
+- `test_get_format_valid` — known format returns FormatDef
+- `test_get_format_invalid` — unknown name returns None
+- `test_list_formats` — returns sorted list of all names
+- `test_validate_value_match` — valid values for each format
+- `test_validate_value_no_match` — invalid values rejected
+- `test_all_patterns_compile` — ensure no regex errors at import
+
+---
+
+### US-002: `format` Field on FieldRequirement + Schema Loading
+
+**Description:** Add `format: str | None = None` to `FieldRequirement`. Update `from_file()` to load it from JSON and `to_dict()` to serialize it. Backward compatible — existing eval.json files without `format` continue to work.
+
+**Traces to:** DEC-003
+
+**Acceptance Criteria:**
+- [ ] `FieldRequirement` has `format` field defaulting to `None`
+- [ ] `EvalSpec.from_file()` reads `format` from field dicts
+- [ ] `EvalSpec.to_dict()` serializes `format` when present (conditional, like `pattern`)
+- [ ] Round-trip test: load JSON with `format`, serialize back, verify preserved
+- [ ] Existing tests continue to pass (backward compat)
+- [ ] `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+
+**Done when:** `FieldRequirement(name="phone", format="phone_us")` serializes to `{"name": "phone", "required": true, "format": "phone_us"}` and loads back identically.
+
+**Files:**
+- `src/clauditor/schemas.py` (modify: FieldRequirement, from_file, to_dict)
+- `tests/test_schemas.py` (add format round-trip tests)
+
+**Depends on:** none
+
+---
+
+### US-003: Field Pattern + Format Enforcement in grade_extraction
+
+**Description:** After the existing `has_value` check in `grade_extraction()` (grader.py:109), add validation against `field_req.pattern` (inline regex) and `field_req.format` (registry lookup). Use `re.fullmatch()` for strict matching. If both are set, both must match. Failed matches produce an `AssertionResult` with the extracted value as evidence.
+
+**Traces to:** DEC-003, DEC-005, DEC-006
+
+**Acceptance Criteria:**
+- [ ] When `field_req.pattern` is set and field has a value, `re.fullmatch(pattern, value)` is applied
+- [ ] When `field_req.format` is set, format is resolved via `get_format()` and its pattern applied via `re.fullmatch()`
+- [ ] If both `pattern` and `format` are set, both must match (AND logic)
+- [ ] Failed pattern/format produces `AssertionResult(passed=False)` with value as evidence
+- [ ] Invalid `format` name produces a failing assertion (not a crash)
+- [ ] Invalid `pattern` regex produces a failing assertion with `re.error` message
+- [ ] Assertion names follow convention: `section:{Name}/{tier}[{i}].{field}:pattern` and `:format`
+- [ ] `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+
+**Done when:** A FieldRequirement with `pattern=r"\(\d{3}\) \d{3}-\d{4}"` correctly fails an entry where phone is `"call for hours"` and passes one where phone is `"(408) 298-5437"`.
+
+**Files:**
+- `src/clauditor/grader.py` (modify: grade_extraction)
+- `tests/test_grader.py` (add pattern/format enforcement tests)
+
+**Depends on:** US-001 (format registry), US-002 (format field on FieldRequirement)
+
+**TDD:**
+- `test_grade_extraction_pattern_match` — value matches inline pattern → pass
+- `test_grade_extraction_pattern_mismatch` — value doesn't match → fail with evidence
+- `test_grade_extraction_format_match` — value matches named format → pass
+- `test_grade_extraction_format_mismatch` — value doesn't match → fail
+- `test_grade_extraction_format_and_pattern` — both set, both must pass
+- `test_grade_extraction_unknown_format` — unknown name → fail assertion
+- `test_grade_extraction_invalid_pattern` — bad regex → fail assertion
+- `test_grade_extraction_pattern_on_optional_missing` — optional field missing, pattern set → skip (no fail)
+
+---
+
+### US-004: `has_format` Layer 1 Assertion
+
+**Description:** Add a generalized `has_format` assertion type to Layer 1. Spec format: `{"type": "has_format", "format": "email", "value": "3"}`. Looks up the format's `extract_pattern` in the registry, runs `re.findall()` against the full output, counts matches. Fails if fewer than the threshold.
+
+**Traces to:** DEC-004
+
+**Acceptance Criteria:**
+- [ ] New `assert_has_format(output, format_name, minimum)` function in assertions.py
+- [ ] Dispatched from `run_assertions()` for type `"has_format"`
+- [ ] Uses `extract_pattern` from format registry (not `pattern`, which is for fullmatch)
+- [ ] Unknown format name returns a failing assertion (not a crash)
+- [ ] Assertion name: `has_format:{format_name}≥{minimum}`
+- [ ] Evidence: first 5 matches joined by "; "
+- [ ] `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+
+**Done when:** `{"type": "has_format", "format": "email", "value": "2"}` against output containing 3 email addresses passes with count 3.
+
+**Files:**
+- `src/clauditor/assertions.py` (modify: add function + dispatch case)
+- `tests/test_assertions.py` (add TestHasFormat class)
+
+**Depends on:** US-001 (format registry)
+
+**TDD:**
+- `test_has_format_found` — output has enough matches → pass
+- `test_has_format_insufficient` — output has fewer than threshold → fail
+- `test_has_format_unknown` — unknown format name → fail
+- `test_has_format_evidence` — evidence contains first 5 matches
+- `test_has_format_via_run_assertions` — end-to-end through dispatcher
+
+---
+
+### US-005: `urls_reachable` Layer 1 Assertion
+
+**Description:** Add `urls_reachable` assertion to Layer 1. Extracts URLs from output (reusing `has_urls` regex), sends HTTP HEAD requests with SSRF protections, counts 2xx responses. Uses `urllib.request` by default, `httpx` if installed. Spec: `{"type": "urls_reachable", "value": "3"}`.
+
+**Traces to:** DEC-001, DEC-007
+
+**Acceptance Criteria:**
+- [ ] New `assert_urls_reachable(output, minimum)` function in assertions.py
+- [ ] Dispatched from `run_assertions()` for type `"urls_reachable"`
+- [ ] SSRF protections: block private IPs (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16), metadata (169.254.169.254)
+- [ ] Only `http://` and `https://` schemes allowed
+- [ ] 5-second timeout per request
+- [ ] Max 3 redirects
+- [ ] Uses `httpx.head()` if httpx installed, else `urllib.request.urlopen` with HEAD method
+- [ ] Evidence: per-URL status ("url: 200", "url: timeout", "url: blocked")
+- [ ] Assertion name: `urls_reachable≥{minimum}`
+- [ ] `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+
+**Done when:** Output with 3 real URLs and 1 fake URL, threshold 3 → passes if 3 return 2xx. Blocked IPs (127.0.0.1, 169.254.169.254) never receive requests.
+
+**Files:**
+- `src/clauditor/assertions.py` (modify: add function + dispatch case + SSRF helper)
+- `tests/test_assertions.py` (add TestUrlsReachable class with mocked HTTP)
+
+**Depends on:** none
+
+**TDD:**
+- `test_urls_reachable_all_ok` — mock all URLs returning 200 → pass
+- `test_urls_reachable_below_threshold` — some 404 → fail
+- `test_urls_reachable_ssrf_blocked` — private IP URL → blocked, not requested
+- `test_urls_reachable_timeout` — mock timeout → counted as unreachable
+- `test_urls_reachable_no_urls` — output has no URLs, threshold 1 → fail
+- `test_urls_reachable_httpx_fallback` — test urllib path when httpx not available
+- `test_urls_reachable_via_run_assertions` — end-to-end through dispatcher
+
+---
+
+### US-006: Quality Gate
+
+**Description:** Run code reviewer across the full changeset. Run linter and full test suite. Fix all real bugs found.
+
+**Traces to:** all decisions
+
+**Acceptance Criteria:**
+- [ ] `uv run ruff check src/ tests/` passes with zero warnings
+- [ ] `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥80% coverage
+- [ ] All new public functions have consistent naming and signatures
+- [ ] No security issues in final code (SSRF protections verified)
+- [ ] No dead code or unused imports
+
+**Done when:** All quality checks pass, no regressions.
+
+**Files:** Any files touched by US-001 through US-005
+
+**Depends on:** US-001, US-002, US-003, US-004, US-005
+
+---
+
+### US-007: Patterns & Memory
+
+**Description:** Update project documentation and conventions with new patterns learned. Record any reusable insights from this implementation.
+
+**Traces to:** all decisions
+
+**Acceptance Criteria:**
+- [ ] Any new conventions documented
+- [ ] Memory updated with relevant insights
+
+**Done when:** Documentation reflects the new validation capabilities.
+
+**Files:** docs/, CLAUDE.md, or memory as appropriate
+
+**Depends on:** US-006
+
+## Beads Manifest
+
+*Pending.*

--- a/plans/super/13-field-validation.md
+++ b/plans/super/13-field-validation.md
@@ -3,7 +3,7 @@
 ## Meta
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/13
 - **Branch:** `feature/13-field-validation`
-- **Phase:** `detailing`
+- **Phase:** `devolved`
 - **Sessions:** 1
 - **Last session:** 2026-04-10
 
@@ -393,4 +393,16 @@ Public API: `get_format(name) -> FormatDef | None`, `list_formats() -> list[str]
 
 ## Beads Manifest
 
-*Pending.*
+- **Epic:** `clauditor-6eh` — #13: Field-Level Validation Assertions
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/13-field-validation`
+- **Branch:** `feature/13-field-validation`
+
+| Bead ID | Story | Depends on |
+|---------|-------|------------|
+| `clauditor-6eh.1` | US-001 — Format Registry Module | none |
+| `clauditor-6eh.2` | US-002 — format Field on FieldRequirement | none |
+| `clauditor-6eh.3` | US-005 — urls_reachable Layer 1 Assertion | none |
+| `clauditor-6eh.4` | US-003 — Field Pattern + Format Enforcement | 6eh.1, 6eh.2 |
+| `clauditor-6eh.5` | US-004 — has_format Layer 1 Assertion | 6eh.1 |
+| `clauditor-6eh.6` | US-006 — Quality Gate | 6eh.1–6eh.5 |
+| `clauditor-6eh.7` | US-007 — Patterns & Memory | 6eh.6 |

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -142,12 +142,12 @@ def assert_has_entries(output: str, minimum: int = 1) -> AssertionResult:
 
 
 def _is_private_ip(hostname: str) -> bool:
-    """Check if a hostname resolves to a private/reserved IP address."""
+    """Check if a hostname resolves to a non-global IP address."""
     try:
         infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
         for info in infos:
             addr = ipaddress.ip_address(info[4][0])
-            if addr.is_private or addr.is_loopback or addr.is_link_local:
+            if not addr.is_global:
                 return True
     except (socket.gaierror, ValueError):
         return True  # Can't resolve = treat as unsafe
@@ -165,50 +165,73 @@ def _is_safe_url(url: str) -> bool:
     return not _is_private_ip(hostname)
 
 
-class _HeadRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Redirect handler that preserves HEAD method across redirects."""
-
-    def redirect_request(
-        self, req, fp, code, msg, headers, newurl,
-    ):
-        new_req = super().redirect_request(
-            req, fp, code, msg, headers, newurl,
-        )
-        if new_req is not None:
-            new_req.method = req.method
-        return new_req
+_MAX_REDIRECTS = 5
 
 
 def _check_url(url: str, timeout: int = 5) -> tuple[str, int | str]:
-    """Send HEAD request, return (url, status_code_or_error_string)."""
+    """Send HEAD request with SSRF-safe redirect following."""
     try:
         import httpx
     except ImportError:
         httpx = None  # type: ignore[assignment]
 
     if httpx is not None:
+        current = url
         try:
-            resp = httpx.head(
-                url, timeout=timeout, follow_redirects=True
-            )
-            return (url, resp.status_code)
+            for _ in range(_MAX_REDIRECTS + 1):
+                resp = httpx.head(
+                    current, timeout=timeout, follow_redirects=False
+                )
+                if 300 <= resp.status_code < 400:
+                    location = resp.headers.get("location")
+                    if not location:
+                        return (url, resp.status_code)
+                    next_url = urllib.parse.urljoin(current, location)
+                    if not _is_safe_url(next_url):
+                        return (url, "blocked")
+                    current = next_url
+                    continue
+                return (url, resp.status_code)
+            return (url, "TooManyRedirects")
         except Exception as e:
             return (url, type(e).__name__)
 
+    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, hdrs, newurl):
+            return None
+
+    opener = urllib.request.build_opener(_NoRedirect)
+    current = url
     try:
-        req = urllib.request.Request(url, method="HEAD")
-        opener = urllib.request.build_opener(_HeadRedirectHandler)
-        with opener.open(req, timeout=timeout) as resp:
-            return (url, resp.status)
-    except urllib.error.HTTPError as e:
-        return (url, e.code)
+        for _ in range(_MAX_REDIRECTS + 1):
+            req = urllib.request.Request(current, method="HEAD")
+            try:
+                with opener.open(req, timeout=timeout) as resp:
+                    return (url, resp.status)
+            except urllib.error.HTTPError as e:
+                if 300 <= e.code < 400:
+                    location = e.headers.get("Location")
+                    if not location:
+                        return (url, e.code)
+                    next_url = urllib.parse.urljoin(
+                        current, location
+                    )
+                    if not _is_safe_url(next_url):
+                        return (url, "blocked")
+                    current = next_url
+                    continue
+                return (url, e.code)
+        return (url, "TooManyRedirects")
     except Exception as e:
         return (url, type(e).__name__)
 
 
+_MAX_URL_CHECKS = 20
+
+
 def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
     """Check that at least N URLs in the output are reachable (HTTP 2xx)."""
-    urls = re.findall(r"https?://[^\s\)\"'>]+", output)
+    urls = list(dict.fromkeys(re.findall(r"https?://[^\s\)\"'>]+", output)))
     if not urls:
         return AssertionResult(
             name=f"urls_reachable≥{minimum}",
@@ -218,7 +241,8 @@ def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
 
     statuses: list[str] = []
     reachable = 0
-    for url in urls:
+    check_urls = urls[:_MAX_URL_CHECKS]
+    for url in check_urls:
         if not _is_safe_url(url):
             statuses.append(f"{url}: blocked")
             continue

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -5,7 +5,11 @@ No API calls, no LLM — just regex, string matching, and counting.
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass, field
 
 
@@ -136,6 +140,107 @@ def assert_has_entries(output: str, minimum: int = 1) -> AssertionResult:
     )
 
 
+def _is_private_ip(hostname: str) -> bool:
+    """Check if a hostname resolves to a private/reserved IP address."""
+    try:
+        infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
+        for info in infos:
+            addr = ipaddress.ip_address(info[4][0])
+            if addr.is_private or addr.is_loopback or addr.is_link_local:
+                return True
+    except (socket.gaierror, ValueError):
+        return True  # Can't resolve = treat as unsafe
+    return False
+
+
+def _is_safe_url(url: str) -> bool:
+    """Check if a URL is safe to request (no SSRF risk)."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    return not _is_private_ip(hostname)
+
+
+def _check_url(url: str, timeout: int = 5) -> tuple[str, int | str]:
+    """Send HEAD request, return (url, status_code_or_error_string)."""
+    try:
+        import httpx
+
+        resp = httpx.head(url, timeout=timeout, follow_redirects=True)
+        return (url, resp.status_code)
+    except ImportError:
+        pass
+    except Exception:
+        pass  # Fall through to urllib
+
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return (url, resp.status)
+    except urllib.error.HTTPError as e:
+        return (url, e.code)
+    except Exception as e:
+        return (url, type(e).__name__)
+
+
+def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
+    """Check that at least N URLs in the output are reachable (HTTP 2xx)."""
+    urls = re.findall(r"https?://[^\s\)\"'>]+", output)
+    if not urls:
+        return AssertionResult(
+            name=f"urls_reachable≥{minimum}",
+            passed=0 >= minimum,
+            message=f"Found 0 URLs to check (need ≥{minimum})",
+        )
+
+    statuses: list[str] = []
+    reachable = 0
+    for url in urls:
+        if not _is_safe_url(url):
+            statuses.append(f"{url}: blocked")
+            continue
+        url, status = _check_url(url)
+        if isinstance(status, int) and 200 <= status < 300:
+            reachable += 1
+            statuses.append(f"{url}: {status}")
+        else:
+            statuses.append(f"{url}: {status}")
+
+    return AssertionResult(
+        name=f"urls_reachable≥{minimum}",
+        passed=reachable >= minimum,
+        message=f"{reachable}/{len(urls)} URLs reachable (need ≥{minimum})",
+        evidence="; ".join(statuses[:5]),
+    )
+
+
+def assert_has_format(
+    output: str, format_name: str, minimum: int = 1,
+) -> AssertionResult:
+    """Check that output contains at least N matches of a named format."""
+    from clauditor.formats import get_format
+
+    fmt = get_format(format_name)
+    if fmt is None:
+        return AssertionResult(
+            name=f"has_format:{format_name}",
+            passed=False,
+            message=f"Unknown format: {format_name}",
+        )
+
+    matches = fmt.extract_pattern.findall(output)
+    count = len(matches)
+    return AssertionResult(
+        name=f"has_format:{format_name}≥{minimum}",
+        passed=count >= minimum,
+        message=f"Found {count} {format_name} matches (need ≥{minimum})",
+        evidence="; ".join(str(m) for m in matches[:5]) if matches else None,
+    )
+
+
 def run_assertions(output: str, assertions: list[dict]) -> AssertionSet:
     """Run a list of assertion dicts against output.
 
@@ -165,6 +270,16 @@ def run_assertions(output: str, assertions: list[dict]) -> AssertionSet:
         elif atype == "has_entries":
             results.results.append(
                 assert_has_entries(output, int(value) if value else 1)
+            )
+        elif atype == "urls_reachable":
+            results.results.append(
+                assert_urls_reachable(output, int(value) if value else 1)
+            )
+        elif atype == "has_format":
+            results.results.append(
+                assert_has_format(
+                    output, a.get("format", ""), int(value) if value else 1
+                )
             )
         else:
             results.results.append(

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -165,6 +165,20 @@ def _is_safe_url(url: str) -> bool:
     return not _is_private_ip(hostname)
 
 
+class _HeadRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that preserves HEAD method across redirects."""
+
+    def redirect_request(
+        self, req, fp, code, msg, headers, newurl,
+    ):
+        new_req = super().redirect_request(
+            req, fp, code, msg, headers, newurl,
+        )
+        if new_req is not None:
+            new_req.method = req.method
+        return new_req
+
+
 def _check_url(url: str, timeout: int = 5) -> tuple[str, int | str]:
     """Send HEAD request, return (url, status_code_or_error_string)."""
     try:
@@ -183,7 +197,8 @@ def _check_url(url: str, timeout: int = 5) -> tuple[str, int | str]:
 
     try:
         req = urllib.request.Request(url, method="HEAD")
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        opener = urllib.request.build_opener(_HeadRedirectHandler)
+        with opener.open(req, timeout=timeout) as resp:
             return (url, resp.status)
     except urllib.error.HTTPError as e:
         return (url, e.code)

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import ipaddress
 import re
 import socket
+import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
@@ -168,13 +169,17 @@ def _check_url(url: str, timeout: int = 5) -> tuple[str, int | str]:
     """Send HEAD request, return (url, status_code_or_error_string)."""
     try:
         import httpx
-
-        resp = httpx.head(url, timeout=timeout, follow_redirects=True)
-        return (url, resp.status_code)
     except ImportError:
-        pass
-    except Exception:
-        pass  # Fall through to urllib
+        httpx = None  # type: ignore[assignment]
+
+    if httpx is not None:
+        try:
+            resp = httpx.head(
+                url, timeout=timeout, follow_redirects=True
+            )
+            return (url, resp.status_code)
+        except Exception as e:
+            return (url, type(e).__name__)
 
     try:
         req = urllib.request.Request(url, method="HEAD")

--- a/src/clauditor/formats.py
+++ b/src/clauditor/formats.py
@@ -1,0 +1,158 @@
+"""Named format patterns for field-level validation.
+
+Provides a registry of common data formats (email, phone, URL, etc.)
+with pre-compiled regex patterns for both fullmatch validation and
+findall extraction.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FormatDef:
+    """A named format with compiled patterns for validation and extraction."""
+
+    name: str
+    pattern: re.Pattern[str]  # For re.fullmatch (strict, anchored)
+    description: str
+    extract_pattern: re.Pattern[str]  # For re.findall (scanning)
+
+
+def _def(
+    name: str,
+    pattern: str,
+    description: str,
+    extract: str | None = None,
+) -> FormatDef:
+    """Build a FormatDef, compiling both patterns at module load time."""
+    return FormatDef(
+        name=name,
+        pattern=re.compile(pattern),
+        description=description,
+        extract_pattern=re.compile(extract or pattern),
+    )
+
+
+FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
+    _def(
+        "phone_us",
+        r"\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}",
+        "US phone number, e.g. (408) 298-5437",
+    ),
+    _def(
+        "phone_intl",
+        r"\+\d{1,3}[\s.-]?\d{4,14}",
+        "International phone number, e.g. +44 7911123456",
+    ),
+    _def(
+        "email",
+        r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+        "Email address, e.g. user@example.com",
+    ),
+    _def(
+        "url",
+        r"https?://[^\s\)\"'>]+",
+        "HTTP(S) URL",
+    ),
+    _def(
+        "date_iso",
+        r"\d{4}-\d{2}-\d{2}",
+        "ISO 8601 date, e.g. 2026-04-10",
+    ),
+    _def(
+        "date_us",
+        r"\d{1,2}/\d{1,2}/\d{2,4}",
+        "US date format, e.g. 4/10/2026 or 04/10/26",
+    ),
+    _def(
+        "time_24h",
+        r"\d{1,2}:\d{2}(?::\d{2})?",
+        "24-hour time, e.g. 14:30 or 14:30:00",
+    ),
+    _def(
+        "time_12h",
+        r"\d{1,2}:\d{2}\s?[AaPp][Mm]",
+        "12-hour time, e.g. 2:30 PM or 2:30pm",
+    ),
+    _def(
+        "currency_usd",
+        r"\$[\d,]+(?:\.\d{2})?",
+        "US dollar amount, e.g. $1,234.56 or $50",
+    ),
+    _def(
+        "currency_eur",
+        r"€[\d.,]+",
+        "Euro amount, e.g. €1.234,56",
+    ),
+    _def(
+        "zip_us",
+        r"\d{5}(?:-\d{4})?",
+        "US ZIP code, e.g. 95110 or 95110-1234",
+    ),
+    _def(
+        "zip_uk",
+        r"[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}",
+        "UK postcode, e.g. SW1A 1AA",
+        extract=r"[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}",
+    ),
+    _def(
+        "percentage",
+        r"\d+(?:\.\d+)?%",
+        "Percentage, e.g. 95% or 99.9%",
+    ),
+    _def(
+        "ipv4",
+        r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+        "IPv4 address, e.g. 192.168.1.1",
+    ),
+    _def(
+        "uuid",
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        "UUID, e.g. 550e8400-e29b-41d4-a716-446655440000",
+        extract=r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+    ),
+    _def(
+        "hex_color",
+        r"#[0-9a-fA-F]{6}",
+        "Hex color code, e.g. #FF5733",
+    ),
+    _def(
+        "latitude",
+        r"-?\d{1,2}\.\d+",
+        "Latitude coordinate, e.g. 37.3382",
+    ),
+    _def(
+        "longitude",
+        r"-?\d{1,3}\.\d+",
+        "Longitude coordinate, e.g. -121.8863",
+    ),
+    _def(
+        "star_rating",
+        r"\d(?:\.\d)?\s?(?:stars?|★|⭐)",
+        "Star rating, e.g. 4.5 stars or 3 ★",
+    ),
+]}
+
+
+def get_format(name: str) -> FormatDef | None:
+    """Look up a format by name. Returns None if not found."""
+    return FORMAT_REGISTRY.get(name)
+
+
+def list_formats() -> list[str]:
+    """Return sorted list of all registered format names."""
+    return sorted(FORMAT_REGISTRY)
+
+
+def validate_value(value: str, format_name: str) -> bool:
+    """Validate a value against a named format using fullmatch.
+
+    Returns False if the format name is unknown.
+    """
+    fmt = FORMAT_REGISTRY.get(format_name)
+    if fmt is None:
+        return False
+    return fmt.pattern.fullmatch(value) is not None

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -7,9 +7,11 @@ then validates the extracted data against the eval spec's schema.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 
 from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.formats import get_format
 from clauditor.schemas import EvalSpec
 
 
@@ -122,6 +124,72 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                             evidence=entry.fields.get(field_req.name),
                         )
                     )
+
+                # Validate pattern/format on fields that have values
+                for field_req in tier.fields:
+                    value = entry.fields.get(field_req.name)
+                    if not value:
+                        continue
+
+                    base = (
+                        f"section:{section_req.name}"
+                        f"/{tier.label}[{i}].{field_req.name}"
+                    )
+
+                    if field_req.pattern:
+                        try:
+                            pat_match = re.fullmatch(field_req.pattern, value)
+                            results.results.append(
+                                AssertionResult(
+                                    name=f"{base}:pattern",
+                                    passed=pat_match is not None,
+                                    message=(
+                                        "Pattern matched"
+                                        if pat_match
+                                        else f"Value does not match "
+                                        f"pattern /{field_req.pattern}/"
+                                    ),
+                                    evidence=value,
+                                )
+                            )
+                        except re.error as e:
+                            results.results.append(
+                                AssertionResult(
+                                    name=f"{base}:pattern",
+                                    passed=False,
+                                    message=f"Invalid pattern: {e}",
+                                    evidence=field_req.pattern,
+                                )
+                            )
+
+                    if field_req.format:
+                        fmt = get_format(field_req.format)
+                        if fmt is None:
+                            results.results.append(
+                                AssertionResult(
+                                    name=f"{base}:format",
+                                    passed=False,
+                                    message=(
+                                        f"Unknown format: "
+                                        f"{field_req.format}"
+                                    ),
+                                )
+                            )
+                        else:
+                            fmt_match = fmt.pattern.fullmatch(value)
+                            results.results.append(
+                                AssertionResult(
+                                    name=f"{base}:format",
+                                    passed=fmt_match is not None,
+                                    message=(
+                                        f"Format '{field_req.format}' matched"
+                                        if fmt_match
+                                        else f"Value does not match "
+                                        f"format '{field_req.format}'"
+                                    ),
+                                    evidence=value,
+                                )
+                            )
 
     return results
 

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -127,9 +127,10 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
 
                 # Validate pattern/format on fields that have values
                 for field_req in tier.fields:
-                    value = entry.fields.get(field_req.name)
-                    if not value:
+                    raw_value = entry.fields.get(field_req.name)
+                    if not raw_value:
                         continue
+                    value = str(raw_value)
 
                     base = (
                         f"section:{section_req.name}"

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -17,6 +17,7 @@ class FieldRequirement:
     name: str
     required: bool = True
     pattern: str | None = None  # Optional regex the field value must match
+    format: str | None = None  # Named format from formats registry
 
 
 @dataclass
@@ -99,6 +100,7 @@ class EvalSpec:
                             name=f["name"],
                             required=f.get("required", True),
                             pattern=f.get("pattern"),
+                            format=f.get("format"),
                         )
                         for f in t.get("fields", [])
                     ]
@@ -117,6 +119,7 @@ class EvalSpec:
                         name=f["name"],
                         required=f.get("required", True),
                         pattern=f.get("pattern"),
+                        format=f.get("format"),
                     )
                     for f in s.get("fields", [])
                 ]
@@ -199,6 +202,11 @@ class EvalSpec:
                                     **(
                                         {"pattern": f.pattern}
                                         if f.pattern
+                                        else {}
+                                    ),
+                                    **(
+                                        {"format": f.format}
+                                        if f.format
                                         else {}
                                     ),
                                 }

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -6,7 +6,7 @@ import clauditor.assertions as _assertions_mod
 
 importlib.reload(_assertions_mod)
 
-from unittest.mock import MagicMock, patch  # noqa: E402
+from unittest.mock import patch  # noqa: E402
 
 from clauditor.assertions import (  # noqa: E402
     AssertionResult,
@@ -295,21 +295,16 @@ class TestRunAssertionsEdgeCases:
 
     def test_urls_reachable_via_run(self):
         with patch(
-            "clauditor.assertions.urllib.request.urlopen"
-        ) as mock_urlopen:
-            mock_resp = MagicMock()
-            mock_resp.status = 200
-            mock_resp.__enter__ = lambda s: s
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            mock_urlopen.return_value = mock_resp
-            with patch(
-                "clauditor.assertions._is_safe_url", return_value=True
-            ):
-                result = run_assertions(
-                    "visit https://example.com",
-                    [{"type": "urls_reachable", "value": "1"}],
-                )
-                assert result.passed
+            "clauditor.assertions._is_safe_url", return_value=True
+        ), patch(
+            "clauditor.assertions._check_url",
+            return_value=("https://example.com", 200),
+        ):
+            result = run_assertions(
+                "visit https://example.com",
+                [{"type": "urls_reachable", "value": "1"}],
+            )
+            assert result.passed
 
     def test_has_format_via_run(self):
         result = run_assertions(

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -385,7 +385,7 @@ class TestSsrfProtection:
 
 
 class TestCheckUrl:
-    """Tests for _check_url covering httpx and urllib paths."""
+    """Tests for _check_url with SSRF-safe redirect following."""
 
     def test_urllib_success(self):
         mock_resp = MagicMock()
@@ -399,7 +399,7 @@ class TestCheckUrl:
             url, status = _check_url("https://example.com")
             assert status == 200
 
-    def test_urllib_http_error(self):
+    def test_urllib_http_error_404(self):
         import urllib.error
 
         with patch.dict("sys.modules", {"httpx": None}), patch(
@@ -413,6 +413,40 @@ class TestCheckUrl:
             )
             url, status = _check_url("https://example.com")
             assert status == 404
+
+    def test_urllib_redirect_to_private_blocked(self):
+        import urllib.error
+
+        headers = MagicMock()
+        headers.get.return_value = "http://127.0.0.1/evil"
+        with patch.dict("sys.modules", {"httpx": None}), patch(
+            "clauditor.assertions.urllib.request.build_opener"
+        ) as mock_opener:
+            mock_opener.return_value.open.side_effect = (
+                urllib.error.HTTPError(
+                    "https://example.com", 302, "Found",
+                    headers, None,
+                )
+            )
+            url, status = _check_url("https://example.com")
+            assert status == "blocked"
+
+    def test_urllib_redirect_no_location(self):
+        import urllib.error
+
+        headers = MagicMock()
+        headers.get.return_value = None
+        with patch.dict("sys.modules", {"httpx": None}), patch(
+            "clauditor.assertions.urllib.request.build_opener"
+        ) as mock_opener:
+            mock_opener.return_value.open.side_effect = (
+                urllib.error.HTTPError(
+                    "https://example.com", 301, "Moved",
+                    headers, None,
+                )
+            )
+            url, status = _check_url("https://example.com")
+            assert status == 301
 
     def test_urllib_generic_exception(self):
         with patch.dict("sys.modules", {"httpx": None}), patch(
@@ -435,6 +469,47 @@ class TestCheckUrl:
             url, status = _check_url("https://example.com")
             assert status == 200
 
+    def test_httpx_redirect_to_private_blocked(self):
+        mock_httpx = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"location": "http://127.0.0.1/evil"}
+        mock_httpx.head.return_value = mock_resp
+        with patch.dict(
+            "sys.modules", {"httpx": mock_httpx}
+        ):
+            url, status = _check_url("https://example.com")
+            assert status == "blocked"
+
+    def test_httpx_redirect_no_location(self):
+        mock_httpx = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 301
+        mock_resp.headers = {}
+        mock_httpx.head.return_value = mock_resp
+        with patch.dict(
+            "sys.modules", {"httpx": mock_httpx}
+        ):
+            url, status = _check_url("https://example.com")
+            assert status == 301
+
+    def test_httpx_too_many_redirects(self):
+        mock_httpx = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {
+            "location": "https://example.com/loop"
+        }
+        mock_httpx.head.return_value = mock_resp
+        with patch.dict(
+            "sys.modules", {"httpx": mock_httpx}
+        ), patch(
+            "clauditor.assertions._is_safe_url",
+            return_value=True,
+        ):
+            url, status = _check_url("https://example.com")
+            assert status == "TooManyRedirects"
+
     def test_httpx_exception(self):
         mock_httpx = MagicMock()
         mock_httpx.head.side_effect = ConnectionError("fail")
@@ -443,6 +518,26 @@ class TestCheckUrl:
         ):
             url, status = _check_url("https://example.com")
             assert status == "ConnectionError"
+
+    def test_urllib_too_many_redirects(self):
+        import urllib.error
+
+        headers = MagicMock()
+        headers.get.return_value = "https://example.com/loop"
+        with patch.dict("sys.modules", {"httpx": None}), patch(
+            "clauditor.assertions.urllib.request.build_opener"
+        ) as mock_opener, patch(
+            "clauditor.assertions._is_safe_url",
+            return_value=True,
+        ):
+            mock_opener.return_value.open.side_effect = (
+                urllib.error.HTTPError(
+                    "https://example.com", 302, "Found",
+                    headers, None,
+                )
+            )
+            url, status = _check_url("https://example.com")
+            assert status == "TooManyRedirects"
 
 
 class TestUrlsReachable:

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -6,11 +6,12 @@ import clauditor.assertions as _assertions_mod
 
 importlib.reload(_assertions_mod)
 
-from unittest.mock import patch  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
 from clauditor.assertions import (  # noqa: E402
     AssertionResult,
     AssertionSet,
+    _check_url,
     _is_private_ip,
     _is_safe_url,
     assert_contains,
@@ -381,6 +382,67 @@ class TestSsrfProtection:
             return_value=True,
         ):
             assert not _is_safe_url("http://10.0.0.1/admin")
+
+
+class TestCheckUrl:
+    """Tests for _check_url covering httpx and urllib paths."""
+
+    def test_urllib_success(self):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch.dict("sys.modules", {"httpx": None}), patch(
+            "clauditor.assertions.urllib.request.build_opener"
+        ) as mock_opener:
+            mock_opener.return_value.open.return_value = mock_resp
+            url, status = _check_url("https://example.com")
+            assert status == 200
+
+    def test_urllib_http_error(self):
+        import urllib.error
+
+        with patch.dict("sys.modules", {"httpx": None}), patch(
+            "clauditor.assertions.urllib.request.build_opener"
+        ) as mock_opener:
+            mock_opener.return_value.open.side_effect = (
+                urllib.error.HTTPError(
+                    "https://example.com", 404, "Not Found",
+                    {}, None,
+                )
+            )
+            url, status = _check_url("https://example.com")
+            assert status == 404
+
+    def test_urllib_generic_exception(self):
+        with patch.dict("sys.modules", {"httpx": None}), patch(
+            "clauditor.assertions.urllib.request.build_opener"
+        ) as mock_opener:
+            mock_opener.return_value.open.side_effect = (
+                TimeoutError("timed out")
+            )
+            url, status = _check_url("https://example.com")
+            assert status == "TimeoutError"
+
+    def test_httpx_success(self):
+        mock_httpx = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_httpx.head.return_value = mock_resp
+        with patch.dict(
+            "sys.modules", {"httpx": mock_httpx}
+        ):
+            url, status = _check_url("https://example.com")
+            assert status == 200
+
+    def test_httpx_exception(self):
+        mock_httpx = MagicMock()
+        mock_httpx.head.side_effect = ConnectionError("fail")
+        with patch.dict(
+            "sys.modules", {"httpx": mock_httpx}
+        ):
+            url, status = _check_url("https://example.com")
+            assert status == "ConnectionError"
 
 
 class TestUrlsReachable:

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -6,17 +6,23 @@ import clauditor.assertions as _assertions_mod
 
 importlib.reload(_assertions_mod)
 
+from unittest.mock import MagicMock, patch  # noqa: E402
+
 from clauditor.assertions import (  # noqa: E402
     AssertionResult,
     AssertionSet,
+    _is_private_ip,
+    _is_safe_url,
     assert_contains,
     assert_has_entries,
+    assert_has_format,
     assert_has_urls,
     assert_max_length,
     assert_min_count,
     assert_min_length,
     assert_not_contains,
     assert_regex,
+    assert_urls_reachable,
     run_assertions,
 )
 
@@ -285,4 +291,215 @@ class TestRunAssertionsEdgeCases:
             "**1. Item** **2. Item**",
             [{"type": "has_entries", "value": "2"}],
         )
+        assert result.passed
+
+    def test_urls_reachable_via_run(self):
+        with patch(
+            "clauditor.assertions.urllib.request.urlopen"
+        ) as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+            with patch(
+                "clauditor.assertions._is_safe_url", return_value=True
+            ):
+                result = run_assertions(
+                    "visit https://example.com",
+                    [{"type": "urls_reachable", "value": "1"}],
+                )
+                assert result.passed
+
+    def test_has_format_via_run(self):
+        result = run_assertions(
+            "contact user@example.com or admin@test.org",
+            [{"type": "has_format", "format": "email", "value": "2"}],
+        )
+        assert result.passed
+
+
+class TestSsrfProtection:
+    """Tests for SSRF protection helpers."""
+
+    def test_private_ip_loopback(self):
+        with patch(
+            "clauditor.assertions.socket.getaddrinfo"
+        ) as mock_dns:
+            mock_dns.return_value = [
+                (2, 1, 6, "", ("127.0.0.1", 0))
+            ]
+            assert _is_private_ip("localhost")
+
+    def test_private_ip_rfc1918(self):
+        with patch(
+            "clauditor.assertions.socket.getaddrinfo"
+        ) as mock_dns:
+            mock_dns.return_value = [
+                (2, 1, 6, "", ("10.0.0.1", 0))
+            ]
+            assert _is_private_ip("internal.corp")
+
+    def test_private_ip_link_local(self):
+        with patch(
+            "clauditor.assertions.socket.getaddrinfo"
+        ) as mock_dns:
+            mock_dns.return_value = [
+                (2, 1, 6, "", ("169.254.169.254", 0))
+            ]
+            assert _is_private_ip("metadata.cloud")
+
+    def test_public_ip(self):
+        with patch(
+            "clauditor.assertions.socket.getaddrinfo"
+        ) as mock_dns:
+            mock_dns.return_value = [
+                (2, 1, 6, "", ("93.184.216.34", 0))
+            ]
+            assert not _is_private_ip("example.com")
+
+    def test_dns_failure_treated_as_unsafe(self):
+        import socket as _socket
+
+        with patch(
+            "clauditor.assertions.socket.getaddrinfo",
+            side_effect=_socket.gaierror("DNS failed"),
+        ):
+            assert _is_private_ip("nonexistent.invalid")
+
+    def test_safe_url_http(self):
+        with patch(
+            "clauditor.assertions._is_private_ip",
+            return_value=False,
+        ):
+            assert _is_safe_url("https://example.com/path")
+
+    def test_unsafe_url_file_scheme(self):
+        assert not _is_safe_url("file:///etc/passwd")
+
+    def test_unsafe_url_no_host(self):
+        assert not _is_safe_url("http://")
+
+    def test_unsafe_url_private_ip(self):
+        with patch(
+            "clauditor.assertions._is_private_ip",
+            return_value=True,
+        ):
+            assert not _is_safe_url("http://10.0.0.1/admin")
+
+
+class TestUrlsReachable:
+    """Tests for urls_reachable assertion with mocked HTTP."""
+
+    def test_all_ok(self):
+        output = (
+            "Visit https://a.com and https://b.com"
+        )
+        with patch(
+            "clauditor.assertions._is_safe_url", return_value=True
+        ), patch(
+            "clauditor.assertions._check_url",
+            side_effect=[
+                ("https://a.com", 200),
+                ("https://b.com", 200),
+            ],
+        ):
+            result = assert_urls_reachable(output, minimum=2)
+            assert result.passed
+            assert "2/2" in result.message
+
+    def test_below_threshold(self):
+        output = "Visit https://a.com and https://b.com"
+        with patch(
+            "clauditor.assertions._is_safe_url", return_value=True
+        ), patch(
+            "clauditor.assertions._check_url",
+            side_effect=[
+                ("https://a.com", 200),
+                ("https://b.com", 404),
+            ],
+        ):
+            result = assert_urls_reachable(output, minimum=2)
+            assert not result.passed
+            assert "1/2" in result.message
+
+    def test_ssrf_blocked(self):
+        output = "Visit http://127.0.0.1/admin"
+        with patch(
+            "clauditor.assertions._is_safe_url", return_value=False
+        ):
+            result = assert_urls_reachable(output, minimum=1)
+            assert not result.passed
+            assert "blocked" in result.evidence
+
+    def test_timeout(self):
+        output = "Visit https://slow.example.com"
+        with patch(
+            "clauditor.assertions._is_safe_url", return_value=True
+        ), patch(
+            "clauditor.assertions._check_url",
+            return_value=(
+                "https://slow.example.com", "TimeoutError"
+            ),
+        ):
+            result = assert_urls_reachable(output, minimum=1)
+            assert not result.passed
+
+    def test_no_urls(self):
+        result = assert_urls_reachable(
+            "no urls here", minimum=1
+        )
+        assert not result.passed
+        assert "0 URLs" in result.message
+
+    def test_no_urls_zero_threshold(self):
+        result = assert_urls_reachable(
+            "no urls here", minimum=0
+        )
+        assert result.passed
+
+
+class TestHasFormat:
+    """Tests for has_format assertion."""
+
+    def test_found(self):
+        output = (
+            "Contact user@example.com, admin@test.org, "
+            "support@help.io"
+        )
+        result = assert_has_format(output, "email", minimum=3)
+        assert result.passed
+        assert "3" in result.message
+
+    def test_insufficient(self):
+        output = "Contact user@example.com"
+        result = assert_has_format(output, "email", minimum=3)
+        assert not result.passed
+
+    def test_unknown_format(self):
+        result = assert_has_format("text", "bogus_format")
+        assert not result.passed
+        assert "Unknown format" in result.message
+
+    def test_evidence_limited(self):
+        output = " ".join(
+            f"u{i}@example.com" for i in range(10)
+        )
+        result = assert_has_format(output, "email", minimum=1)
+        assert result.passed
+        # Evidence should show at most 5
+        assert result.evidence is not None
+        assert result.evidence.count("@") <= 5
+
+    def test_phone_us(self):
+        output = "Call (408) 298-5437 or (650) 123-4567"
+        result = assert_has_format(output, "phone_us", minimum=2)
+        assert result.passed
+
+    def test_url_format(self):
+        output = (
+            "See https://example.com and "
+            "http://test.org/page"
+        )
+        result = assert_has_format(output, "url", minimum=2)
         assert result.passed

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,263 @@
+"""Tests for the format registry module."""
+
+import pytest
+
+from clauditor.formats import (
+    FORMAT_REGISTRY,
+    FormatDef,
+    get_format,
+    list_formats,
+    validate_value,
+)
+
+
+class TestGetFormat:
+    def test_valid_format(self):
+        fmt = get_format("email")
+        assert fmt is not None
+        assert isinstance(fmt, FormatDef)
+        assert fmt.name == "email"
+
+    def test_invalid_format(self):
+        assert get_format("nonexistent") is None
+
+    def test_all_registry_entries_accessible(self):
+        for name in FORMAT_REGISTRY:
+            assert get_format(name) is not None
+
+
+class TestListFormats:
+    def test_returns_sorted_list(self):
+        names = list_formats()
+        assert names == sorted(names)
+
+    def test_correct_count(self):
+        names = list_formats()
+        assert len(names) == len(FORMAT_REGISTRY)
+        assert len(names) >= 19
+
+    def test_contains_expected_formats(self):
+        names = list_formats()
+        expected = [
+            "phone_us", "phone_intl", "email", "url", "date_iso", "date_us",
+            "time_24h", "time_12h", "currency_usd", "currency_eur",
+            "zip_us", "zip_uk", "percentage", "ipv4", "uuid", "hex_color",
+            "latitude", "longitude", "star_rating",
+        ]
+        for name in expected:
+            assert name in names, f"Missing format: {name}"
+
+
+class TestAllPatternsCompile:
+    def test_patterns_are_compiled(self):
+        """All patterns should be pre-compiled at import time."""
+        import re
+
+        for name, fmt in FORMAT_REGISTRY.items():
+            assert isinstance(fmt.pattern, re.Pattern), (
+                f"{name}.pattern is not compiled"
+            )
+            assert isinstance(fmt.extract_pattern, re.Pattern), (
+                f"{name}.extract_pattern is not compiled"
+            )
+
+
+class TestValidateValue:
+    """Test validate_value against known good and bad inputs for each format."""
+
+    @pytest.mark.parametrize("value", [
+        "(408) 298-5437",
+        "408-298-5437",
+        "408.298.5437",
+        "4082985437",
+    ])
+    def test_phone_us_valid(self, value):
+        assert validate_value(value, "phone_us")
+
+    def test_phone_us_invalid(self):
+        assert not validate_value("call for hours", "phone_us")
+        assert not validate_value("123", "phone_us")
+
+    @pytest.mark.parametrize("value", [
+        "+1 4082985437",
+        "+44 7911123456",
+        "+353 861234567",
+    ])
+    def test_phone_intl_valid(self, value):
+        assert validate_value(value, "phone_intl")
+
+    def test_phone_intl_invalid(self):
+        assert not validate_value("4082985437", "phone_intl")
+
+    @pytest.mark.parametrize("value", [
+        "user@example.com",
+        "first.last@company.co.uk",
+        "test+tag@gmail.com",
+    ])
+    def test_email_valid(self, value):
+        assert validate_value(value, "email")
+
+    def test_email_invalid(self):
+        assert not validate_value("not-an-email", "email")
+        assert not validate_value("@missing.com", "email")
+
+    @pytest.mark.parametrize("value", [
+        "https://example.com",
+        "http://example.com/path?q=1",
+        "https://sub.domain.co.uk/page",
+    ])
+    def test_url_valid(self, value):
+        assert validate_value(value, "url")
+
+    def test_url_invalid(self):
+        assert not validate_value("ftp://example.com", "url")
+        assert not validate_value("not a url", "url")
+
+    @pytest.mark.parametrize("value", [
+        "2026-04-10",
+        "2000-01-01",
+    ])
+    def test_date_iso_valid(self, value):
+        assert validate_value(value, "date_iso")
+
+    def test_date_iso_invalid(self):
+        assert not validate_value("04/10/2026", "date_iso")
+
+    @pytest.mark.parametrize("value", [
+        "4/10/2026",
+        "04/10/26",
+        "12/31/2025",
+    ])
+    def test_date_us_valid(self, value):
+        assert validate_value(value, "date_us")
+
+    def test_date_us_invalid(self):
+        assert not validate_value("2026-04-10", "date_us")
+
+    @pytest.mark.parametrize("value", [
+        "14:30",
+        "14:30:00",
+        "0:00",
+    ])
+    def test_time_24h_valid(self, value):
+        assert validate_value(value, "time_24h")
+
+    def test_time_24h_invalid(self):
+        assert not validate_value("2:30 PM", "time_24h")
+
+    @pytest.mark.parametrize("value", [
+        "2:30 PM",
+        "2:30pm",
+        "12:00 AM",
+    ])
+    def test_time_12h_valid(self, value):
+        assert validate_value(value, "time_12h")
+
+    def test_time_12h_invalid(self):
+        assert not validate_value("14:30", "time_12h")
+
+    @pytest.mark.parametrize("value", [
+        "$50",
+        "$1,234.56",
+        "$0.99",
+    ])
+    def test_currency_usd_valid(self, value):
+        assert validate_value(value, "currency_usd")
+
+    def test_currency_usd_invalid(self):
+        assert not validate_value("50 dollars", "currency_usd")
+        assert not validate_value("€50", "currency_usd")
+
+    @pytest.mark.parametrize("value", [
+        "€50",
+        "€1.234,56",
+    ])
+    def test_currency_eur_valid(self, value):
+        assert validate_value(value, "currency_eur")
+
+    def test_currency_eur_invalid(self):
+        assert not validate_value("$50", "currency_eur")
+
+    @pytest.mark.parametrize("value", [
+        "95110",
+        "95110-1234",
+    ])
+    def test_zip_us_valid(self, value):
+        assert validate_value(value, "zip_us")
+
+    def test_zip_us_invalid(self):
+        assert not validate_value("ABCDE", "zip_us")
+
+    @pytest.mark.parametrize("value", [
+        "SW1A 1AA",
+        "EC1A 1BB",
+        "W1A 0AX",
+    ])
+    def test_zip_uk_valid(self, value):
+        assert validate_value(value, "zip_uk")
+
+    def test_zip_uk_invalid(self):
+        assert not validate_value("95110", "zip_uk")
+
+    @pytest.mark.parametrize("value", [
+        "95%",
+        "99.9%",
+        "0%",
+    ])
+    def test_percentage_valid(self, value):
+        assert validate_value(value, "percentage")
+
+    def test_percentage_invalid(self):
+        assert not validate_value("ninety-five percent", "percentage")
+
+    @pytest.mark.parametrize("value", [
+        "192.168.1.1",
+        "10.0.0.1",
+        "255.255.255.0",
+    ])
+    def test_ipv4_valid(self, value):
+        assert validate_value(value, "ipv4")
+
+    def test_ipv4_invalid(self):
+        assert not validate_value("not.an.ip", "ipv4")
+
+    def test_uuid_valid(self):
+        assert validate_value(
+            "550e8400-e29b-41d4-a716-446655440000", "uuid"
+        )
+
+    def test_uuid_invalid(self):
+        assert not validate_value("not-a-uuid", "uuid")
+
+    def test_hex_color_valid(self):
+        assert validate_value("#FF5733", "hex_color")
+        assert validate_value("#aabbcc", "hex_color")
+
+    def test_hex_color_invalid(self):
+        assert not validate_value("#FFF", "hex_color")
+        assert not validate_value("red", "hex_color")
+
+    def test_latitude_valid(self):
+        assert validate_value("37.3382", "latitude")
+        assert validate_value("-33.8688", "latitude")
+
+    def test_latitude_invalid(self):
+        assert not validate_value("north", "latitude")
+
+    def test_longitude_valid(self):
+        assert validate_value("-121.8863", "longitude")
+        assert validate_value("151.2093", "longitude")
+
+    def test_longitude_invalid(self):
+        assert not validate_value("west", "longitude")
+
+    def test_star_rating_valid(self):
+        assert validate_value("4.5 stars", "star_rating")
+        assert validate_value("3 ★", "star_rating")
+        assert validate_value("5 star", "star_rating")
+
+    def test_star_rating_invalid(self):
+        assert not validate_value("excellent", "star_rating")
+
+    def test_unknown_format(self):
+        assert not validate_value("anything", "nonexistent")

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -886,3 +886,43 @@ class TestPatternFormatEnforcement:
         assert pattern_r[0].passed
         assert len(format_r) == 1
         assert format_r[0].passed
+
+    def test_non_string_field_value_coerced(self):
+        """Non-string values (e.g. int from LLM) should be coerced to str."""
+        spec = EvalSpec(
+            skill_name="test",
+            sections=[
+                SectionRequirement(
+                    name="Items",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(
+                                    name="count",
+                                    required=True,
+                                    pattern=r"\d+",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        extracted = ExtractedOutput(
+            sections={
+                "Items": {
+                    "default": [
+                        ExtractedEntry(fields={"count": 42}),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, spec)
+        pattern_r = [
+            r for r in results.results if ":pattern" in r.name
+        ]
+        assert len(pattern_r) == 1
+        assert pattern_r[0].passed
+        assert pattern_r[0].evidence == "42"

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -600,3 +600,289 @@ class TestExtractAndGrade:
         with patch("anthropic.AsyncAnthropic", return_value=mock_client):
             result = await extract_and_grade("some output", _make_spec())
         assert result.passed
+
+
+def _make_pattern_spec() -> EvalSpec:
+    """Spec with pattern and format validation on fields."""
+    return EvalSpec(
+        skill_name="test-skill",
+        sections=[
+            SectionRequirement(
+                name="Restaurants",
+                tiers=[
+                    TierRequirement(
+                        label="default",
+                        min_entries=1,
+                        fields=[
+                            FieldRequirement(
+                                name="name", required=True
+                            ),
+                            FieldRequirement(
+                                name="phone",
+                                required=True,
+                                pattern=r"\(\d{3}\) \d{3}-\d{4}",
+                            ),
+                            FieldRequirement(
+                                name="website",
+                                required=True,
+                                format="url",
+                            ),
+                            FieldRequirement(
+                                name="email",
+                                required=False,
+                                format="email",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+class TestPatternFormatEnforcement:
+    def test_pattern_match(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Restaurants": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "Paesano's",
+                                "phone": "(408) 298-5437",
+                                "website": "https://paesanos.com",
+                            }
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_pattern_spec())
+        pattern_results = [
+            r for r in results.results if ":pattern" in r.name
+        ]
+        assert all(r.passed for r in pattern_results)
+
+    def test_pattern_mismatch(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Restaurants": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "Paesano's",
+                                "phone": "call for hours",
+                                "website": "https://paesanos.com",
+                            }
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_pattern_spec())
+        pattern_results = [
+            r for r in results.results if ":pattern" in r.name
+        ]
+        assert len(pattern_results) == 1
+        assert not pattern_results[0].passed
+        assert pattern_results[0].evidence == "call for hours"
+
+    def test_format_match(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Restaurants": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "Paesano's",
+                                "phone": "(408) 298-5437",
+                                "website": "https://paesanos.com",
+                            }
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_pattern_spec())
+        format_results = [
+            r for r in results.results if ":format" in r.name
+        ]
+        assert all(r.passed for r in format_results)
+
+    def test_format_mismatch(self):
+        extracted = ExtractedOutput(
+            sections={
+                "Restaurants": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "Paesano's",
+                                "phone": "(408) 298-5437",
+                                "website": "not-a-url",
+                            }
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_pattern_spec())
+        format_results = [
+            r for r in results.results if ":format" in r.name
+        ]
+        failed = [r for r in format_results if not r.passed]
+        assert len(failed) == 1
+        assert "website" in failed[0].name
+
+    def test_unknown_format_name(self):
+        spec = EvalSpec(
+            skill_name="test",
+            sections=[
+                SectionRequirement(
+                    name="Items",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(
+                                    name="val",
+                                    required=True,
+                                    format="bogus_format",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        extracted = ExtractedOutput(
+            sections={
+                "Items": {
+                    "default": [
+                        ExtractedEntry(fields={"val": "anything"}),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, spec)
+        format_results = [
+            r for r in results.results if ":format" in r.name
+        ]
+        assert len(format_results) == 1
+        assert not format_results[0].passed
+        assert "Unknown format" in format_results[0].message
+
+    def test_invalid_pattern_regex(self):
+        spec = EvalSpec(
+            skill_name="test",
+            sections=[
+                SectionRequirement(
+                    name="Items",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(
+                                    name="val",
+                                    required=True,
+                                    pattern="[invalid",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        extracted = ExtractedOutput(
+            sections={
+                "Items": {
+                    "default": [
+                        ExtractedEntry(fields={"val": "test"}),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, spec)
+        pattern_results = [
+            r for r in results.results if ":pattern" in r.name
+        ]
+        assert len(pattern_results) == 1
+        assert not pattern_results[0].passed
+        assert "Invalid pattern" in pattern_results[0].message
+
+    def test_optional_field_missing_skips_validation(self):
+        """If an optional field is missing, pattern/format are not checked."""
+        extracted = ExtractedOutput(
+            sections={
+                "Restaurants": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "name": "Paesano's",
+                                "phone": "(408) 298-5437",
+                                "website": "https://paesanos.com",
+                                # email is optional, not present
+                            }
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, _make_pattern_spec())
+        # No format check on email since it's not present
+        email_format = [
+            r
+            for r in results.results
+            if "email" in r.name and ":format" in r.name
+        ]
+        assert len(email_format) == 0
+
+    def test_both_pattern_and_format(self):
+        """When both pattern and format are set, both must match."""
+        spec = EvalSpec(
+            skill_name="test",
+            sections=[
+                SectionRequirement(
+                    name="Items",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(
+                                    name="phone",
+                                    required=True,
+                                    pattern=r"\(\d{3}\) \d{3}-\d{4}",
+                                    format="phone_us",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        extracted = ExtractedOutput(
+            sections={
+                "Items": {
+                    "default": [
+                        ExtractedEntry(
+                            fields={
+                                "phone": "(408) 298-5437"
+                            }
+                        ),
+                    ]
+                }
+            }
+        )
+        results = grade_extraction(extracted, spec)
+        pattern_r = [
+            r for r in results.results if ":pattern" in r.name
+        ]
+        format_r = [
+            r for r in results.results if ":format" in r.name
+        ]
+        assert len(pattern_r) == 1
+        assert pattern_r[0].passed
+        assert len(format_r) == 1
+        assert format_r[0].passed

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -112,10 +112,125 @@ class TestFieldRequirement:
         f = FieldRequirement(name="test")
         assert f.required is True
         assert f.pattern is None
+        assert f.format is None
 
     def test_with_pattern(self):
         f = FieldRequirement(name="phone", pattern=r"\(\d{3}\)\s\d{3}-\d{4}")
         assert f.pattern is not None
+
+    def test_with_format(self):
+        f = FieldRequirement(name="phone", format="phone_us")
+        assert f.format == "phone_us"
+
+    def test_with_both_pattern_and_format(self):
+        f = FieldRequirement(
+            name="phone",
+            pattern=r"\(\d{3}\)\s\d{3}-\d{4}",
+            format="phone_us",
+        )
+        assert f.pattern is not None
+        assert f.format == "phone_us"
+
+
+class TestFormatFieldRoundTrip:
+    def test_format_preserved_in_roundtrip(self):
+        data = {
+            "skill_name": "test",
+            "sections": [
+                {
+                    "name": "Items",
+                    "min_entries": 1,
+                    "fields": [
+                        {
+                            "name": "phone",
+                            "required": True,
+                            "format": "phone_us",
+                        },
+                        {
+                            "name": "email",
+                            "required": False,
+                            "format": "email",
+                            "pattern": r".+@.+",
+                        },
+                    ],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".eval.json", delete=False
+        ) as f:
+            json.dump(data, f)
+            f.flush()
+            spec = EvalSpec.from_file(f.name)
+
+        tier = spec.sections[0].tiers[0]
+        assert tier.fields[0].format == "phone_us"
+        assert tier.fields[1].format == "email"
+        assert tier.fields[1].pattern == r".+@.+"
+
+        d = spec.to_dict()
+        fields_out = d["sections"][0]["tiers"][0]["fields"]
+        assert fields_out[0]["format"] == "phone_us"
+        assert fields_out[1]["format"] == "email"
+        assert fields_out[1]["pattern"] == r".+@.+"
+
+    def test_format_absent_backward_compat(self):
+        data = {
+            "skill_name": "test",
+            "sections": [
+                {
+                    "name": "Items",
+                    "min_entries": 1,
+                    "fields": [
+                        {"name": "name", "required": True},
+                    ],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".eval.json", delete=False
+        ) as f:
+            json.dump(data, f)
+            f.flush()
+            spec = EvalSpec.from_file(f.name)
+
+        tier = spec.sections[0].tiers[0]
+        assert tier.fields[0].format is None
+
+        d = spec.to_dict()
+        fields_out = d["sections"][0]["tiers"][0]["fields"]
+        assert "format" not in fields_out[0]
+
+    def test_format_in_tiered_sections(self):
+        data = {
+            "skill_name": "test",
+            "sections": [
+                {
+                    "name": "Items",
+                    "tiers": [
+                        {
+                            "label": "main",
+                            "min_entries": 1,
+                            "fields": [
+                                {
+                                    "name": "url",
+                                    "required": True,
+                                    "format": "url",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".eval.json", delete=False
+        ) as f:
+            json.dump(data, f)
+            f.flush()
+            spec = EvalSpec.from_file(f.name)
+
+        assert spec.sections[0].tiers[0].fields[0].format == "url"
 
 
 class TestSectionRequirement:


### PR DESCRIPTION
## Summary
Super plan for #13 — Field-Level Validation Assertions.

- **Phase:** detailing (awaiting approval)
- **Stories:** 5 implementation stories + Quality Gate + Patterns & Memory
- **Decisions:** 7 decisions captured (DEC-001 through DEC-007)

### Work Streams
1. **Format registry** — `formats.py` with ~19 named patterns (email, phone, date, currency, URL, IP, UUID, etc.)
2. **`format` field on FieldRequirement** — new field alongside `pattern`, with schema load/serialize
3. **Field pattern/format enforcement** — wire up validation in `grade_extraction()` (Layer 2)
4. **`has_format` assertion** — generalized Layer 1 format counting: `{"type": "has_format", "format": "email", "value": "3"}`
5. **`urls_reachable` assertion** — HTTP HEAD reachability check with SSRF protections

### Key Decisions
- **DEC-001:** urllib default, httpx if installed (zero new required deps)
- **DEC-002:** Format registry as pure-data module (~19 built-in formats)
- **DEC-003:** New `format` field separate from `pattern` on FieldRequirement
- **DEC-006:** ReDoS — pragmatic (pre-compile, no timeout)
- **DEC-007:** SSRF — denylist private IPs, 5s timeout, redirect limit

## Plan document
See `plans/super/13-field-validation.md` for the full plan.

## Next steps
- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)

Generated with [Claude Code](https://claude.com/claude-code)