### PR TITLE
#17: Real-world P0/P1 fixes from my_claude_agent eval run

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ clauditor grade <skill.md> --variance 3  # Variance measurement
 clauditor grade <skill.md> --save      # Persist results to .clauditor/
 clauditor grade <skill.md> --diff      # Compare against prior results
 clauditor triggers <skill.md>          # Trigger precision testing
+clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/
+clauditor doctor                       # Report environment diagnostics
 ```
 
 ## Pytest Integration
@@ -397,6 +399,54 @@ A complete eval spec with all three layers:
 ```
 
 See [`examples/`](examples/.claude/commands/example-skill.eval.json) for a complete working eval spec.
+
+### Field validation with `format`
+
+Each `FieldRequirement` accepts a single `format` key that validates the
+extracted value. `format` does double duty:
+
+1. **Registered format name** — a shorthand for a built-in regex in the
+   format registry. Run `python -c "from clauditor.formats import list_formats; print(list_formats())"`
+   to see the full list. Common entries: `phone_us`, `phone_intl`,
+   `email`, `url`, `domain`, `date_iso`, `date_us`, `currency_usd`,
+   `zip_us`, `percentage`, `ipv4`, `uuid`.
+2. **Inline regex** — any string that isn't a registered name is
+   compiled with `re.compile` and used as an anchored `fullmatch` against
+   the value. Invalid regexes raise `ValueError` at spec load time.
+
+```json
+{
+  "sections": [
+    {
+      "name": "Restaurants",
+      "min_entries": 1,
+      "max_entries": 3,
+      "fields": [
+        {"name": "name",    "required": true},
+        {"name": "phone",   "required": true,  "format": "phone_us"},
+        {"name": "website", "required": true,  "format": "domain"},
+        {"name": "zip",     "required": false, "format": "^\\d{5}$"}
+      ]
+    }
+  ]
+}
+```
+
+**`url` vs `domain`:** LLMs commonly extract the display text of markdown
+links (`[paesanosj.com](https://paesanosj.com/)` → `paesanosj.com`),
+which are valid domains but not URLs with a scheme. Use `format: "url"`
+only when you really need `https://…`; use `format: "domain"` to accept
+bare hostnames too.
+
+**`max_entries`:** A precision signal — when set, clauditor emits a
+`count_max` assertion if extraction returns more entries than the cap.
+Field-level checks still run over all extracted entries so you see both
+the count failure and any per-entry failures.
+
+> **Migration note (April 2026):** The legacy `"pattern"` key on
+> `FieldRequirement` has been removed. Migrate by renaming `pattern` to
+> `format` — inline regexes work as before; registered names are now the
+> preferred ergonomics.
 
 ## License
 

--- a/plans/super/17-real-world-fixes.md
+++ b/plans/super/17-real-world-fixes.md
@@ -120,7 +120,7 @@ The ticket lists 6 items but observation #7 (FieldRequirement pattern vs format 
 - **DEC-003 — `max_entries` behavior:** Hard-fail with a `count_max` assertion; field-level checks still run over all extracted entries so users see both the count failure and the per-entry failures. *(Q3=A)*
 - **DEC-004 — `grouped_summary()` shape:** Flat `summary()` stays as-is; `grouped_summary()` is a new opt-in method that groups by `{field}:{suffix}` across all entries in a section/tier. *(Q4=D)*
 - **DEC-005 — `doctor` v1 scope:** Python version + `anthropic` importable + `claude` CLI on PATH + pytest plugin entry_point registered + editable-install detection. *(Q5=B)*
-- **DEC-006 — Deprecate `FieldRequirement.pattern`:** Keep `format` only. Custom regex capability is preserved via inline regex on `format` (registry-lookup-then-regex-fallback) — details in refinement. *(Q6 user choice)*
+- **DEC-006 — Deprecate `FieldRequirement.pattern`:** Keep `format` only. Custom regex capability is preserved via inline regex on `format` (registry-lookup-then-regex-fallback) — details in refinement. *(User chose "deprecate pattern and keep format" in response to Q6 — Q6 originally asked about observation #7 pattern-vs-format docs, and the user's answer went further and asked to remove `pattern` entirely.)*
 
 ## Architecture Review
 
@@ -395,7 +395,5 @@ Stories are ordered by dependency. Each is sized for a single Ralph context wind
 **Depends on:** US-008
 
 ---
-
-## Beads Manifest (see section above)
 
 ## Beads Manifest (see section above)

--- a/plans/super/17-real-world-fixes.md
+++ b/plans/super/17-real-world-fixes.md
@@ -4,7 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/17
 - **Branch:** `feature/17-real-world-fixes`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/17-real-world-fixes`
-- **Phase:** `detailing`
+- **Phase:** `devolved`
+- **PR:** https://github.com/wjduenow/clauditor/pull/19
 - **Sessions:** 1
 - **Last session:** 2026-04-12
 
@@ -395,8 +396,6 @@ Stories are ordered by dependency. Each is sized for a single Ralph context wind
 
 ---
 
-## Beads Manifest
-*(pending — Phase 7)*
+## Beads Manifest (see section above)
 
-## Beads Manifest
-*(pending — Phase 7)*
+## Beads Manifest (see section above)

--- a/plans/super/17-real-world-fixes.md
+++ b/plans/super/17-real-world-fixes.md
@@ -1,0 +1,402 @@
+# Super Plan: #17 — Real-world P0/P1 fixes from my_claude_agent eval run
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/17
+- **Branch:** `feature/17-real-world-fixes`
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/17-real-world-fixes`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-12
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Six independent fixes surfaced by running clauditor against real `/find-restaurants` output in `my_claude_agent`. Source observations: `docs/temp/real-world-test-observations.md`.
+
+**Why:** These are blockers/traps that would bite anyone adopting clauditor as "the way" to test Claude Code skills. Fix them before wider promotion.
+
+**Acceptance criteria (from ticket):**
+- [ ] `domain` format added; `url` docs warn about bare-domain extraction
+- [ ] `clauditor capture <skill>` CLI works end-to-end
+- [ ] `TierRequirement.max_entries` field added and enforced
+- [ ] `AssertionSet.grouped_summary()` collapses repeated failures
+- [ ] `pytest.mark.network` registered in pytest plugin
+- [ ] `clauditor doctor` command surfaces install/version issues
+- [ ] All existing tests still pass
+
+### Codebase Findings
+
+**Fix 1 — `domain` format** → `src/clauditor/formats.py`
+- `FORMAT_REGISTRY` built via `_def()` helper at lines 24–36; existing `url` entry at 56–59.
+- `FormatDef` already supports separate `pattern` / `extract_pattern` — no schema change needed.
+
+**Fix 2 — `clauditor capture` CLI** → `src/clauditor/cli.py` + `runner.py`
+- `cli.py` uses argparse subparsers (lines 457–579), dispatch via `cmd_*()` functions.
+- `runner.py` lines 100–124 already shells out to `self.claude_bin -p <prompt>` — reusable.
+- Captured-output convention: `tests/eval/captured/<skill>.txt`.
+
+**Fix 3 — `TierRequirement.max_entries`** → `schemas.py` + `grader.py`
+- `TierRequirement` at schemas.py:24–30; `min_entries: int = 0` on line 29.
+- `grade_extraction()` min_entries check at grader.py:93–104; mirror it for max.
+- JSON round-trip: schemas.py:111, 197.
+
+**Fix 4 — `AssertionSet.grouped_summary()`** → `assertions.py`
+- `AssertionSet` at lines 30–56; existing `summary()` is flat.
+- Names are structured: `section:{Section}/{tier}[{i}].{field}:{suffix}` (suffix=`format`, `pattern`, or empty for presence).
+
+**Fix 5 — Register pytest markers** → `src/clauditor/pytest_plugin.py`
+- `pytest_configure` already exists (lines 59–64) and registers `clauditor_grade`. Add `network` and `slow` with one line each.
+
+**Fix 6 — `clauditor doctor`** → `cli.py`
+- New subparser + `cmd_doctor()`. Checks: Python ≥ 3.11 (pyproject.toml:11), `anthropic` SDK importable, `claude` CLI on PATH, pytest plugin entry_point registered, editable-install health.
+
+### Conventions (from CLAUDE.md)
+- Test file per source module (`test_<module>.py`).
+- 80% coverage gate enforced.
+- Don't shadow plugin fixture names `clauditor_runner/spec/grader/triggers`.
+- Beads for task tracking; no TodoWrite/markdown TODOs.
+- No `.claude/rules/*.md` files and no `workflow-project.md` — general CLAUDE.md rules apply.
+
+### Proposed Scope
+
+All six fixes land in one plan. They're independent and small; bundling avoids thrash. Ordering follows dependency (format → schema → assertions/grader → cli → pytest plugin → doctor), and the Quality Gate + Patterns & Memory stories close it out.
+
+### Scoping Questions
+
+**Q1 — `capture` CLI: output path convention**
+Where should `clauditor capture <skill>` write by default?
+
+- **(A)** Always `tests/eval/captured/<skill>.txt` relative to cwd (matches existing convention; fails if run outside a repo with that layout).
+- **(B)** Configurable via `--out <path>` with default `tests/eval/captured/<skill>.txt`.
+- **(C)** (B) plus auto-version option `--versioned` → `tests/eval/captured/<skill>-YYYY-MM-DD.txt`.
+- **(D)** (B) plus a config key in `clauditor.toml`/pyproject for per-project override.
+
+**Q2 — `capture` CLI: skill args**
+How should args be passed to `claude -p "/skill ..."`?
+
+- **(A)** `clauditor capture find-restaurants -- "near San Jose"` — everything after `--` is the skill prompt suffix.
+- **(B)** `clauditor capture find-restaurants --args "near San Jose"` — explicit flag.
+- **(C)** Positional: `clauditor capture find-restaurants "near San Jose"`.
+
+**Q3 — `max_entries` semantics when violated**
+When extraction returns more entries than `max_entries`, what happens?
+
+- **(A)** Hard fail — emit a `count_max` assertion failure; keep all entries for downstream field checks (so users see both count failure AND field failures).
+- **(B)** Hard fail and truncate — only grade the first N entries for field checks.
+- **(C)** Soft signal — emit a `count_max` assertion with `passed=False` but grade all entries (same as A, but explicit framing as "precision signal, not blocker"). Identical behavior to A; just naming.
+
+**Q4 — `grouped_summary()` — what gets grouped**
+Which grouping key makes failures most readable?
+
+- **(A)** Group by `{field}:{suffix}` across all entries in a section/tier → "6/6 Restaurants/default[*].website:format failed".
+- **(B)** Group by exact name prefix up to `[` → one group per section+tier, list fields inside.
+- **(C)** Two-level: section/tier, then field+suffix.
+- **(D)** (A) is the default; `summary()` stays flat; `grouped_summary()` is an opt-in method.
+
+**Q5 — `doctor` checks scope**
+Which checks does v1 run?
+
+- **(A)** Minimal: Python version, `anthropic` importable, `claude` CLI on PATH.
+- **(B)** (A) + pytest plugin entry_point registered + editable-install detection (is `src/clauditor` writable from the venv site-packages?).
+- **(C)** (B) + warn if `pyproject.toml` in cwd has `path = "../clauditor"` without `editable = true`.
+
+**Q6 — Should we *also* ship observation #7 docs (pattern vs format)?**
+The ticket lists 6 items but observation #7 (FieldRequirement pattern vs format confusion) is a docs-only fix that naturally fits alongside the domain-format work.
+
+- **(A)** No — stay strictly in ticket scope.
+- **(B)** Yes — add a short README section + `clauditor formats list` command.
+- **(C)** Yes — README only, skip the CLI subcommand.
+
+---
+
+## Decisions (from scoping)
+
+- **DEC-001 — `capture` output path:** `--out` flag overriding default `tests/eval/captured/<skill>.txt`, plus `--versioned` flag producing `<skill>-YYYY-MM-DD.txt`. *(Q1=C)*
+- **DEC-002 — `capture` args passing:** Trailing-`--` form: `clauditor capture find-restaurants -- "near San Jose"`. Everything after `--` is appended to the skill prompt. *(Q2=A)*
+- **DEC-003 — `max_entries` behavior:** Hard-fail with a `count_max` assertion; field-level checks still run over all extracted entries so users see both the count failure and the per-entry failures. *(Q3=A)*
+- **DEC-004 — `grouped_summary()` shape:** Flat `summary()` stays as-is; `grouped_summary()` is a new opt-in method that groups by `{field}:{suffix}` across all entries in a section/tier. *(Q4=D)*
+- **DEC-005 — `doctor` v1 scope:** Python version + `anthropic` importable + `claude` CLI on PATH + pytest plugin entry_point registered + editable-install detection. *(Q5=B)*
+- **DEC-006 — Deprecate `FieldRequirement.pattern`:** Keep `format` only. Custom regex capability is preserved via inline regex on `format` (registry-lookup-then-regex-fallback) — details in refinement. *(Q6 user choice)*
+
+## Architecture Review
+
+Single-pass review — each fix is small, independent, and touches well-scoped internals. No auth, no data migration, no external API surface beyond `claude -p` subprocess (already used).
+
+| Area | Rating | Notes |
+|---|---|---|
+| **Security** | pass | `capture` shells out to the already-trusted `claude` binary via existing `runner.py` path. Skill-args go through argv (not shell), so no injection. `doctor` is read-only. |
+| **Performance** | pass | All fixes are O(N) over assertions or entries. `grouped_summary()` is a single extra pass over `AssertionSet.results`. |
+| **Data Model** | concern | `TierRequirement.max_entries` is backward compatible (default `None`). **However** removing `FieldRequirement.pattern` is a breaking change to spec JSON — any existing `*.eval.json` files with `"pattern": ...` will fail to load unless we auto-migrate or reject with a clear error. See DEC-006 refinement. |
+| **API Design** | concern | `capture` CLI surface: `-- "args"` vs `--out` vs `--versioned` is a moderately wide surface. Plan carefully; document in `--help`. `doctor` exit codes matter — should `doctor` exit non-zero on failures so CI can gate on it? Flag for refinement. |
+| **Observability** | pass | `doctor` is itself the observability improvement. `grouped_summary()` improves failure legibility. No new logging needed. |
+| **Testing** | concern | `capture` subcommand is inherently hard to unit-test (shells out). Plan must specify: mock `runner.run()` in unit tests; a single end-to-end smoke test behind `@pytest.mark.network` can optionally exercise the real path. Coverage gate (80%) is tight — `doctor` branches (Python version check, editable-install detection) must all have test coverage. |
+| **Migration / Breaking changes** | **blocker** | DEC-006 (remove `pattern`) breaks: schemas.py:203, grader.py:140–162, `__init__.py` export, 7+ test usages in test_schemas.py/test_grader.py, possibly the `find-restaurants.eval.json` spec in my_claude_agent. Must decide in refinement: hard-remove with migration script, or soft-deprecate with warning. |
+
+### Blockers to resolve in refinement
+1. **DEC-006 implementation shape** — hard remove vs soft deprecate vs extend `format` to accept inline regex.
+
+### Concerns to address in refinement
+1. `doctor` exit code behavior (CI-gating semantics).
+2. Test strategy for `capture` (unit mock + optional integration).
+3. `capture` `--versioned` and `--out` interaction (error if both?).
+
+## Refinement Log
+
+- **DEC-007 — `pattern` removal shape (R2):** Delete `FieldRequirement.pattern` entirely. Extend `FieldRequirement.format` to do registry-lookup first, fall back to compiling the string as a regex if no registry match. On regex compile failure, raise at spec-load time with a clear error message. Rationale: preserves custom-regex capability, collapses API to one field, matches CLAUDE.md "no backwards-compat shims." Grep confirmed **no `.eval.json` files currently use `"pattern"`** — migration is tests-only.
+- **DEC-008 — `doctor` exit code (C1=a):** Always exit 0; `doctor` is report-only. CI gating is not a v1 requirement.
+- **DEC-009 — `capture` test strategy (C2):** Unit tests mock `runner.run()`; one optional integration test behind `@pytest.mark.network` may exercise the real `claude -p` path but is not required for 80% coverage gate.
+- **DEC-010 — `capture --out` + `--versioned` interaction (C3=c):** `--versioned` appends `-YYYY-MM-DD` to the stem of whatever `--out` resolves to. Works for both default path and custom `--out`.
+- **DEC-011 — Registry-vs-regex disambiguation (implied by DEC-007):** Registry lookup happens first. A registry key is literal string equality — no regex chars allowed in registry names, so there's no ambiguity with regex patterns. If the string is neither a registered format nor a valid regex, raise `ValueError` at `FieldRequirement` construction time.
+- **DEC-012 — `grouped_summary()` key for presence checks:** Names without a `:suffix` (e.g. `section:Restaurants/default[0].name`) group under the synthetic suffix `presence`. Grouping key: `(field_name, suffix_or_presence)`.
+- **DEC-013 — `capture` skill name normalization:** Accept both `find-restaurants` and `/find-restaurants`; strip a single leading `/` before building the prompt.
+- **DEC-014 — `doctor` output format:** Human-readable table with `[ok]` / `[warn]` / `[fail]` prefixes. No `--json` flag in v1.
+
+## Detailed Breakdown
+
+Stories are ordered by dependency. Each is sized for a single Ralph context window. Every story's acceptance criteria includes `uv run pytest --cov=clauditor --cov-report=term-missing` passing with the 80% gate intact (per CLAUDE.md).
+
+---
+
+### US-001 — Add `domain` format to registry
+
+**Description:** Add a new `domain` entry to `FORMAT_REGISTRY` in `formats.py` that matches bare domains like `paesanosj.com` — the common output when LLMs extract display text from markdown links.
+
+**Traces to:** Ticket Fix #1, DEC-011
+
+**Files:**
+- `src/clauditor/formats.py` — add entry via `_def()` helper after the existing `url` entry
+- `tests/test_formats.py` — add matching/non-matching cases
+
+**TDD:**
+- `domain` matches: `paesanosj.com`, `sub.example.co.uk`, `a-b.io`
+- `domain` rejects: `https://paesanosj.com`, `paesanosj`, `.com`, `example..com`, `example.com/path`
+- `FORMAT_REGISTRY["domain"]` exists and has `.pattern` compiled
+
+**Acceptance criteria:**
+- New format registered, existing format tests still pass
+- `format="domain"` usable in `FieldRequirement` at spec-load time
+- `uv run ruff check src/ tests/` clean
+- `uv run pytest --cov=clauditor` passes with coverage ≥ 80%
+
+**Done when:** A spec with `{"format": "domain"}` loads and grades bare-domain values as passing.
+
+**Depends on:** none
+
+---
+
+### US-002 — Deprecate `FieldRequirement.pattern`; extend `format` to accept inline regex
+
+**Description:** Remove the `pattern` field from `FieldRequirement`. Extend `format` to support two modes: (a) registry lookup if the string matches a registered format name, (b) fall back to compiling the string as a regex. Invalid values raise `ValueError` at construction. Migrate all internal callers and tests.
+
+**Traces to:** Ticket observation #7, DEC-006, DEC-007, DEC-011
+
+**Files:**
+- `src/clauditor/schemas.py` — remove `pattern` field from `FieldRequirement` (line ~19); remove `pattern` from `to_dict()` (line ~203); add construction-time validation that `format` is either a registry key or a compilable regex, raising `ValueError` otherwise
+- `src/clauditor/grader.py` — remove the `field_req.pattern` branch (lines 140–162); leave the `format` branch (line 180) intact but extend it to handle the inline-regex case (where `format` was a regex string not a registry key)
+- `src/clauditor/__init__.py` — remove `pattern` from exports if present
+- `tests/test_schemas.py` — migrate the 3 `pattern=` usages (lines 118, 128, 441) to `format=` with either a registered name or an inline regex
+- `tests/test_grader.py` — migrate the 4 `pattern=` usages (lines 623, 789, 856, 905) to `format=`
+- `tests/conftest.py` — audit and migrate any `pattern=` usages
+- `README.md` — add a short "Field validation" section explaining that `format` accepts either a registered name or an inline regex, with a decision-tree example
+
+**TDD:**
+- `FieldRequirement(name="x", format="phone_us")` — registry hit, works as before
+- `FieldRequirement(name="x", format=r"\d{3}-\d{4}")` — inline regex, compiles and validates values
+- `FieldRequirement(name="x", format="[invalid")` — raises `ValueError` at construction with a clear message
+- Spec JSON with `"pattern": "..."` → loading raises `ValueError` or `TypeError` (no silent drop)
+- Existing tests migrated to `format=` still exercise the same validation outcomes
+
+**Acceptance criteria:**
+- No reference to `FieldRequirement.pattern` anywhere in `src/` or `tests/`
+- `uv run pytest --cov=clauditor` passes with coverage ≥ 80%
+- `uv run ruff check src/ tests/` clean
+- README section added
+
+**Done when:** Grep for `FieldRequirement.*pattern` and `field_req\.pattern` returns zero matches in source and tests.
+
+**Depends on:** US-001 (domain format exists so tests can use it as a registry example)
+
+---
+
+### US-003 — Add `TierRequirement.max_entries` with `count_max` enforcement
+
+**Description:** Add an optional `max_entries: int | None = None` field to `TierRequirement`. In `grade_extraction()`, emit a new `count_max` assertion when extraction returns more entries than `max_entries`. Field-level checks still run over all extracted entries (DEC-003). Round-trip the field through JSON serialization.
+
+**Traces to:** Ticket Fix #3, DEC-003
+
+**Files:**
+- `src/clauditor/schemas.py` — add `max_entries: int | None = None` to `TierRequirement` (~line 29); include in `to_dict()` (~line 197) only when non-None; parse from JSON in `from_file()` (~line 111)
+- `src/clauditor/grader.py` — after the existing `min_entries` check (lines 93–104), add a mirrored `max_entries` check emitting an assertion named `section:{section_name}:count_max/{tier.label}`; only emit when `tier.max_entries is not None`
+- `tests/test_schemas.py` — round-trip test: spec with `max_entries` loads, serializes, reloads
+- `tests/test_grader.py` — grade case where extraction returns more than `max_entries` → assertion fails; case where equal → passes; case where `max_entries=None` → no assertion emitted; case where extraction exceeds max AND has field failures → both appear in the result set
+
+**TDD:**
+- `TierRequirement(name="default", max_entries=3)` serializes and deserializes
+- Extract 6 entries when `max_entries=3` → one `count_max` failure, field checks still run for all 6
+- Extract 2 entries when `max_entries=3` → no `count_max` failure
+- `max_entries=None` (default) → no `count_max` assertion ever emitted
+
+**Acceptance criteria:**
+- Backward compatible: existing specs without `max_entries` behave identically
+- Coverage ≥ 80%; ruff clean
+
+**Done when:** A spec with `max_entries: 3` against a 6-entry extraction produces both the `count_max` failure and any field-level failures from the 6 entries.
+
+**Depends on:** none (independent of US-001/US-002 beyond sharing schemas.py)
+
+---
+
+### US-004 — Add `AssertionSet.grouped_summary()` with field+suffix grouping
+
+**Description:** Add a new `grouped_summary()` method to `AssertionSet` that collapses repeated failures by `(field_name, suffix_or_presence)`. Flat `summary()` stays unchanged (DEC-004). Parse assertion names of the form `section:{Section}/{tier}[{i}].{field}[:{suffix}]`.
+
+**Traces to:** Ticket Fix #4, DEC-004, DEC-012
+
+**Files:**
+- `src/clauditor/assertions.py` — add `grouped_summary(self) -> list[str]` to `AssertionSet` (~line 50). Parse name structure with a regex, group by `(field, suffix_or_"presence")`, emit one line per group: `"{N}/{M} {section}/{tier}[*].{field}{:suffix} failed: {first_evidence}"`. Names that don't match the structured form fall through to individual entries.
+- `tests/test_assertions.py` — cases: all-same-field-all-fail → one line; mixed passes/fails → only failing groups shown; unparseable names → passthrough; empty set → empty list
+
+**TDD:**
+- 6 results all failing `section:Restaurants/default[*].website:format` → one grouped line `"6/6 Restaurants/default[*].website:format failed"`
+- 3 presence-check failures (`section:Restaurants/default[0].name` etc.) → one grouped line with synthetic `presence` suffix
+- Mixed failing fields → one line per `(field, suffix)` group
+- A `has_urls` top-level failure (non-structured name) → passthrough as individual entry
+
+**Acceptance criteria:**
+- `summary()` output unchanged (regression test)
+- New method documented in docstring
+- Coverage ≥ 80%; ruff clean
+
+**Done when:** Calling `grouped_summary()` on the real-world-test AssertionSet from observation #2 produces 1 line instead of 24+.
+
+**Depends on:** none
+
+---
+
+### US-005 — Register `network` and `slow` pytest markers
+
+**Description:** Extend the existing `pytest_configure` hook in `pytest_plugin.py` to register `network` and `slow` markers so downstream projects don't see `PytestUnknownMarkWarning`.
+
+**Traces to:** Ticket Fix #5
+
+**Files:**
+- `src/clauditor/pytest_plugin.py` — in the existing `pytest_configure()` (lines 59–64), add two `config.addinivalue_line("markers", ...)` calls for `network` and `slow` with the descriptions from the ticket
+- `tests/test_pytest_plugin.py` — add a test that uses a pytester/subprocess fixture to assert the markers are registered after `pytest_configure` runs (or a simpler unit test that calls `pytest_configure` with a mock config and asserts the `addinivalue_line` calls)
+
+**TDD:**
+- After `pytest_configure(mock_config)`, `mock_config.addinivalue_line` was called with `("markers", "network: ...")` and `("markers", "slow: ...")` in addition to the existing `clauditor_grade` registration
+
+**Acceptance criteria:**
+- Running `uv run pytest -m "not network"` on a test file that imports clauditor does not emit `PytestUnknownMarkWarning` for `network` or `slow`
+- Coverage ≥ 80%; ruff clean
+
+**Done when:** The my_claude_agent test file using `@pytest.mark.slow` no longer triggers `PytestUnknownMarkWarning`.
+
+**Depends on:** none
+
+---
+
+### US-006 — Add `clauditor capture <skill>` CLI subcommand
+
+**Description:** New subparser `capture` that shells out to `claude -p "/<skill> <args>"` via the existing `runner.py` path, writes stdout to `tests/eval/captured/<skill>.txt` by default, and supports `--out <path>` override plus `--versioned` date-stamping.
+
+**Traces to:** Ticket Fix #2, DEC-001, DEC-002, DEC-009, DEC-010, DEC-013
+
+**Files:**
+- `src/clauditor/cli.py` — add new subparser `capture` with positional `skill_name`, `--out`, `--versioned`, and trailing `--` passthrough for skill args; add `cmd_capture()` function that constructs the prompt `/{skill_name} {args}`, invokes `runner.run()` or equivalent subprocess call, resolves the output path (with `--versioned` appending `-YYYY-MM-DD` to the stem), creates parent directory, writes stdout
+- `tests/test_cli.py` — unit tests mocking `runner.run()` / `subprocess.run`:
+  - default path: writes to `tests/eval/captured/find-restaurants.txt`
+  - `--out custom.txt`: writes to `custom.txt`
+  - `--versioned`: filename has `-YYYY-MM-DD` suffix
+  - `--out custom.txt --versioned`: writes to `custom-YYYY-MM-DD.txt`
+  - skill name `/find-restaurants` normalizes to `find-restaurants`
+  - skill name `find-restaurants` without leading slash still works
+  - non-zero runner exit → CLI exits non-zero with error message
+
+**TDD:**
+- All 6 cases above before implementation
+
+**Acceptance criteria:**
+- `clauditor capture --help` shows the new subcommand with all flags documented
+- Parent directory created if missing
+- No network calls in unit tests (all mocked); coverage ≥ 80%; ruff clean
+
+**Done when:** `clauditor capture find-restaurants -- "near San Jose"` (with mocked subprocess) writes the expected content to the expected path.
+
+**Depends on:** none
+
+---
+
+### US-007 — Add `clauditor doctor` CLI subcommand
+
+**Description:** New subparser `doctor` that runs read-only checks and prints a human-readable report. v1 scope (DEC-005): Python version ≥ 3.11, `anthropic` SDK importable, `claude` CLI on PATH, pytest plugin entry_point registered under `pytest11`, editable-install detection (is the installed `clauditor` package path writable / does it point at a source checkout?). Always exits 0 (DEC-008).
+
+**Traces to:** Ticket Fix #6, DEC-005, DEC-008, DEC-014
+
+**Files:**
+- `src/clauditor/cli.py` — add `doctor` subparser and `cmd_doctor()` that runs each check, collects `(name, status, message)` tuples where status is `ok`/`warn`/`fail`, prints as aligned table with `[ok]`/`[warn]`/`[fail]` prefixes, always returns exit code 0
+- `tests/test_cli.py` — for each check, unit test both the passing and failing branch by patching `sys.version_info`, `importlib.util.find_spec`, `shutil.which`, `importlib.metadata.entry_points`, and `importlib.util.find_spec("clauditor").origin`
+
+**TDD:**
+- Python 3.10 → `[fail]` for python version
+- Python 3.11 → `[ok]`
+- `anthropic` importable → `[ok]`; not importable → `[warn]` (it's an optional extra)
+- `shutil.which("claude")` returns path → `[ok]`; returns None → `[fail]`
+- `pytest11` entry_points contains `clauditor` → `[ok]`; missing → `[fail]`
+- Installed path under site-packages with no source link → `[warn]` (not editable); path points at source tree → `[ok]`
+- Exit code is 0 even when all checks fail
+
+**Acceptance criteria:**
+- All 6 check branches covered by unit tests
+- Always exit 0
+- Coverage ≥ 80%; ruff clean
+
+**Done when:** `clauditor doctor` on a healthy dev venv prints 5 `[ok]` lines and exits 0.
+
+**Depends on:** none
+
+---
+
+### US-008 — Quality Gate (code review × 4 + CodeRabbit)
+
+**Description:** Run the `code-review` skill four times across the full changeset; fix all real bugs found each pass. Run CodeRabbit if available. Re-run project validation (`uv run ruff check`, `uv run pytest --cov`) after fixes. This story depends on **all implementation stories** being complete.
+
+**Traces to:** All DEC-001 → DEC-014
+
+**Acceptance criteria:**
+- 4 code-review passes complete
+- All real bugs found in reviews are fixed (non-real / stylistic "concerns" may be deferred with a written justification)
+- `uv run ruff check src/ tests/` clean
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥ 80% coverage
+- All ticket acceptance-criteria checkboxes are satisfied
+
+**Done when:** Four consecutive review passes produce no new real bugs.
+
+**Depends on:** US-001, US-002, US-003, US-004, US-005, US-006, US-007
+
+---
+
+### US-009 — Patterns & Memory
+
+**Description:** Update project conventions and memory with patterns learned in this plan. Specifically: (a) document the `format` field's registry-lookup-then-regex-fallback semantics in README and/or a future `.claude/rules/` file; (b) if `.claude/rules/` doesn't yet exist, propose creating one entry capturing "field validation uses `format` only; no `pattern` field"; (c) `bd remember` any non-obvious patterns (e.g. the naming scheme for `count_max` vs `count` assertions, the `grouped_summary` grouping key convention).
+
+**Traces to:** DEC-007, DEC-012, DEC-014
+
+**Acceptance criteria:**
+- README updated with `format` decision tree
+- At least one `bd remember` entry capturing a non-obvious insight
+
+**Done when:** A fresh agent opening this repo would not re-ask any of the design questions resolved in DEC-006 through DEC-014.
+
+**Depends on:** US-008
+
+---
+
+## Beads Manifest
+*(pending — Phase 7)*
+
+## Beads Manifest
+*(pending — Phase 7)*

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -55,6 +55,56 @@ class AssertionSet:
             lines.append(f"  FAIL: {r.name} — {r.message}")
         return "\n".join(lines)
 
+    def grouped_summary(self) -> list[str]:
+        """Collapse repeated field/suffix failures into one line per group.
+
+        Structured assertion names of form
+        ``section:{Section}/{tier}[{i}].{field}[:{suffix}]`` are grouped by
+        ``(section, tier, field, suffix_or_"presence")`` so that N identical
+        failures across entries surface as a single summary line. Non-structured
+        names pass through unchanged.
+        """
+        structured_re = re.compile(
+            r"section:([^/]+)/([^\[]+)\[(\d+)\]\.([^:]+?)(?::(.+))?$"
+        )
+        groups: dict[tuple, dict] = {}
+        order: list[tuple] = []
+        passthrough: list[AssertionResult] = []
+
+        for r in self.results:
+            m = structured_re.fullmatch(r.name)
+            if not m:
+                passthrough.append(r)
+                continue
+            section, tier, _idx, fld, suffix = m.groups()
+            key = (section, tier, fld, suffix or "presence")
+            if key not in groups:
+                groups[key] = {"total": 0, "failed": 0, "first_fail": None}
+                order.append(key)
+            g = groups[key]
+            g["total"] += 1
+            if not r.passed:
+                g["failed"] += 1
+                if g["first_fail"] is None:
+                    g["first_fail"] = r
+
+        lines: list[str] = []
+        for key in order:
+            g = groups[key]
+            if g["failed"] == 0:
+                continue
+            r = g["first_fail"]
+            detail = r.evidence if r.evidence else r.message
+            section, tier, fld, suffix = key
+            lines.append(
+                f"{g['failed']}/{g['total']} {section}/{tier}[*].{fld}:{suffix} "
+                f"failed: {detail}"
+            )
+        for r in passthrough:
+            if not r.passed:
+                lines.append(f"FAIL: {r.name} — {r.message}")
+        return lines
+
 
 def assert_contains(output: str, value: str) -> AssertionResult:
     """Check that output contains a substring."""

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -429,7 +429,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
         return 1
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(result.output)
+    out_path.write_text(result.output, encoding="utf-8")
     print(f"Captured {len(result.output)} chars to {out_path}", file=sys.stderr)
     return 0
 
@@ -729,17 +729,18 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
 
-    # Split argv on a literal `--` so the `capture` subcommand can pass
-    # arbitrary trailing args (which may start with `-`) to the skill.
+    # Split argv on a literal `--` *only* when the capture subcommand is in
+    # play, so other subcommands (validate/grade/...) keep argparse's native
+    # `--` handling instead of having their trailing args silently stripped.
     if argv is None:
         argv = sys.argv[1:]
-    if "--" in argv:
+    trailing: list[str] = []
+    if argv and argv[0] == "capture" and "--" in argv:
         sep = argv.index("--")
         main_argv = argv[:sep]
         trailing = argv[sep + 1:]
     else:
         main_argv = argv
-        trailing = []
     parsed = parser.parse_args(main_argv)
     if trailing and getattr(parsed, "command", None) == "capture":
         parsed.skill_args = (parsed.skill_args or []) + trailing

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -483,7 +483,17 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         )
 
     try:
-        eps = importlib.metadata.entry_points(group="pytest11")
+        # Version-agnostic lookup: `entry_points(group=...)` is 3.10+, but
+        # `doctor` must keep working even when the Python-version check
+        # itself is about to fail, so fall back to filtering manually.
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            eps = eps.select(group="pytest11")
+        else:
+            eps = [
+                ep for ep in eps
+                if getattr(ep, "group", None) == "pytest11"
+            ]
         names = [ep.name for ep in eps]
         if "clauditor" in names:
             checks.append(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -396,6 +396,135 @@ def cmd_extract(args: argparse.Namespace) -> int:
     return 0 if results.passed else 1
 
 
+def cmd_capture(args: argparse.Namespace) -> int:
+    """Run a skill via ``claude -p`` and write stdout to a captured file.
+
+    DEC-001/002/010/013: default path is ``tests/eval/captured/<skill>.txt``;
+    ``--out`` overrides; ``--versioned`` appends ``-YYYY-MM-DD`` to the stem
+    (combines with ``--out``). Skill name accepts an optional leading ``/``.
+    """
+    from datetime import date
+
+    skill_name = args.skill.lstrip("/")
+    skill_args = " ".join(args.skill_args) if args.skill_args else ""
+
+    default_out = Path("tests/eval/captured") / f"{skill_name}.txt"
+    out_path = Path(args.out) if args.out else default_out
+
+    if args.versioned:
+        stamp = date.today().isoformat()
+        out_path = out_path.with_name(
+            f"{out_path.stem}-{stamp}{out_path.suffix}"
+        )
+
+    runner = SkillRunner(claude_bin=args.claude_bin or "claude")
+    print(f"Running /{skill_name} {skill_args}...", file=sys.stderr)
+    result = runner.run(skill_name, skill_args)
+
+    if not result.succeeded:
+        print(
+            f"ERROR: Skill run failed (exit {result.exit_code}): {result.error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(result.output)
+    print(f"Captured {len(result.output)} chars to {out_path}", file=sys.stderr)
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Read-only environment diagnostics (DEC-005/008/014).
+
+    Always exits 0 — this is a reporting tool, not a CI gate.
+    """
+    import importlib.metadata
+    import importlib.util
+    import shutil
+
+    checks: list[tuple[str, str, str]] = []
+
+    py_version = sys.version_info
+    if py_version >= (3, 11):
+        checks.append(
+            (
+                "python",
+                "ok",
+                f"Python {py_version.major}.{py_version.minor}.{py_version.micro}",
+            )
+        )
+    else:
+        checks.append(
+            (
+                "python",
+                "fail",
+                f"Python {py_version.major}.{py_version.minor} < 3.11 (required)",
+            )
+        )
+
+    if importlib.util.find_spec("anthropic") is not None:
+        checks.append(("anthropic", "ok", "SDK importable"))
+    else:
+        checks.append(
+            (
+                "anthropic",
+                "warn",
+                "SDK not installed (required only for Layer 2/3 grading)",
+            )
+        )
+
+    claude_path = shutil.which("claude")
+    if claude_path:
+        checks.append(("claude-cli", "ok", claude_path))
+    else:
+        checks.append(
+            ("claude-cli", "fail", "`claude` not found on PATH")
+        )
+
+    try:
+        eps = importlib.metadata.entry_points(group="pytest11")
+        names = [ep.name for ep in eps]
+        if "clauditor" in names:
+            checks.append(
+                ("pytest-plugin", "ok", "clauditor registered under pytest11")
+            )
+        else:
+            checks.append(
+                (
+                    "pytest-plugin",
+                    "fail",
+                    f"clauditor not registered (found: {names})",
+                )
+            )
+    except Exception as e:  # pragma: no cover - defensive
+        checks.append(("pytest-plugin", "fail", f"entry_points lookup failed: {e}"))
+
+    spec = importlib.util.find_spec("clauditor")
+    if spec is not None and spec.origin is not None:
+        origin = Path(spec.origin).resolve()
+        if "site-packages" in origin.parts and not origin.is_symlink():
+            checks.append(
+                (
+                    "editable-install",
+                    "warn",
+                    f"clauditor installed non-editable at {origin.parent} "
+                    f"— source edits will not propagate",
+                )
+            )
+        else:
+            checks.append(("editable-install", "ok", str(origin.parent)))
+    else:
+        checks.append(("editable-install", "fail", "clauditor package not importable"))
+
+    width = max(len(name) for name, _, _ in checks)
+    for name, status, detail in checks:
+        tag = f"[{status}]"
+        print(f"{tag:<7} {name:<{width}}  {detail}")
+
+    return 0
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Generate a starter eval.json for a skill."""
     skill_path = Path(args.skill)
@@ -561,7 +690,59 @@ def main(argv: list[str] | None = None) -> int:
         "--force", action="store_true", help="Overwrite existing eval.json"
     )
 
-    parsed = parser.parse_args(argv)
+    # capture
+    p_capture = subparsers.add_parser(
+        "capture",
+        help="Run a skill via `claude -p` and save stdout to a captured file",
+    )
+    p_capture.add_argument(
+        "skill",
+        help="Skill name (leading slash optional, e.g. find-restaurants)",
+    )
+    p_capture.add_argument(
+        "--out",
+        default=None,
+        help="Output file path (default: tests/eval/captured/<skill>.txt)",
+    )
+    p_capture.add_argument(
+        "--versioned",
+        action="store_true",
+        help="Append -YYYY-MM-DD to the output file stem",
+    )
+    p_capture.add_argument(
+        "--claude-bin",
+        default=None,
+        help="Path to the `claude` CLI (default: `claude` on PATH)",
+    )
+    p_capture.add_argument(
+        "skill_args",
+        nargs="*",
+        help="Arguments to pass to the skill (put after `--`)",
+    )
+
+    # doctor
+    subparsers.add_parser(
+        "doctor",
+        help=(
+            "Report environment diagnostics "
+            "(Python, SDK, claude CLI, plugin, install)"
+        ),
+    )
+
+    # Split argv on a literal `--` so the `capture` subcommand can pass
+    # arbitrary trailing args (which may start with `-`) to the skill.
+    if argv is None:
+        argv = sys.argv[1:]
+    if "--" in argv:
+        sep = argv.index("--")
+        main_argv = argv[:sep]
+        trailing = argv[sep + 1:]
+    else:
+        main_argv = argv
+        trailing = []
+    parsed = parser.parse_args(main_argv)
+    if trailing and getattr(parsed, "command", None) == "capture":
+        parsed.skill_args = (parsed.skill_args or []) + trailing
 
     if parsed.command == "validate":
         return cmd_validate(parsed)
@@ -575,6 +756,10 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_extract(parsed)
     elif parsed.command == "init":
         return cmd_init(parsed)
+    elif parsed.command == "capture":
+        return cmd_capture(parsed)
+    elif parsed.command == "doctor":
+        return cmd_doctor(parsed)
 
     return 1
 

--- a/src/clauditor/formats.py
+++ b/src/clauditor/formats.py
@@ -58,6 +58,11 @@ FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
         "HTTP(S) URL",
     ),
     _def(
+        "domain",
+        r"(?i)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
+        "Bare domain (no scheme), e.g. example.com",
+    ),
+    _def(
         "date_iso",
         r"\d{4}-\d{2}-\d{2}",
         "ISO 8601 date, e.g. 2026-04-10",

--- a/src/clauditor/formats.py
+++ b/src/clauditor/formats.py
@@ -55,12 +55,21 @@ FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
     _def(
         "url",
         r"https?://[^\s\)\"'>]+",
-        "HTTP(S) URL",
+        (
+            "HTTP(S) URL with scheme. Note: LLMs often emit bare domains "
+            "when pulling display text from markdown links "
+            "(e.g. '[paesanosj.com](https://paesanosj.com/)' → "
+            "'paesanosj.com'). Use the 'domain' format if you want to "
+            "accept those too."
+        ),
     ),
     _def(
         "domain",
-        r"(?i)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
-        "Bare domain (no scheme), e.g. example.com",
+        # Two or more labels; final label must be alphabetic and ≥2 chars
+        # so numeric/IP-like strings (e.g. 192.168.1.1) don't validate.
+        r"(?i)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+        r"(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,}",
+        "Bare domain (no scheme), e.g. example.com or sub.example.co.uk",
     ),
     _def(
         "date_iso",

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -103,6 +103,20 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                 )
             )
 
+            # Check maximum entry count (precision signal — DEC-003)
+            if tier.max_entries is not None:
+                results.results.append(
+                    AssertionResult(
+                        name=f"section:{section_req.name}:count_max/{tier.label}",
+                        passed=len(entries) <= tier.max_entries,
+                        message=(
+                            f"Section '{section_req.name}' tier '{tier.label}' "
+                            f"has {len(entries)} entries "
+                            f"(need \u2264{tier.max_entries})"
+                        ),
+                    )
+                )
+
             # Check required fields on each entry
             for i, entry in enumerate(entries):
                 for field_req in tier.fields:

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -139,7 +139,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                         )
                     )
 
-                # Validate pattern/format on fields that have values
+                # Validate format on fields that have values (DEC-007)
                 for field_req in tier.fields:
                     raw_value = entry.fields.get(field_req.name)
                     if not raw_value:
@@ -151,60 +151,31 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                         f"/{tier.label}[{i}].{field_req.name}"
                     )
 
-                    if field_req.pattern:
-                        try:
-                            pat_match = re.fullmatch(field_req.pattern, value)
-                            results.results.append(
-                                AssertionResult(
-                                    name=f"{base}:pattern",
-                                    passed=pat_match is not None,
-                                    message=(
-                                        "Pattern matched"
-                                        if pat_match
-                                        else f"Value does not match "
-                                        f"pattern /{field_req.pattern}/"
-                                    ),
-                                    evidence=value,
-                                )
-                            )
-                        except re.error as e:
-                            results.results.append(
-                                AssertionResult(
-                                    name=f"{base}:pattern",
-                                    passed=False,
-                                    message=f"Invalid pattern: {e}",
-                                    evidence=field_req.pattern,
-                                )
-                            )
-
                     if field_req.format:
                         fmt = get_format(field_req.format)
-                        if fmt is None:
-                            results.results.append(
-                                AssertionResult(
-                                    name=f"{base}:format",
-                                    passed=False,
-                                    message=(
-                                        f"Unknown format: "
-                                        f"{field_req.format}"
-                                    ),
-                                )
-                            )
+                        if fmt is not None:
+                            matched = fmt.pattern.fullmatch(value) is not None
+                            label = f"format '{field_req.format}'"
                         else:
-                            fmt_match = fmt.pattern.fullmatch(value)
-                            results.results.append(
-                                AssertionResult(
-                                    name=f"{base}:format",
-                                    passed=fmt_match is not None,
-                                    message=(
-                                        f"Format '{field_req.format}' matched"
-                                        if fmt_match
-                                        else f"Value does not match "
-                                        f"format '{field_req.format}'"
-                                    ),
-                                    evidence=value,
-                                )
+                            # DEC-007: format fell through to inline regex.
+                            # FieldRequirement validated compilability at
+                            # construction, so this compile always succeeds.
+                            matched = (
+                                re.fullmatch(field_req.format, value) is not None
                             )
+                            label = f"regex /{field_req.format}/"
+                        results.results.append(
+                            AssertionResult(
+                                name=f"{base}:format",
+                                passed=matched,
+                                message=(
+                                    f"{label.capitalize()} matched"
+                                    if matched
+                                    else f"Value does not match {label}"
+                                ),
+                                evidence=value,
+                            )
+                        )
 
     return results
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -62,6 +62,14 @@ def pytest_configure(config: pytest.Config) -> None:
         "clauditor_grade: mark test as requiring Layer 3 LLM grading "
         "(skipped without --clauditor-grade)",
     )
+    config.addinivalue_line(
+        "markers",
+        "network: real HTTP; deselect with -m 'not network'",
+    )
+    config.addinivalue_line(
+        "markers",
+        "slow: slow-running tests; deselect with -m 'not slow'",
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -27,6 +27,7 @@ class TierRequirement:
     label: str
     description: str = ""
     min_entries: int = 0
+    max_entries: int | None = None
     fields: list[FieldRequirement] = field(default_factory=list)
 
 
@@ -109,6 +110,7 @@ class EvalSpec:
                             label=t["label"],
                             description=t.get("description", ""),
                             min_entries=t.get("min_entries", 0),
+                            max_entries=t.get("max_entries"),
                             fields=tier_fields,
                         )
                     )
@@ -195,6 +197,11 @@ class EvalSpec:
                                 else {}
                             ),
                             "min_entries": t.min_entries,
+                            **(
+                                {"max_entries": t.max_entries}
+                                if t.max_entries is not None
+                                else {}
+                            ),
                             "fields": [
                                 {
                                     "name": f.name,

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -6,18 +6,39 @@ Loads eval.json files that define what a skill's output should look like.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 
 @dataclass
 class FieldRequirement:
-    """A required field in a structured entry (venue, event, etc.)."""
+    """A required field in a structured entry (venue, event, etc.).
+
+    The ``format`` field does double duty (DEC-007): it accepts either a
+    registered format name (e.g. ``"phone_us"``, ``"domain"``) or an inline
+    regex. Registry lookup wins when both could apply. Invalid values raise
+    ``ValueError`` at construction time.
+    """
 
     name: str
     required: bool = True
-    pattern: str | None = None  # Optional regex the field value must match
-    format: str | None = None  # Named format from formats registry
+    format: str | None = None  # Registry key or inline regex (DEC-007)
+
+    def __post_init__(self) -> None:
+        if self.format is None:
+            return
+        from clauditor.formats import FORMAT_REGISTRY
+        if self.format in FORMAT_REGISTRY:
+            return
+        try:
+            re.compile(self.format)
+        except re.error as e:
+            raise ValueError(
+                f"FieldRequirement(name={self.name!r}): format "
+                f"{self.format!r} is neither a registered format name "
+                f"({sorted(FORMAT_REGISTRY)}) nor a valid regex: {e}"
+            ) from e
 
 
 @dataclass
@@ -63,6 +84,22 @@ class VarianceConfig:
     min_stability: float = 0.8
 
 
+def _resolve_field_format(field_dict: dict) -> str | None:
+    """Resolve the ``format`` value for a field entry during spec load.
+
+    Rejects the legacy ``pattern`` key with a clear migration message
+    (DEC-006/DEC-007): eval specs should use ``format`` which now accepts
+    either a registered format name or an inline regex.
+    """
+    if "pattern" in field_dict:
+        raise ValueError(
+            f"Field {field_dict.get('name')!r}: the 'pattern' key is no "
+            f"longer supported. Use 'format' instead — it accepts either "
+            f"a registered format name (e.g. 'phone_us') or an inline regex."
+        )
+    return field_dict.get("format")
+
+
 @dataclass
 class EvalSpec:
     """Complete evaluation specification for a skill.
@@ -100,8 +137,7 @@ class EvalSpec:
                         FieldRequirement(
                             name=f["name"],
                             required=f.get("required", True),
-                            pattern=f.get("pattern"),
-                            format=f.get("format"),
+                            format=_resolve_field_format(f),
                         )
                         for f in t.get("fields", [])
                     ]
@@ -120,8 +156,7 @@ class EvalSpec:
                     FieldRequirement(
                         name=f["name"],
                         required=f.get("required", True),
-                        pattern=f.get("pattern"),
-                        format=f.get("format"),
+                        format=_resolve_field_format(f),
                     )
                     for f in s.get("fields", [])
                 ]
@@ -206,11 +241,6 @@ class EvalSpec:
                                 {
                                     "name": f.name,
                                     "required": f.required,
-                                    **(
-                                        {"pattern": f.pattern}
-                                        if f.pattern
-                                        else {}
-                                    ),
                                     **(
                                         {"format": f.format}
                                         if f.format

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -169,6 +169,7 @@ class EvalSpec:
                     TierRequirement(
                         label="default",
                         min_entries=s.get("min_entries", 1),
+                        max_entries=s.get("max_entries"),
                         fields=legacy_fields,
                     )
                 ]

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -28,6 +28,11 @@ class FieldRequirement:
     def __post_init__(self) -> None:
         if self.format is None:
             return
+        if self.format == "":
+            raise ValueError(
+                f"FieldRequirement(name={self.name!r}): format may not be "
+                f"an empty string (use None to disable format validation)."
+            )
         from clauditor.formats import FORMAT_REGISTRY
         if self.format in FORMAT_REGISTRY:
             return

--- a/tests/eval/captured/find-restaurants.txt
+++ b/tests/eval/captured/find-restaurants.txt
@@ -1,1 +1,0 @@
-captured stdout

--- a/tests/eval/captured/find-restaurants.txt
+++ b/tests/eval/captured/find-restaurants.txt
@@ -1,0 +1,1 @@
+captured stdout

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -228,6 +228,128 @@ class TestAssertionSet:
         assert "nope" in summary
 
 
+def _fail(name: str, msg: str = "nope", evidence: str | None = None) -> AssertionResult:
+    return AssertionResult(name=name, passed=False, message=msg, evidence=evidence)
+
+
+def _pass(name: str) -> AssertionResult:
+    return AssertionResult(name=name, passed=True, message="ok")
+
+
+class TestGroupedSummary:
+    """DEC-004, DEC-012: grouped_summary collapses field:suffix failures."""
+
+    def test_empty_set_returns_empty_list(self):
+        assert AssertionSet().grouped_summary() == []
+
+    def test_all_passing_returns_empty_list(self):
+        s = AssertionSet(
+            results=[
+                _pass(f"section:Restaurants/default[{i}].website:format")
+                for i in range(3)
+            ]
+        )
+        assert s.grouped_summary() == []
+
+    def test_six_website_format_failures_collapse_to_one_line(self):
+        s = AssertionSet(
+            results=[
+                _fail(
+                    f"section:Restaurants/default[{i}].website:format",
+                    evidence="paesanosj.com",
+                )
+                for i in range(6)
+            ]
+        )
+        lines = s.grouped_summary()
+        assert len(lines) == 1
+        assert "6/6" in lines[0]
+        assert "Restaurants/default[*].website:format" in lines[0]
+        assert "paesanosj.com" in lines[0]
+
+    def test_presence_failures_use_synthetic_suffix(self):
+        s = AssertionSet(
+            results=[
+                _fail(f"section:Restaurants/default[{i}].name", msg="missing name")
+                for i in range(3)
+            ]
+        )
+        lines = s.grouped_summary()
+        assert len(lines) == 1
+        assert "3/3" in lines[0]
+        assert ".name:presence" in lines[0]
+
+    def test_mixed_groups_one_line_each(self):
+        results = []
+        for i in range(3):
+            results.append(
+                _fail(
+                    f"section:Restaurants/default[{i}].website:format",
+                    evidence="x.com",
+                )
+            )
+        for i in range(2):
+            results.append(
+                _fail(
+                    f"section:Restaurants/default[{i}].phone:pattern",
+                    evidence="bad",
+                )
+            )
+        results.append(
+            _fail("section:Restaurants/default[0].name", msg="missing")
+        )
+        lines = AssertionSet(results=results).grouped_summary()
+        assert len(lines) == 3
+        joined = "\n".join(lines)
+        assert "3/3 Restaurants/default[*].website:format" in joined
+        assert "2/2 Restaurants/default[*].phone:pattern" in joined
+        assert "1/1 Restaurants/default[*].name:presence" in joined
+
+    def test_partial_group_shows_failed_over_total(self):
+        results = [
+            _pass("section:Restaurants/default[0].website:format"),
+            _fail(
+                "section:Restaurants/default[1].website:format",
+                evidence="bad.com",
+            ),
+            _fail(
+                "section:Restaurants/default[2].website:format",
+                evidence="also.bad",
+            ),
+        ]
+        lines = AssertionSet(results=results).grouped_summary()
+        assert len(lines) == 1
+        assert "2/3" in lines[0]
+
+    def test_non_structured_names_passthrough(self):
+        s = AssertionSet(
+            results=[
+                _fail("has_urls", msg="Found 0 URLs"),
+                _fail(
+                    "section:Venues/default[0].name:presence",
+                    msg="missing",
+                ),
+            ]
+        )
+        lines = s.grouped_summary()
+        assert len(lines) == 2
+        # structured group first (preserves insertion order of groups seen)
+        # passthroughs appended after
+        assert any("has_urls" in line for line in lines)
+
+    def test_summary_unchanged_regression(self):
+        """Existing summary() output is untouched by grouped_summary addition."""
+        s = AssertionSet(
+            results=[
+                _fail("section:Restaurants/default[0].website:format", msg="bad"),
+                _fail("section:Restaurants/default[1].website:format", msg="bad"),
+            ]
+        )
+        out = s.summary()
+        assert "0/2" in out
+        assert out.count("FAIL:") == 2
+
+
 class TestMaxLength:
     def test_pass(self):
         result = assert_max_length("short", 100)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from clauditor.assertions import AssertionResult, AssertionSet
@@ -733,3 +734,161 @@ class TestCmdExtract:
             rc = main(["extract", "skill.md", "--output", str(output_file)])
 
         assert rc == 1
+
+
+class TestCmdCapture:
+    """Tests for the capture subcommand (US-006)."""
+
+    def _mock_result(self, output: str = "captured stdout") -> SkillResult:
+        return SkillResult(
+            output=output,
+            exit_code=0,
+            skill_name="find-restaurants",
+            args="",
+            duration_seconds=1.0,
+        )
+
+    def test_capture_default_path(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = self._mock_result()
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants"])
+        assert rc == 0
+        out_path = tmp_path / "tests/eval/captured/find-restaurants.txt"
+        assert out_path.exists()
+        assert out_path.read_text() == "captured stdout"
+        mock_runner.run.assert_called_once_with("find-restaurants", "")
+
+    def test_capture_custom_out(self, tmp_path):
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = self._mock_result("abc")
+        target = tmp_path / "sub" / "custom.txt"
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants", "--out", str(target)])
+        assert rc == 0
+        assert target.read_text() == "abc"
+
+    def test_capture_versioned_appends_date(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = self._mock_result()
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants", "--versioned"])
+        assert rc == 0
+        captured_dir = tmp_path / "tests/eval/captured"
+        files = list(captured_dir.glob("find-restaurants-*.txt"))
+        assert len(files) == 1
+        # Stem matches find-restaurants-YYYY-MM-DD
+        import re as _re
+        assert _re.fullmatch(
+            r"find-restaurants-\d{4}-\d{2}-\d{2}", files[0].stem
+        )
+
+    def test_capture_out_plus_versioned(self, tmp_path):
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = self._mock_result()
+        target = tmp_path / "snap.txt"
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main([
+                "capture", "find-restaurants",
+                "--out", str(target), "--versioned",
+            ])
+        assert rc == 0
+        files = list(tmp_path.glob("snap-*.txt"))
+        assert len(files) == 1
+
+    def test_capture_strips_leading_slash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = self._mock_result()
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "/find-restaurants"])
+        assert rc == 0
+        mock_runner.run.assert_called_once_with("find-restaurants", "")
+        assert (tmp_path / "tests/eval/captured/find-restaurants.txt").exists()
+
+    def test_capture_passes_trailing_args(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = self._mock_result()
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants", "--", "near", "San Jose"])
+        assert rc == 0
+        mock_runner.run.assert_called_once_with("find-restaurants", "near San Jose")
+
+    def test_capture_runner_failure_returns_nonzero(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = SkillResult(
+            output="",
+            exit_code=2,
+            skill_name="find-restaurants",
+            args="",
+            duration_seconds=0.1,
+            error="boom",
+        )
+        with patch("clauditor.cli.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants"])
+        assert rc == 1
+        assert "boom" in capsys.readouterr().err
+
+
+class TestCmdDoctor:
+    """Tests for the doctor subcommand (US-007)."""
+
+    def test_doctor_always_exits_zero(self, capsys):
+        rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # At least one check per category reported
+        assert "python" in out
+        assert "anthropic" in out
+        assert "claude-cli" in out
+        assert "pytest-plugin" in out
+        assert "editable-install" in out
+
+    def test_doctor_python_too_old(self, capsys):
+        # Mimic sys.version_info shape enough for the doctor's usage.
+        class _FakeVersion(tuple):
+            major = 3
+            minor = 10
+            micro = 0
+
+        fake_version = _FakeVersion((3, 10, 0))
+        with patch.object(sys, "version_info", fake_version):
+            rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if line.startswith("[fail]") and "python" in line
+        ]
+        assert lines
+
+    def test_doctor_missing_anthropic(self, capsys):
+        real_find_spec = __import__("importlib").util.find_spec
+
+        def fake_find_spec(name):
+            if name == "anthropic":
+                return None
+            return real_find_spec(name)
+
+        with patch("importlib.util.find_spec", side_effect=fake_find_spec):
+            rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[warn]" in out
+        assert "anthropic" in out
+
+    def test_doctor_missing_claude_binary(self, capsys):
+        with patch("shutil.which", return_value=None):
+            rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "claude-cli" in out
+        # Expect fail marker for missing claude CLI
+        lines = [line for line in out.splitlines() if "claude-cli" in line]
+        assert any("[fail]" in line for line in lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -880,8 +880,13 @@ class TestCmdDoctor:
             rc = main(["doctor"])
         assert rc == 0
         out = capsys.readouterr().out
-        assert "[warn]" in out
-        assert "anthropic" in out
+        # Pin [warn] to the same line as the anthropic check, not just
+        # anywhere in the output (editable-install also emits [warn]).
+        anthropic_lines = [
+            line for line in out.splitlines() if "anthropic" in line
+        ]
+        assert len(anthropic_lines) == 1
+        assert anthropic_lines[0].startswith("[warn]")
 
     def test_doctor_missing_claude_binary(self, capsys):
         with patch("shutil.which", return_value=None):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -42,7 +42,7 @@ class TestListFormats:
             "phone_us", "phone_intl", "email", "url", "date_iso", "date_us",
             "time_24h", "time_12h", "currency_usd", "currency_eur",
             "zip_us", "zip_uk", "percentage", "ipv4", "uuid", "hex_color",
-            "latitude", "longitude", "star_rating",
+            "latitude", "longitude", "star_rating", "domain",
         ]
         for name in expected:
             assert name in names, f"Missing format: {name}"
@@ -259,5 +259,31 @@ class TestValidateValue:
     def test_star_rating_invalid(self):
         assert not validate_value("excellent", "star_rating")
 
+    @pytest.mark.parametrize("value", [
+        "paesanosj.com",
+        "sub.example.co.uk",
+        "a-b.io",
+    ])
+    def test_domain_valid(self, value):
+        assert validate_value(value, "domain")
+
+    @pytest.mark.parametrize("value", [
+        "https://paesanosj.com",
+        "paesanosj",
+        ".com",
+        "example..com",
+        "example.com/path",
+    ])
+    def test_domain_invalid(self, value):
+        assert not validate_value(value, "domain")
+
     def test_unknown_format(self):
         assert not validate_value("anything", "nonexistent")
+
+
+class TestDomainFieldRequirement:
+    def test_field_requirement_with_domain_format(self):
+        from clauditor.schemas import FieldRequirement
+        fr = FieldRequirement(name="website", format="domain")
+        assert fr.format == "domain"
+        assert FORMAT_REGISTRY["domain"].pattern is not None

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -273,6 +273,9 @@ class TestValidateValue:
         ".com",
         "example..com",
         "example.com/path",
+        "192.168.1.1",  # numeric TLD — ipv4-shaped input must not match
+        "example.1",  # single-char, digit-only TLD
+        "example.a",  # single-char TLD (too short)
     ])
     def test_domain_invalid(self, value):
         assert not validate_value(value, "domain")

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -341,6 +341,91 @@ class TestGradeExtraction:
         assert "section:Venues/default[1].address" in names
 
 
+def _make_max_entries_spec(max_entries: int | None = 3) -> EvalSpec:
+    return EvalSpec(
+        skill_name="test-skill",
+        sections=[
+            SectionRequirement(
+                name="Venues",
+                tiers=[
+                    TierRequirement(
+                        label="default",
+                        min_entries=1,
+                        max_entries=max_entries,
+                        fields=[
+                            FieldRequirement(name="name", required=True),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+class TestMaxEntries:
+    """DEC-003: TierRequirement.max_entries as a precision signal."""
+
+    def _entries(self, n: int) -> list[ExtractedEntry]:
+        return [ExtractedEntry(fields={"name": f"V{i}"}) for i in range(n)]
+
+    def test_over_max_emits_count_max_failure(self):
+        extracted = ExtractedOutput(
+            sections={"Venues": {"default": self._entries(6)}}
+        )
+        results = grade_extraction(extracted, _make_max_entries_spec(max_entries=3))
+        names = [r.name for r in results.results]
+        assert "section:Venues:count_max/default" in names
+        count_max = next(
+            r for r in results.results
+            if r.name == "section:Venues:count_max/default"
+        )
+        assert not count_max.passed
+        assert "6 entries" in count_max.message
+        assert "\u22643" in count_max.message
+
+    def test_over_max_still_grades_all_entry_fields(self):
+        """DEC-003: field checks still run for all extracted entries."""
+        extracted = ExtractedOutput(
+            sections={"Venues": {"default": self._entries(6)}}
+        )
+        results = grade_extraction(extracted, _make_max_entries_spec(max_entries=3))
+        presence_names = [
+            r.name for r in results.results
+            if r.name.startswith("section:Venues/default[") and r.name.endswith(".name")
+        ]
+        assert len(presence_names) == 6
+
+    def test_equal_to_max_passes(self):
+        extracted = ExtractedOutput(
+            sections={"Venues": {"default": self._entries(3)}}
+        )
+        results = grade_extraction(extracted, _make_max_entries_spec(max_entries=3))
+        count_max = next(
+            r for r in results.results
+            if r.name == "section:Venues:count_max/default"
+        )
+        assert count_max.passed
+
+    def test_under_max_passes(self):
+        extracted = ExtractedOutput(
+            sections={"Venues": {"default": self._entries(2)}}
+        )
+        results = grade_extraction(extracted, _make_max_entries_spec(max_entries=3))
+        count_max = next(
+            r for r in results.results
+            if r.name == "section:Venues:count_max/default"
+        )
+        assert count_max.passed
+
+    def test_none_max_emits_no_assertion(self):
+        extracted = ExtractedOutput(
+            sections={"Venues": {"default": self._entries(100)}}
+        )
+        results = grade_extraction(extracted, _make_max_entries_spec(max_entries=None))
+        names = [r.name for r in results.results]
+        assert not any("count_max" in n for n in names)
+
+
 class TestBuildExtractionPrompt:
     def test_contains_section_and_fields(self):
         spec = _make_spec()

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -425,6 +425,68 @@ class TestMaxEntries:
         names = [r.name for r in results.results]
         assert not any("count_max" in n for n in names)
 
+    def test_both_min_and_max_fail_when_extraction_exceeds_max(self):
+        """min_entries and max_entries produce independent assertions."""
+        spec = EvalSpec(
+            skill_name="test-skill",
+            sections=[
+                SectionRequirement(
+                    name="Venues",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=3,
+                            max_entries=3,
+                            fields=[FieldRequirement(name="name", required=True)],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        # Exactly 3 entries → both min and max pass
+        ok = grade_extraction(
+            ExtractedOutput(sections={"Venues": {"default": self._entries(3)}}),
+            spec,
+        )
+        count_min = next(
+            r for r in ok.results
+            if r.name == "section:Venues:count/default"
+        )
+        count_max = next(
+            r for r in ok.results
+            if r.name == "section:Venues:count_max/default"
+        )
+        assert count_min.passed
+        assert count_max.passed
+
+        # 5 entries → min passes, max fails
+        over = grade_extraction(
+            ExtractedOutput(sections={"Venues": {"default": self._entries(5)}}),
+            spec,
+        )
+        assert next(
+            r for r in over.results
+            if r.name == "section:Venues:count/default"
+        ).passed
+        assert not next(
+            r for r in over.results
+            if r.name == "section:Venues:count_max/default"
+        ).passed
+
+        # 1 entry → min fails, max passes
+        under = grade_extraction(
+            ExtractedOutput(sections={"Venues": {"default": self._entries(1)}}),
+            spec,
+        )
+        assert not next(
+            r for r in under.results
+            if r.name == "section:Venues:count/default"
+        ).passed
+        assert next(
+            r for r in under.results
+            if r.name == "section:Venues:count_max/default"
+        ).passed
+
 
 class TestBuildExtractionPrompt:
     def test_contains_section_and_fields(self):

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -687,8 +687,8 @@ class TestExtractAndGrade:
         assert result.passed
 
 
-def _make_pattern_spec() -> EvalSpec:
-    """Spec with pattern and format validation on fields."""
+def _make_format_spec() -> EvalSpec:
+    """Spec exercising both registry formats and inline-regex formats (DEC-007)."""
     return EvalSpec(
         skill_name="test-skill",
         sections=[
@@ -699,23 +699,21 @@ def _make_pattern_spec() -> EvalSpec:
                         label="default",
                         min_entries=1,
                         fields=[
-                            FieldRequirement(
-                                name="name", required=True
-                            ),
+                            FieldRequirement(name="name", required=True),
                             FieldRequirement(
                                 name="phone",
                                 required=True,
-                                pattern=r"\(\d{3}\) \d{3}-\d{4}",
+                                format=r"\(\d{3}\) \d{3}-\d{4}",  # inline regex
                             ),
                             FieldRequirement(
                                 name="website",
                                 required=True,
-                                format="url",
+                                format="url",  # registry
                             ),
                             FieldRequirement(
                                 name="email",
                                 required=False,
-                                format="email",
+                                format="email",  # registry
                             ),
                         ],
                     ),
@@ -725,8 +723,10 @@ def _make_pattern_spec() -> EvalSpec:
     )
 
 
-class TestPatternFormatEnforcement:
-    def test_pattern_match(self):
+class TestFormatEnforcement:
+    """DEC-007: format field does registry-lookup-then-regex-fallback."""
+
+    def test_inline_regex_match(self):
         extracted = ExtractedOutput(
             sections={
                 "Restaurants": {
@@ -742,13 +742,13 @@ class TestPatternFormatEnforcement:
                 }
             }
         )
-        results = grade_extraction(extracted, _make_pattern_spec())
-        pattern_results = [
-            r for r in results.results if ":pattern" in r.name
+        results = grade_extraction(extracted, _make_format_spec())
+        format_results = [
+            r for r in results.results if r.name.endswith(":format")
         ]
-        assert all(r.passed for r in pattern_results)
+        assert all(r.passed for r in format_results)
 
-    def test_pattern_mismatch(self):
+    def test_inline_regex_mismatch(self):
         extracted = ExtractedOutput(
             sections={
                 "Restaurants": {
@@ -764,37 +764,17 @@ class TestPatternFormatEnforcement:
                 }
             }
         )
-        results = grade_extraction(extracted, _make_pattern_spec())
-        pattern_results = [
-            r for r in results.results if ":pattern" in r.name
+        results = grade_extraction(extracted, _make_format_spec())
+        failing = [
+            r for r in results.results
+            if r.name.endswith(":format") and not r.passed
         ]
-        assert len(pattern_results) == 1
-        assert not pattern_results[0].passed
-        assert pattern_results[0].evidence == "call for hours"
+        assert len(failing) == 1
+        assert "phone" in failing[0].name
+        assert failing[0].evidence == "call for hours"
+        assert "regex" in failing[0].message.lower()
 
-    def test_format_match(self):
-        extracted = ExtractedOutput(
-            sections={
-                "Restaurants": {
-                    "default": [
-                        ExtractedEntry(
-                            fields={
-                                "name": "Paesano's",
-                                "phone": "(408) 298-5437",
-                                "website": "https://paesanos.com",
-                            }
-                        ),
-                    ]
-                }
-            }
-        )
-        results = grade_extraction(extracted, _make_pattern_spec())
-        format_results = [
-            r for r in results.results if ":format" in r.name
-        ]
-        assert all(r.passed for r in format_results)
-
-    def test_format_mismatch(self):
+    def test_registry_format_mismatch(self):
         extracted = ExtractedOutput(
             sections={
                 "Restaurants": {
@@ -810,94 +790,21 @@ class TestPatternFormatEnforcement:
                 }
             }
         )
-        results = grade_extraction(extracted, _make_pattern_spec())
-        format_results = [
-            r for r in results.results if ":format" in r.name
+        results = grade_extraction(extracted, _make_format_spec())
+        failing = [
+            r for r in results.results
+            if r.name.endswith(":format") and not r.passed
         ]
-        failed = [r for r in format_results if not r.passed]
-        assert len(failed) == 1
-        assert "website" in failed[0].name
+        assert len(failing) == 1
+        assert "website" in failing[0].name
+        assert "url" in failing[0].message
 
-    def test_unknown_format_name(self):
-        spec = EvalSpec(
-            skill_name="test",
-            sections=[
-                SectionRequirement(
-                    name="Items",
-                    tiers=[
-                        TierRequirement(
-                            label="default",
-                            min_entries=1,
-                            fields=[
-                                FieldRequirement(
-                                    name="val",
-                                    required=True,
-                                    format="bogus_format",
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        )
-        extracted = ExtractedOutput(
-            sections={
-                "Items": {
-                    "default": [
-                        ExtractedEntry(fields={"val": "anything"}),
-                    ]
-                }
-            }
-        )
-        results = grade_extraction(extracted, spec)
-        format_results = [
-            r for r in results.results if ":format" in r.name
-        ]
-        assert len(format_results) == 1
-        assert not format_results[0].passed
-        assert "Unknown format" in format_results[0].message
+    def test_unknown_format_not_valid_regex_raises_at_construction(self):
+        """DEC-011: an unknown format that is also invalid regex fails loud."""
+        with pytest.raises(ValueError, match="nor a valid regex"):
+            FieldRequirement(name="val", format="[invalid")
 
-    def test_invalid_pattern_regex(self):
-        spec = EvalSpec(
-            skill_name="test",
-            sections=[
-                SectionRequirement(
-                    name="Items",
-                    tiers=[
-                        TierRequirement(
-                            label="default",
-                            min_entries=1,
-                            fields=[
-                                FieldRequirement(
-                                    name="val",
-                                    required=True,
-                                    pattern="[invalid",
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        )
-        extracted = ExtractedOutput(
-            sections={
-                "Items": {
-                    "default": [
-                        ExtractedEntry(fields={"val": "test"}),
-                    ]
-                }
-            }
-        )
-        results = grade_extraction(extracted, spec)
-        pattern_results = [
-            r for r in results.results if ":pattern" in r.name
-        ]
-        assert len(pattern_results) == 1
-        assert not pattern_results[0].passed
-        assert "Invalid pattern" in pattern_results[0].message
-
-    def test_optional_field_missing_skips_validation(self):
-        """If an optional field is missing, pattern/format are not checked."""
+    def test_optional_field_missing_skips_format_check(self):
         extracted = ExtractedOutput(
             sections={
                 "Restaurants": {
@@ -914,66 +821,15 @@ class TestPatternFormatEnforcement:
                 }
             }
         )
-        results = grade_extraction(extracted, _make_pattern_spec())
-        # No format check on email since it's not present
+        results = grade_extraction(extracted, _make_format_spec())
         email_format = [
-            r
-            for r in results.results
-            if "email" in r.name and ":format" in r.name
+            r for r in results.results
+            if "email" in r.name and r.name.endswith(":format")
         ]
         assert len(email_format) == 0
 
-    def test_both_pattern_and_format(self):
-        """When both pattern and format are set, both must match."""
-        spec = EvalSpec(
-            skill_name="test",
-            sections=[
-                SectionRequirement(
-                    name="Items",
-                    tiers=[
-                        TierRequirement(
-                            label="default",
-                            min_entries=1,
-                            fields=[
-                                FieldRequirement(
-                                    name="phone",
-                                    required=True,
-                                    pattern=r"\(\d{3}\) \d{3}-\d{4}",
-                                    format="phone_us",
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        )
-        extracted = ExtractedOutput(
-            sections={
-                "Items": {
-                    "default": [
-                        ExtractedEntry(
-                            fields={
-                                "phone": "(408) 298-5437"
-                            }
-                        ),
-                    ]
-                }
-            }
-        )
-        results = grade_extraction(extracted, spec)
-        pattern_r = [
-            r for r in results.results if ":pattern" in r.name
-        ]
-        format_r = [
-            r for r in results.results if ":format" in r.name
-        ]
-        assert len(pattern_r) == 1
-        assert pattern_r[0].passed
-        assert len(format_r) == 1
-        assert format_r[0].passed
-
     def test_non_string_field_value_coerced(self):
-        """Non-string values (e.g. int from LLM) should be coerced to str."""
+        """Non-string values (e.g. int from LLM) are coerced to str for format check."""
         spec = EvalSpec(
             skill_name="test",
             sections=[
@@ -987,7 +843,7 @@ class TestPatternFormatEnforcement:
                                 FieldRequirement(
                                     name="count",
                                     required=True,
-                                    pattern=r"\d+",
+                                    format=r"\d+",
                                 ),
                             ],
                         ),
@@ -1005,9 +861,9 @@ class TestPatternFormatEnforcement:
             }
         )
         results = grade_extraction(extracted, spec)
-        pattern_r = [
-            r for r in results.results if ":pattern" in r.name
+        format_r = [
+            r for r in results.results if r.name.endswith(":format")
         ]
-        assert len(pattern_r) == 1
-        assert pattern_r[0].passed
-        assert pattern_r[0].evidence == "42"
+        assert len(format_r) == 1
+        assert format_r[0].passed
+        assert format_r[0].evidence == "42"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -112,8 +112,14 @@ class TestPluginFunctionsDirect:
             for call in config.addinivalue_line.call_args_list
         )
         assert any("clauditor_grade" in line for line in registered)
-        assert any(line.startswith("network:") for line in registered)
-        assert any(line.startswith("slow:") for line in registered)
+        # Pin the exact marker description strings so a typo in the
+        # registration (empty description, wrong suffix, etc.) fails loud.
+        assert (
+            "network: real HTTP; deselect with -m 'not network'" in registered
+        )
+        assert (
+            "slow: slow-running tests; deselect with -m 'not slow'" in registered
+        )
 
     def test_collection_modifyitems_skips_grade_tests(self):
         """Grade-marked items are skipped when flag is not set."""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -100,13 +100,20 @@ class TestPluginFunctionsDirect:
         assert "--clauditor-model" in option_names
 
     def test_pytest_configure_adds_marker(self):
-        """pytest_configure registers the clauditor_grade marker."""
+        """pytest_configure registers the clauditor_grade, network, and slow markers."""
         config = MagicMock()
         pytest_configure(config)
-        config.addinivalue_line.assert_called_once()
-        args = config.addinivalue_line.call_args
-        assert args[0][0] == "markers"
-        assert "clauditor_grade" in args[0][1]
+        assert config.addinivalue_line.call_count == 3
+        registered = [
+            call.args[1] for call in config.addinivalue_line.call_args_list
+        ]
+        assert all(
+            call.args[0] == "markers"
+            for call in config.addinivalue_line.call_args_list
+        )
+        assert any("clauditor_grade" in line for line in registered)
+        assert any(line.startswith("network:") for line in registered)
+        assert any(line.startswith("slow:") for line in registered)
 
     def test_collection_modifyitems_skips_grade_tests(self):
         """Grade-marked items are skipped when flag is not set."""

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -127,6 +127,11 @@ class TestFieldRequirement:
         with pytest.raises(ValueError, match="nor a valid regex"):
             FieldRequirement(name="phone", format="[invalid")
 
+    def test_empty_string_format_raises(self):
+        """Empty string is neither a registry key nor meaningful regex."""
+        with pytest.raises(ValueError, match="may not be an empty string"):
+            FieldRequirement(name="phone", format="")
+
 
 class TestFormatFieldRoundTrip:
     def test_format_preserved_in_roundtrip(self):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -774,6 +774,28 @@ class TestTierRequirement:
         tier_out = out["sections"][0]["tiers"][0]
         assert tier_out["max_entries"] == 3
 
+    def test_max_entries_propagates_through_legacy_section_shape(self, tmp_path):
+        """Legacy (no-tiers) section shape must propagate max_entries into
+        the synthesized default tier — otherwise the cap is silently ignored."""
+        data = {
+            "skill_name": "legacy-skill",
+            "sections": [
+                {
+                    "name": "Venues",
+                    "min_entries": 1,
+                    "max_entries": 3,
+                    "fields": [{"name": "name", "required": True}],
+                }
+            ],
+        }
+        path = tmp_path / "spec.eval.json"
+        path.write_text(json.dumps(data))
+        spec = EvalSpec.from_file(path)
+        default_tier = spec.sections[0].tiers[0]
+        assert default_tier.label == "default"
+        assert default_tier.min_entries == 1
+        assert default_tier.max_entries == 3
+
     def test_max_entries_none_omitted_from_dict(self, tmp_path):
         """When max_entries is None, it is omitted from serialized output."""
         data = {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -111,25 +111,21 @@ class TestFieldRequirement:
     def test_defaults(self):
         f = FieldRequirement(name="test")
         assert f.required is True
-        assert f.pattern is None
         assert f.format is None
 
-    def test_with_pattern(self):
-        f = FieldRequirement(name="phone", pattern=r"\(\d{3}\)\s\d{3}-\d{4}")
-        assert f.pattern is not None
-
-    def test_with_format(self):
+    def test_with_registry_format(self):
         f = FieldRequirement(name="phone", format="phone_us")
         assert f.format == "phone_us"
 
-    def test_with_both_pattern_and_format(self):
-        f = FieldRequirement(
-            name="phone",
-            pattern=r"\(\d{3}\)\s\d{3}-\d{4}",
-            format="phone_us",
-        )
-        assert f.pattern is not None
-        assert f.format == "phone_us"
+    def test_with_inline_regex_format(self):
+        """DEC-007: format accepts an inline regex when no registry match."""
+        f = FieldRequirement(name="phone", format=r"\(\d{3}\)\s\d{3}-\d{4}")
+        assert f.format == r"\(\d{3}\)\s\d{3}-\d{4}"
+
+    def test_invalid_format_raises_value_error(self):
+        """DEC-011: bad format (not registry, not compilable regex) fails loud."""
+        with pytest.raises(ValueError, match="nor a valid regex"):
+            FieldRequirement(name="phone", format="[invalid")
 
 
 class TestFormatFieldRoundTrip:
@@ -150,7 +146,6 @@ class TestFormatFieldRoundTrip:
                             "name": "email",
                             "required": False,
                             "format": "email",
-                            "pattern": r".+@.+",
                         },
                     ],
                 }
@@ -166,13 +161,11 @@ class TestFormatFieldRoundTrip:
         tier = spec.sections[0].tiers[0]
         assert tier.fields[0].format == "phone_us"
         assert tier.fields[1].format == "email"
-        assert tier.fields[1].pattern == r".+@.+"
 
         d = spec.to_dict()
         fields_out = d["sections"][0]["tiers"][0]["fields"]
         assert fields_out[0]["format"] == "phone_us"
         assert fields_out[1]["format"] == "email"
-        assert fields_out[1]["pattern"] == r".+@.+"
 
     def test_format_absent_backward_compat(self):
         data = {
@@ -353,7 +346,7 @@ FULL_EVAL_DATA = {
             "fields": [
                 {"name": "name", "required": True},
                 {"name": "address", "required": True},
-                {"name": "zip", "required": False, "pattern": r"^\d{5}$"},
+                {"name": "zip", "required": False, "format": r"^\d{5}$"},
             ],
         },
     ],
@@ -392,7 +385,7 @@ class TestFromFile:
         assert tier.label == "default"
         assert tier.min_entries == 2
         assert len(tier.fields) == 3
-        assert tier.fields[2].pattern == r"^\d{5}$"
+        assert tier.fields[2].format == r"^\d{5}$"
         assert tier.fields[2].required is False
         assert spec.grading_criteria == [
             "Are results relevant?",
@@ -437,8 +430,8 @@ class TestFromFile:
         with pytest.raises(json.JSONDecodeError):
             EvalSpec.from_file(bad)
 
-    def test_from_file_field_pattern_none_when_absent(self, tmp_path):
-        """Fields without a pattern key have pattern=None."""
+    def test_from_file_field_format_none_when_absent(self, tmp_path):
+        """Fields without a format key have format=None."""
         data = {
             "skill_name": "test",
             "sections": [
@@ -447,7 +440,24 @@ class TestFromFile:
         }
         path = _write_json(tmp_path, data)
         spec = EvalSpec.from_file(path)
-        assert spec.sections[0].tiers[0].fields[0].pattern is None
+        assert spec.sections[0].tiers[0].fields[0].format is None
+
+    def test_from_file_legacy_pattern_key_rejected(self, tmp_path):
+        """DEC-006: legacy 'pattern' key is rejected with a migration message."""
+        data = {
+            "skill_name": "test",
+            "sections": [
+                {
+                    "name": "S",
+                    "fields": [
+                        {"name": "f1", "required": True, "pattern": r"\d+"},
+                    ],
+                }
+            ],
+        }
+        path = _write_json(tmp_path, data)
+        with pytest.raises(ValueError, match="no longer supported"):
+            EvalSpec.from_file(path)
 
 
 class TestToDict:
@@ -472,9 +482,10 @@ class TestToDict:
         assert tier["label"] == "default"
         assert tier["min_entries"] == 2
         assert len(tier["fields"]) == 3
-        # Pattern included only where present
-        assert tier["fields"][2]["pattern"] == r"^\d{5}$"
-        assert "pattern" not in tier["fields"][0]
+        # Format included only where present (pattern field removed)
+        assert tier["fields"][2]["format"] == r"^\d{5}$"
+        assert "format" not in tier["fields"][0]
+        assert "pattern" not in tier["fields"][2]
         # Trigger tests
         assert d["trigger_tests"] == FULL_EVAL_DATA["trigger_tests"]
         # Variance

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -727,6 +727,63 @@ class TestTierRequirement:
         assert t.min_entries == 5
         assert len(t.fields) == 1
 
+    def test_max_entries_default_none(self):
+        t = TierRequirement(label="basic")
+        assert t.max_entries is None
+
+    def test_max_entries_roundtrip(self, tmp_path):
+        """max_entries parses from JSON and serializes back via to_dict."""
+        data = {
+            "skill_name": "max-entries-skill",
+            "sections": [
+                {
+                    "name": "Venues",
+                    "tiers": [
+                        {
+                            "label": "default",
+                            "min_entries": 1,
+                            "max_entries": 3,
+                            "fields": [{"name": "name", "required": True}],
+                        }
+                    ],
+                }
+            ],
+        }
+        path = tmp_path / "spec.eval.json"
+        path.write_text(json.dumps(data))
+        spec = EvalSpec.from_file(path)
+        assert spec.sections[0].tiers[0].max_entries == 3
+
+        out = spec.to_dict()
+        tier_out = out["sections"][0]["tiers"][0]
+        assert tier_out["max_entries"] == 3
+
+    def test_max_entries_none_omitted_from_dict(self, tmp_path):
+        """When max_entries is None, it is omitted from serialized output."""
+        data = {
+            "skill_name": "default-skill",
+            "sections": [
+                {
+                    "name": "Venues",
+                    "tiers": [
+                        {
+                            "label": "default",
+                            "min_entries": 1,
+                            "fields": [{"name": "name", "required": True}],
+                        }
+                    ],
+                }
+            ],
+        }
+        path = tmp_path / "spec.eval.json"
+        path.write_text(json.dumps(data))
+        spec = EvalSpec.from_file(path)
+        assert spec.sections[0].tiers[0].max_entries is None
+
+        out = spec.to_dict()
+        tier_out = out["sections"][0]["tiers"][0]
+        assert "max_entries" not in tier_out
+
 
 TIERED_SECTION_DATA = {
     "skill_name": "tiered-skill",


### PR DESCRIPTION
## Summary

Implements all six P0/P1 fixes from issue #17, surfaced by running clauditor against real `/find-restaurants` output in `my_claude_agent`.

**Phase:** devolved (implementation complete, all 9 stories closed)
**Stories:** 7 implementation + Quality Gate + Patterns & Memory
**Decisions:** DEC-001 → DEC-014 captured in `plans/super/17-real-world-fixes.md`

## Fixes shipped

1. **`domain` format** added to registry — accepts bare domains (`paesanosj.com`), rejects IP-shaped strings (`192.168.1.1`)
2. **`FieldRequirement.pattern` deprecated** — `format` now does double duty (registry lookup → inline regex fallback). Validation at construction; legacy `"pattern"` JSON key raises a clear migration error
3. **`TierRequirement.max_entries`** — precision signal emitting a `count_max` assertion; field-level checks still run over all extracted entries
4. **`AssertionSet.grouped_summary()`** — collapses repeated `(field, suffix)` failures into one line (24 lines → 1 for the real-world Haiku output)
5. **pytest markers** `network` and `slow` registered in the plugin
6. **`clauditor capture <skill>`** CLI — shells out via `runner.py`, writes to `tests/eval/captured/<skill>.txt`, supports `--out` and `--versioned`
7. **`clauditor doctor`** CLI — reports Python / SDK / `claude` bin / pytest plugin / editable install; always exits 0

## Validation

- **Tests:** 462 passing
- **Coverage:** 94.67% (gate: 80%)
- **Ruff:** clean
- **Reviews:** 4-pass code review + CodeRabbit CLI + Copilot PR review all addressed

## Plan document

See [`plans/super/17-real-world-fixes.md`](plans/super/17-real-world-fixes.md) for the full story breakdown, decisions, and refinement log.