### PR TITLE
#18: Real-world P2/P3 polish (plan)

### DIFF
--- a/.clauditor/history.jsonl
+++ b/.clauditor/history.jsonl
@@ -1,4 +1,0 @@
-{"ts": "2026-04-13T21:52:13.966774+00:00", "skill": "test-skill", "pass_rate": 1.0, "mean_score": 0.9, "metrics": {}}
-{"ts": "2026-04-13T21:52:13.973905+00:00", "skill": "test-skill", "pass_rate": 0.0, "mean_score": 0.3, "metrics": {}}
-{"ts": "2026-04-13T21:52:18.179387+00:00", "skill": "test-skill", "pass_rate": 1.0, "mean_score": 0.9, "metrics": {}}
-{"ts": "2026-04-13T21:52:18.195489+00:00", "skill": "test-skill", "pass_rate": 0.0, "mean_score": 0.3, "metrics": {}}

--- a/.clauditor/history.jsonl
+++ b/.clauditor/history.jsonl
@@ -1,0 +1,4 @@
+{"ts": "2026-04-13T21:52:13.966774+00:00", "skill": "test-skill", "pass_rate": 1.0, "mean_score": 0.9, "metrics": {}}
+{"ts": "2026-04-13T21:52:13.973905+00:00", "skill": "test-skill", "pass_rate": 0.0, "mean_score": 0.3, "metrics": {}}
+{"ts": "2026-04-13T21:52:18.179387+00:00", "skill": "test-skill", "pass_rate": 1.0, "mean_score": 0.9, "metrics": {}}
+{"ts": "2026-04-13T21:52:18.195489+00:00", "skill": "test-skill", "pass_rate": 0.0, "mean_score": 0.3, "metrics": {}}

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ coverage.xml
 .claude/agents/code-reviewer.md
 .claude/agents/planner.md
 
+# Clauditor local state (history, saved grade reports)
+.clauditor/
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/README.md
+++ b/README.md
@@ -219,15 +219,17 @@ clauditor grade .claude/commands/my-skill.md --diff       # Compare against prio
 
 Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--save` to persist results for regression tracking, and `--diff` to compare against a prior run (flags regressions where a criterion's score drops by more than 0.1).
 
-#### A/B Comparison
+#### Regression Comparison
 
-Runs your skill and raw Claude side-by-side against the same rubric. Flags regressions where the baseline passes but your skill fails.
+Diffs two saved grade reports (from `--save`) or two captured outputs, printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression.
 
 ```bash
 clauditor compare before.grade.json after.grade.json
+# Or re-grade two raw captures against a spec:
+clauditor compare before.txt after.txt --spec <skill.md>
 ```
 
-Diffs two saved grade reports (from `--save`) or two captured outputs (with `--spec`), printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression.
+For a true baseline A/B run (skill vs raw Claude against the same rubric), use the Python API `clauditor.comparator.compare_ab()` directly — the `grade --compare` CLI flag was removed in favor of the file-diff workflow above.
 
 #### Variance Measurement
 
@@ -321,7 +323,7 @@ clauditor grade <skill.md> --only-criterion clarity  # Run a subset (repeatable,
 clauditor grade <skill.md> --save      # Persist results to .clauditor/
 clauditor grade <skill.md> --diff      # Compare against prior results
 clauditor compare before.grade.json after.grade.json  # Diff two saved grade reports
-clauditor compare before.txt after.txt --spec eval.json  # Re-grade two captures
+clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
 clauditor trend <skill> --metric pass_rate       # Tab-separated history + ASCII sparkline
 clauditor triggers <skill.md>          # Trigger precision testing
 clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/

--- a/README.md
+++ b/README.md
@@ -317,13 +317,26 @@ clauditor extract <skill.md>           # Layer 2 schema extraction
 clauditor extract <skill.md> --dry-run # Print extraction prompt only
 clauditor grade <skill.md>             # Layer 3 quality grading
 clauditor grade <skill.md> --variance 3  # Variance measurement
-clauditor compare before.grade.json after.grade.json  # Diff two saved grade reports
+clauditor grade <skill.md> --only-criterion clarity  # Run a subset (repeatable, substring match)
 clauditor grade <skill.md> --save      # Persist results to .clauditor/
 clauditor grade <skill.md> --diff      # Compare against prior results
+clauditor compare before.grade.json after.grade.json  # Diff two saved grade reports
+clauditor compare before.txt after.txt --spec eval.json  # Re-grade two captures
+clauditor trend <skill> --metric pass_rate       # Tab-separated history + ASCII sparkline
 clauditor triggers <skill.md>          # Trigger precision testing
 clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/
 clauditor doctor                       # Report environment diagnostics
 ```
+
+### Persistent metric history
+
+Every `clauditor grade` run appends a JSON line to `.clauditor/history.jsonl`:
+
+```json
+{"ts": "2026-04-13T15:00:00+00:00", "skill": "find-restaurants", "pass_rate": 0.83, "mean_score": 0.75, "metrics": {}}
+```
+
+Use `clauditor trend <skill> --metric pass_rate --last 20` to view the last N values with an ASCII sparkline (`_.-=#` glyph set). Runs with `--only-criterion` skip the history append to keep longitudinal data comparable.
 
 ## Pytest Integration
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,26 @@ The eval spec defines what fields each section should have:
 }
 ```
 
+#### Field validation (`format`)
+
+Each field can declare a `format` that validates the extracted value. The `format` key accepts **either** a registered format name **or** an inline regex — clauditor looks up the string in `FORMAT_REGISTRY` first and falls back to compiling it as a regex if there's no match.
+
+Decision tree:
+
+- Is there a registered name in `FORMAT_REGISTRY` that fits? Use it (e.g. `"format": "phone_us"`).
+- Need something custom? Put a regex string directly in `format` (e.g. `"format": "^[a-z0-9-]+$"`).
+- Lookup is **registry-first, regex-fallback**. Invalid regexes raise `ValueError` at spec construction time, so typos fail fast.
+
+```json
+{"name": "phone", "format": "phone_us"}
+```
+
+```json
+{"name": "slug", "format": "^[a-z0-9-]+$"}
+```
+
+See [`FORMAT_REGISTRY` in `src/clauditor/formats.py`](src/clauditor/formats.py) for the full list of registered names (common entries: `phone_us`, `phone_intl`, `email`, `url`, `domain`, `date_iso`, `zip_us`, `uuid`).
+
 ### Layer 3: Quality Grading (expensive, release-only)
 
 Uses Sonnet to grade skill output against a rubric you define. Requires `ANTHROPIC_API_KEY` and `pip install clauditor[grader]`.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ clauditor registers as a pytest plugin automatically. Available fixtures:
 - `clauditor_spec` — factory for loading `SkillSpec` from skill files
 - `clauditor_grader` — factory for Layer 3 quality grading
 - `clauditor_triggers` — factory for trigger precision testing
+- `clauditor_capture` — factory returning a `Path` to `tests/eval/captured/<skill>.txt` for captured-output tests
 
 Options:
 

--- a/README.md
+++ b/README.md
@@ -224,10 +224,10 @@ Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and 
 Runs your skill and raw Claude side-by-side against the same rubric. Flags regressions where the baseline passes but your skill fails.
 
 ```bash
-clauditor grade .claude/commands/my-skill.md --compare
+clauditor compare before.grade.json after.grade.json
 ```
 
-Requires `test_args` in the eval spec — these become the baseline prompt.
+Diffs two saved grade reports (from `--save`) or two captured outputs (with `--spec`), printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression.
 
 #### Variance Measurement
 
@@ -316,8 +316,8 @@ clauditor run <skill-name> --args "…"  # Run skill, print output
 clauditor extract <skill.md>           # Layer 2 schema extraction
 clauditor extract <skill.md> --dry-run # Print extraction prompt only
 clauditor grade <skill.md>             # Layer 3 quality grading
-clauditor grade <skill.md> --compare   # A/B comparison
 clauditor grade <skill.md> --variance 3  # Variance measurement
+clauditor compare before.grade.json after.grade.json  # Diff two saved grade reports
 clauditor grade <skill.md> --save      # Persist results to .clauditor/
 clauditor grade <skill.md> --diff      # Compare against prior results
 clauditor triggers <skill.md>          # Trigger precision testing

--- a/plans/super/18-real-world-polish.md
+++ b/plans/super/18-real-world-polish.md
@@ -4,7 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/18
 - **Branch:** `feature/18-real-world-polish`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/18-real-world-polish`
-- **Phase:** `detailing`
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/20
 - **Sessions:** 1
 - **Last session:** 2026-04-13
 

--- a/plans/super/18-real-world-polish.md
+++ b/plans/super/18-real-world-polish.md
@@ -4,7 +4,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/18
 - **Branch:** `feature/18-real-world-polish`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/18-real-world-polish`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/20
 - **Sessions:** 1
 - **Last session:** 2026-04-13
@@ -473,4 +473,18 @@ Stories ordered by commit sequence (DEC-016). Each is sized for a single Ralph c
 
 ## Beads Manifest
 
-_pending_
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/18-real-world-polish`
+- **Epic:** `clauditor-98s` — #18: Real-world P2/P3 polish
+- **Tasks:**
+  - US-001 → `clauditor-98s.1` — AssertionResult.kind field
+  - US-002 → `clauditor-98s.2` — FORMAT_REGISTRY strict/extract audit
+  - US-003 → `clauditor-98s.3` — clauditor compare subcommand
+  - US-004 → `clauditor-98s.4` — README format dual-mode docs
+  - US-005 → `clauditor-98s.5` — raw_data field + -v surfacing
+  - US-006 → `clauditor-98s.6` — history.jsonl + trend command
+  - US-007 → `clauditor-98s.7` — clauditor_capture fixture
+  - US-008 → `clauditor-98s.8` — ASCII >=/<= replacement
+  - US-009 → `clauditor-98s.9` — --only-criterion flag
+  - US-010 → `clauditor-98s.10` — Quality Gate
+  - US-011 → `clauditor-98s.11` — Patterns & Memory
+- **Dependencies:** US-003, US-005, US-008 → US-001; US-010 → US-001..US-009; US-011 → US-010.

--- a/plans/super/18-real-world-polish.md
+++ b/plans/super/18-real-world-polish.md
@@ -1,0 +1,475 @@
+# Super Plan: #18 — Real-world P2/P3 polish from my_claude_agent eval run
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/18
+- **Branch:** `feature/18-real-world-polish`
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/18-real-world-polish`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-13
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Nine independent polish items (4× P2, 5× P3) surfaced by the same `my_claude_agent` eval run that drove #17. Quality-of-life and structural improvements: comparator workflow, assertion metadata, docs, strict/loose format patterns, metric history, grader debugging, pytest fixture, ASCII mode, and single-criterion Layer 3 re-runs.
+
+**Why:** Reduce friction for adopters and tighten the feedback loop. None are blockers individually, but together they close the observability and ergonomics gaps found in real-world usage.
+
+**Ticket acceptance criteria:**
+- [ ] `clauditor compare` command implemented
+- [ ] `AssertionResult.kind` field added
+- [ ] README documents `pattern` vs `format` decision (now: `format` dual-mode semantics, since #17 removed `pattern`)
+- [ ] All format registry entries have correct strict/extract patterns
+- [ ] `.clauditor/history.jsonl` persists metrics
+- [ ] Raw Haiku JSON surfaced on Layer 2 failure
+- [ ] `clauditor_capture` pytest fixture added
+- [ ] ASCII mode for assertion names
+- [ ] `--only-criterion` flag for Layer 3
+
+### Codebase Findings (from scout)
+
+**P2.1 `clauditor compare`** → `comparator.py` (already has `compare_ab(spec, model)` → `ABReport`, lines 62–126) + `cli.py:596–779` argparse subparser pattern. `cmd_grade()` already has a `--compare` flag (cli.py:131–134). A new `compare` subcommand needs to load *two captured outputs* against one spec and diff `AssertionResult.passed` flips (pass↔fail).
+
+**P2.2 `AssertionResult.kind`** → `assertions.py:17–27` dataclass. Name-to-kind mapping currently implicit in suffixes: `:format`, `:count`, `:count_max`, `has_format:{name}`, bare = presence, `≥N` inside name = count threshold. Naming call sites: assertions.py lines 113, 123, 145, 155, 176, 307, 323, 331; grader.py lines 96, 110, 169.
+
+**P2.3 README docs — `format` dual-mode** → `schemas.py:15–46` already has an accurate docstring (DEC-007 from #17). README lines 147–150 don't surface it. Add a "Field validation" section under Layer 2 with a decision tree.
+
+**P2.4 Format registry strict vs extract** → `formats.py:14–36`. `FormatDef` has separate `pattern` (strict, fullmatch) and `extract_pattern` (loose, findall). Only `zip_uk` (109–113) and `uuid` (125–129) currently set a distinct `extract=`. All others reuse the strict pattern for extraction, so `has_format(...)` undercounts. `validate_value()` (formats.py:164) uses strict, `assert_has_format()` (assertions.py:314–335) uses extract.
+
+**P3.5 Persistent metric history** → No `.jsonl` writers exist. `.clauditor/` convention exists (`cli.py:202–255` writes `{skill}.grade.json` on `--save`). Natural home: extend `--save` to also append a line to `.clauditor/history.jsonl`.
+
+**P3.6 Raw Haiku JSON on failure** → `grader.py:29–33` — `ExtractedOutput.raw_json` populated at line 239 but discarded on failure (lines 226–236). Parse-failure path emits one `grader:parse` assertion with only first 200 chars of response text.
+
+**P3.7 `clauditor_capture` fixture** → `pytest_plugin.py:85–112` has `clauditor_runner`/`clauditor_spec`/`clauditor_grader`/`clauditor_triggers`. Capture convention: `tests/eval/captured/<skill>.txt` (from #17, DEC-001). New fixture slots in next to the existing four.
+
+**P3.8 ASCII assertion names** → `≥`/`≤` literals in 7 locations in `assertions.py` (145, 155, 165, 176, 188, 307, 331). Rendered verbatim via `cli.py:64, 193`.
+
+**P3.9 `--only-criterion` for Layer 3** → `quality_grader.py:215–260` iterates `eval_spec.grading_criteria` with no filter. `cli.py:625–658` `p_grade` subparser is the natural home for the flag.
+
+### Conventions (from CLAUDE.md, confirmed by scout)
+- Test file per source module, class-based organization.
+- 80% coverage gate enforced.
+- Don't shadow plugin fixture names (`clauditor_runner/spec/grader/triggers`).
+- Beads for task tracking; no TodoWrite/markdown TODOs.
+- No `.claude/rules/*.md` files and no `workflow-project.md` — general CLAUDE.md rules apply.
+
+### Proposed Scope
+
+Ship all nine items in one plan. They're independent and share the same review surfaces as #17 (schemas/assertions/grader/cli/pytest_plugin). Ordering follows dependency: kind/format foundations first, then the features that build on them, then docs/history. Quality Gate + Patterns & Memory close it out.
+
+### Scoping Questions
+
+**Q1 — `clauditor compare` input shape**
+How does `compare` consume its inputs?
+
+- **(A)** `clauditor compare <before.txt> <after.txt> --spec x.eval.json` — two captured stdout files + one spec. Outputs a diff of assertion results.
+- **(B)** `clauditor compare <before.grade.json> <after.grade.json>` — diff two saved grade reports from `.clauditor/` (no re-grading, pure diff).
+- **(C)** Both: positional args auto-detect `.txt` vs `.grade.json`; require `--spec` only for `.txt`.
+- **(D)** Skip — `cmd_grade --compare` already exists; ship a README doc pointing at it instead.
+
+**Q2 — `AssertionResult.kind` population strategy**
+How does `kind` get set?
+
+- **(A)** New required enum field on `AssertionResult`; every construction site passes it explicitly. Most principled, touches ~10 call sites.
+- **(B)** Derived property that parses `self.name` on access. Zero call-site churn but fragile to name format drift.
+- **(C)** Optional field defaulting to `"custom"`; internal builders pass it, external callers (there are none currently) get the fallback.
+- **(D)** Same as (A) but also remove the suffix from `name` (e.g. `website` instead of `website:format`) once `kind` carries it — big refactor, breaks grouped_summary from #17.
+
+**Q3 — Format registry strict-vs-extract rollout**
+Which entries get distinct `extract_pattern`?
+
+- **(A)** All phone/email/url/domain — the high-traffic ones. Leave `uuid`/`zip_uk` as-is. Document the convention in a formats.py module docstring.
+- **(B)** Every entry, audited one at a time. Biggest correctness win, highest review load.
+- **(C)** (A) plus a unit-test matrix that asserts, for every registry entry, that `validate_value("X")==True → extract_pattern.findall("prefix X suffix")` finds ≥1 match. Enforces invariant going forward.
+
+**Q4 — Metric history format**
+What schema does `.clauditor/history.jsonl` use?
+
+- **(A)** One line per run, flat: `{ts, skill, pass_rate, mean_score, <metric>: <value>, ...}`. Simple but mixes dimensions.
+- **(B)** One line per (run, metric): `{ts, skill, metric_name, value}`. Easier to query, more lines.
+- **(C)** (A) plus a `clauditor trend <skill> --metric <name>` read command in the same story (ticket asks for it).
+- **(D)** (B) plus `clauditor trend`.
+
+**Q5 — Raw Haiku JSON surfacing mechanism**
+Where does `raw_json` go on failure?
+
+- **(A)** Attach as `evidence` on the failing `grader:parse` / `grader:shape` `AssertionResult` (string, truncated to ~2KB).
+- **(B)** Write to `.clauditor/last_grader_response.json` automatically on every grade (success or failure), overwriting each time.
+- **(C)** Both: evidence carries a reference string (`"see .clauditor/last_grader_response.json"`) and the file is always written.
+- **(D)** New optional `AssertionResult.raw_data: dict | None` field; CLI pretty-prints it when `-v`.
+
+**Q6 — `clauditor_capture` fixture behavior**
+What does the fixture do when the capture file is missing?
+
+- **(A)** Return the `Path` only; missing file is the test's problem (`.read_text()` will raise `FileNotFoundError`).
+- **(B)** Return the text, skip the test with `pytest.skip("no capture for {skill}")` if missing.
+- **(C)** Return the text, auto-run `clauditor capture <skill>` to populate if missing (slow, costs tokens, surprising).
+- **(D)** (A) with a helper: `clauditor_capture("skill").read_text()` returns text and `clauditor_capture("skill").path` returns the Path — small wrapper object.
+
+**Q7 — ASCII mode scope**
+How wide is the ASCII fix?
+
+- **(A)** Replace `≥`/`≤` at the source (in `assertions.py`). Permanent ASCII everywhere. Simplest, breaks anyone grepping for `≥`.
+- **(B)** Keep Unicode in name construction; add `--ascii` flag on relevant CLI subcommands that rewrites names at render time.
+- **(C)** New `AssertionSet.ascii_summary()` / `ascii_grouped_summary()` methods mirroring the existing ones. CLI flag toggles which one is called.
+- **(D)** Environment variable `CLAUDITOR_ASCII=1` toggles at render time — no CLI surface change.
+
+**Q8 — Layer 3 `--only-criterion` matching**
+How does the filter match criterion names?
+
+- **(A)** Exact substring match on the criterion name/description.
+- **(B)** Exact name match only; name must match a criterion identifier field.
+- **(C)** Repeatable flag: `--only-criterion a --only-criterion b` runs multiple.
+- **(D)** (C) + substring matching.
+
+**Q9 — Bundling vs splitting**
+All nine items in one PR, or split?
+
+- **(A)** One PR, one plan (matches #17 precedent).
+- **(B)** Two PRs: P2 items (compare, kind, docs, strict/loose) land first; P3 items (history, raw json, fixture, ascii, only-criterion) follow. Smaller review surfaces.
+- **(C)** (A) but ordered so P2 items land as the first N commits for easy partial-review.
+
+---
+
+## Decisions (from scoping)
+
+- **DEC-001 — `compare` input shape (Q1=C):** `clauditor compare <before> <after> [--spec x.eval.json]` auto-detects file type by extension. Two `.txt` files require `--spec` and re-grade both. Two `.grade.json` files diff saved reports with no re-grading. Mixed inputs error out.
+- **DEC-002 — `AssertionResult.kind` population (Q2=A):** Add a required `kind` field to `AssertionResult` (enum-like `Literal` type). Every construction site passes it explicitly. Kinds: `presence`, `format`, `pattern`, `count`, `count_max`, `custom`. Touches ~10 call sites across `assertions.py` and `grader.py`.
+- **DEC-003 — Format registry strict/extract audit (Q3=B):** Audit every entry in `FORMAT_REGISTRY`. For each, decide whether `extract_pattern` should differ from `pattern` (the strict validator). Document per-entry rationale in code comments.
+- **DEC-004 — `history.jsonl` schema + `clauditor trend` (Q4=C):** One line per run, flat shape: `{ts, skill, pass_rate, mean_score, metrics: {metric_name: value, ...}}`. Append-only to `.clauditor/history.jsonl`. Ship `clauditor trend <skill> --metric <name>` read command in the same plan.
+- **DEC-005 — Raw Haiku JSON surfacing (Q5=D):** Add optional `raw_data: dict | None = None` field to `AssertionResult`. Populate on Layer 2 parse/shape failure with the full `ExtractedOutput.raw_json`. CLI pretty-prints when `-v`/`--verbose` is set.
+- **DEC-006 — `clauditor_capture` fixture shape (Q6=A):** Fixture returns a `Path` for `tests/eval/captured/<skill>.txt`. Missing file is the test's problem — `.read_text()` raises `FileNotFoundError`, which is the correct signal.
+- **DEC-007 — ASCII assertion names (Q7=A):** Replace `≥`/`≤` with `>=`/`<=` at every source location in `assertions.py`. Permanent ASCII — no flag, no mode. Acknowledged cost: any downstream user grepping for `≥` breaks.
+- **DEC-008 — `--only-criterion` matching (Q8=D):** Repeatable flag with substring matching: `--only-criterion foo --only-criterion bar` keeps criteria whose name contains `foo` OR `bar` (case-insensitive).
+- **DEC-009 — Bundling (Q9=C):** One PR, one plan. Order commits so all P2 stories (US-001 through US-004) land before P3 stories. This gives a natural partial-review cut line.
+
+## Architecture Review
+
+Single-pass review (matching #17 precedent) — items are small, additive, and touch well-scoped internals. No auth, no data migration, no new external API surface.
+
+| Area | Rating | Notes |
+|---|---|---|
+| **Security** | pass | Read-only changes except `history.jsonl` append (local file, no user input echoed). Raw Haiku JSON (DEC-005) is already trusted content; surfacing it doesn't introduce new attack surface. |
+| **Performance** | pass | `history.jsonl` append is O(1) per run. `grouped_summary` already computed lazily. `compare` on `.grade.json` is pure deserialize + set diff. `clauditor trend` reads jsonl sequentially — no index needed until history grows past ~10k entries. |
+| **Data Model** | concern | **DEC-002 adds a required field to `AssertionResult`.** Constructors without `kind` will break at runtime. Every call site in `assertions.py` (lines 113, 123, 145, 155, 165, 176, 188, 307, 323, 331) + `grader.py` (lines 96, 110, 169) must be updated in one commit. Tests that construct `AssertionResult` directly (grep `AssertionResult(` in `tests/`) must also be migrated. **DEC-005 adds an optional field** — safer, backward compatible. |
+| **API Design** | concern | `clauditor compare` (DEC-001) overlaps with existing `cmd_grade --compare` flag. Need to clarify in `--help` and README: `cmd_grade --compare` = A/B within one grade run; `cmd compare` = diff two captures/reports. Risk of user confusion. Also: `clauditor trend` is a new read surface that needs to tolerate missing/corrupt history files gracefully. |
+| **Observability** | pass | DEC-005 (raw_json) and DEC-004 (history) are themselves observability improvements. No new logging needed. |
+| **Testing** | concern | DEC-003 (audit every format) is the biggest test surface change. Each registry entry needs: strict validation positive + negative cases, extract positive + negative cases, and the invariant `validate_value(X)==True → extract.findall("prefix X suffix").count ≥ 1`. That's ~15 entries × ~4 cases = ~60 new assertions. 80% coverage gate must stay green. |
+| **Migration / Breaking changes** | **blocker** | **DEC-007 (hard ASCII replacement)** breaks any `.eval.json` spec or test that asserts on `name=="has_urls≥3"` exactly. Grep for `≥` across `tests/` and `my_claude_agent` before committing. **DEC-002** is also a breaking API change for any external caller constructing `AssertionResult` — there are none in this repo, but worth confirming. |
+
+### Blockers to resolve in refinement
+1. **DEC-007 grep sweep** — need to enumerate every literal `≥`/`≤` reference in tests and specs before flipping the source. If my_claude_agent has eval specs referencing `has_urls≥3` by exact name, those will regress silently.
+
+### Concerns to address in refinement
+1. **DEC-002 rollout sequencing** — do we add `kind` as a required positional arg (breaks in one commit) or stage it as `kind: str = "custom"` first, migrate all call sites, then tighten to required? The two-step path is safer but adds a second commit. One-shot is cleaner but needs a thorough grep first.
+2. **`compare` vs `grade --compare` naming** — should we rename the existing `--compare` flag to avoid clash? Or document the distinction and move on?
+3. **DEC-003 test matrix size** — is a per-entry parametrized test acceptable, or do we need one test method per format? Affects readability and coverage numbers.
+4. **`clauditor trend` scope** — minimum viable: print last N values for a metric. Stretch: sparkline, regression detection. Where's the line?
+5. **`history.jsonl` flush timing** — append on every `cmd_grade` run, only on `--save`, or new `--history` flag?
+
+## Refinement Log
+
+- **DEC-010 — B1 downgraded (no release yet):** clauditor is unreleased. DEC-007 (hard ASCII replacement) proceeds as written; update any broken clauditor tests in the same story. my_claude_agent is out of scope. No alias, no CHANGELOG entry, no deprecation window.
+- **DEC-011 — `kind` field rollout shape (C1=one-shot):** Add `kind` as a required field on `AssertionResult` in a single commit. Update all ~13 construction call sites (`assertions.py` lines 113, 123, 145, 155, 165, 176, 188, 307, 323, 331 + `grader.py` lines 96, 110, 169 + any test constructors) in the same commit. No two-step migration.
+- **DEC-012 — `compare` entry point consolidation (C2=c):** Remove `grade --compare` entirely. `clauditor compare` becomes the sole entry point for A/B and diff comparison workflows. The new subcommand absorbs the existing `compare_ab()` machinery from `comparator.py`.
+- **DEC-013 — DEC-003 test matrix shape (C3=b):** One test class per format entry (e.g. `TestPhoneUsFormat`, `TestEmailFormat`). Each class has methods for strict positive, strict negative, extract positive, extract negative, and the invariant (`validate_value(X) ⇒ findall("prefix X suffix") ≥ 1`). Verbose but readable; easier to track regressions per format.
+- **DEC-014 — `clauditor trend` scope (C4=b):** v1 ships last-N-values tab-separated plus an ASCII sparkline (using `▁▂▃▄▅▆▇█` or `- . : | #` — pick the simpler set). No regression detection in v1. **Wait — DEC-007 requires ASCII.** Sparkline must use ASCII characters only (`_.-=#` or similar) to stay consistent. Update: use ASCII-only sparkline glyphs.
+- **DEC-015 — `history.jsonl` flush timing (C5=a):** Append a record to `.clauditor/history.jsonl` on every `cmd_grade` run, unconditionally. No `--save` gate, no opt-in flag. If `.clauditor/` doesn't exist, create it. If the file is corrupt, `clauditor trend` reports the corrupt line and continues.
+- **DEC-016 — Commit ordering within the PR (DEC-009=C):** Commits land in this order for easy partial review: US-001 (kind) → US-002 (formats) → US-003 (compare) → US-004 (README) → US-005 (raw_data) → US-006 (history+trend) → US-007 (fixture) → US-008 (ascii) → US-009 (only-criterion) → US-010 (Quality Gate) → US-011 (Patterns & Memory). P2 items (US-001..US-004) form the first review cut.
+- **DEC-017 — `clauditor compare` file type detection:** Extension-based. `.txt` → captured stdout, requires `--spec`. `.grade.json` → saved grade report, no `--spec` needed. Other extensions → error with a clear message. Mixed types (one `.txt` + one `.grade.json`) → error. Both files must resolve to the same spec.
+- **DEC-018 — `AssertionResult.kind` values:** `Literal["presence", "format", "pattern", "count", "count_max", "reachability", "custom"]`. `pattern` is retained even though DEC-007 of #17 removed `FieldRequirement.pattern` — it still describes the *kind* of check (regex pattern match), which is distinct from a registered format. Bare `presence` is the default for fields without a format. `reachability` is a dedicated kind for URL-reachability assertions (assertions.py:307). `custom` is the escape hatch for top-level assertions that don't fit a structured category.
+- **DEC-019 — `--only-criterion` CLI flag shape (from DEC-008):** `--only-criterion` is repeatable (`action="append"`), substring match, case-insensitive. If no `--only-criterion` is passed, all criteria run. If any are passed, only criteria whose name/description contains at least one substring run. Empty filtered set → exit with a clear error naming the available criteria.
+
+## Detailed Breakdown
+
+Stories ordered by commit sequence (DEC-016). Each is sized for a single Ralph context window. Every story's acceptance includes `uv run pytest --cov=clauditor --cov-report=term-missing` passing with the 80% gate and `uv run ruff check src/ tests/` clean.
+
+---
+
+### US-001 — Add `AssertionResult.kind` field (required)
+
+**Description:** Add a required `kind: Literal[...]` field to `AssertionResult`. Update every construction site in `assertions.py`, `grader.py`, and tests to pass an explicit kind. No suffix parsing, no fallback — the field is the source of truth going forward.
+
+**Traces to:** DEC-002, DEC-011, DEC-018
+
+**Files:**
+- `src/clauditor/assertions.py` — extend dataclass (line ~17) with `kind: Literal["presence", "format", "pattern", "count", "count_max", "reachability", "custom"]`. Update call sites at lines 113 (`contains:` → `kind="presence"`), 123 (`not_contains:` → `"presence"`), 145 (`min_count:` → `"count"`), 155 (`min_length` → `"count"`), 165 (`max_length` → `"count"`), 176 (`has_urls` → `"count"`), 188 (URL reachability count → `"count"`), 307 (`urls_reachable` → `"reachability"`), 323 (`has_format` bare → `"format"`), 331 (`has_format...≥N` → `"count"`).
+- `src/clauditor/grader.py` — update call sites at 96 (`:count/{tier}` → `"count"`), 110 (`:count_max` → `"count_max"`), 169 (`:format` suffix → `"format"`), and any presence check (bare `section:...` construction) → `"presence"`.
+- `tests/test_assertions.py` — update any direct `AssertionResult(...)` constructors to pass `kind`.
+- `tests/test_grader.py` — same.
+- `tests/test_schemas.py` — same.
+
+**TDD:**
+- Every kind value is produced by at least one call site (parametrized test asserting coverage of the enum).
+- `AssertionResult(...)` without `kind` raises `TypeError` at construction.
+- `AssertionSet.grouped_summary()` from #17 still works — grouping key continues to use the name; kind is supplementary.
+- Existing `summary()` output unchanged (regression test).
+
+**Acceptance criteria:**
+- Every `AssertionResult` construction in `src/` and `tests/` passes an explicit `kind`.
+- Grep for `AssertionResult(` returns zero matches without a `kind=` kwarg in the same call.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** Running `uv run pytest` is green and every failing/passing assertion in the test suite has a non-`custom` kind (unless explicitly a custom check).
+
+**Depends on:** none
+
+---
+
+### US-002 — Audit every FORMAT_REGISTRY entry for strict/extract correctness
+
+**Description:** Walk every entry in `FORMAT_REGISTRY` and decide whether `extract_pattern` must differ from `pattern`. For each entry, add inline comments explaining the choice. Add a per-entry test class asserting the strict/extract invariant.
+
+**Traces to:** DEC-003, DEC-013
+
+**Files:**
+- `src/clauditor/formats.py` — audit every entry. For entries like `phone_us`, `email`, `url`, `domain`, `zip_us`, `uuid`, `ipv4`, `iso_date`, etc., separate strict (fullmatch) from extract (findall-in-prose). Add a comment above each `_def(...)` call explaining: "strict = <intent>; extract = <intent>." For entries where strict === extract, say so explicitly.
+- `tests/test_formats.py` — add one `Test<Format>Format` class per registry entry (DEC-013). Each class has: `test_strict_accepts_canonical`, `test_strict_rejects_malformed`, `test_extract_finds_in_prose`, `test_extract_rejects_pure_noise`, and `test_invariant_validate_implies_extract` (if `validate_value(X)` is True, then `extract_pattern.findall(f"prefix {X} suffix")` returns at least one match containing X).
+
+**TDD:**
+- For each of the ~15 entries: 5 test methods × 15 classes = ~75 new test cases. List the entries to audit before writing code so none are missed.
+- Existing `test_formats.py` cases pass unchanged (regression).
+- `FORMAT_REGISTRY` key set unchanged (no additions/removals in this story).
+
+**Acceptance criteria:**
+- Every current registry entry has a test class.
+- Every entry has an inline comment justifying its strict/extract shape.
+- The invariant test passes for every entry.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `uv run pytest tests/test_formats.py -v` lists one class per format entry, all green.
+
+**Depends on:** none
+
+---
+
+### US-003 — Add `clauditor compare` subcommand; remove `grade --compare`
+
+**Description:** New `compare` subparser that takes two positional file args, auto-detects `.txt` vs `.grade.json`, loads and diffs assertion results, prints the flipped assertions (regressions and improvements). Remove the existing `grade --compare` flag entirely (DEC-012).
+
+**Traces to:** DEC-001, DEC-012, DEC-017
+
+**Files:**
+- `src/clauditor/cli.py` — add `p_compare = subparsers.add_parser("compare", ...)` with positional `before`, `after`, optional `--spec`. Add `cmd_compare()` that:
+  1. Detects file type by extension; errors on mismatch.
+  2. For `.txt`: requires `--spec`; runs `SkillSpec.from_file(...).grade()` on each, extracts `AssertionSet` from each.
+  3. For `.grade.json`: deserializes saved reports into `AssertionSet`.
+  4. Diffs the two `AssertionSet`s by assertion `name`: regressions (was pass, now fail), improvements (was fail, now pass), unchanged (skipped in output).
+  5. Prints a human-readable diff with `[REGRESSION]` / `[IMPROVEMENT]` prefixes. Exit code 1 if any regressions, 0 otherwise.
+- `src/clauditor/cli.py` — remove `p_grade.add_argument("--compare", ...)` (line ~634) and the branch in `cmd_grade()` that calls `compare_ab()` (lines 131–134).
+- `src/clauditor/comparator.py` — `compare_ab()` stays (future use) but is no longer wired into `cmd_grade`. Add a new `diff_assertion_sets(before: AssertionSet, after: AssertionSet) -> list[Flip]` helper that the new subcommand uses.
+- `tests/test_cli.py` — add `TestCmdCompare` class with cases: (a) two `.txt` files + spec, (b) two `.grade.json` files, (c) mixed extensions errors, (d) `.txt` without `--spec` errors, (e) regression detection returns exit 1, (f) no flips returns exit 0.
+- `tests/test_comparator.py` — add test class for `diff_assertion_sets()`.
+
+**TDD:**
+- All 6 CLI cases above.
+- `diff_assertion_sets` handles: name only in before, name only in after, name in both with same passed, name in both with flipped passed.
+
+**Acceptance criteria:**
+- `clauditor compare --help` shows the new subcommand.
+- `clauditor grade --compare` errors (flag removed).
+- All prior `cmd_grade --compare` test cases migrated or deleted.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `clauditor compare before.grade.json after.grade.json` prints a diff and exits with the right code.
+
+**Depends on:** US-001 (kind field is referenced by the diff output to categorize flips).
+
+---
+
+### US-004 — README: document `format` dual-mode semantics
+
+**Description:** Add a "Field validation" section to README under Layer 2 explaining that `FieldRequirement.format` accepts either a registered format name or an inline regex, with a decision tree and examples. Link to `FORMAT_REGISTRY` entries.
+
+**Traces to:** DEC-007 (from #17), DEC-011 (from #17)
+
+**Files:**
+- `README.md` — add a subsection under Layer 2 (after line ~150). Include: (a) a one-sentence overview, (b) a decision tree (registered name? use it. custom? inline regex.), (c) two examples: `{"name": "phone", "format": "phone_us"}` and `{"name": "slug", "format": r"^[a-z0-9-]+$"}`, (d) a pointer to `FORMAT_REGISTRY` in `formats.py` and the `clauditor formats list` command from #17 (if that command shipped — verify before linking).
+
+**Acceptance criteria:**
+- README renders (manual spot check via `grip` or similar, not required).
+- `uv run ruff check` clean (no code changes to lint).
+- Links work (verify `formats.py` path).
+
+**Done when:** A new user can read README and know when to use a registry name vs inline regex without opening source.
+
+**Depends on:** none (docs only).
+
+---
+
+### US-005 — Add `AssertionResult.raw_data` + surface raw Haiku JSON on Layer 2 failure
+
+**Description:** Add optional `raw_data: dict | None = None` field to `AssertionResult`. On Layer 2 parse/shape failure, attach `ExtractedOutput.raw_json` to the failing assertion's `raw_data`. CLI pretty-prints `raw_data` when `-v`/`--verbose` is set.
+
+**Traces to:** DEC-005
+
+**Files:**
+- `src/clauditor/assertions.py` — extend dataclass with `raw_data: dict | None = None` (optional, default None). Do not require it anywhere.
+- `src/clauditor/grader.py` — at the parse-failure path (lines 226–236), populate `raw_data=response_json_if_available` on the `grader:parse` assertion (set to the parsed-but-malformed dict if the shape check failed, or `None` if JSON parse itself failed). At the shape-failure path (find via grep for `grader:shape` or equivalent), same treatment.
+- `src/clauditor/cli.py` — in the assertion-rendering code (cli.py:64, 193), when `args.verbose` is set and `result.raw_data is not None`, pretty-print the JSON under the failing assertion with a 4-space indent.
+- `tests/test_grader.py` — case: grading a malformed-but-parseable response attaches `raw_data` to the shape failure. Case: grading an unparseable response leaves `raw_data=None` but still attaches response text as evidence.
+- `tests/test_cli.py` — case: `cmd_grade` with `-v` prints raw_data for failing assertions that have it.
+
+**TDD:**
+- All 4 cases above.
+
+**Acceptance criteria:**
+- `raw_data` is optional and defaults to None everywhere.
+- Non-failure assertions never carry raw_data (verify via a negative test).
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** A Haiku response that fails shape validation shows the full JSON in `clauditor grade -v` output.
+
+**Depends on:** US-001 (both modify `AssertionResult`; US-001 goes first for a cleaner diff).
+
+---
+
+### US-006 — Persistent metric history + `clauditor trend` command
+
+**Description:** On every `cmd_grade` run, append a flat record to `.clauditor/history.jsonl`: `{ts, skill, pass_rate, mean_score, metrics: {metric_name: value, ...}}`. Add a `clauditor trend <skill> --metric <name>` subcommand that reads the history file, prints the last N values tab-separated, and renders an ASCII sparkline (DEC-014).
+
+**Traces to:** DEC-004, DEC-014, DEC-015
+
+**Files:**
+- `src/clauditor/history.py` (new) — functions `append_record(skill, pass_rate, mean_score, metrics, path=".clauditor/history.jsonl")` and `read_records(skill, metric_name, path=...)`. Handles missing dir (creates), missing file (treats as empty), corrupt line (skips with a warning to stderr).
+- `src/clauditor/cli.py` — in `cmd_grade`, after grading completes, call `append_record(...)`. Extract numeric metrics from the `AssertionSet` (any result with a numeric evidence string that looks like a count, plus `pass_rate` and `mean_score` from the existing summary).
+- `src/clauditor/cli.py` — add `p_trend = subparsers.add_parser("trend", ...)` with positional `skill_name`, required `--metric <name>`, optional `--last N` (default 20). Add `cmd_trend()` that calls `history.read_records(...)`, prints tab-separated values, and an ASCII sparkline using only ASCII characters (DEC-014 note — e.g. `_.-=#` mapped to normalized value ranges).
+- `tests/test_history.py` (new) — round-trip: append then read. Corrupt line handling. Missing file → empty list. Multiple skills interleaved → filter works.
+- `tests/test_cli.py` — `TestCmdTrend` class: happy path, missing metric, no history yet, `--last` truncation, sparkline rendering (snapshot test on a known value sequence).
+
+**TDD:**
+- All cases above before implementation.
+- Sparkline function is a pure helper, unit-tested separately.
+
+**Acceptance criteria:**
+- `.clauditor/history.jsonl` written on every grade (verify via tmp_path).
+- `clauditor trend` reads and renders correctly for a seeded history file.
+- Sparkline uses only ASCII characters (DEC-014).
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** A sequence of five grade runs produces a trendable series visible in `clauditor trend`.
+
+**Depends on:** none (independent of US-001..US-005; uses existing `AssertionSet` read API).
+
+---
+
+### US-007 — Add `clauditor_capture` pytest fixture
+
+**Description:** Add a `clauditor_capture` fixture to `pytest_plugin.py` that returns a factory: `clauditor_capture("skill-name")` → `Path("tests/eval/captured/skill-name.txt")`. Missing files raise `FileNotFoundError` on `.read_text()` (DEC-006).
+
+**Traces to:** DEC-006
+
+**Files:**
+- `src/clauditor/pytest_plugin.py` — add the fixture alongside `clauditor_runner`/`clauditor_spec`/`clauditor_grader`/`clauditor_triggers` (after line ~112). Fixture scope: `session`. The factory accepts an optional `base_dir` kwarg (default `tests/eval/captured`).
+- `tests/test_pytest_plugin.py` — add test cases: (a) fixture returns a Path, (b) Path points to the conventional location, (c) custom `base_dir` works, (d) missing file still returns a Path (error deferred to read). Use pytester for integration-style tests if needed.
+- Document the fixture in README under the pytest plugin section (if that section exists; add a one-liner if not).
+
+**TDD:**
+- All 4 cases above.
+
+**Acceptance criteria:**
+- Fixture registered, discoverable by `pytest --fixtures`.
+- Does not shadow existing fixture names (CLAUDE.md rule).
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `def test_x(clauditor_capture): assert clauditor_capture("find-restaurants").name == "find-restaurants.txt"` passes.
+
+**Depends on:** none.
+
+---
+
+### US-008 — Replace `≥`/`≤` with ASCII `>=`/`<=` at source
+
+**Description:** Hard-replace all `≥` and `≤` literals in `src/clauditor/assertions.py` (and anywhere else they appear in source) with `>=`/`<=`. Update any test that asserts on exact assertion names.
+
+**Traces to:** DEC-007, DEC-010
+
+**Files:**
+- `src/clauditor/assertions.py` — replace `≥` → `>=` at lines 145, 155, 165, 176, 188, 307, 331 (and any missed). Replace `≤` similarly if present.
+- Grep the rest of `src/` for any stray `≥`/`≤` and fix.
+- Grep `tests/` for any test asserting on exact names containing `≥`/`≤`; update the expected strings.
+- Grep `plans/super/` — don't modify historical plan docs, but note in the commit message that names have changed.
+
+**TDD:**
+- After replacement, grep `src/clauditor/` for `≥`/`≤` returns zero matches.
+- `uv run pytest` still green.
+- Existing `test_assertions.py` tests that referenced `≥`-containing names now reference `>=`-containing names.
+
+**Acceptance criteria:**
+- Zero Unicode `≥`/`≤` in `src/clauditor/`.
+- All tests pass.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `grep -r '≥\|≤' src/clauditor/ tests/` returns no matches.
+
+**Depends on:** US-001 (both touch assertions.py name-construction lines; US-001 first avoids merge conflict churn).
+
+---
+
+### US-009 — Add `--only-criterion` to Layer 3 grading
+
+**Description:** Add a repeatable `--only-criterion <substring>` flag to `cmd_grade` (or wherever Layer 3 grading is triggered). Filter `eval_spec.grading_criteria` before calling `grade_quality()` — keep criteria whose name/description contains any provided substring (case-insensitive). Empty filtered set → clear error naming the available criteria.
+
+**Traces to:** DEC-008, DEC-019
+
+**Files:**
+- `src/clauditor/cli.py` — at `p_grade` (line ~625), add `p_grade.add_argument("--only-criterion", action="append", default=None, help="...")`. In `cmd_grade()` (or `_run_grade`), before calling `grade_quality()`, if `args.only_criterion` is set, filter `spec.grading_criteria` (case-insensitive substring match against name and description). If result is empty, print an error listing available criteria and exit 2.
+- `src/clauditor/quality_grader.py` — no changes needed; filtering happens at the CLI layer before the grader is invoked. Keeps the grader API pure.
+- `tests/test_cli.py` — `TestOnlyCriterion` class: (a) single substring matches subset, (b) multiple substrings match union, (c) no match → exit 2 with criterion list in stderr, (d) no flag → all criteria run (regression), (e) case insensitivity.
+
+**TDD:**
+- All 5 cases above.
+
+**Acceptance criteria:**
+- Flag documented in `--help`.
+- Filtering happens before LLM call (saves tokens — verify via mock call count).
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `clauditor grade <skill> --only-criterion clarity --only-criterion accuracy` runs only the clarity and accuracy criteria.
+
+**Depends on:** none.
+
+---
+
+### US-010 — Quality Gate (code review × 4 + CodeRabbit)
+
+**Description:** Run the `code-review` skill four times across the full changeset; fix all real bugs found each pass. Run CodeRabbit if available. Re-run project validation (`uv run ruff check`, `uv run pytest --cov`) after fixes. Depends on **all implementation stories** being complete.
+
+**Traces to:** All DEC-001 → DEC-019.
+
+**Acceptance criteria:**
+- 4 code-review passes complete.
+- All real bugs fixed (stylistic deferrals documented).
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥ 80% coverage.
+- All ticket acceptance-criteria checkboxes satisfied.
+
+**Done when:** Four consecutive review passes produce no new real bugs.
+
+**Depends on:** US-001 through US-009.
+
+---
+
+### US-011 — Patterns & Memory
+
+**Description:** Update project conventions and memory with patterns learned. Specifically: (a) document `AssertionResult.kind` enum values and the "kind is source of truth; name is for humans" convention; (b) record the "strict fullmatch / extract findall" format registry invariant; (c) record the `.clauditor/history.jsonl` schema shape for future additions; (d) `bd remember` any non-obvious insights (e.g. why `pattern` is still a valid kind despite `FieldRequirement.pattern` being removed in #17).
+
+**Traces to:** DEC-002, DEC-003, DEC-004, DEC-018.
+
+**Acceptance criteria:**
+- README updated with `compare`, `trend`, and `--only-criterion` docs.
+- At least two `bd remember` entries capturing non-obvious insights.
+- No MEMORY.md files created (beads is the project's memory store).
+
+**Done when:** A fresh agent opening this repo would not re-ask any of the design questions resolved in DEC-001 through DEC-019.
+
+**Depends on:** US-010.
+
+---
+
+## Beads Manifest
+
+_pending_

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -34,6 +34,7 @@ class AssertionResult:
     message: str
     kind: AssertionKind
     evidence: str | None = None
+    raw_data: dict | None = None
 
     def __bool__(self) -> bool:
         return self.passed

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -12,6 +12,17 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from typing import Literal
+
+AssertionKind = Literal[
+    "presence",
+    "format",
+    "pattern",
+    "count",
+    "count_max",
+    "reachability",
+    "custom",
+]
 
 
 @dataclass
@@ -21,6 +32,7 @@ class AssertionResult:
     name: str
     passed: bool
     message: str
+    kind: AssertionKind
     evidence: str | None = None
 
     def __bool__(self) -> bool:
@@ -113,6 +125,7 @@ def assert_contains(output: str, value: str) -> AssertionResult:
         name=f"contains:{value[:40]}",
         passed=found,
         message=f"Found '{value[:40]}'" if found else f"Missing '{value[:40]}'",
+        kind="presence",
     )
 
 
@@ -123,6 +136,7 @@ def assert_not_contains(output: str, value: str) -> AssertionResult:
         name=f"not_contains:{value[:40]}",
         passed=not found,
         message="Correctly absent" if not found else f"Unexpected '{value[:40]}' found",
+        kind="presence",
     )
 
 
@@ -133,6 +147,7 @@ def assert_regex(output: str, pattern: str) -> AssertionResult:
         name=f"regex:{pattern[:40]}",
         passed=match is not None,
         message="Pattern matched" if match else f"Pattern not found: {pattern[:40]}",
+        kind="pattern",
         evidence=match.group(0)[:100] if match else None,
     )
 
@@ -145,6 +160,7 @@ def assert_min_count(output: str, pattern: str, minimum: int) -> AssertionResult
         name=f"min_count:{pattern[:30]}≥{minimum}",
         passed=count >= minimum,
         message=f"Found {count} matches (need ≥{minimum})",
+        kind="count",
     )
 
 
@@ -155,6 +171,7 @@ def assert_min_length(output: str, minimum: int) -> AssertionResult:
         name=f"min_length≥{minimum}",
         passed=length >= minimum,
         message=f"Length {length} (need ≥{minimum})",
+        kind="count",
     )
 
 
@@ -165,6 +182,7 @@ def assert_max_length(output: str, maximum: int) -> AssertionResult:
         name=f"max_length≤{maximum}",
         passed=length <= maximum,
         message=f"Length {length} (need ≤{maximum})",
+        kind="count",
     )
 
 
@@ -176,6 +194,7 @@ def assert_has_urls(output: str, minimum: int = 1) -> AssertionResult:
         name=f"has_urls≥{minimum}",
         passed=count >= minimum,
         message=f"Found {count} URLs (need ≥{minimum})",
+        kind="count",
         evidence="; ".join(urls[:5]) if urls else None,
     )
 
@@ -188,6 +207,7 @@ def assert_has_entries(output: str, minimum: int = 1) -> AssertionResult:
         name=f"has_entries≥{minimum}",
         passed=count >= minimum,
         message=f"Found {count} numbered entries (need ≥{minimum})",
+        kind="count",
     )
 
 
@@ -287,6 +307,7 @@ def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
             name=f"urls_reachable≥{minimum}",
             passed=0 >= minimum,
             message=f"Found 0 URLs to check (need ≥{minimum})",
+            kind="count",
         )
 
     statuses: list[str] = []
@@ -307,6 +328,7 @@ def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
         name=f"urls_reachable≥{minimum}",
         passed=reachable >= minimum,
         message=f"{reachable}/{len(urls)} URLs reachable (need ≥{minimum})",
+        kind="reachability",
         evidence="; ".join(statuses[:5]),
     )
 
@@ -323,6 +345,7 @@ def assert_has_format(
             name=f"has_format:{format_name}",
             passed=False,
             message=f"Unknown format: {format_name}",
+            kind="format",
         )
 
     matches = fmt.extract_pattern.findall(output)
@@ -331,6 +354,7 @@ def assert_has_format(
         name=f"has_format:{format_name}≥{minimum}",
         passed=count >= minimum,
         message=f"Found {count} {format_name} matches (need ≥{minimum})",
+        kind="count",
         evidence="; ".join(str(m) for m in matches[:5]) if matches else None,
     )
 
@@ -381,6 +405,7 @@ def run_assertions(output: str, assertions: list[dict]) -> AssertionSet:
                     name=f"unknown:{atype}",
                     passed=False,
                     message=f"Unknown assertion type: {atype}",
+                    kind="custom",
                 )
             )
 

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -157,9 +157,9 @@ def assert_min_count(output: str, pattern: str, minimum: int) -> AssertionResult
     matches = re.findall(pattern, output)
     count = len(matches)
     return AssertionResult(
-        name=f"min_count:{pattern[:30]}≥{minimum}",
+        name=f"min_count:{pattern[:30]}>={minimum}",
         passed=count >= minimum,
-        message=f"Found {count} matches (need ≥{minimum})",
+        message=f"Found {count} matches (need >={minimum})",
         kind="count",
     )
 
@@ -168,9 +168,9 @@ def assert_min_length(output: str, minimum: int) -> AssertionResult:
     """Check that output is at least N characters."""
     length = len(output)
     return AssertionResult(
-        name=f"min_length≥{minimum}",
+        name=f"min_length>={minimum}",
         passed=length >= minimum,
-        message=f"Length {length} (need ≥{minimum})",
+        message=f"Length {length} (need >={minimum})",
         kind="count",
     )
 
@@ -179,9 +179,9 @@ def assert_max_length(output: str, maximum: int) -> AssertionResult:
     """Check that output is at most N characters."""
     length = len(output)
     return AssertionResult(
-        name=f"max_length≤{maximum}",
+        name=f"max_length<={maximum}",
         passed=length <= maximum,
-        message=f"Length {length} (need ≤{maximum})",
+        message=f"Length {length} (need <={maximum})",
         kind="count",
     )
 
@@ -191,9 +191,9 @@ def assert_has_urls(output: str, minimum: int = 1) -> AssertionResult:
     urls = re.findall(r"https?://[^\s\)\"'>]+", output)
     count = len(urls)
     return AssertionResult(
-        name=f"has_urls≥{minimum}",
+        name=f"has_urls>={minimum}",
         passed=count >= minimum,
-        message=f"Found {count} URLs (need ≥{minimum})",
+        message=f"Found {count} URLs (need >={minimum})",
         kind="count",
         evidence="; ".join(urls[:5]) if urls else None,
     )
@@ -204,9 +204,9 @@ def assert_has_entries(output: str, minimum: int = 1) -> AssertionResult:
     entries = re.findall(r"\*\*\d+\.\s+", output)
     count = len(entries)
     return AssertionResult(
-        name=f"has_entries≥{minimum}",
+        name=f"has_entries>={minimum}",
         passed=count >= minimum,
-        message=f"Found {count} numbered entries (need ≥{minimum})",
+        message=f"Found {count} numbered entries (need >={minimum})",
         kind="count",
     )
 
@@ -304,9 +304,9 @@ def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
     urls = list(dict.fromkeys(re.findall(r"https?://[^\s\)\"'>]+", output)))
     if not urls:
         return AssertionResult(
-            name=f"urls_reachable≥{minimum}",
+            name=f"urls_reachable>={minimum}",
             passed=0 >= minimum,
-            message=f"Found 0 URLs to check (need ≥{minimum})",
+            message=f"Found 0 URLs to check (need >={minimum})",
             kind="count",
         )
 
@@ -325,9 +325,9 @@ def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
             statuses.append(f"{url}: {status}")
 
     return AssertionResult(
-        name=f"urls_reachable≥{minimum}",
+        name=f"urls_reachable>={minimum}",
         passed=reachable >= minimum,
-        message=f"{reachable}/{len(urls)} URLs reachable (need ≥{minimum})",
+        message=f"{reachable}/{len(urls)} URLs reachable (need >={minimum})",
         kind="reachability",
         evidence="; ".join(statuses[:5]),
     )
@@ -351,9 +351,9 @@ def assert_has_format(
     matches = fmt.extract_pattern.findall(output)
     count = len(matches)
     return AssertionResult(
-        name=f"has_format:{format_name}≥{minimum}",
+        name=f"has_format:{format_name}>={minimum}",
         passed=count >= minimum,
-        message=f"Found {count} {format_name} matches (need ≥{minimum})",
+        message=f"Found {count} {format_name} matches (need >={minimum})",
         kind="count",
         evidence="; ".join(str(m) for m in matches[:5]) if matches else None,
     )

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -308,7 +308,7 @@ def assert_urls_reachable(output: str, minimum: int = 1) -> AssertionResult:
             name=f"urls_reachable>={minimum}",
             passed=0 >= minimum,
             message=f"Found 0 URLs to check (need >={minimum})",
-            kind="count",
+            kind="reachability",
         )
 
     statuses: list[str] = []

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -7,6 +7,7 @@ import json
 import sys
 from pathlib import Path
 
+from clauditor import history
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.runner import SkillRunner
 from clauditor.spec import SkillSpec
@@ -258,6 +259,17 @@ def cmd_grade(args: argparse.Namespace) -> int:
         save_dir.mkdir(parents=True, exist_ok=True)
         save_path.write_text(report.to_json())
         print(f"\nGrade report saved to {save_path}", file=diff_out)
+
+    # Append a history record for trendability (US-006)
+    try:
+        history.append_record(
+            skill=spec.skill_name,
+            pass_rate=report.pass_rate,
+            mean_score=report.mean_score,
+            metrics={},
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"WARNING: failed to append history: {e}", file=sys.stderr)
 
     # Determine exit code
     passed = report.passed
@@ -715,6 +727,51 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_trend(args: argparse.Namespace) -> int:
+    """Render a trend line (TSV + ASCII sparkline) for a skill metric."""
+    records = history.read_records(skill=args.skill_name)
+    if not records:
+        print(
+            f"ERROR: no history records for skill '{args.skill_name}'. "
+            "Run `clauditor grade` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    last_n = args.last
+    if last_n is not None and last_n > 0:
+        records = records[-last_n:]
+
+    metric = args.metric
+    timestamps: list[str] = []
+    values: list[float] = []
+    for rec in records:
+        if metric in ("pass_rate", "mean_score"):
+            v = rec.get(metric)
+        else:
+            v = rec.get("metrics", {}).get(metric)
+        if v is None:
+            continue
+        timestamps.append(str(rec.get("ts", "")))
+        try:
+            values.append(float(v))
+        except (TypeError, ValueError):
+            continue
+
+    if not values:
+        print(
+            f"ERROR: no records with metric '{metric}' for skill "
+            f"'{args.skill_name}'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for ts, v in zip(timestamps, values):
+        print(f"{ts}\t{v}")
+    print(history.sparkline(values))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="clauditor",
@@ -886,6 +943,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Arguments to pass to the skill (put after `--`)",
     )
 
+    # trend
+    p_trend = subparsers.add_parser(
+        "trend",
+        help="Print a trend line (TSV + ASCII sparkline) from grade history",
+    )
+    p_trend.add_argument("skill_name", help="Skill name to trend")
+    p_trend.add_argument(
+        "--metric",
+        required=True,
+        help="Metric to trend (pass_rate, mean_score, or a metrics.<name>)",
+    )
+    p_trend.add_argument(
+        "--last", type=int, default=20, help="Show last N records (default 20)"
+    )
+
     # doctor
     subparsers.add_parser(
         "doctor",
@@ -929,6 +1001,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_capture(parsed)
     elif parsed.command == "doctor":
         return cmd_doctor(parsed)
+    elif parsed.command == "trend":
+        return cmd_trend(parsed)
 
     return 1
 

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -13,6 +13,17 @@ from clauditor.runner import SkillRunner
 from clauditor.spec import SkillSpec
 
 
+def _positive_int(value: str) -> int:
+    """argparse type: accept integers >= 1."""
+    try:
+        ivalue = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from e
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {ivalue}")
+    return ivalue
+
+
 def cmd_validate(args: argparse.Namespace) -> int:
     """Validate a skill's output against its eval spec (Layer 1 only)."""
     spec = SkillSpec.from_file(args.skill, eval_path=args.eval)
@@ -54,6 +65,11 @@ def cmd_validate(args: argparse.Namespace) -> int:
                             "passed": r.passed,
                             "message": r.message,
                             **({"evidence": r.evidence} if r.evidence else {}),
+                            **(
+                                {"raw_data": r.raw_data}
+                                if r.raw_data is not None
+                                else {}
+                            ),
                         }
                         for r in results.results
                     ],
@@ -122,7 +138,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
                 f"No grading criteria match filter. Available: {available}",
                 file=sys.stderr,
             )
-            sys.exit(2)
+            return 2
         spec.eval_spec.grading_criteria = filtered
 
     model = args.model or spec.eval_spec.grading_model
@@ -260,16 +276,19 @@ def cmd_grade(args: argparse.Namespace) -> int:
         save_path.write_text(report.to_json())
         print(f"\nGrade report saved to {save_path}", file=diff_out)
 
-    # Append a history record for trendability (US-006)
-    try:
-        history.append_record(
-            skill=spec.skill_name,
-            pass_rate=report.pass_rate,
-            mean_score=report.mean_score,
-            metrics={},
-        )
-    except Exception as e:  # pragma: no cover - defensive
-        print(f"WARNING: failed to append history: {e}", file=sys.stderr)
+    # Append a history record for trendability (US-006). Skip when
+    # --only-criterion is set: partial-criterion runs would silently
+    # corrupt longitudinal pass_rate/mean_score trends.
+    if not getattr(args, "only_criterion", None):
+        try:
+            history.append_record(
+                skill=spec.skill_name,
+                pass_rate=report.pass_rate,
+                mean_score=report.mean_score,
+                metrics={},
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"WARNING: failed to append history: {e}", file=sys.stderr)
 
     # Determine exit code
     passed = report.passed
@@ -511,6 +530,11 @@ def cmd_extract(args: argparse.Namespace) -> int:
                             "passed": r.passed,
                             "message": r.message,
                             **({"evidence": r.evidence} if r.evidence else {}),
+                            **(
+                                {"raw_data": r.raw_data}
+                                if r.raw_data is not None
+                                else {}
+                            ),
                         }
                         for r in results.results
                     ],
@@ -955,7 +979,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Metric to trend (pass_rate, mean_score, or a metrics.<name>)",
     )
     p_trend.add_argument(
-        "--last", type=int, default=20, help="Show last N records (default 20)"
+        "--last",
+        type=_positive_int,
+        default=20,
+        help="Show last N records (default 20; must be >= 1)",
     )
 
     # doctor

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -776,11 +776,12 @@ def cmd_trend(args: argparse.Namespace) -> int:
             v = rec.get("metrics", {}).get(metric)
         if v is None:
             continue
-        timestamps.append(str(rec.get("ts", "")))
         try:
-            values.append(float(v))
+            value = float(v)
         except (TypeError, ValueError):
             continue
+        timestamps.append(str(rec.get("ts", "")))
+        values.append(value)
 
     if not values:
         print(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -97,6 +97,33 @@ def cmd_grade(args: argparse.Namespace) -> int:
         print("ERROR: No grading_criteria defined in eval spec", file=sys.stderr)
         return 1
 
+    # --only-criterion: filter criteria before LLM call (token savings)
+    only = getattr(args, "only_criterion", None)
+    if only:
+        needles = [s.lower() for s in only]
+        original = list(spec.eval_spec.grading_criteria)
+
+        def _match(item: object) -> bool:
+            name = getattr(item, "name", None) or ""
+            desc = getattr(item, "description", None) or ""
+            if not name and not desc:
+                # list-of-strings case
+                name = str(item)
+            hay = f"{name}\n{desc}".lower()
+            return any(n in hay for n in needles)
+
+        filtered = [c for c in original if _match(c)]
+        if not filtered:
+            available = ", ".join(
+                (getattr(c, "name", None) or str(c)) for c in original
+            )
+            print(
+                f"No grading criteria match filter. Available: {available}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        spec.eval_spec.grading_criteria = filtered
+
     model = args.model or spec.eval_spec.grading_model
 
     # --dry-run: print prompt and exit
@@ -741,6 +768,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_grade.add_argument(
         "--diff", action="store_true", help="Compare against prior grade results"
+    )
+    p_grade.add_argument(
+        "--only-criterion",
+        action="append",
+        default=None,
+        metavar="SUBSTRING",
+        help=(
+            "Run only criteria whose name/description contains SUBSTRING"
+            " (case-insensitive, repeatable)"
+        ),
     )
 
     # compare

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -509,6 +509,11 @@ def cmd_extract(args: argparse.Namespace) -> int:
     else:
         print(f"Schema Extraction: {spec.skill_name} ({model})")
         print(results.summary())
+        if getattr(args, "verbose", False):
+            for r in results.results:
+                if not r.passed and r.raw_data is not None:
+                    print(f"\nRaw data for {r.name}:")
+                    print(json.dumps(r.raw_data, indent=2))
 
     return 0 if results.passed else 1
 
@@ -834,6 +839,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_extract.add_argument(
         "--dry-run", action="store_true", help="Print prompt without making API calls"
+    )
+    p_extract.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print raw Haiku JSON under failing assertions when available",
     )
 
     # init

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -7,7 +7,7 @@ import json
 import sys
 from pathlib import Path
 
-from clauditor.assertions import run_assertions
+from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.runner import SkillRunner
 from clauditor.spec import SkillSpec
 
@@ -119,7 +119,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
             return 1
         output = result.output
 
-    # Grade (and optionally compare / measure variance in a single event loop)
+    # Grade (and optionally measure variance in a single event loop)
     from clauditor.quality_grader import grade_quality
 
     async def _run_grade():
@@ -127,11 +127,6 @@ def cmd_grade(args: argparse.Namespace) -> int:
             output, spec.eval_spec, model,
             thresholds=spec.eval_spec.grade_thresholds,
         )
-        ab_report = None
-        if args.compare:
-            from clauditor.comparator import compare_ab
-
-            ab_report = await compare_ab(spec, model)
         variance_report = None
         if args.variance:
             from clauditor.quality_grader import measure_variance
@@ -139,9 +134,9 @@ def cmd_grade(args: argparse.Namespace) -> int:
             variance_report = await measure_variance(
                 spec, args.variance, model
             )
-        return report, ab_report, variance_report
+        return report, variance_report
 
-    report, ab_report, variance_report = asyncio.run(_run_grade())
+    report, variance_report = asyncio.run(_run_grade())
 
     if args.json:
         data: dict = {
@@ -162,23 +157,8 @@ def cmd_grade(args: argparse.Namespace) -> int:
                     for r in report.results
                 ],
             },
-            "comparison": None,
             "variance": None,
         }
-        if ab_report:
-            data["comparison"] = {
-                "passed": ab_report.passed,
-                "regressions": len(ab_report.regressions),
-                "results": [
-                    {
-                        "criterion": r.criterion,
-                        "skill_passed": r.skill_grade.passed,
-                        "baseline_passed": r.baseline_grade.passed,
-                        "regression": r.regression,
-                    }
-                    for r in ab_report.results
-                ],
-            }
         if variance_report:
             data["variance"] = {
                 "passed": variance_report.passed,
@@ -192,8 +172,6 @@ def cmd_grade(args: argparse.Namespace) -> int:
     else:
         print(f"Quality Grade: {spec.skill_name} ({model})")
         print(report.summary())
-        if ab_report:
-            print(f"\n{ab_report.summary()}")
         if variance_report:
             print(f"\n{variance_report.summary()}")
 
@@ -256,11 +234,123 @@ def cmd_grade(args: argparse.Namespace) -> int:
 
     # Determine exit code
     passed = report.passed
-    if ab_report:
-        passed = passed and ab_report.passed
     if variance_report:
         passed = passed and variance_report.passed
     return 0 if passed else 1
+
+
+def _load_assertion_set(
+    path: Path, spec_path: str | None, eval_path: str | None
+) -> AssertionSet:
+    """Load an AssertionSet from either a ``.txt`` or ``.grade.json`` file.
+
+    For ``.txt`` files, a skill spec is required and Layer 1 assertions are
+    run against the file's contents. For ``.grade.json`` files, the saved
+    GradingReport is deserialized and each GradingResult is adapted into an
+    AssertionResult so the two formats can be diffed uniformly.
+    """
+    from clauditor.assertions import AssertionResult
+    from clauditor.quality_grader import GradingReport
+
+    suffix = "".join(path.suffixes)
+    if path.suffix == ".txt":
+        if not spec_path:
+            raise ValueError(
+                f"--spec is required when diffing .txt files ({path})"
+            )
+        spec = SkillSpec.from_file(spec_path, eval_path=eval_path)
+        if not spec.eval_spec:
+            raise ValueError(f"No eval spec found for {spec_path}")
+        output = path.read_text()
+        return run_assertions(output, spec.eval_spec.assertions)
+    if suffix.endswith(".grade.json") or path.name.endswith(".grade.json"):
+        report = GradingReport.from_json(path.read_text())
+        results = [
+            AssertionResult(
+                name=r.criterion,
+                passed=r.passed,
+                message=r.reasoning or ("pass" if r.passed else "fail"),
+                kind="custom",
+                evidence=r.evidence or None,
+            )
+            for r in report.results
+        ]
+        return AssertionSet(results=results)
+    raise ValueError(
+        f"Unsupported file type for {path}: expected .txt or .grade.json"
+    )
+
+
+def _file_kind(path: Path) -> str:
+    """Return a coarse file-kind label for mismatch detection."""
+    if path.name.endswith(".grade.json"):
+        return "grade.json"
+    if path.suffix == ".txt":
+        return "txt"
+    return path.suffix or path.name
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    """Diff assertion results between two captured runs or saved grade reports.
+
+    Accepts two positional files of matching type (both ``.txt`` or both
+    ``.grade.json``). Prints flipped assertions (regressions + improvements)
+    and exits non-zero if any regressions are detected.
+    """
+    from clauditor.comparator import diff_assertion_sets
+
+    before_path = Path(args.before)
+    after_path = Path(args.after)
+
+    before_kind = _file_kind(before_path)
+    after_kind = _file_kind(after_path)
+    if before_kind != after_kind:
+        print(
+            f"ERROR: Mismatched file types: {before_path} ({before_kind}) "
+            f"vs {after_path} ({after_kind})",
+            file=sys.stderr,
+        )
+        return 2
+    if before_kind not in ("txt", "grade.json"):
+        print(
+            f"ERROR: Unsupported file type '{before_kind}'. "
+            "Expected .txt or .grade.json.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        before_set = _load_assertion_set(before_path, args.spec, args.eval)
+        after_set = _load_assertion_set(after_path, args.spec, args.eval)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    flips = diff_assertion_sets(before_set, after_set)
+
+    regressions = [f for f in flips if f.kind == "regression"]
+    improvements = [f for f in flips if f.kind == "improvement"]
+
+    if not flips:
+        print("no flips: assertion results match")
+        return 0
+
+    for f in flips:
+        if f.kind == "regression":
+            print(f"[REGRESSION] {f.name}: pass -> fail")
+        elif f.kind == "improvement":
+            print(f"[IMPROVEMENT] {f.name}: fail -> pass")
+        elif f.kind == "new":
+            tag = "pass" if f.after_passed else "fail"
+            print(f"[NEW] {f.name}: {tag}")
+        elif f.kind == "removed":
+            tag = "pass" if f.before_passed else "fail"
+            print(f"[REMOVED] {f.name}: was {tag}")
+
+    print(
+        f"\n{len(regressions)} regression(s), {len(improvements)} improvement(s)"
+    )
+    return 1 if regressions else 0
 
 
 def cmd_triggers(args: argparse.Namespace) -> int:
@@ -641,9 +731,6 @@ def main(argv: list[str] | None = None) -> int:
         "--dry-run", action="store_true", help="Print prompt without making API calls"
     )
     p_grade.add_argument(
-        "--compare", action="store_true", help="Also run A/B comparison"
-    )
-    p_grade.add_argument(
         "--variance",
         type=int,
         metavar="N",
@@ -654,6 +741,27 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_grade.add_argument(
         "--diff", action="store_true", help="Compare against prior grade results"
+    )
+
+    # compare
+    p_compare = subparsers.add_parser(
+        "compare",
+        help=(
+            "Diff assertion results between two captured outputs "
+            "(.txt) or saved grade reports (.grade.json)"
+        ),
+    )
+    p_compare.add_argument("before", help="Baseline file (.txt or .grade.json)")
+    p_compare.add_argument("after", help="Candidate file (.txt or .grade.json)")
+    p_compare.add_argument(
+        "--spec",
+        default=None,
+        help="Path to skill .md (required when diffing .txt files)",
+    )
+    p_compare.add_argument(
+        "--eval",
+        default=None,
+        help="Path to eval.json (auto-discovered if omitted)",
     )
 
     # triggers
@@ -761,6 +869,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_run(parsed)
     elif parsed.command == "grade":
         return cmd_grade(parsed)
+    elif parsed.command == "compare":
+        return cmd_compare(parsed)
     elif parsed.command == "triggers":
         return cmd_triggers(parsed)
     elif parsed.command == "extract":

--- a/src/clauditor/comparator.py
+++ b/src/clauditor/comparator.py
@@ -7,9 +7,79 @@ rubric, flagging regressions where the baseline passes but the skill fails.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
+from clauditor.assertions import AssertionSet
 from clauditor.quality_grader import GradingReport, GradingResult, grade_quality
 from clauditor.spec import SkillSpec
+
+FlipKind = Literal["regression", "improvement", "new", "removed"]
+
+
+@dataclass
+class Flip:
+    """A single assertion that differs between two AssertionSets."""
+
+    name: str
+    before_passed: bool
+    after_passed: bool
+    kind: FlipKind
+
+
+def diff_assertion_sets(
+    before: AssertionSet, after: AssertionSet
+) -> list[Flip]:
+    """Diff two AssertionSets, returning a list of Flips sorted by name.
+
+    - ``regression``: was passing, now failing
+    - ``improvement``: was failing, now passing
+    - ``new``: assertion only present in ``after``
+    - ``removed``: assertion only present in ``before``
+
+    Assertions present in both with the same ``passed`` value are omitted.
+    """
+    before_by_name = {r.name: r for r in before.results}
+    after_by_name = {r.name: r for r in after.results}
+    all_names = set(before_by_name) | set(after_by_name)
+
+    flips: list[Flip] = []
+    for name in all_names:
+        b = before_by_name.get(name)
+        a = after_by_name.get(name)
+        if b is None and a is not None:
+            flips.append(
+                Flip(
+                    name=name,
+                    before_passed=False,
+                    after_passed=a.passed,
+                    kind="new",
+                )
+            )
+        elif a is None and b is not None:
+            flips.append(
+                Flip(
+                    name=name,
+                    before_passed=b.passed,
+                    after_passed=False,
+                    kind="removed",
+                )
+            )
+        elif b is not None and a is not None:
+            if b.passed == a.passed:
+                continue
+            kind: FlipKind = (
+                "regression" if b.passed and not a.passed else "improvement"
+            )
+            flips.append(
+                Flip(
+                    name=name,
+                    before_passed=b.passed,
+                    after_passed=a.passed,
+                    kind=kind,
+                )
+            )
+    flips.sort(key=lambda f: f.name)
+    return flips
 
 
 @dataclass

--- a/src/clauditor/formats.py
+++ b/src/clauditor/formats.py
@@ -76,12 +76,12 @@ FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
             "accept those too."
         ),
     ),
-    # strict === extract: labels plus a ≥2-char alphabetic TLD make the
+    # strict === extract: labels plus a >=2-char alphabetic TLD make the
     # shape self-delimiting. Fullmatch correctly rejects values with a
     # scheme or path, and findall locates bare domains inside prose.
     _def(
         "domain",
-        # Two or more labels; final label must be alphabetic and ≥2 chars
+        # Two or more labels; final label must be alphabetic and >=2 chars
         # so numeric/IP-like strings (e.g. 192.168.1.1) don't validate.
         r"(?i)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
         r"(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,}",

--- a/src/clauditor/formats.py
+++ b/src/clauditor/formats.py
@@ -37,21 +37,34 @@ def _def(
 
 
 FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
+    # strict === extract: the pattern has no anchors and the token shape
+    # (3-3-4 digits with optional separators) is already self-delimiting,
+    # so the same regex works for fullmatch of a canonical value and
+    # findall inside prose like "call me at 408-298-5437 today".
     _def(
         "phone_us",
         r"\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}",
         "US phone number, e.g. (408) 298-5437",
     ),
+    # strict === extract: the leading '+' and country code make this
+    # self-delimiting in prose, and fullmatch of a canonical value works
+    # with the same unanchored pattern.
     _def(
         "phone_intl",
         r"\+\d{1,3}[\s.-]?\d{4,14}",
         "International phone number, e.g. +44 7911123456",
     ),
+    # strict === extract: email local@domain shape is self-delimiting
+    # (the '@' plus TLD requirement), so the same pattern handles both
+    # fullmatch of a canonical address and findall inside a sentence.
     _def(
         "email",
         r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
         "Email address, e.g. user@example.com",
     ),
+    # strict === extract: the required "https?://" prefix plus the
+    # explicit non-whitespace/non-quote terminator set make the URL
+    # naturally self-delimiting in prose.
     _def(
         "url",
         r"https?://[^\s\)\"'>]+",
@@ -63,6 +76,9 @@ FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
             "accept those too."
         ),
     ),
+    # strict === extract: labels plus a ≥2-char alphabetic TLD make the
+    # shape self-delimiting. Fullmatch correctly rejects values with a
+    # scheme or path, and findall locates bare domains inside prose.
     _def(
         "domain",
         # Two or more labels; final label must be alphabetic and ≥2 chars
@@ -71,78 +87,112 @@ FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
         r"(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,}",
         "Bare domain (no scheme), e.g. example.com or sub.example.co.uk",
     ),
+    # strict === extract: fixed-width YYYY-MM-DD is self-delimiting.
     _def(
         "date_iso",
         r"\d{4}-\d{2}-\d{2}",
         "ISO 8601 date, e.g. 2026-04-10",
     ),
+    # strict === extract: M/D/Y shape with '/' separators is
+    # self-delimiting in prose.
     _def(
         "date_us",
         r"\d{1,2}/\d{1,2}/\d{2,4}",
         "US date format, e.g. 4/10/2026 or 04/10/26",
     ),
+    # strict === extract: HH:MM[:SS] with ':' separator is
+    # self-delimiting in prose.
     _def(
         "time_24h",
         r"\d{1,2}:\d{2}(?::\d{2})?",
         "24-hour time, e.g. 14:30 or 14:30:00",
     ),
+    # strict === extract: HH:MM with required AM/PM suffix is
+    # self-delimiting in prose.
     _def(
         "time_12h",
         r"\d{1,2}:\d{2}\s?[AaPp][Mm]",
         "12-hour time, e.g. 2:30 PM or 2:30pm",
     ),
+    # strict === extract: leading '$' sigil makes the token
+    # self-delimiting in prose.
     _def(
         "currency_usd",
         r"\$[\d,]+(?:\.\d{2})?",
         "US dollar amount, e.g. $1,234.56 or $50",
     ),
+    # strict === extract: leading '€' sigil makes the token
+    # self-delimiting in prose.
     _def(
         "currency_eur",
         r"€[\d.,]+",
         "Euro amount, e.g. €1.234,56",
     ),
+    # strict === extract: 5 digits (optional -4) is a self-delimiting
+    # numeric token; findall will locate it inside prose without
+    # grabbing adjacent characters.
     _def(
         "zip_us",
         r"\d{5}(?:-\d{4})?",
         "US ZIP code, e.g. 95110 or 95110-1234",
     ),
+    # strict === extract (explicit): an explicit extract= is provided
+    # for clarity, identical to the strict pattern. The UK postcode
+    # alternation of letters/digits is already self-delimiting, so no
+    # looser extract shape is needed.
     _def(
         "zip_uk",
         r"[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}",
         "UK postcode, e.g. SW1A 1AA",
         extract=r"[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}",
     ),
+    # strict === extract: trailing '%' sigil makes the token
+    # self-delimiting in prose.
     _def(
         "percentage",
         r"\d+(?:\.\d+)?%",
         "Percentage, e.g. 95% or 99.9%",
     ),
+    # strict === extract: four dot-separated numeric octets are
+    # self-delimiting in prose.
     _def(
         "ipv4",
         r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
         "IPv4 address, e.g. 192.168.1.1",
     ),
+    # strict === extract (explicit): the canonical 8-4-4-4-12 hex shape
+    # is self-delimiting; the explicit extract= is kept for clarity and
+    # parity with the strict pattern.
     _def(
         "uuid",
         r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
         "UUID, e.g. 550e8400-e29b-41d4-a716-446655440000",
         extract=r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
     ),
+    # strict === extract: leading '#' sigil + fixed 6 hex chars is
+    # self-delimiting in prose.
     _def(
         "hex_color",
         r"#[0-9a-fA-F]{6}",
         "Hex color code, e.g. #FF5733",
     ),
+    # strict === extract: a signed decimal with at least one fractional
+    # digit is self-delimiting enough for prose extraction. Both
+    # fullmatch and findall use the same shape.
     _def(
         "latitude",
         r"-?\d{1,2}\.\d+",
         "Latitude coordinate, e.g. 37.3382",
     ),
+    # strict === extract: same rationale as latitude, with a wider
+    # integer-part (3 digits) for values like -121.8863.
     _def(
         "longitude",
         r"-?\d{1,3}\.\d+",
         "Longitude coordinate, e.g. -121.8863",
     ),
+    # strict === extract: the required "star(s)"/★/⭐ suffix makes the
+    # token self-delimiting in prose.
     _def(
         "star_rating",
         r"\d(?:\.\d)?\s?(?:stars?|★|⭐)",

--- a/src/clauditor/formats.py
+++ b/src/clauditor/formats.py
@@ -114,18 +114,20 @@ FORMAT_REGISTRY: dict[str, FormatDef] = {f.name: f for f in [
         r"\d{1,2}:\d{2}\s?[AaPp][Mm]",
         "12-hour time, e.g. 2:30 PM or 2:30pm",
     ),
-    # strict === extract: leading '$' sigil makes the token
-    # self-delimiting in prose.
+    # strict === extract: leading '$' sigil + lookahead requiring at
+    # least one digit makes the token self-delimiting in prose and
+    # rejects nonsense like "$,,,".
     _def(
         "currency_usd",
-        r"\$[\d,]+(?:\.\d{2})?",
+        r"\$(?=[\d,]*\d)[\d,]+(?:\.\d{2})?",
         "US dollar amount, e.g. $1,234.56 or $50",
     ),
-    # strict === extract: leading '€' sigil makes the token
-    # self-delimiting in prose.
+    # strict === extract: leading '€' sigil + lookahead requiring at
+    # least one digit makes the token self-delimiting in prose and
+    # rejects nonsense like "€...".
     _def(
         "currency_eur",
-        r"€[\d.,]+",
+        r"€(?=[\d.,]*\d)[\d.,]+",
         "Euro amount, e.g. €1.234,56",
     ),
     # strict === extract: 5 digits (optional -4) is a self-delimiting

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -100,6 +100,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                         f"has {len(entries)} entries "
                         f"(need \u2265{tier.min_entries})"
                     ),
+                    kind="count",
                 )
             )
 
@@ -114,6 +115,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                             f"has {len(entries)} entries "
                             f"(need \u2264{tier.max_entries})"
                         ),
+                        kind="count_max",
                     )
                 )
 
@@ -135,6 +137,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                                 f"{section_req.name} tier "
                                 f"'{tier.label}' entry {i + 1}"
                             ),
+                            kind="presence",
                             evidence=entry.fields.get(field_req.name),
                         )
                     )
@@ -173,6 +176,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                                     if matched
                                     else f"Value does not match {label}"
                                 ),
+                                kind="format",
                                 evidence=value,
                             )
                         )
@@ -230,6 +234,7 @@ async def extract_and_grade(
                     name="grader:parse",
                     passed=False,
                     message="Failed to parse grader response as JSON",
+                    kind="custom",
                     evidence=response_text[:200],
                 )
             ]
@@ -265,6 +270,7 @@ async def extract_and_grade(
                         f"Section '{section_name}' returned flat list "
                         f"instead of tier-grouped dict"
                     ),
+                    kind="custom",
                 )
             )
 

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -271,6 +271,7 @@ async def extract_and_grade(
                         f"instead of tier-grouped dict"
                     ),
                     kind="custom",
+                    raw_data=raw,
                 )
             )
 

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -271,7 +271,7 @@ async def extract_and_grade(
                         f"instead of tier-grouped dict"
                     ),
                     kind="custom",
-                    raw_data=raw,
+                    raw_data=dict(raw),
                 )
             )
 

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -98,7 +98,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                     message=(
                         f"Section '{section_req.name}' tier '{tier.label}' "
                         f"has {len(entries)} entries "
-                        f"(need \u2265{tier.min_entries})"
+                        f"(need >={tier.min_entries})"
                     ),
                     kind="count",
                 )
@@ -113,7 +113,7 @@ def grade_extraction(extracted: ExtractedOutput, eval_spec: EvalSpec) -> Asserti
                         message=(
                             f"Section '{section_req.name}' tier '{tier.label}' "
                             f"has {len(entries)} entries "
-                            f"(need \u2264{tier.max_entries})"
+                            f"(need <={tier.max_entries})"
                         ),
                         kind="count_max",
                     )

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -1,0 +1,100 @@
+"""Persistent metric history for clauditor grade runs.
+
+Appends a JSON line per grade run to ``.clauditor/history.jsonl`` so the
+``clauditor trend`` subcommand can render a time series + ASCII sparkline.
+
+ASCII-only (DEC-014): the sparkline uses ``"_.-=#"`` glyphs — no Unicode
+block characters.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+_DEFAULT_PATH = Path(".clauditor/history.jsonl")
+SPARK_GLYPHS = "_.-=#"
+
+
+def append_record(
+    skill: str,
+    pass_rate: float,
+    mean_score: float | None,
+    metrics: dict,
+    path: Path = _DEFAULT_PATH,
+) -> None:
+    """Append one history record for a grade run.
+
+    Creates the parent directory if it does not already exist.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "ts": datetime.now(UTC).isoformat(),
+        "skill": skill,
+        "pass_rate": pass_rate,
+        "mean_score": mean_score,
+        "metrics": metrics,
+    }
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def read_records(
+    skill: str | None = None,
+    path: Path = _DEFAULT_PATH,
+) -> list[dict]:
+    """Read all history records, optionally filtered by skill.
+
+    Missing file -> empty list. Corrupt lines are skipped with a warning to
+    stderr.
+    """
+    if not path.exists():
+        return []
+
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as e:
+                print(
+                    f"WARNING: skipping corrupt history line {lineno} "
+                    f"in {path}: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            if skill is not None and record.get("skill") != skill:
+                continue
+            records.append(record)
+    return records
+
+
+def sparkline(values: list[float]) -> str:
+    """Render a list of values as an ASCII sparkline.
+
+    Uses the 5-glyph set ``"_.-=#"``. Empty input returns ``""``. A single
+    value returns the middle glyph.
+    """
+    if not values:
+        return ""
+    n = len(SPARK_GLYPHS)
+    if len(values) == 1:
+        return SPARK_GLYPHS[n // 2]
+
+    lo = min(values)
+    hi = max(values)
+    if hi == lo:
+        return SPARK_GLYPHS[n // 2] * len(values)
+
+    out = []
+    for v in values:
+        norm = (v - lo) / (hi - lo)
+        idx = round(norm * (n - 1))
+        idx = max(0, min(n - 1, idx))
+        out.append(SPARK_GLYPHS[idx])
+    return "".join(out)

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -69,6 +69,13 @@ def read_records(
                     file=sys.stderr,
                 )
                 continue
+            if not isinstance(record, dict):
+                print(
+                    f"WARNING: skipping non-object history line {lineno} "
+                    f"in {path}",
+                    file=sys.stderr,
+                )
+                continue
             if skill is not None and record.get("skill") != skill:
                 continue
             records.append(record)

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -24,12 +24,16 @@ def append_record(
     pass_rate: float,
     mean_score: float | None,
     metrics: dict,
-    path: Path = _DEFAULT_PATH,
+    path: Path | None = None,
 ) -> None:
     """Append one history record for a grade run.
 
     Creates the parent directory if it does not already exist.
+    ``path`` defaults to :data:`_DEFAULT_PATH` resolved at call time, so
+    tests can monkeypatch the module attribute.
     """
+    if path is None:
+        path = _DEFAULT_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     record = {
         "ts": datetime.now(UTC).isoformat(),
@@ -44,13 +48,16 @@ def append_record(
 
 def read_records(
     skill: str | None = None,
-    path: Path = _DEFAULT_PATH,
+    path: Path | None = None,
 ) -> list[dict]:
     """Read all history records, optionally filtered by skill.
 
     Missing file -> empty list. Corrupt lines are skipped with a warning to
-    stderr.
+    stderr. ``path`` defaults to :data:`_DEFAULT_PATH` resolved at call
+    time so tests can monkeypatch the module attribute.
     """
+    if path is None:
+        path = _DEFAULT_PATH
     if not path.exists():
         return []
 

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -10,6 +10,7 @@ block characters.
 from __future__ import annotations
 
 import json
+import math
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -83,16 +84,25 @@ def sparkline(values: list[float]) -> str:
     if not values:
         return ""
     n = len(SPARK_GLYPHS)
-    if len(values) == 1:
-        return SPARK_GLYPHS[n // 2]
+    mid = SPARK_GLYPHS[n // 2]
+    # Replace non-finite (nan/inf) with the midpoint glyph so bad data
+    # never crashes the renderer.
+    finite = [v for v in values if math.isfinite(v)]
+    if not finite:
+        return mid * len(values)
+    if len(finite) == 1 and len(values) == 1:
+        return mid
 
-    lo = min(values)
-    hi = max(values)
+    lo = min(finite)
+    hi = max(finite)
     if hi == lo:
-        return SPARK_GLYPHS[n // 2] * len(values)
+        return mid * len(values)
 
     out = []
     for v in values:
+        if not math.isfinite(v):
+            out.append(mid)
+            continue
         norm = (v - lo) / (hi - lo)
         idx = round(norm * (n - 1))
         idx = max(0, min(n - 1, idx))

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -137,6 +137,34 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
     return _factory
 
 
+@pytest.fixture(scope="session")
+def clauditor_capture(request: pytest.FixtureRequest):
+    """Fixture factory returning a Path to a captured skill output file.
+
+    Usage:
+        def test_my_skill(clauditor_capture):
+            path = clauditor_capture("find-restaurants")
+            output = path.read_text()  # raises FileNotFoundError if missing
+
+    Default location: ``tests/eval/captured/<skill_name>.txt`` resolved
+    relative to the pytest rootdir. Pass ``base_dir`` to override.
+    The fixture does NOT run capture or skip on missing files — a missing
+    file is the test's problem (DEC-006).
+    """
+    rootdir = Path(str(request.config.rootdir))
+
+    def _factory(
+        skill_name: str, base_dir: str | Path | None = None
+    ) -> Path:
+        if base_dir is None:
+            base = rootdir / "tests" / "eval" / "captured"
+        else:
+            base = Path(base_dir)
+        return base / f"{skill_name}.txt"
+
+    return _factory
+
+
 @pytest.fixture
 def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
     """Fixture factory for trigger precision testing."""

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -134,4 +134,5 @@ def _failed_run_result(skill_name: str, error: str):
         name="skill_execution",
         passed=False,
         message=f"Skill '{skill_name}' failed to run: {error}",
+        kind="custom",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,32 +26,14 @@ def _isolate_clauditor_history(tmp_path, monkeypatch):
     """Redirect history.jsonl writes to a per-test tmp dir so running the
     suite never writes ``.clauditor/history.jsonl`` in the real cwd.
 
-    ``history.append_record`` uses a default-arg ``path=_DEFAULT_PATH`` that
-    is frozen at import time, so monkeypatching ``_DEFAULT_PATH`` alone is a
-    no-op. Replace the module function with a thin wrapper that injects a
-    tmp path whenever callers omit one.
+    ``history.append_record`` / ``read_records`` resolve ``_DEFAULT_PATH``
+    at call time, so monkeypatching the module attribute is sufficient.
     """
     from clauditor import history as _history
 
-    real_append = _history.append_record
-    real_read = _history.read_records
-    tmp_default = tmp_path / ".clauditor" / "history.jsonl"
-
-    def _append(skill, pass_rate, mean_score, metrics, path=None):
-        return real_append(
-            skill,
-            pass_rate,
-            mean_score,
-            metrics,
-            path=tmp_default if path is None else path,
-        )
-
-    def _read(skill=None, path=None):
-        return real_read(skill=skill, path=tmp_default if path is None else path)
-
-    monkeypatch.setattr(_history, "append_record", _append)
-    monkeypatch.setattr(_history, "read_records", _read)
-    monkeypatch.setattr(_history, "_DEFAULT_PATH", tmp_default)
+    monkeypatch.setattr(
+        _history, "_DEFAULT_PATH", tmp_path / ".clauditor" / "history.jsonl"
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,39 @@ from clauditor.schemas import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_clauditor_history(tmp_path, monkeypatch):
+    """Redirect history.jsonl writes to a per-test tmp dir so running the
+    suite never writes ``.clauditor/history.jsonl`` in the real cwd.
+
+    ``history.append_record`` uses a default-arg ``path=_DEFAULT_PATH`` that
+    is frozen at import time, so monkeypatching ``_DEFAULT_PATH`` alone is a
+    no-op. Replace the module function with a thin wrapper that injects a
+    tmp path whenever callers omit one.
+    """
+    from clauditor import history as _history
+
+    real_append = _history.append_record
+    real_read = _history.read_records
+    tmp_default = tmp_path / ".clauditor" / "history.jsonl"
+
+    def _append(skill, pass_rate, mean_score, metrics, path=None):
+        return real_append(
+            skill,
+            pass_rate,
+            mean_score,
+            metrics,
+            path=tmp_default if path is None else path,
+        )
+
+    def _read(skill=None, path=None):
+        return real_read(skill=skill, path=tmp_default if path is None else path)
+
+    monkeypatch.setattr(_history, "append_record", _append)
+    monkeypatch.setattr(_history, "read_records", _read)
+    monkeypatch.setattr(_history, "_DEFAULT_PATH", tmp_default)
+
+
 @pytest.fixture
 def sample_eval_data() -> dict:
     """Return a dict matching eval.json format with all fields populated."""

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -814,10 +814,11 @@ class TestAssertionKind:
     def test_has_entries_kind_count(self):
         assert assert_has_entries("**1. Foo**", 1).kind == "count"
 
-    def test_urls_reachable_no_urls_kind_count(self):
-        # Short-circuit branch when no URLs present
+    def test_urls_reachable_no_urls_kind_reachability(self):
+        # Short-circuit branch when no URLs present still reports the
+        # reachability kind — both code paths describe the same check.
         r = assert_urls_reachable("no urls here", 0)
-        assert r.kind == "count"
+        assert r.kind == "reachability"
 
     def test_urls_reachable_with_urls_kind_reachability(self):
         with patch(

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -229,11 +229,13 @@ class TestAssertionSet:
 
 
 def _fail(name: str, msg: str = "nope", evidence: str | None = None) -> AssertionResult:
-    return AssertionResult(name=name, passed=False, message=msg, evidence=evidence)
+    return AssertionResult(
+        name=name, passed=False, message=msg, kind="presence", evidence=evidence
+    )
 
 
 def _pass(name: str) -> AssertionResult:
-    return AssertionResult(name=name, passed=True, message="ok")
+    return AssertionResult(name=name, passed=True, message="ok", kind="presence")
 
 
 class TestGroupedSummary:
@@ -367,11 +369,11 @@ class TestMaxLength:
 
 class TestAssertionResultBool:
     def test_bool_true(self):
-        r = AssertionResult(name="test", passed=True, message="ok")
+        r = AssertionResult(name="test", passed=True, message="ok", kind="custom")
         assert bool(r) is True
 
     def test_bool_false(self):
-        r = AssertionResult(name="test", passed=False, message="fail")
+        r = AssertionResult(name="test", passed=False, message="fail", kind="custom")
         assert bool(r) is False
 
 
@@ -777,3 +779,108 @@ class TestHasFormat:
         )
         result = assert_has_format(output, "url", minimum=2)
         assert result.passed
+
+
+class TestAssertionKind:
+    """US-001: AssertionResult.kind is required and enumerated."""
+
+    def test_kind_required_typeerror(self):
+        import pytest
+
+        with pytest.raises(TypeError):
+            AssertionResult(name="x", passed=True, message="m")  # type: ignore[call-arg]
+
+    def test_contains_kind_presence(self):
+        assert assert_contains("hello world", "hello").kind == "presence"
+
+    def test_not_contains_kind_presence(self):
+        assert assert_not_contains("abc", "zz").kind == "presence"
+
+    def test_regex_kind_pattern(self):
+        assert assert_regex("abc123", r"\d+").kind == "pattern"
+
+    def test_min_count_kind_count(self):
+        assert assert_min_count("a a a", r"a", 1).kind == "count"
+
+    def test_min_length_kind_count(self):
+        assert assert_min_length("hello", 1).kind == "count"
+
+    def test_max_length_kind_count(self):
+        assert assert_max_length("hi", 100).kind == "count"
+
+    def test_has_urls_kind_count(self):
+        assert assert_has_urls("https://example.com", 1).kind == "count"
+
+    def test_has_entries_kind_count(self):
+        assert assert_has_entries("**1. Foo**", 1).kind == "count"
+
+    def test_urls_reachable_no_urls_kind_count(self):
+        # Short-circuit branch when no URLs present
+        r = assert_urls_reachable("no urls here", 0)
+        assert r.kind == "count"
+
+    def test_urls_reachable_with_urls_kind_reachability(self):
+        with patch(
+            "clauditor.assertions._check_url",
+            return_value=("https://example.com", 200),
+        ):
+            r = assert_urls_reachable("see https://example.com", 1)
+        assert r.kind == "reachability"
+
+    def test_has_format_unknown_kind_format(self):
+        r = assert_has_format("x", "this_format_does_not_exist_xyz")
+        assert r.kind == "format"
+
+    def test_has_format_known_kind_count(self):
+        r = assert_has_format("(408) 298-5437", "phone_us", minimum=1)
+        assert r.kind == "count"
+
+    def test_unknown_run_assertions_kind_custom(self):
+        rs = run_assertions("t", [{"type": "nope"}])
+        assert rs.results[0].kind == "custom"
+
+    def test_all_enum_values_constructable(self):
+        for k in (
+            "presence",
+            "format",
+            "pattern",
+            "count",
+            "count_max",
+            "reachability",
+            "custom",
+        ):
+            r = AssertionResult(name="n", passed=True, message="m", kind=k)
+            assert r.kind == k
+
+    def test_grouped_summary_still_groups_by_name(self):
+        """Regression: kind is supplementary; grouping key continues to use name."""
+        s = AssertionSet(
+            results=[
+                AssertionResult(
+                    name=f"section:S/default[{i}].website:format",
+                    passed=False,
+                    message="bad",
+                    kind="format",
+                    evidence="x",
+                )
+                for i in range(3)
+            ]
+        )
+        lines = s.grouped_summary()
+        assert len(lines) == 1
+        assert "3/3" in lines[0]
+
+    def test_summary_output_unchanged_regression(self):
+        s = AssertionSet(
+            results=[
+                AssertionResult(
+                    name="a", passed=True, message="ok", kind="presence"
+                ),
+                AssertionResult(
+                    name="b", passed=False, message="no", kind="presence"
+                ),
+            ]
+        )
+        out = s.summary()
+        assert "1/2" in out
+        assert "FAIL: b" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -978,6 +978,69 @@ class TestCmdExtract:
 
         assert rc == 1
 
+    def _make_raw_data_results(self):
+        raw = {"Venues": [{"name": "A"}]}
+        return AssertionSet(
+            results=[
+                AssertionResult(
+                    name="grader:parse:Venues",
+                    passed=False,
+                    message="shape wrong",
+                    kind="custom",
+                    raw_data=raw,
+                ),
+            ]
+        ), raw
+
+    def test_extract_verbose_prints_raw_data(self, tmp_path, capsys):
+        """US-005: -v prints raw_data for failing assertion that has it."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("output")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        results, raw = self._make_raw_data_results()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(
+                ["extract", "skill.md", "--output", str(output_file), "-v"]
+            )
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Raw data for grader:parse:Venues" in out
+        assert json.dumps(raw, indent=2) in out
+
+    def test_extract_without_verbose_omits_raw_data(self, tmp_path, capsys):
+        """US-005: without -v, raw_data is not printed even when present."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("output")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        results, _ = self._make_raw_data_results()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Raw data for" not in out
+
 
 class TestCmdCapture:
     """Tests for the capture subcommand (US-006)."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,116 @@ class TestCmdGrade:
         assert rc == 1
 
 
+class TestOnlyCriterion:
+    """Tests for --only-criterion filter on the grade subcommand."""
+
+    def _report(self):
+        return GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="x",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+    def _run(self, tmp_path, criteria, extra_args):
+        output_file = tmp_path / "o.txt"
+        output_file.write_text("out")
+        eval_spec = _make_eval_spec(grading_criteria=list(criteria))
+        spec = _make_spec(eval_spec=eval_spec)
+        mock_grade = AsyncMock(return_value=self._report())
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch("clauditor.quality_grader.grade_quality", mock_grade),
+        ):
+            rc = main(
+                ["grade", "skill.md", "--output", str(output_file)] + extra_args
+            )
+        return rc, mock_grade, spec
+
+    def test_single_substring_filters(self, tmp_path):
+        """--only-criterion foo keeps only matching criteria."""
+        rc, mock_grade, spec = self._run(
+            tmp_path,
+            ["foo bar", "baz qux", "other foo"],
+            ["--only-criterion", "foo"],
+        )
+        assert rc == 0
+        assert spec.eval_spec.grading_criteria == ["foo bar", "other foo"]
+        # Grader called with filtered spec
+        mock_grade.assert_called_once()
+        passed_spec = mock_grade.call_args.args[1]
+        assert passed_spec.grading_criteria == ["foo bar", "other foo"]
+
+    def test_multiple_substrings_union(self, tmp_path):
+        """Multiple --only-criterion flags use OR semantics."""
+        rc, mock_grade, spec = self._run(
+            tmp_path,
+            ["alpha", "beta", "gamma", "alphabeta"],
+            ["--only-criterion", "alpha", "--only-criterion", "gamma"],
+        )
+        assert rc == 0
+        assert spec.eval_spec.grading_criteria == ["alpha", "gamma", "alphabeta"]
+
+    def test_no_match_exits_2(self, tmp_path, capsys):
+        """No match prints Available and exits 2."""
+        import pytest
+
+        output_file = tmp_path / "o.txt"
+        output_file.write_text("out")
+        eval_spec = _make_eval_spec(
+            grading_criteria=["clarity", "accuracy"]
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        mock_grade = AsyncMock(return_value=self._report())
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch("clauditor.quality_grader.grade_quality", mock_grade),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--only-criterion",
+                    "nonexistent",
+                ]
+            )
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "No grading criteria match filter" in err
+        assert "Available:" in err
+        assert "clarity" in err
+        assert "accuracy" in err
+        # Grader must NOT have been called
+        mock_grade.assert_not_called()
+
+    def test_no_flag_passes_all(self, tmp_path):
+        """Without --only-criterion, all criteria are passed through."""
+        rc, mock_grade, spec = self._run(
+            tmp_path, ["one", "two", "three"], []
+        )
+        assert rc == 0
+        assert spec.eval_spec.grading_criteria == ["one", "two", "three"]
+
+    def test_case_insensitive(self, tmp_path):
+        """--only-criterion FOO matches criterion 'foo'."""
+        rc, _mock, spec = self._run(
+            tmp_path, ["foo", "bar"], ["--only-criterion", "FOO"]
+        )
+        assert rc == 0
+        assert spec.eval_spec.grading_criteria == ["foo"]
+
+
 class TestCmdGradeSaveDiff:
     """Tests for --save and --diff flags on the grade subcommand."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -469,6 +469,137 @@ class TestCmdGradeSaveDiff:
             os.chdir(orig_dir)
 
 
+class TestCmdCompare:
+    """Tests for the compare subcommand (US-003)."""
+
+    def _make_saved_grade_json(
+        self, tmp_path, name: str, *, criterion_passes: dict[str, bool]
+    ):
+        """Write a GradingReport to a .grade.json file and return the path."""
+        results = [
+            GradingResult(
+                criterion=c,
+                passed=p,
+                score=0.9 if p else 0.3,
+                evidence="",
+                reasoning="",
+            )
+            for c, p in criterion_passes.items()
+        ]
+        report = GradingReport(
+            skill_name=name,
+            model="test-model",
+            results=results,
+            duration_seconds=0.0,
+        )
+        path = tmp_path / f"{name}.grade.json"
+        path.write_text(report.to_json())
+        return path
+
+    def test_compare_two_grade_json_no_flips(self, tmp_path, capsys):
+        """Two identical .grade.json files produce no flips and exit 0."""
+        before = self._make_saved_grade_json(
+            tmp_path, "before", criterion_passes={"c1": True, "c2": True}
+        )
+        after = self._make_saved_grade_json(
+            tmp_path, "after", criterion_passes={"c1": True, "c2": True}
+        )
+        rc = main(["compare", str(before), str(after)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "no flips" in out
+
+    def test_compare_two_grade_json_regression(self, tmp_path, capsys):
+        """A flipped-to-fail criterion yields [REGRESSION] and exit 1."""
+        before = self._make_saved_grade_json(
+            tmp_path, "before", criterion_passes={"c1": True, "c2": True}
+        )
+        after = self._make_saved_grade_json(
+            tmp_path, "after", criterion_passes={"c1": True, "c2": False}
+        )
+        rc = main(["compare", str(before), str(after)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "[REGRESSION]" in out
+        assert "c2" in out
+
+    def test_compare_two_grade_json_improvement(self, tmp_path, capsys):
+        """A flipped-to-pass criterion yields [IMPROVEMENT] and exit 0."""
+        before = self._make_saved_grade_json(
+            tmp_path, "before", criterion_passes={"c1": True, "c2": False}
+        )
+        after = self._make_saved_grade_json(
+            tmp_path, "after", criterion_passes={"c1": True, "c2": True}
+        )
+        rc = main(["compare", str(before), str(after)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[IMPROVEMENT]" in out
+        assert "c2" in out
+
+    def test_compare_two_txt_with_spec(self, tmp_path, capsys):
+        """Two .txt files plus --spec re-grade both and diff Layer 1 results."""
+        before_txt = tmp_path / "before.txt"
+        after_txt = tmp_path / "after.txt"
+        before_txt.write_text("nothing matching")
+        after_txt.write_text("hello world")
+
+        eval_spec = _make_eval_spec(
+            assertions=[{"type": "contains", "value": "hello"}]
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(
+                [
+                    "compare",
+                    str(before_txt),
+                    str(after_txt),
+                    "--spec",
+                    "skill.md",
+                ]
+            )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[IMPROVEMENT]" in out
+
+    def test_compare_txt_without_spec_errors(self, tmp_path, capsys):
+        """.txt diff without --spec errors with a clear message."""
+        before_txt = tmp_path / "before.txt"
+        after_txt = tmp_path / "after.txt"
+        before_txt.write_text("a")
+        after_txt.write_text("b")
+        rc = main(["compare", str(before_txt), str(after_txt)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--spec" in err
+
+    def test_compare_mixed_extensions_errors(self, tmp_path, capsys):
+        """Mixed .txt + .grade.json inputs error before loading."""
+        before_txt = tmp_path / "before.txt"
+        before_txt.write_text("something")
+        after = self._make_saved_grade_json(
+            tmp_path, "after", criterion_passes={"c1": True}
+        )
+        rc = main(["compare", str(before_txt), str(after)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "Mismatched" in err
+
+
+class TestCmdGradeCompareFlagRemoved:
+    """US-003: the legacy --compare flag on grade is gone."""
+
+    def test_grade_compare_flag_rejected(self, capsys):
+        import pytest as _pytest
+
+        with _pytest.raises(SystemExit):
+            main(["grade", "skill.md", "--compare"])
+        err = capsys.readouterr().err
+        assert "--compare" in err or "unrecognized" in err
+
+
 class TestCmdTriggers:
     """Tests for the triggers subcommand."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1203,3 +1203,119 @@ class TestCmdDoctor:
         # Expect fail marker for missing claude CLI
         lines = [line for line in out.splitlines() if "claude-cli" in line]
         assert any("[fail]" in line for line in lines)
+
+
+class TestCmdTrend:
+    """Tests for the trend subcommand (US-006)."""
+
+    def _seed(self, path, skill="test-skill", n=3):
+        from clauditor import history
+
+        for i in range(n):
+            history.append_record(
+                skill=skill,
+                pass_rate=0.5 + i * 0.1,
+                mean_score=0.6 + i * 0.05,
+                metrics={"count": i + 1},
+                path=path,
+            )
+
+    def test_happy_path(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl")
+
+        rc = main(["trend", "test-skill", "--metric", "pass_rate"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "0.5" in out
+        assert "0.7" in out
+        # Sparkline line present (non-empty last line)
+        lines = [ln for ln in out.splitlines() if ln]
+        assert lines
+        # Sparkline should use only glyphs from SPARK_GLYPHS
+        from clauditor.history import SPARK_GLYPHS
+
+        spark = lines[-1]
+        assert all(c in SPARK_GLYPHS for c in spark)
+
+    def test_metric_in_metrics_dict(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl")
+
+        rc = main(["trend", "test-skill", "--metric", "count"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "1" in out and "3" in out
+
+    def test_missing_metric_exits_1(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl")
+
+        rc = main(["trend", "test-skill", "--metric", "nonexistent"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "nonexistent" in err
+
+    def test_no_history_file(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        rc = main(["trend", "test-skill", "--metric", "pass_rate"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "no history" in err.lower() or "no records" in err.lower()
+
+    def test_last_n_truncates(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl", n=10)
+
+        rc = main(["trend", "test-skill", "--metric", "pass_rate", "--last", "5"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data_lines = [ln for ln in out.splitlines() if "\t" in ln]
+        assert len(data_lines) == 5
+
+
+class TestCmdGradeHistory:
+    """cmd_grade appends a history record (US-006)."""
+
+    def test_grade_appends_history(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="Is the output relevant?",
+                    passed=True,
+                    score=0.9,
+                    evidence="ok",
+                    reasoning="ok",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        assert history_path.exists()
+        lines = [ln for ln in history_path.read_text().splitlines() if ln]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["skill"] == "test-skill"
+        assert record["pass_rate"] == 1.0
+        assert record["mean_score"] == 0.9

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,6 +615,7 @@ class TestCmdExtract:
                     name="section:Results:count",
                     passed=passed,
                     message="Section 'Results' has 3 entries (need >=2)",
+                    kind="count",
                 ),
                 AssertionResult(
                     name="section:Results[0].name",
@@ -624,6 +625,7 @@ class TestCmdExtract:
                         if passed
                         else "Missing required field 'name'"
                     ),
+                    kind="presence",
                     evidence="Test Place" if passed else None,
                 ),
             ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -321,9 +321,7 @@ class TestOnlyCriterion:
         assert spec.eval_spec.grading_criteria == ["alpha", "gamma", "alphabeta"]
 
     def test_no_match_exits_2(self, tmp_path, capsys):
-        """No match prints Available and exits 2."""
-        import pytest
-
+        """No match prints Available and returns exit code 2."""
         output_file = tmp_path / "o.txt"
         output_file.write_text("out")
         eval_spec = _make_eval_spec(
@@ -334,9 +332,8 @@ class TestOnlyCriterion:
         with (
             patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
             patch("clauditor.quality_grader.grade_quality", mock_grade),
-            pytest.raises(SystemExit) as exc_info,
         ):
-            main(
+            rc = main(
                 [
                     "grade",
                     "skill.md",
@@ -346,7 +343,7 @@ class TestOnlyCriterion:
                     "nonexistent",
                 ]
             )
-        assert exc_info.value.code == 2
+        assert rc == 2
         err = capsys.readouterr().err
         assert "No grading criteria match filter" in err
         assert "Available:" in err

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -4,9 +4,85 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from clauditor.comparator import ABReport, ABResult, compare_ab
+from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.comparator import (
+    ABReport,
+    ABResult,
+    Flip,
+    compare_ab,
+    diff_assertion_sets,
+)
 from clauditor.quality_grader import GradingReport, GradingResult
 from clauditor.runner import SkillResult
+
+
+def _ar(name: str, passed: bool) -> AssertionResult:
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        message="ok" if passed else "fail",
+        kind="custom",
+    )
+
+
+class TestDiffAssertionSets:
+    """Tests for diff_assertion_sets helper."""
+
+    def test_only_in_before_is_removed(self):
+        before = AssertionSet(results=[_ar("only_before", True)])
+        after = AssertionSet(results=[])
+        flips = diff_assertion_sets(before, after)
+        assert len(flips) == 1
+        assert flips[0].name == "only_before"
+        assert flips[0].kind == "removed"
+
+    def test_only_in_after_is_new(self):
+        before = AssertionSet(results=[])
+        after = AssertionSet(results=[_ar("only_after", True)])
+        flips = diff_assertion_sets(before, after)
+        assert len(flips) == 1
+        assert flips[0].name == "only_after"
+        assert flips[0].kind == "new"
+
+    def test_both_same_passed_is_omitted(self):
+        before = AssertionSet(results=[_ar("a", True), _ar("b", False)])
+        after = AssertionSet(results=[_ar("a", True), _ar("b", False)])
+        assert diff_assertion_sets(before, after) == []
+
+    def test_flipped_pass_to_fail_is_regression(self):
+        before = AssertionSet(results=[_ar("a", True)])
+        after = AssertionSet(results=[_ar("a", False)])
+        flips = diff_assertion_sets(before, after)
+        assert len(flips) == 1
+        assert flips[0].kind == "regression"
+        assert flips[0].before_passed is True
+        assert flips[0].after_passed is False
+
+    def test_flipped_fail_to_pass_is_improvement(self):
+        before = AssertionSet(results=[_ar("a", False)])
+        after = AssertionSet(results=[_ar("a", True)])
+        flips = diff_assertion_sets(before, after)
+        assert len(flips) == 1
+        assert flips[0].kind == "improvement"
+
+    def test_result_sorted_by_name(self):
+        before = AssertionSet(
+            results=[_ar("zeta", True), _ar("alpha", True), _ar("mu", False)]
+        )
+        after = AssertionSet(
+            results=[_ar("zeta", False), _ar("alpha", False), _ar("mu", True)]
+        )
+        flips = diff_assertion_sets(before, after)
+        names = [f.name for f in flips]
+        assert names == sorted(names)
+        assert names == ["alpha", "mu", "zeta"]
+
+    def test_flip_dataclass_fields(self):
+        f = Flip(
+            name="x", before_passed=True, after_passed=False, kind="regression"
+        )
+        assert f.name == "x"
+        assert f.kind == "regression"
 
 
 def _make_grade(criterion: str, passed: bool, score: float = 0.8) -> GradingResult:

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -290,3 +290,636 @@ class TestDomainFieldRequirement:
         fr = FieldRequirement(name="website", format="domain")
         assert fr.format == "domain"
         assert FORMAT_REGISTRY["domain"].pattern is not None
+
+
+# ---------------------------------------------------------------------------
+# Per-entry strict/extract invariant tests (one class per FORMAT_REGISTRY
+# entry). Each class verifies:
+#   1. strict pattern fullmatches canonical values
+#   2. strict pattern rejects malformed values
+#   3. extract pattern finds the value inside surrounding prose
+#   4. extract pattern rejects pure noise
+#   5. invariant: validate_value(X) True → extract_pattern.findall finds X
+# ---------------------------------------------------------------------------
+
+
+def _assert_extract_contains(fmt_name: str, value: str) -> None:
+    """Helper asserting the extract pattern finds `value` inside prose."""
+    fmt = FORMAT_REGISTRY[fmt_name]
+    prose = f"prefix blah {value} suffix blah"
+    matches = fmt.extract_pattern.findall(prose)
+    # findall returns full matches (we only use non-capturing groups).
+    assert any(value == m or value in m for m in matches), (
+        f"{fmt_name}: extract_pattern did not find {value!r} in prose; "
+        f"got matches={matches!r}"
+    )
+
+
+class TestPhoneUsFormat:
+    name = "phone_us"
+    canonical = ["(408) 298-5437", "408-298-5437", "408.298.5437", "4082985437"]
+    malformed = ["call for hours", "123", "abcdefghij"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("call me at 408-298-5437 today")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("just some harmless words here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestPhoneIntlFormat:
+    name = "phone_intl"
+    canonical = ["+1 4082985437", "+44 7911123456", "+353 861234567"]
+    malformed = ["4082985437", "+", "not a phone"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("call +44 7911123456 please")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no numbers at all here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestEmailFormat:
+    name = "email"
+    canonical = ["user@example.com", "first.last@company.co.uk", "test+tag@gmail.com"]
+    malformed = ["not-an-email", "@missing.com", "no-at-sign.com"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("write to user@example.com today")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no email address in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestUrlFormat:
+    name = "url"
+    canonical = [
+        "https://example.com",
+        "http://example.com/path?q=1",
+        "https://sub.domain.co.uk/page",
+    ]
+    malformed = ["ftp://example.com", "example.com", "not a url"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        matches = fmt.extract_pattern.findall("see https://example.com for more")
+        assert any("https://example.com" in m for m in matches)
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("plain text with no link")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestDomainFormat:
+    name = "domain"
+    canonical = ["paesanosj.com", "sub.example.co.uk", "a-b.io"]
+    malformed = ["https://paesanosj.com", "paesanosj", ".com", "192.168.1.1"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        matches = fmt.extract_pattern.findall("visit paesanosj.com today")
+        assert any("paesanosj.com" in m for m in matches)
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("plain words without a host")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestDateIsoFormat:
+    name = "date_iso"
+    canonical = ["2026-04-10", "2000-01-01"]
+    malformed = ["04/10/2026", "2026/04/10", "not a date"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("due on 2026-04-10 please")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no date in this sentence")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestDateUsFormat:
+    name = "date_us"
+    canonical = ["4/10/2026", "04/10/26", "12/31/2025"]
+    malformed = ["2026-04-10", "not a date"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("due 4/10/2026 ok")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no date here at all")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestTime24hFormat:
+    name = "time_24h"
+    canonical = ["14:30", "14:30:00", "0:00"]
+    malformed = ["2:30 PM", "not a time"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("meet at 14:30 sharp")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no clock reading in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestTime12hFormat:
+    name = "time_12h"
+    canonical = ["2:30 PM", "2:30pm", "12:00 AM"]
+    malformed = ["14:30", "not a time"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("meet at 2:30 PM please")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no clock reading in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestCurrencyUsdFormat:
+    name = "currency_usd"
+    canonical = ["$50", "$1,234.56", "$0.99"]
+    malformed = ["50 dollars", "€50", "USD 50"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("costs $1,234.56 total")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no price mentioned here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestCurrencyEurFormat:
+    name = "currency_eur"
+    canonical = ["€50", "€1.234,56"]
+    malformed = ["$50", "50 EUR"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("price is €50 total")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no price mentioned here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestZipUsFormat:
+    name = "zip_us"
+    canonical = ["95110", "95110-1234"]
+    malformed = ["ABCDE", "9511", "notazip"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("ship to 95110 today")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no zip code in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestZipUkFormat:
+    name = "zip_uk"
+    canonical = ["SW1A 1AA", "EC1A 1BB", "W1A 0AX"]
+    malformed = ["95110", "not a postcode"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("ship to SW1A 1AA please")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no postcode in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestPercentageFormat:
+    name = "percentage"
+    canonical = ["95%", "99.9%", "0%"]
+    malformed = ["ninety-five percent", "95", "percent"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("reached 99.9% uptime today")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("plain words only here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestIpv4Format:
+    name = "ipv4"
+    canonical = ["192.168.1.1", "10.0.0.1", "255.255.255.0"]
+    malformed = ["not.an.ip", "1.2.3", "abcd"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("reach 192.168.1.1 now")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no address here at all")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestUuidFormat:
+    name = "uuid"
+    canonical = ["550e8400-e29b-41d4-a716-446655440000"]
+    malformed = ["not-a-uuid", "550e8400", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall(
+            "id=550e8400-e29b-41d4-a716-446655440000 foo"
+        )
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no identifier mentioned here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestHexColorFormat:
+    name = "hex_color"
+    canonical = ["#FF5733", "#aabbcc"]
+    malformed = ["#FFF", "red", "FF5733"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("use #FF5733 for the header")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no color mentioned here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestLatitudeFormat:
+    name = "latitude"
+    canonical = ["37.3382", "-33.8688"]
+    malformed = ["north", "37", "abc"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("at lat 37.3382 approximately")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no coordinates in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestLongitudeFormat:
+    name = "longitude"
+    canonical = ["-121.8863", "151.2093"]
+    malformed = ["west", "121", "abc"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("at lon -121.8863 approximately")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no coordinates in here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestStarRatingFormat:
+    name = "star_rating"
+    canonical = ["4.5 stars", "3 ★", "5 star"]
+    malformed = ["excellent", "five stars", "rating"]
+
+    def test_strict_accepts_canonical(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.canonical:
+            assert fmt.pattern.fullmatch(v)
+
+    def test_strict_rejects_malformed(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        for v in self.malformed:
+            assert fmt.pattern.fullmatch(v) is None
+
+    def test_extract_finds_in_prose(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert fmt.extract_pattern.findall("earned 4.5 stars overall")
+
+    def test_extract_rejects_pure_noise(self):
+        fmt = FORMAT_REGISTRY[self.name]
+        assert not fmt.extract_pattern.findall("no rating mentioned here")
+
+    def test_invariant_validate_implies_extract(self):
+        for v in self.canonical:
+            assert validate_value(v, self.name)
+            _assert_extract_contains(self.name, v)
+
+
+class TestEveryRegistryEntryHasATestClass:
+    """Meta-test: make sure we didn't forget any entry."""
+
+    def test_one_class_per_entry(self):
+        import sys
+        mod = sys.modules[__name__]
+        covered = set()
+        for attr in dir(mod):
+            obj = getattr(mod, attr)
+            name = getattr(obj, "name", None)
+            if (
+                isinstance(obj, type)
+                and attr.startswith("Test")
+                and attr.endswith("Format")
+                and isinstance(name, str)
+                and name in FORMAT_REGISTRY
+            ):
+                covered.add(name)
+        missing = set(FORMAT_REGISTRY) - covered
+        assert not missing, f"Missing per-entry test classes for: {missing}"

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -381,7 +381,7 @@ class TestMaxEntries:
         )
         assert not count_max.passed
         assert "6 entries" in count_max.message
-        assert "\u22643" in count_max.message
+        assert "<=3" in count_max.message
 
     def test_over_max_still_grades_all_entry_fields(self):
         """DEC-003: field checks still run for all extracted entries."""

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -748,6 +748,59 @@ class TestExtractAndGrade:
             result = await extract_and_grade("some output", _make_spec())
         assert result.passed
 
+    @pytest.mark.asyncio
+    async def test_shape_failure_attaches_raw_data(self):
+        """US-005: parseable-but-wrong-shape response attaches raw_data."""
+        data = {
+            "Venues": [
+                {"name": "CDM", "address": "X", "website": "Y"},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        failed = [r for r in result.results if r.name == "grader:parse:Venues"]
+        assert len(failed) == 1
+        assert failed[0].raw_data == data
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure_leaves_raw_data_none(self):
+        """US-005: unparseable response keeps raw_data=None and evidence."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="not valid json at all")]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        parse_failures = [r for r in result.results if r.name == "grader:parse"]
+        assert len(parse_failures) == 1
+        assert parse_failures[0].raw_data is None
+        assert parse_failures[0].evidence == "not valid json at all"
+
+    @pytest.mark.asyncio
+    async def test_non_failure_result_has_no_raw_data(self):
+        """US-005 negative regression: passing assertions never carry raw_data."""
+        data = {
+            "Venues": {
+                "default": [
+                    {"name": "A", "address": "B", "website": "C"},
+                    {"name": "D", "address": "E", "website": "F"},
+                ]
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert result.passed
+        for r in result.results:
+            assert r.raw_data is None
+
 
 def _make_format_spec() -> EvalSpec:
     """Spec exercising both registry formats and inline-regex formats (DEC-007)."""

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,70 @@
+"""Tests for clauditor.history."""
+
+from __future__ import annotations
+
+from clauditor.history import SPARK_GLYPHS, append_record, read_records, sparkline
+
+
+class TestAppendAndRead:
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        append_record("skill-a", 0.8, 0.75, {"foo": 1}, path=path)
+        append_record("skill-b", 0.5, None, {}, path=path)
+        append_record("skill-a", 0.9, 0.85, {"foo": 2}, path=path)
+
+        all_records = read_records(path=path)
+        assert len(all_records) == 3
+        assert all_records[0]["skill"] == "skill-a"
+        assert all_records[0]["pass_rate"] == 0.8
+        assert all_records[0]["mean_score"] == 0.75
+        assert all_records[0]["metrics"] == {"foo": 1}
+        assert "ts" in all_records[0]
+
+        a_records = read_records(skill="skill-a", path=path)
+        assert len(a_records) == 2
+        assert all(r["skill"] == "skill-a" for r in a_records)
+
+    def test_append_creates_parent_dir(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "history.jsonl"
+        append_record("s", 1.0, 1.0, {}, path=path)
+        assert path.exists()
+        assert len(read_records(path=path)) == 1
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        path = tmp_path / "nope.jsonl"
+        assert read_records(path=path) == []
+        assert read_records(skill="x", path=path) == []
+
+    def test_corrupt_line_skipped_with_warning(self, tmp_path, capsys):
+        path = tmp_path / "history.jsonl"
+        append_record("s", 0.5, 0.5, {}, path=path)
+        with path.open("a", encoding="utf-8") as f:
+            f.write("{not valid json\n")
+        append_record("s", 0.7, 0.7, {}, path=path)
+
+        records = read_records(path=path)
+        assert len(records) == 2
+        err = capsys.readouterr().err
+        assert "corrupt history line" in err
+
+
+class TestSparkline:
+    def test_empty(self):
+        assert sparkline([]) == ""
+
+    def test_single_value_middle_glyph(self):
+        mid = SPARK_GLYPHS[len(SPARK_GLYPHS) // 2]
+        assert sparkline([1.0]) == mid
+
+    def test_three_value_range(self):
+        # Glyph set is "_.-=#" (5 levels). With min=0, max=1, values
+        # [0, 0.5, 1.0] normalize to indices [0, 2, 4] -> "_-#".
+        assert sparkline([0.0, 0.5, 1.0]) == "_-#"
+
+    def test_all_equal_values(self):
+        mid = SPARK_GLYPHS[len(SPARK_GLYPHS) // 2]
+        assert sparkline([0.5, 0.5, 0.5]) == mid * 3
+
+    def test_ascii_only(self):
+        out = sparkline([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        assert all(ord(c) < 128 for c in out)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import clauditor.pytest_plugin as _plugin_mod
 from clauditor.pytest_plugin import (
+    clauditor_capture,
     clauditor_runner,
     clauditor_spec,
     pytest_addoption,
@@ -174,6 +175,50 @@ class TestPluginFunctionsDirect:
         )
         factory = clauditor_spec.__wrapped__(request)
         assert callable(factory)
+
+    def test_capture_fixture_returns_path(self, tmp_path):
+        """clauditor_capture factory returns a pathlib.Path."""
+        from pathlib import Path
+
+        request = MagicMock()
+        request.config.rootdir = str(tmp_path)
+        factory = clauditor_capture.__wrapped__(request)
+        result = factory("find-restaurants")
+        assert isinstance(result, Path)
+
+    def test_capture_default_path(self, tmp_path):
+        """Default base_dir is tests/eval/captured relative to rootdir."""
+        request = MagicMock()
+        request.config.rootdir = str(tmp_path)
+        factory = clauditor_capture.__wrapped__(request)
+        result = factory("find-restaurants")
+        expected = (
+            tmp_path / "tests" / "eval" / "captured" / "find-restaurants.txt"
+        )
+        assert result == expected
+        assert result.name == "find-restaurants.txt"
+
+    def test_capture_custom_base_dir(self, tmp_path):
+        """Custom base_dir is respected."""
+        request = MagicMock()
+        request.config.rootdir = str(tmp_path)
+        factory = clauditor_capture.__wrapped__(request)
+        custom = tmp_path / "custom"
+        result = factory("my-skill", base_dir=custom)
+        assert result == custom / "my-skill.txt"
+
+    def test_capture_missing_file_lazy(self, tmp_path):
+        """Missing file does not raise at fixture call; only on read_text()."""
+        import pytest as _pytest
+
+        request = MagicMock()
+        request.config.rootdir = str(tmp_path)
+        factory = clauditor_capture.__wrapped__(request)
+        # Does not raise:
+        path = factory("nonexistent")
+        # But reading it does:
+        with _pytest.raises(FileNotFoundError):
+            path.read_text()
 
     def test_spec_factory_calls_from_file(self):
         """clauditor_spec factory delegates to SkillSpec.from_file."""


### PR DESCRIPTION
## Summary
Super plan for #18 — Real-world P2/P3 polish from my_claude_agent eval run.

**Phase:** detailing (awaiting approval)
**Stories:** 9 implementation stories + Quality Gate + Patterns & Memory
**Decisions:** 19 decisions captured (DEC-001 through DEC-019)

## Scope
Nine independent polish items surfaced by running clauditor against real \`/find-restaurants\` output:

**P2 items**
- US-001 \`AssertionResult.kind\` required enum field
- US-002 Audit every \`FORMAT_REGISTRY\` entry for strict/extract correctness
- US-003 \`clauditor compare\` subcommand (removes \`grade --compare\`)
- US-004 README docs for \`format\` dual-mode semantics

**P3 items**
- US-005 \`AssertionResult.raw_data\` + raw Haiku JSON on \`-v\`
- US-006 \`.clauditor/history.jsonl\` + \`clauditor trend\` (ASCII sparkline)
- US-007 \`clauditor_capture\` pytest fixture
- US-008 Replace \`≥\`/\`≤\` → ASCII \`>=\`/\`<=\` at source
- US-009 \`--only-criterion\` repeatable substring flag for Layer 3

## Plan document
See \`plans/super/18-real-world-polish.md\` for the full plan.

## Next steps
- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)