### PR TITLE
#21: Capture timing + token usage per skill run (plan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ Uses a stronger model (Sonnet) to grade output against a rubric you write: "Are 
 
 You ship AI features faster because you catch regressions automatically instead of manually spot-checking output. Layer 1 runs in CI on every push for free. Layer 3 runs before releases to catch quality problems that would otherwise reach users. The layered approach means you're not burning API dollars on every commit — just on the checks that need intelligence.
 
+## Alignment with agentskills.io
+
+clauditor implements (and in places extends) the skill evaluation workflow described at [agentskills.io/skill-creation/evaluating-skills](https://agentskills.io/skill-creation/evaluating-skills). If you're coming from that spec, this table maps the concepts to clauditor terminology:
+
+| agentskills.io concept | clauditor |
+|---|---|
+| Test case (prompt + expected + files) | `.eval.json` with `test_args`, `sections`, `fields`, `grading_criteria` |
+| Deterministic assertions | **Layer 1** — `assertions.py`, `FORMAT_REGISTRY` (20 canonical types), strict/extract invariants |
+| LLM-judged structural checks | **Layer 2** — `grader.py`, tiered schema extraction with per-tier field requirements |
+| Rubric quality grading | **Layer 3** — `quality_grader.py`, per-criterion scoring + variance measurement |
+| With-skill vs without-skill baseline | `compare_ab()` Python API (`clauditor.comparator`) |
+| Regression diff between runs | `clauditor compare <before> <after>` |
+| Timing + token capture | `SkillResult.input_tokens/output_tokens/duration_seconds`, persisted to `history.jsonl` and `.grade.json` under nested bucket keys (`skill`, `grader`, `quality`, `triggers`, `total`) |
+| Longitudinal history | `.clauditor/history.jsonl` schema v2 + `clauditor trend --metric <dotted.path>` with ASCII sparklines |
+
+**Beyond the spec**, clauditor adds: trigger precision testing (`triggers.py`), a strict/extract `FORMAT_REGISTRY` invariant for canonical types, tiered section extraction (top-3 restaurants require more fields than the next 7), a reusable pytest plugin, and an `AssertionResult.kind` enum for programmatic filtering.
+
+**Deliberately out of scope**: per-iteration workspace dirs, automated with/without pair runs, blind A/B judges, human-feedback capture, and LLM-driven skill improvement proposers. These are tracked as follow-up issues (#22–#27).
+
 ## Install
 
 ```bash
@@ -324,7 +343,9 @@ clauditor grade <skill.md> --save      # Persist results to .clauditor/
 clauditor grade <skill.md> --diff      # Compare against prior results
 clauditor compare before.grade.json after.grade.json  # Diff two saved grade reports
 clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
-clauditor trend <skill> --metric pass_rate       # Tab-separated history + ASCII sparkline
+clauditor trend <skill> --metric total.total     # Tab-separated history + ASCII sparkline
+clauditor trend <skill> --list-metrics           # List available metric paths
+clauditor trend <skill> --metric pass_rate --command extract  # Filter by subcommand
 clauditor triggers <skill.md>          # Trigger precision testing
 clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/
 clauditor doctor                       # Report environment diagnostics
@@ -332,13 +353,30 @@ clauditor doctor                       # Report environment diagnostics
 
 ### Persistent metric history
 
-Every `clauditor grade` run appends a JSON line to `.clauditor/history.jsonl`:
+Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Records are schema v2 with a `command` discriminator and a nested `metrics` dict:
 
 ```json
-{"ts": "2026-04-13T15:00:00+00:00", "skill": "find-restaurants", "pass_rate": 0.83, "mean_score": 0.75, "metrics": {}}
+{
+  "schema_version": 2,
+  "command": "grade",
+  "ts": "2026-04-13T15:00:00+00:00",
+  "skill": "find-restaurants",
+  "pass_rate": 0.83,
+  "mean_score": 0.75,
+  "metrics": {
+    "skill":   {"input_tokens": 1200, "output_tokens": 800},
+    "quality": {"input_tokens": 900,  "output_tokens": 350},
+    "total":   {"input_tokens": 2100, "output_tokens": 1150, "total": 3250},
+    "duration_seconds": 12.3
+  }
+}
 ```
 
-Use `clauditor trend <skill> --metric pass_rate --last 20` to view the last N values with an ASCII sparkline (`_.-=#` glyph set). Runs with `--only-criterion` skip the history append to keep longitudinal data comparable.
+Token buckets: `skill` (subprocess), `grader` (Layer 2 extract), `quality` (Layer 3 rubric), `triggers` (trigger precision). Buckets are **absent** when the command doesn't invoke them — e.g. `extract` records have `skill` + `grader`, `validate` records have `skill` only. `total` aggregates across all present buckets.
+
+Use `clauditor trend <skill> --metric <dotted.path>` to view a series. Paths walk the nested `metrics` dict (`total.total`, `grader.input_tokens`, `skill.output_tokens`, `duration_seconds`) with `pass_rate` and `mean_score` as top-level shortcuts. `--command {grade,extract,validate,all}` filters by subcommand (default `grade`). `--list-metrics` prints every resolvable metric path for the skill.
+
+Runs with `--only-criterion` skip the history append to keep longitudinal data comparable.
 
 ## Pytest Integration
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ clauditor compare before.grade.json after.grade.json  # Diff two saved grade rep
 clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
 clauditor trend <skill> --metric total.total     # Tab-separated history + ASCII sparkline
 clauditor trend <skill> --list-metrics           # List available metric paths
-clauditor trend <skill> --metric pass_rate --command extract  # Filter by subcommand
+clauditor trend <skill> --metric grader.input_tokens --command extract  # Filter by subcommand
 clauditor triggers <skill.md>          # Trigger precision testing
 clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/
 clauditor doctor                       # Report environment diagnostics

--- a/plans/super/21-timing-tokens.md
+++ b/plans/super/21-timing-tokens.md
@@ -4,7 +4,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/21
 - **Branch:** `feature/21-timing-tokens`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/21-timing-tokens`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/30
 - **Sessions:** 1
 - **Last session:** 2026-04-13
@@ -399,4 +399,15 @@ Stories are ordered by dependency. Each is sized for a single Ralph context wind
 
 ## Beads Manifest
 
-_pending_
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/21-timing-tokens`
+- **Epic:** `clauditor-ar2` — #21: Capture timing + token usage per skill run
+- **Tasks:**
+  - US-001 → `clauditor-ar2.1` — Stream-json runner foundation
+  - US-002 → `clauditor-ar2.2` — Token capture at Anthropic SDK call sites
+  - US-003 → `clauditor-ar2.3` — build_metrics aggregation helper
+  - US-004 → `clauditor-ar2.4` — cmd_grade metrics wiring
+  - US-005 → `clauditor-ar2.5` — cmd_extract + cmd_validate history recording
+  - US-006 → `clauditor-ar2.6` — cmd_trend dotted-path + --command + --list-metrics
+  - US-007 → `clauditor-ar2.7` — Quality Gate
+  - US-008 → `clauditor-ar2.8` — Patterns & Memory
+- **Dependencies:** US-003←{001,002}; US-004←{001,002,003}; US-005←{003,004}; US-006←{005}; US-007←{001..006}; US-008←{007}.

--- a/plans/super/21-timing-tokens.md
+++ b/plans/super/21-timing-tokens.md
@@ -1,0 +1,401 @@
+# Super Plan: #21 — Capture timing + token usage per skill run
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/21
+- **Branch:** `feature/21-timing-tokens`
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/21-timing-tokens`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-13
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Wire timing and token-usage data through to `history.jsonl` so the `clauditor trend` command (from #18) can render real series for efficiency metrics.
+
+**Why:** The agentskills.io eval spec treats timing/token capture as table-stakes. Clauditor's `history.jsonl` has a `metrics: {}` field that is always empty — this gap is what #18 identified when the command shipped. Without it, skill authors can't answer "did this skill get faster/cheaper?"
+
+**Ticket acceptance criteria:**
+- [ ] `runner.SkillResult` carries duration + token fields
+- [ ] `cmd_grade` records timing + tokens into `history.append_record(metrics=...)`
+- [ ] `clauditor trend <skill> --metric tokens` renders a real series
+- [ ] `.grade.json` includes the same data (per-run detail)
+
+### Codebase Findings
+
+**Already in place:**
+- `SkillResult.duration_seconds: float = 0.0` at `runner.py:22–36` — already a field, populated in `runner.run()` at lines 114–116 via `time.monotonic()`. **FileNotFoundError path misses it** (lines 144–151); would be fixed incidentally.
+- `GradingReport.to_json()` at `quality_grader.py:70–93` already serializes `duration_seconds`. Easy to extend with a `metrics` dict.
+- `history.append_record(metrics=...)` call site at `cli.py:284–289` — the target insertion point. `metrics={}` today.
+- Mock patterns for both `subprocess.run` (test_runner.py:174–187) and `AsyncAnthropic` (test_quality_grader.py, test_grader.py) are established.
+
+**Missing entirely:**
+- Token capture anywhere. The three Anthropic SDK call sites (`grader.py:207`, `quality_grader.py:237`, `triggers.py:238`) all discard `response.usage`. These are Layer 2/3 calls made by clauditor itself — easy to capture.
+- **Skill-side tokens.** `runner.py` invokes `subprocess.run([claude_bin, "-p", prompt])` with no `--output-format stream-json`. The default text mode returns no usage metadata. Getting skill-side tokens requires either parsing stream-json or accepting we don't have them.
+
+**Relevant conventions:**
+- 80% coverage gate, ruff clean, no TodoWrite (CLAUDE.md:57–79)
+- `.claude/rules/` still doesn't exist (confirmed in #17/#18 plans)
+- `workflow-project.md` doesn't exist
+- `asyncio_mode = "strict"` — async tests need the marker
+- Don't shadow plugin fixture names
+- `history.append_record` is skipped when `--only-criterion` is set (cli.py:282) to prevent partial runs from corrupting longitudinal data
+
+### Proposed Scope
+
+Wire timing (already captured internally) and token usage (newly captured from SDK responses) through to both `.grade.json` and `history.jsonl`. Most plumbing is straightforward; the one real decision is **whether to add `--output-format stream-json` parsing to `runner.py`** to get skill-side tokens, or accept that we only record clauditor's own API calls (grader/quality_grader/triggers).
+
+Ordering: SDK-level usage capture → SkillResult field additions → GradingReport serialization → history.append_record wiring → trend validation → Quality Gate → Patterns & Memory.
+
+### Scoping Questions
+
+**Q1 — Which tokens do we track?**
+- **(A)** Layer 2/3 tokens only (grader + quality_grader + triggers — i.e. the API calls clauditor makes directly). Skill-side tokens stay zero / unavailable.
+- **(B)** Layer 2/3 + skill-side, via new `--output-format stream-json` parsing in `runner.py`. Significant new code path.
+- **(C)** (A) now, file (B) as a follow-up ticket once the core plumbing lands.
+
+**Q2 — How are the different token buckets represented?**
+- **(A)** One flat `total_tokens` field summed across all calls.
+- **(B)** Structured: `{skill_tokens: int, grader_tokens: int, quality_tokens: int, triggers_tokens: int, total: int}`.
+- **(C)** Two-level: `{input_tokens: int, output_tokens: int, total_tokens: int}` flat, buckets aggregated.
+- **(D)** (B) but with `{input, output}` per bucket (the SDK's native shape).
+
+**Q3 — Where does timing/tokens live in the persisted data?**
+- **(A)** Only in `history.jsonl.metrics` (longitudinal view).
+- **(B)** Only in `.grade.json` (per-run detail).
+- **(C)** Both — history gets scalars, grade.json gets the full structured shape.
+- **(D)** (C) plus a dedicated `timing.json` alongside each grade save (matches the agentskills.io spec's file layout precisely).
+
+**Q4 — `cmd_validate` and `cmd_extract` — do they also record history?**
+Today only `cmd_grade` writes to history.jsonl.
+- **(A)** Keep status quo — only `cmd_grade` records history. `validate`/`extract` are free-form.
+- **(B)** `cmd_extract` also records (since it uses a Layer 2 LLM call that consumes tokens).
+- **(C)** All three record; `metrics` includes a `command: "grade"|"extract"|"validate"` discriminator so `trend` can filter.
+
+**Q5 — Skill-run duration on the FileNotFoundError path**
+The scout found that `runner.run()` doesn't set `duration_seconds` when the subprocess binary is missing. Fix?
+- **(A)** Yes — wrap everything in the same `time.monotonic()` block; trivial fix.
+- **(B)** No — out of scope; file a separate issue.
+
+**Q6 — `clauditor trend` metric names**
+Today `trend` accepts any metric name and looks it up in `metrics` dict (or top-level for `pass_rate`/`mean_score`).
+- **(A)** Add `duration_seconds`, `total_tokens`, `input_tokens`, `output_tokens` as recognized metric names with friendly error if misspelled.
+- **(B)** Keep trend generic — any key in `metrics` works, no special-case validation.
+- **(C)** (B) plus a new `clauditor trend <skill> --list-metrics` subcommand that prints what's available for the skill.
+
+---
+
+## Decisions (from scoping)
+
+- **DEC-001 — Skill-side tokens via stream-json (Q1=B):** `runner.run()` switches to `claude -p --output-format stream-json --verbose` (or equivalent; exact flag combo TBD in refinement). Parse the JSON line stream to extract final text + usage. Bigger surface than option A but delivers the full agentskills.io vision.
+- **DEC-002 — Structured token buckets (Q2=D):** Persist as `{skill: {input, output}, grader: {input, output}, quality: {input, output}, triggers: {input, output}, total: {input, output, sum}}`. Matches the SDK's native shape per bucket; `total.sum` is the aggregate for trend line charts.
+- **DEC-003 — Persistence locations (Q3=D):** Data lands in three places: (1) `history.jsonl` metrics dict (flat scalars for trend); (2) `.grade.json` (full structured shape for per-run detail); (3) a new `timing.json` sibling file alongside each grade save, matching the agentskills.io spec layout precisely.
+- **DEC-004 — All three commands record history (Q4=C):** `cmd_grade`, `cmd_extract`, and `cmd_validate` all call `history.append_record(...)`. A new `command: Literal["grade", "extract", "validate"]` discriminator distinguishes them. `clauditor trend` grows a `--command` filter.
+- **DEC-005 — Fix FileNotFoundError duration (Q5=A):** Wrap the full `runner.run()` body in a single `time.monotonic()` block so every exit path — success, timeout, binary-missing — records duration.
+- **DEC-006 — Generic trend metrics + list (Q6=C):** Keep `clauditor trend --metric <name>` free-form (any key resolvable via dotted path into the history record). Add `--list-metrics` which inspects the last N records and prints the union of available metric keys.
+
+## Architecture Review
+
+Six review areas. The stream-json work (DEC-001) is the big one — everything else is plumbing.
+
+| Area | Rating | Notes |
+|---|---|---|
+| **Security** | pass | stream-json input comes from the already-trusted `claude` binary. JSON parsing uses the stdlib `json` module on line-delimited input — no eval, no shell. Redaction concerns are out of scope (that's #24 transcripts). |
+| **Performance** | pass | Reading `claude -p` output line-by-line vs buffering is a wash at typical skill-run sizes. No new network, no new disk churn beyond the small `timing.json` file per grade. History record grows from ~200B to ~800B — still negligible over tens of thousands of runs. |
+| **Data Model** | concern | DEC-002's nested token shape means `history.jsonl` records are now nested. `clauditor trend` currently reads `record["metrics"][metric_name]` flat — need to support dotted paths like `metrics.grader.input` or `metrics.total.sum`. Backward compat for existing history.jsonl files: old rows have `metrics: {}` — trend should handle both shapes gracefully. |
+| **API Design** | **blocker** | **DEC-001 reshapes `runner.run()` output.** Currently returns `SkillResult(output=<stdout>, exit_code, ...)`. With stream-json, `output` becomes the joined text extracted from `type: "assistant"` messages — not raw stdout. Any existing caller that reads raw stdout (the captured-output workflow from #17, maybe `cmd_run`) may see different output. Need to verify: (a) text extraction is lossless for the skill's final message; (b) `cmd_run` still produces expected user-visible output; (c) `tests/eval/captured/<skill>.txt` files committed to the repo are still reproducible. |
+| **Observability** | concern | DEC-004 (all three commands record history) changes semantics: `trend --metric pass_rate` without `--command grade` now includes validate/extract runs where `pass_rate` may mean something different. Need a sensible default — probably `--command grade` is implicit unless `--command` is explicitly passed, to preserve the current mental model. |
+| **Testing** | concern | stream-json changes the subprocess mock pattern. Current tests mock `subprocess.run` with a `stdout` string — new code reads the child's stdout stream line-by-line. Two options: (a) still call `subprocess.run` with `capture_output=True`, then split stdout on newlines and parse each — simpler, mock unchanged; (b) switch to `subprocess.Popen` for true streaming, which the existing mocks don't cover. Option (a) is easier; option (b) enables future work on long-running skills (progress bars, live transcripts for #24). |
+
+### Blockers to resolve in refinement
+1. **B1. stream-json output extraction correctness.** Decide how `SkillResult.output` is populated from stream-json — which message types are concatenated, whether tool-use blocks are included, whether system messages are filtered. Verify against a real `claude -p --output-format stream-json` run that captured-output files from #17 remain reproducible.
+
+### Concerns to address in refinement
+1. **C1. Dotted-path metric resolution in `cmd_trend`.** Do we introduce a small path walker (`metrics.grader.input`) or flatten the nested shape on write (`grader_input_tokens`)?
+2. **C2. `--command` filter default.** Should `trend` default to `command=grade` implicitly, require explicit `--command`, or union across all commands?
+3. **C3. subprocess.run vs Popen for stream-json.** Which subprocess API do we use?
+4. **C4. `timing.json` file path convention.** #22 (per-iteration workspace) hasn't landed yet. Where does `timing.json` live today? Sibling of `.grade.json` in `.clauditor/`? Under `.clauditor/timing/<skill>-<ts>.json`? One file per grade run, or rolling?
+5. **C5. Extract command token tracking.** `cmd_extract` ships the Layer 2 grader call but doesn't compute `pass_rate`/`mean_score` the same way `cmd_grade` does. What does its history record look like schema-wise?
+
+### Follow-up / discussion items
+- **F1. Usage field on Anthropic SDK responses.** Verify the SDK version pinned in `pyproject.toml` returns `response.usage.input_tokens` / `output_tokens`. Older SDK versions may not. (Should be trivially present on current versions.)
+
+## Refinement Log
+
+**Guiding principle** (user direction): clauditor is pre-production. No backward-compatibility constraints. Break existing behavior freely when it produces a cleaner tool that aligns more closely with agentskills.io. Previously-committed captured-output files can be regenerated.
+
+- **DEC-007 — stream-json output semantics (B1):** `SkillResult.output` is populated from the concatenation of all `type == "assistant"` message text blocks joined by `\n`. Tool-use and tool-result blocks are NOT included in `output` (they are intermediate reasoning, not skill output). The final `type == "result"` message supplies `usage.input_tokens` and `usage.output_tokens`. Story US-001 begins with a schema-verification step against a real `claude -p --output-format stream-json --verbose` invocation before writing parser code.
+- **DEC-008 — Captured-output regeneration (corollary to DEC-007):** After US-001 lands, any `tests/eval/captured/<skill>.txt` files committed to the repo must be regenerated via `clauditor capture` to match the new text-extraction path. This is a breaking change; acceptable per project direction.
+- **DEC-009 — Path walker for metrics (C1=a):** `clauditor trend --metric <path>` resolves dotted paths like `grader.input_tokens` against `record["metrics"]` (and top-level for `pass_rate`/`mean_score`/`duration_seconds` as special cases for backwards readability). No flat aliases — the nested shape IS the canonical form. The resolver is a pure helper function, unit-testable in isolation.
+- **DEC-010 — Implicit --command grade filter (C2=a):** `clauditor trend <skill> --metric X` implicitly filters to `command == "grade"` unless the user passes `--command <value>` explicitly (or `--command all` to union). Preserves the existing mental model and keeps the most common trend query one-liner.
+- **DEC-011 — Popen for stream-json (C3=b):** `runner.run()` switches from `subprocess.run` to `subprocess.Popen` with `stdout=PIPE`, reading one line at a time. True streaming. This is prerequisite infrastructure for #24 (execution transcripts). Tests re-mock at the Popen level; a small `_FakePopen` helper in `tests/conftest.py` abstracts the pattern so future tests don't re-invent it.
+- **DEC-012 — Drop separate timing.json for now (revises DEC-003 for C4):** The full structured timing+token shape lives in `.grade.json`. History records get scalar metrics (nested under `metrics.<bucket>.<kind>`). **Do NOT ship a separate `timing.json` file in this ticket.** The agentskills.io spec puts `timing.json` inside an iteration directory — that directory doesn't exist until #22 ships. Building a temporary path convention now would be churn. File a follow-up note in #22 to emit `timing.json` inside iteration dirs as part of that ticket.
+- **DEC-013 — cmd_extract history shape (C5=a):** Extract runs record `pass_rate=None, mean_score=None, command="extract"` plus full `metrics` (timing + tokens). `clauditor trend` handles `None` values by filtering them out before sparkline computation, with a friendly message if the filtered set is empty.
+- **DEC-014 — Token bucket keys:** Canonical bucket names: `skill`, `grader` (Layer 2 schema extraction), `quality` (Layer 3 rubric grading), `triggers` (trigger precision testing). Per-bucket shape: `{input_tokens: int, output_tokens: int}`. Total shape: `{input_tokens: int, output_tokens: int, total: int}`. `total` is `input + output` across all buckets present in that run. A bucket is omitted from `metrics` if that command didn't invoke it (e.g., `cmd_validate` only has `skill` + `total`; `cmd_extract` has `skill` + `grader` + `total`; `cmd_grade` has all four — skill + grader + quality + triggers + total).
+- **DEC-015 — history.jsonl schema versioning:** Add a `schema_version: 2` field at the top level of each new record. Records without `schema_version` are treated as v1 (old `metrics: {}` rows) and skipped by `trend` when the requested metric is a new v2 key. No migration of old records — pre-production.
+- **DEC-016 — cmd_validate token capture:** Layer 1 is deterministic; it makes no LLM calls. So `cmd_validate` records only `skill` bucket tokens (from the stream-json skill run) + `total`. The `grader`/`quality`/`triggers` buckets are absent. This still lets users trend skill token cost across validate runs.
+
+## Detailed Breakdown
+
+Stories are ordered by dependency. Each is sized for a single Ralph context window. Every story's acceptance includes `uv run ruff check src/ tests/` clean and `uv run pytest --cov=clauditor --cov-report=term-missing` passing with the 80% gate.
+
+---
+
+### US-001 — Stream-json runner foundation (Popen + parser + output extraction)
+
+**Description:** Switch `runner.run()` from `subprocess.run(... -p prompt)` to `subprocess.Popen(... -p prompt --output-format stream-json --verbose)`. Parse the NDJSON stream line-by-line. Extract the concatenated assistant-message text as `SkillResult.output`. Extract token usage from the final result message into new `SkillResult` fields. Re-mock existing tests at the Popen layer via a shared `_FakePopen` helper.
+
+**Traces to:** DEC-001, DEC-007, DEC-008, DEC-011, DEC-014
+
+**Before writing code:**
+1. Manually run `claude -p --output-format stream-json --verbose "/<any-skill> <any-arg>"` in a shell and capture 3-5 lines of the stream.
+2. Document the exact message types and the shape of the final `result` message in a comment at the top of the new parser module or function.
+3. Verify `usage.input_tokens` and `usage.output_tokens` are present on the terminal message.
+
+**Files:**
+- `src/clauditor/runner.py`:
+  - Extend `SkillResult` dataclass with: `input_tokens: int = 0`, `output_tokens: int = 0`, `raw_messages: list[dict] = field(default_factory=list)` (future-proofing for #24 transcripts — unused by other modules for now, but captured).
+  - Rewrite `run()` to use `subprocess.Popen(..., stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)`. Read `stdout` line by line in a loop, parse each as JSON, dispatch by `type`. Accumulate assistant-message text. Capture `usage` from the final `result` message. Handle the timeout path via a manual deadline check (time.monotonic() + timeout). Wrap everything in a single try/finally so `duration_seconds` is set on every exit path (DEC-005).
+  - Keep the `run_raw()` helper for prompts that don't need stream-json — or remove it entirely if unused (grep first). If removed, note as a breaking change.
+- `tests/conftest.py`:
+  - New helper `_FakePopen` that takes a list of stream-json dicts and a final result dict, serializes them as newline-separated JSON, and presents as a Popen-compatible object with `.stdout`, `.wait()`, `.returncode`, `.pid`.
+  - Helper: `make_fake_skill_stream(text: str, input_tokens: int = 100, output_tokens: int = 50)` builds a plausible assistant + result sequence.
+- `tests/test_runner.py`:
+  - Update every test that mocks `subprocess.run` to mock `subprocess.Popen` instead, using `_FakePopen`.
+  - New tests: assistant-text concatenation across multiple messages; single assistant message; token extraction; malformed line handling (parse error on one line doesn't crash the whole run); missing final result message (fall back to zero tokens + a warning); timeout path still records duration; binary-not-found path still records duration (DEC-005).
+
+**TDD:**
+- `_FakePopen` with a single assistant message + result → `SkillResult.output == "hello"`, `input_tokens == 100`, `output_tokens == 50`.
+- Two assistant messages → output is their text joined by `\n`.
+- Tool-use block in an assistant message → NOT included in output (only the text blocks from that message).
+- Missing final result → `input_tokens == 0`, `output_tokens == 0`, warning printed to stderr.
+- Malformed JSON on one line → that line is skipped (warning to stderr), subsequent lines still parsed.
+- Timeout: `duration_seconds > 0`, `error` field set to "timeout".
+- `FileNotFoundError` for the claude binary: `duration_seconds > 0` (now fixed per DEC-005), `error` field indicates missing binary.
+
+**Acceptance criteria:**
+- `SkillResult` has the new fields with sensible defaults.
+- All existing `tests/test_runner.py` tests pass with the new mock pattern.
+- Coverage ≥ 80% on `runner.py`; line coverage on the new Popen code path ≥ 90%.
+- Ruff clean.
+
+**Done when:** A real (unmocked) `clauditor capture find-restaurants -- "near San Jose"` on a live setup returns a `SkillResult` with non-zero `input_tokens` + `output_tokens` and the assistant's user-visible text as `output`. (User verifies manually before merging; no automated end-to-end test in CI.)
+
+**Depends on:** none.
+
+---
+
+### US-002 — Token bucket capture for clauditor's own Anthropic SDK calls
+
+**Description:** Capture `response.usage.input_tokens` and `response.usage.output_tokens` at each of the three Anthropic SDK call sites in clauditor (`grader.py`, `quality_grader.py`, `triggers.py`). Return these through the existing return types so `cli.py` can aggregate them into the bucketed shape.
+
+**Traces to:** DEC-002, DEC-014
+
+**Files:**
+- `src/clauditor/grader.py`:
+  - At the `await client.messages.create(...)` call (~line 207), capture `response.usage.input_tokens` and `.output_tokens`. Add these as new fields on `ExtractedOutput` (or the equivalent return type): `grader_input_tokens: int`, `grader_output_tokens: int`.
+- `src/clauditor/quality_grader.py`:
+  - Same treatment at `await client.messages.create(...)` (~line 237). The function currently returns a `GradingReport`; extend it with `input_tokens: int`, `output_tokens: int`. Update `GradingReport.to_json` / `from_json` to round-trip these fields.
+  - `measure_variance` calls `grade_quality` multiple times — aggregate tokens across all runs into the returned variance report.
+- `src/clauditor/triggers.py`:
+  - Same treatment at the SDK call (~line 238). Extend the trigger report type with `input_tokens: int`, `output_tokens: int`.
+- `tests/test_grader.py`, `tests/test_quality_grader.py`, `tests/test_triggers.py`:
+  - Update SDK mocks to return responses with a `usage` attribute (use `MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))`).
+  - Assert the captured fields on the returned objects.
+
+**TDD:**
+- Each SDK call site: mock returns `usage.input_tokens=500, output_tokens=200` → returned object carries those values.
+- `measure_variance` with 3 runs, each returning 100/50 tokens → aggregated report carries 300/150.
+- `GradingReport.to_json` → `from_json` round-trip preserves `input_tokens`/`output_tokens`.
+
+**Acceptance criteria:**
+- All three SDK call sites capture usage.
+- Return types carry the fields; serialization round-trips.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `clauditor grade` (mocked) produces a `GradingReport` whose `input_tokens`/`output_tokens` reflect the sum across Layer 3 grading calls.
+
+**Depends on:** none (can run in parallel with US-001; US-003 integrates both).
+
+---
+
+### US-003 — Metrics aggregation helper + bucketed shape
+
+**Description:** Add a new helper module `src/clauditor/metrics.py` that builds the canonical bucketed metrics dict from a `SkillResult` + optional grader/quality/triggers token counts. Pure function, no I/O. Used by US-004/US-005 to produce the `metrics=...` kwarg for `history.append_record` and the in-memory structure embedded in `.grade.json`.
+
+**Traces to:** DEC-002, DEC-014, DEC-015
+
+**Files:**
+- `src/clauditor/metrics.py` (NEW):
+  - `build_metrics(skill: SkillResult, grader_tokens: TokenUsage | None = None, quality_tokens: TokenUsage | None = None, triggers_tokens: TokenUsage | None = None, duration_seconds: float) -> dict` — returns `{skill: {input_tokens, output_tokens}, grader: {...}|None, quality: {...}|None, triggers: {...}|None, total: {input_tokens, output_tokens, total}, duration_seconds: float}`. Omits bucket keys (not sets to None; simply absent) when the corresponding TokenUsage arg is None.
+  - Small `TokenUsage` typed dict or dataclass: `{input_tokens: int, output_tokens: int}`.
+- `tests/test_metrics.py` (NEW):
+  - Only skill tokens → `total` equals skill tokens, `grader`/`quality`/`triggers` absent.
+  - All four buckets present → `total` is the sum.
+  - Empty / zero-token skill → `total` is zero, shape is still correct.
+  - Duration flows through unchanged.
+
+**TDD:**
+- All four cases above.
+
+**Acceptance criteria:**
+- `metrics.py` is pure (no I/O, no imports from `cli` / `runner` beyond types).
+- `build_metrics` is typed and documented.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `build_metrics(...)` produces the exact shape specified in DEC-014 for each command's bucket combination.
+
+**Depends on:** US-001 (needs `SkillResult` new fields), US-002 (needs the return types that carry token counts).
+
+---
+
+### US-004 — `cmd_grade` wires timing + tokens through to history and grade.json
+
+**Description:** Update `cmd_grade` in `cli.py` to aggregate timing + tokens from the skill run, grader call, and quality grader call using `build_metrics()`, then pass the full structured metrics dict to both `history.append_record` and the `.grade.json` save path. Add `schema_version: 2` to history records.
+
+**Traces to:** DEC-003, DEC-004, DEC-014, DEC-015
+
+**Files:**
+- `src/clauditor/cli.py`:
+  - In `cmd_grade`, after the skill run + grading chain completes, call `build_metrics(skill=result, grader_tokens=..., quality_tokens=..., triggers_tokens=..., duration_seconds=...)`.
+  - Pass the returned dict to `history.append_record(..., metrics=<dict>)` (replacing `metrics={}`).
+  - Include the dict in the `.grade.json` saved under `--save`. Report file schema gets a new `metrics` top-level key.
+  - Pass `command="grade"` to `history.append_record` (requires US-005 to add the param).
+- `src/clauditor/history.py`:
+  - `append_record` gains a required `command: Literal["grade", "extract", "validate"]` parameter.
+  - Every record written includes `schema_version: 2`.
+- `src/clauditor/quality_grader.py`:
+  - `GradingReport.to_json()` includes a `metrics` key when the field is populated; `from_json()` round-trips it.
+- `tests/test_cli.py`:
+  - Update `TestCmdGrade` tests to assert the structured metrics appear in `history.append_record` mock calls.
+  - Assert `.grade.json` saved under `--save` contains the new `metrics` key with the bucketed shape.
+  - Assert `schema_version: 2` appears.
+
+**TDD:**
+- `cmd_grade` with a mocked skill run (100 input / 50 output) and mocked grader/quality/triggers (different token counts each) → history record has `metrics.skill`, `metrics.grader`, `metrics.quality`, `metrics.triggers`, `metrics.total.total` equals the sum.
+- `--save` writes `.grade.json` with `metrics` top-level key matching.
+- `history.append_record` is called with `command="grade"`.
+- `schema_version: 2` is present.
+- `--only-criterion` still skips history append (regression from #18).
+
+**Acceptance criteria:**
+- `cmd_grade` produces real, non-empty metrics on every run.
+- `.grade.json` saved shape has the new `metrics` field.
+- History records carry `command` + `schema_version`.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** A mocked `cmd_grade` run produces a history record whose `metrics.total.total > 0`.
+
+**Depends on:** US-001, US-002, US-003.
+
+---
+
+### US-005 — `cmd_extract` and `cmd_validate` record history with command discriminator
+
+**Description:** Extend `cmd_extract` and `cmd_validate` to call `history.append_record(..., command="extract"|"validate", metrics=...)` using `build_metrics()`. `cmd_extract` aggregates skill + grader tokens; `cmd_validate` only aggregates skill tokens (Layer 1 is deterministic). Both pass `pass_rate=None`/`mean_score=None` where those concepts don't apply (DEC-013).
+
+**Traces to:** DEC-004, DEC-013, DEC-016
+
+**Files:**
+- `src/clauditor/cli.py`:
+  - `cmd_validate`: add `history.append_record(skill=spec.skill_name, pass_rate=pass_rate_or_none, mean_score=None, metrics=build_metrics(skill=result, duration_seconds=...), command="validate")` after the assertion run. `pass_rate_or_none` can use the Layer 1 pass rate when available.
+  - `cmd_extract`: add the same call with `command="extract"`, passing `grader_tokens` from the Layer 2 extraction.
+- `tests/test_cli.py`:
+  - `TestCmdExtractHistory` (new class): assert `history.append_record` is called with `command="extract"` and metrics include the skill + grader buckets.
+  - `TestCmdValidateHistory` (new class): assert the call with `command="validate"` and skill-only metrics.
+
+**TDD:**
+- extract run → history record has `command="extract"`, `metrics.grader` present, `metrics.quality` absent, `metrics.triggers` absent.
+- validate run → history record has `command="validate"`, only `metrics.skill` present.
+- Both commands honor the existing conftest isolation fixture (no `.clauditor/` pollution).
+
+**Acceptance criteria:**
+- All three commands record history with a discriminator.
+- Each command's metrics include only the buckets it legitimately populates.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** `clauditor trend <skill> --command extract --metric grader.input_tokens` (once US-006 lands) returns data after an extract run.
+
+**Depends on:** US-003, US-004.
+
+---
+
+### US-006 — `cmd_trend` dotted-path resolution, `--command` filter, `--list-metrics`
+
+**Description:** Extend `cmd_trend` to resolve dotted-path metric names against nested `metrics` dicts, filter by `command` (default `grade`), and support a new `--list-metrics` flag that prints the union of metric paths available for a skill in its history.
+
+**Traces to:** DEC-006, DEC-009, DEC-010, DEC-015
+
+**Files:**
+- `src/clauditor/history.py`:
+  - New helper `resolve_path(record: dict, path: str) -> float | int | None` that walks dotted paths. Treats `pass_rate`/`mean_score`/`duration_seconds` as top-level for readability. Returns `None` if the path is absent or the value isn't numeric.
+- `src/clauditor/cli.py`:
+  - `cmd_trend`: add `--command <name>` arg (default `"grade"`; `"all"` unions across commands). Add `--list-metrics` mutually exclusive with `--metric`. Filter records by command before resolving paths. Skip `schema_version: 1` records when the requested metric is a v2 key.
+  - `cmd_trend` with `--list-metrics` walks the last N records and prints the union of resolvable numeric paths (using a small recursive walker), sorted alphabetically.
+- `tests/test_history.py`: add `TestResolvePath` class.
+- `tests/test_cli.py`: add `TestCmdTrendCommandFilter`, `TestCmdTrendListMetrics`, `TestCmdTrendDottedPath`.
+
+**TDD:**
+- `resolve_path({"metrics": {"grader": {"input_tokens": 500}}}, "grader.input_tokens")` → 500.
+- `resolve_path(record, "pass_rate")` → top-level field.
+- `resolve_path(record, "nonexistent.path")` → None.
+- `trend --metric grader.input_tokens` across 5 grade runs renders a 5-point series.
+- `trend --command extract --metric grader.input_tokens` filters to extract runs only.
+- `trend --command all` unions.
+- `trend --list-metrics` prints a sorted list including both top-level (`pass_rate`) and nested (`metrics.grader.input_tokens`).
+- `trend --metric X` on a history with only v1 records prints a friendly empty-set error.
+
+**Acceptance criteria:**
+- Dotted-path resolver is pure and unit-tested.
+- `--command` filter works with defaults + explicit + `all`.
+- `--list-metrics` prints the union correctly.
+- Coverage ≥ 80%; ruff clean.
+
+**Done when:** After running `cmd_grade`, `cmd_extract`, `cmd_validate` each once, `clauditor trend <skill> --list-metrics` shows the union of available keys.
+
+**Depends on:** US-005.
+
+---
+
+### US-007 — Quality Gate (code review × 4 + CodeRabbit)
+
+**Description:** Run the `code-review` skill four times across the full changeset; fix all real bugs found each pass. Run CodeRabbit if available. Re-run `uv run ruff check` + `uv run pytest --cov` after fixes.
+
+**Traces to:** All DEC-001 → DEC-016.
+
+**Acceptance criteria:**
+- 4 code-review passes complete.
+- All real bugs found are fixed (stylistic deferrals documented).
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥ 80% coverage.
+- All ticket acceptance-criteria checkboxes satisfied.
+
+**Done when:** Four consecutive review passes produce no new real bugs.
+
+**Depends on:** US-001 through US-006.
+
+---
+
+### US-008 — Patterns & Memory
+
+**Description:** Update project conventions and memory with patterns learned. (a) Document the stream-json message schema clauditor relies on (in code comments + README); (b) document the canonical bucket naming + nested metrics shape; (c) document `schema_version` in history.jsonl; (d) `bd remember` non-obvious insights. Update README to reflect new `trend --command` / `--list-metrics` flags and the dotted-path metric resolution.
+
+**Traces to:** DEC-007, DEC-009, DEC-014, DEC-015.
+
+**Acceptance criteria:**
+- README updated with the new trend flags + dotted-path syntax.
+- At least three `bd remember` entries capturing non-obvious insights.
+- A comment at the top of `runner.py` (or a new docs file) documents the stream-json schema contract clauditor depends on.
+
+**Done when:** A fresh agent opening this repo would not re-ask any of the design questions resolved in DEC-007 through DEC-016.
+
+**Depends on:** US-007.
+
+---
+
+## Beads Manifest
+
+_pending_

--- a/plans/super/21-timing-tokens.md
+++ b/plans/super/21-timing-tokens.md
@@ -4,7 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/21
 - **Branch:** `feature/21-timing-tokens`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/21-timing-tokens`
-- **Phase:** `detailing`
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/30
 - **Sessions:** 1
 - **Last session:** 2026-04-13
 

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -45,6 +45,8 @@ class AssertionSet:
     """A collection of assertion results from checking skill output."""
 
     results: list[AssertionResult] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     @property
     def passed(self) -> bool:

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -36,21 +36,48 @@ def cmd_validate(args: argparse.Namespace) -> int:
         )
         return 1
 
+    skill_result = None
     if args.output:
         # Validate against provided output file
         output = Path(args.output).read_text()
     else:
         # Run the skill to get output
         print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
-        result = spec.run()
-        if not result.succeeded:
-            print(f"ERROR: Skill failed to run: {result.error}", file=sys.stderr)
+        skill_result = spec.run()
+        if not skill_result.succeeded:
+            print(
+                f"ERROR: Skill failed to run: {skill_result.error}",
+                file=sys.stderr,
+            )
             return 1
-        output = result.output
-        print(f"Skill completed in {result.duration_seconds:.1f}s")
+        output = skill_result.output
+        print(f"Skill completed in {skill_result.duration_seconds:.1f}s")
 
     # Run Layer 1 assertions
     results = run_assertions(output, spec.eval_spec.assertions)
+
+    # Record history (US-005). Layer 1 only — no grader/quality/triggers.
+    from clauditor.metrics import TokenUsage, build_metrics
+
+    skill_tokens = TokenUsage(
+        input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
+        output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
+    )
+    skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
+    metrics_dict = build_metrics(
+        skill=skill_tokens,
+        duration_seconds=skill_duration,
+    )
+    try:
+        history.append_record(
+            skill=spec.skill_name,
+            pass_rate=results.pass_rate,
+            mean_score=None,
+            metrics=metrics_dict,
+            command="validate",
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"WARNING: failed to append history: {e}", file=sys.stderr)
 
     if args.json:
         print(
@@ -525,20 +552,50 @@ def cmd_extract(args: argparse.Namespace) -> int:
         return 0
 
     # Get output
+    skill_result = None
     if args.output:
         output = Path(args.output).read_text()
     else:
         print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
-        result = spec.run()
-        if not result.succeeded:
-            print(f"ERROR: Skill failed: {result.error}", file=sys.stderr)
+        skill_result = spec.run()
+        if not skill_result.succeeded:
+            print(f"ERROR: Skill failed: {skill_result.error}", file=sys.stderr)
             return 1
-        output = result.output
+        output = skill_result.output
 
     # Extract and grade
     from clauditor.grader import extract_and_grade
 
     results = asyncio.run(extract_and_grade(output, spec.eval_spec, model))
+
+    # Record history (US-005). Extract does not compute Layer 3
+    # pass_rate/mean_score, so those are None (DEC-013).
+    from clauditor.metrics import TokenUsage, build_metrics
+
+    skill_tokens = TokenUsage(
+        input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
+        output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
+    )
+    skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
+    grader_tokens = TokenUsage(
+        input_tokens=getattr(results, "input_tokens", 0) or 0,
+        output_tokens=getattr(results, "output_tokens", 0) or 0,
+    )
+    metrics_dict = build_metrics(
+        skill=skill_tokens,
+        duration_seconds=skill_duration,
+        grader=grader_tokens,
+    )
+    try:
+        history.append_record(
+            skill=spec.skill_name,
+            pass_rate=None,
+            mean_score=None,
+            metrics=metrics_dict,
+            command="extract",
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"WARNING: failed to append history: {e}", file=sys.stderr)
 
     if args.json:
         print(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -303,20 +303,35 @@ def cmd_grade(args: argparse.Namespace) -> int:
 
     # Build the canonical bucketed metrics dict (US-004). For --output
     # runs there's no skill subprocess, so skill tokens/duration are zero.
+    # When --variance N was passed, the variance path runs the skill N
+    # additional times and makes N additional Layer 3 grader calls — those
+    # must be included so longitudinal trends reflect the real cost.
     from clauditor.metrics import TokenUsage, build_metrics
 
+    base_skill_input = getattr(skill_result, "input_tokens", 0) or 0
+    base_skill_output = getattr(skill_result, "output_tokens", 0) or 0
+    base_skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
+    base_quality_input = report.input_tokens
+    base_quality_output = report.output_tokens
+
+    if variance_report is not None:
+        base_skill_input += variance_report.skill_input_tokens
+        base_skill_output += variance_report.skill_output_tokens
+        base_skill_duration += variance_report.skill_duration_seconds
+        base_quality_input += variance_report.input_tokens
+        base_quality_output += variance_report.output_tokens
+
     skill_tokens = TokenUsage(
-        input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
-        output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
+        input_tokens=base_skill_input,
+        output_tokens=base_skill_output,
     )
-    skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
     quality_tokens = TokenUsage(
-        input_tokens=report.input_tokens,
-        output_tokens=report.output_tokens,
+        input_tokens=base_quality_input,
+        output_tokens=base_quality_output,
     )
     metrics_dict = build_metrics(
         skill=skill_tokens,
-        duration_seconds=skill_duration,
+        duration_seconds=base_skill_duration,
         quality=quality_tokens,
     )
     report.metrics = metrics_dict
@@ -845,13 +860,18 @@ def cmd_trend(args: argparse.Namespace) -> int:
 
     command_filter = args.command_filter
     if command_filter != "all":
+        # v1 records (pre-#21) have no "command" key; they were all produced
+        # by cmd_grade, so treat a missing key as "grade" for filter purposes.
         records = [
-            rec for rec in records if rec.get("command") == command_filter
+            rec
+            for rec in records
+            if rec.get("command", "grade") == command_filter
         ]
         if not records:
             print(
                 f"ERROR: no history records for skill '{args.skill_name}' "
-                f"with command '{command_filter}'.",
+                f"with command '{command_filter}'. Try --command all to "
+                "union across all recorded commands.",
                 file=sys.stderr,
             )
             return 1

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -843,26 +843,47 @@ def cmd_trend(args: argparse.Namespace) -> int:
         )
         return 1
 
+    command_filter = args.command_filter
+    if command_filter != "all":
+        records = [
+            rec for rec in records if rec.get("command") == command_filter
+        ]
+        if not records:
+            print(
+                f"ERROR: no history records for skill '{args.skill_name}' "
+                f"with command '{command_filter}'.",
+                file=sys.stderr,
+            )
+            return 1
+
     last_n = args.last
     if last_n is not None and last_n > 0:
         records = records[-last_n:]
+
+    if args.list_metrics:
+        paths: set[str] = set()
+        for rec in records:
+            paths |= history.collect_metric_paths(rec)
+        if not paths:
+            print(
+                f"ERROR: no metric paths available for skill "
+                f"'{args.skill_name}'.",
+                file=sys.stderr,
+            )
+            return 1
+        for path in sorted(paths):
+            print(path)
+        return 0
 
     metric = args.metric
     timestamps: list[str] = []
     values: list[float] = []
     for rec in records:
-        if metric in ("pass_rate", "mean_score"):
-            v = rec.get(metric)
-        else:
-            v = rec.get("metrics", {}).get(metric)
+        v = history.resolve_path(rec, metric)
         if v is None:
             continue
-        try:
-            value = float(v)
-        except (TypeError, ValueError):
-            continue
         timestamps.append(str(rec.get("ts", "")))
-        values.append(value)
+        values.append(float(v))
 
     if not values:
         print(
@@ -1055,10 +1076,25 @@ def main(argv: list[str] | None = None) -> int:
         help="Print a trend line (TSV + ASCII sparkline) from grade history",
     )
     p_trend.add_argument("skill_name", help="Skill name to trend")
-    p_trend.add_argument(
+    p_trend_group = p_trend.add_mutually_exclusive_group(required=True)
+    p_trend_group.add_argument(
         "--metric",
-        required=True,
-        help="Metric to trend (pass_rate, mean_score, or a metrics.<name>)",
+        help=(
+            "Metric to trend (pass_rate, mean_score, or a dotted path "
+            "into metrics like total.total or grader.input_tokens)"
+        ),
+    )
+    p_trend_group.add_argument(
+        "--list-metrics",
+        action="store_true",
+        help="List every available metric path in history for the skill",
+    )
+    p_trend.add_argument(
+        "--command",
+        dest="command_filter",
+        choices=["grade", "extract", "validate", "all"],
+        default="grade",
+        help="Filter history records by command (default: grade)",
     )
     p_trend.add_argument(
         "--last",

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -153,15 +153,18 @@ def cmd_grade(args: argparse.Namespace) -> int:
         return 0
 
     # Get output
+    skill_result = None
     if args.output:
         output = Path(args.output).read_text()
     else:
         print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
-        result = spec.run()
-        if not result.succeeded:
-            print(f"ERROR: Skill failed: {result.error}", file=sys.stderr)
+        skill_result = spec.run()
+        if not skill_result.succeeded:
+            print(
+                f"ERROR: Skill failed: {skill_result.error}", file=sys.stderr
+            )
             return 1
-        output = result.output
+        output = skill_result.output
 
     # Grade (and optionally measure variance in a single event loop)
     from clauditor.quality_grader import grade_quality
@@ -271,6 +274,26 @@ def cmd_grade(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
 
+    # Build the canonical bucketed metrics dict (US-004). For --output
+    # runs there's no skill subprocess, so skill tokens/duration are zero.
+    from clauditor.metrics import TokenUsage, build_metrics
+
+    skill_tokens = TokenUsage(
+        input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
+        output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
+    )
+    skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
+    quality_tokens = TokenUsage(
+        input_tokens=report.input_tokens,
+        output_tokens=report.output_tokens,
+    )
+    metrics_dict = build_metrics(
+        skill=skill_tokens,
+        duration_seconds=skill_duration,
+        quality=quality_tokens,
+    )
+    report.metrics = metrics_dict
+
     if args.save:
         save_dir.mkdir(parents=True, exist_ok=True)
         save_path.write_text(report.to_json())
@@ -285,7 +308,8 @@ def cmd_grade(args: argparse.Namespace) -> int:
                 skill=spec.skill_name,
                 pass_rate=report.pass_rate,
                 mean_score=report.mean_score,
-                metrics={},
+                metrics=metrics_dict,
+                command="grade",
             )
         except Exception as e:  # pragma: no cover - defensive
             print(f"WARNING: failed to append history: {e}", file=sys.stderr)

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -211,6 +211,8 @@ async def extract_and_grade(
             {"role": "user", "content": f"{prompt}\n\nSkill output:\n{output}"},
         ],
     )
+    input_tokens = getattr(response.usage, "input_tokens", 0)
+    output_tokens = getattr(response.usage, "output_tokens", 0)
 
     # Parse the JSON response
     response_text = response.content[0].text
@@ -237,7 +239,9 @@ async def extract_and_grade(
                     kind="custom",
                     evidence=response_text[:200],
                 )
-            ]
+            ],
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     # Convert raw JSON to ExtractedOutput
@@ -276,6 +280,13 @@ async def extract_and_grade(
             )
 
     if parse_errors:
-        return AssertionSet(results=parse_errors)
+        return AssertionSet(
+            results=parse_errors,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
 
-    return grade_extraction(extracted, eval_spec)
+    result = grade_extraction(extracted, eval_spec)
+    result.input_tokens = input_tokens
+    result.output_tokens = output_tokens
+    return result

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -113,6 +113,84 @@ def read_records(
     return records
 
 
+_TOP_LEVEL_KEYS = ("pass_rate", "mean_score")
+
+
+def resolve_path(record: dict, path: str) -> float | int | None:
+    """Resolve a dotted metric path against a history record.
+
+    Rules:
+
+    - ``pass_rate`` and ``mean_score`` resolve at the top level of the
+      record (not inside ``metrics``).
+    - Any other path (including ``duration_seconds``) is walked as dotted
+      keys inside ``record["metrics"]``.
+
+    Returns the numeric value or ``None`` if any intermediate key is
+    missing or the final value is not int/float. Never raises.
+    """
+    if not isinstance(record, dict):
+        return None
+
+    if path in _TOP_LEVEL_KEYS:
+        value = record.get(path)
+    else:
+        node: object = record.get("metrics")
+        if not isinstance(node, dict):
+            return None
+        for part in path.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return None
+            node = node[part]
+        value = node
+
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return None
+
+
+def collect_metric_paths(record: dict) -> set[str]:
+    """Return every dotted metric path in ``record`` that resolves numeric.
+
+    Top-level ``pass_rate``/``mean_score`` are included when numeric.
+    Every numeric leaf inside ``record["metrics"]`` is emitted with its
+    dotted path (e.g. ``grader.input_tokens``, ``total.total``,
+    ``duration_seconds``).
+    """
+    paths: set[str] = set()
+    if not isinstance(record, dict):
+        return paths
+
+    for key in _TOP_LEVEL_KEYS:
+        value = record.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            paths.add(key)
+
+    metrics = record.get("metrics")
+    if isinstance(metrics, dict):
+        _walk_numeric(metrics, (), paths)
+    return paths
+
+
+def _walk_numeric(
+    node: dict, prefix: tuple[str, ...], out: set[str]
+) -> None:
+    for key, value in node.items():
+        if not isinstance(key, str):
+            continue
+        next_prefix = prefix + (key,)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            out.add(".".join(next_prefix))
+        elif isinstance(value, dict):
+            _walk_numeric(value, next_prefix, out)
+
+
 def sparkline(values: list[float]) -> str:
     """Render a list of values as an ASCII sparkline.
 

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -54,6 +54,10 @@ def append_record(
     subcommand produced the record. Every written record includes
     ``schema_version: 2`` at the top level.
     """
+    if command not in ("grade", "extract", "validate"):
+        raise ValueError(
+            f"command must be one of 'grade', 'extract', 'validate'; got {command!r}"
+        )
     if path is None:
         path = _DEFAULT_PATH
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -37,7 +37,7 @@ SCHEMA_VERSION = 2
 
 def append_record(
     skill: str,
-    pass_rate: float,
+    pass_rate: float | None,
     mean_score: float | None,
     metrics: dict,
     *,

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -5,6 +5,20 @@ Appends a JSON line per grade run to ``.clauditor/history.jsonl`` so the
 
 ASCII-only (DEC-014): the sparkline uses ``"_.-=#"`` glyphs — no Unicode
 block characters.
+
+Schema v2 (US-004): each record is a JSON object with the following
+top-level keys:
+
+- ``schema_version``: int, always ``2``
+- ``command``: one of ``"grade"``, ``"extract"``, ``"validate"``
+- ``ts``: ISO-8601 UTC timestamp
+- ``skill``: skill name
+- ``pass_rate``: float or None
+- ``mean_score``: float or None
+- ``metrics``: dict (canonical bucketed metrics from ``clauditor.metrics``)
+
+v1 records (no ``schema_version``, no ``command``) may still exist on disk
+and are returned as-is by :func:`read_records`.
 """
 
 from __future__ import annotations
@@ -14,9 +28,11 @@ import math
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 _DEFAULT_PATH = Path(".clauditor/history.jsonl")
 SPARK_GLYPHS = "_.-=#"
+SCHEMA_VERSION = 2
 
 
 def append_record(
@@ -24,6 +40,8 @@ def append_record(
     pass_rate: float,
     mean_score: float | None,
     metrics: dict,
+    *,
+    command: Literal["grade", "extract", "validate"],
     path: Path | None = None,
 ) -> None:
     """Append one history record for a grade run.
@@ -31,11 +49,17 @@ def append_record(
     Creates the parent directory if it does not already exist.
     ``path`` defaults to :data:`_DEFAULT_PATH` resolved at call time, so
     tests can monkeypatch the module attribute.
+
+    ``command`` is required (keyword-only) and identifies which clauditor
+    subcommand produced the record. Every written record includes
+    ``schema_version: 2`` at the top level.
     """
     if path is None:
         path = _DEFAULT_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     record = {
+        "schema_version": SCHEMA_VERSION,
+        "command": command,
         "ts": datetime.now(UTC).isoformat(),
         "skill": skill,
         "pass_rate": pass_rate,

--- a/src/clauditor/metrics.py
+++ b/src/clauditor/metrics.py
@@ -1,0 +1,65 @@
+"""Token + timing metrics aggregation for clauditor runs.
+
+See plans/super/21-timing-tokens.md DEC-002 and DEC-014 for the canonical
+bucketed shape. This module is pure — no I/O, no SDK calls, no imports
+from cli/history. Import only from typing stdlib and dataclasses.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return {"input_tokens": self.input_tokens, "output_tokens": self.output_tokens}
+
+    @property
+    def total(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+def build_metrics(
+    skill: TokenUsage,
+    duration_seconds: float,
+    grader: TokenUsage | None = None,
+    quality: TokenUsage | None = None,
+    triggers: TokenUsage | None = None,
+) -> dict:
+    """Build the canonical nested metrics dict.
+
+    Bucket keys (``grader``, ``quality``, ``triggers``) are absent from the
+    returned dict when their source arg is ``None``. ``skill`` is always
+    present because every command runs the skill. ``total`` and
+    ``duration_seconds`` are always present.
+
+    ``None`` is the absence signal: passing ``TokenUsage(0, 0)`` explicitly
+    still causes the bucket to appear (with zero values). Only ``None``
+    omits the bucket.
+
+    ``total`` is the sum of ``input_tokens`` and ``output_tokens`` across
+    all present buckets, with a ``total`` sub-key equal to
+    ``input_tokens + output_tokens``.
+    """
+    buckets: dict[str, TokenUsage] = {"skill": skill}
+    if grader is not None:
+        buckets["grader"] = grader
+    if quality is not None:
+        buckets["quality"] = quality
+    if triggers is not None:
+        buckets["triggers"] = triggers
+
+    total_in = sum(b.input_tokens for b in buckets.values())
+    total_out = sum(b.output_tokens for b in buckets.values())
+
+    result: dict = {name: b.to_dict() for name, b in buckets.items()}
+    result["total"] = {
+        "input_tokens": total_in,
+        "output_tokens": total_out,
+        "total": total_in + total_out,
+    }
+    result["duration_seconds"] = duration_seconds
+    return result

--- a/src/clauditor/metrics.py
+++ b/src/clauditor/metrics.py
@@ -33,8 +33,10 @@ def build_metrics(
 
     Bucket keys (``grader``, ``quality``, ``triggers``) are absent from the
     returned dict when their source arg is ``None``. ``skill`` is always
-    present because every command runs the skill. ``total`` and
-    ``duration_seconds`` are always present.
+    present — callers that didn't run a skill subprocess (e.g. ``--output``
+    runs that read a captured file) pass ``TokenUsage(0, 0)``, so the
+    ``skill`` bucket appears with zero tokens/duration in that case.
+    ``total`` and ``duration_seconds`` are always present.
 
     ``None`` is the absence signal: passing ``TokenUsage(0, 0)`` explicitly
     still causes the bucket to appear (with zero values). Only ``None``

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -39,6 +39,8 @@ class GradingReport:
     model: str
     duration_seconds: float = 0.0
     thresholds: GradeThresholds | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     @property
     def passed(self) -> bool:
@@ -73,6 +75,8 @@ class GradingReport:
             "skill_name": self.skill_name,
             "model": self.model,
             "duration_seconds": self.duration_seconds,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
             "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
             "results": [
                 {
@@ -119,6 +123,8 @@ class GradingReport:
             model=parsed.get("model", ""),
             duration_seconds=float(parsed.get("duration_seconds", 0.0)),
             thresholds=thresholds,
+            input_tokens=int(parsed.get("input_tokens", 0)),
+            output_tokens=int(parsed.get("output_tokens", 0)),
         )
 
     def summary(self) -> str:
@@ -247,6 +253,8 @@ async def grade_quality(
         ],
     )
     duration = time.monotonic() - start
+    input_tokens = getattr(response.usage, "input_tokens", 0)
+    output_tokens = getattr(response.usage, "output_tokens", 0)
 
     if not response.content or not hasattr(response.content[0], "text"):
         return GradingReport(
@@ -263,6 +271,8 @@ async def grade_quality(
             model=model,
             duration_seconds=duration,
             thresholds=thresholds,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     response_text = response.content[0].text
@@ -286,6 +296,8 @@ async def grade_quality(
             model=model,
             duration_seconds=duration,
             thresholds=thresholds,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     return GradingReport(
@@ -294,6 +306,8 @@ async def grade_quality(
         model=model,
         duration_seconds=duration,
         thresholds=thresholds,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
     )
 
 
@@ -310,6 +324,8 @@ class VarianceReport:
     stability: float  # Fraction of runs where ALL criteria passed
     min_stability: float = 0.8
     model: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     @property
     def passed(self) -> bool:
@@ -384,4 +400,6 @@ async def measure_variance(
         stability=stability,
         min_stability=min_stability,
         model=model,
+        input_tokens=sum(r.input_tokens for r in reports),
+        output_tokens=sum(r.output_tokens for r in reports),
     )

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -41,6 +41,7 @@ class GradingReport:
     thresholds: GradeThresholds | None = None
     input_tokens: int = 0
     output_tokens: int = 0
+    metrics: dict | None = None
 
     @property
     def passed(self) -> bool:
@@ -94,6 +95,8 @@ class GradingReport:
                 "min_pass_rate": self.thresholds.min_pass_rate,
                 "min_mean_score": self.thresholds.min_mean_score,
             }
+        if self.metrics is not None:
+            data["metrics"] = self.metrics
         return json.dumps(data, indent=2)
 
     @classmethod
@@ -125,6 +128,7 @@ class GradingReport:
             thresholds=thresholds,
             input_tokens=int(parsed.get("input_tokens", 0)),
             output_tokens=int(parsed.get("output_tokens", 0)),
+            metrics=parsed.get("metrics"),
         )
 
     def summary(self) -> str:

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -328,8 +328,11 @@ class VarianceReport:
     stability: float  # Fraction of runs where ALL criteria passed
     min_stability: float = 0.8
     model: str = ""
-    input_tokens: int = 0
+    input_tokens: int = 0  # Layer 3 grader tokens across all runs
     output_tokens: int = 0
+    skill_input_tokens: int = 0  # Skill subprocess tokens across all runs
+    skill_output_tokens: int = 0
+    skill_duration_seconds: float = 0.0  # Sum of skill run durations
 
     @property
     def passed(self) -> bool:
@@ -364,11 +367,18 @@ async def measure_variance(
             f"Cannot measure variance without an eval spec."
         )
 
-    # 1. Run skill n_runs times sequentially (subprocess)
+    # 1. Run skill n_runs times sequentially (subprocess) and accumulate
+    # skill-side tokens + duration for later aggregation into history.
     outputs: list[str] = []
+    skill_input_total = 0
+    skill_output_total = 0
+    skill_duration_total = 0.0
     for _ in range(n_runs):
         result = spec.run()
         outputs.append(result.output)
+        skill_input_total += result.input_tokens
+        skill_output_total += result.output_tokens
+        skill_duration_total += result.duration_seconds
 
     # 2. Grade all outputs in parallel
     reports = list(
@@ -406,4 +416,7 @@ async def measure_variance(
         model=model,
         input_tokens=sum(r.input_tokens for r in reports),
         output_tokens=sum(r.output_tokens for r in reports),
+        skill_input_tokens=skill_input_total,
+        skill_output_tokens=skill_output_total,
+        skill_duration_seconds=skill_duration_total,
     )

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -198,6 +199,44 @@ class SkillRunner:
                 )
                 return result
 
+            # Drain stderr on a background thread so a chatty child does
+            # not deadlock by filling its PIPE buffer while we read stdout.
+            stderr_chunks: list[str] = []
+
+            def _drain_stderr() -> None:
+                if proc is None or proc.stderr is None:
+                    return
+                try:
+                    for chunk in proc.stderr:
+                        stderr_chunks.append(chunk)
+                except Exception:
+                    pass
+
+            stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+            stderr_thread.start()
+
+            # Watchdog: kill the child if it runs past the configured
+            # timeout. A blocked stdout read would otherwise never time out.
+            timed_out = {"hit": False}
+
+            def _on_timeout() -> None:
+                if proc is None:
+                    return
+                # Don't flip the flag if the child already exited cleanly —
+                # prevents a race where the read loop finishes right as the
+                # watchdog fires, yielding a false "timeout" result.
+                if proc.poll() is not None:
+                    return
+                timed_out["hit"] = True
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+
+            watchdog = threading.Timer(self.timeout, _on_timeout)
+            watchdog.daemon = True
+            watchdog.start()
+
             try:
                 if proc.stdout is not None:
                     for raw_line in proc.stdout:
@@ -213,12 +252,19 @@ class SkillRunner:
                                 file=sys.stderr,
                             )
                             continue
+                        if not isinstance(msg, dict):
+                            # Defensive: a well-formed JSON scalar / array is
+                            # not a valid stream-json message.
+                            continue
 
                         raw_messages.append(msg)
                         mtype = msg.get("type")
                         if mtype == "assistant":
                             message = msg.get("message") or {}
-                            for block in message.get("content", []) or []:
+                            content = message.get("content") or []
+                            if not isinstance(content, list):
+                                continue
+                            for block in content:
                                 if (
                                     isinstance(block, dict)
                                     and block.get("type") == "text"
@@ -227,14 +273,22 @@ class SkillRunner:
                         elif mtype == "result":
                             saw_result = True
                             usage = msg.get("usage") or {}
-                            input_tokens = int(usage.get("input_tokens", 0) or 0)
-                            output_tokens = int(
-                                usage.get("output_tokens", 0) or 0
-                            )
+                            if isinstance(usage, dict):
+                                input_tokens = int(
+                                    usage.get("input_tokens", 0) or 0
+                                )
+                                output_tokens = int(
+                                    usage.get("output_tokens", 0) or 0
+                                )
 
-                returncode = proc.wait(timeout=self.timeout)
-            except subprocess.TimeoutExpired:
-                proc.kill()
+                returncode = proc.wait()
+            finally:
+                watchdog.cancel()
+
+            stderr_thread.join(timeout=2.0)
+            stderr_text = "".join(stderr_chunks)
+
+            if timed_out["hit"] and returncode != 0:
                 result = SkillResult(
                     output="\n".join(text_chunks),
                     exit_code=-1,
@@ -246,13 +300,6 @@ class SkillRunner:
                     raw_messages=raw_messages,
                 )
                 return result
-
-            stderr_text = ""
-            if proc.stderr is not None:
-                try:
-                    stderr_text = proc.stderr.read() or ""
-                except Exception:
-                    stderr_text = ""
 
             if not saw_result:
                 print(

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -274,12 +274,20 @@ class SkillRunner:
                             saw_result = True
                             usage = msg.get("usage") or {}
                             if isinstance(usage, dict):
-                                input_tokens = int(
-                                    usage.get("input_tokens", 0) or 0
-                                )
-                                output_tokens = int(
-                                    usage.get("output_tokens", 0) or 0
-                                )
+                                # Defensive int() casts — if the CLI ever
+                                # emits None/str/float, don't abort the run.
+                                try:
+                                    input_tokens = int(
+                                        usage.get("input_tokens", 0) or 0
+                                    )
+                                except (TypeError, ValueError):
+                                    input_tokens = 0
+                                try:
+                                    output_tokens = int(
+                                        usage.get("output_tokens", 0) or 0
+                                    )
+                                except (TypeError, ValueError):
+                                    output_tokens = 0
 
                 returncode = proc.wait()
             finally:

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -204,7 +204,7 @@ class SkillRunner:
             stderr_chunks: list[str] = []
 
             def _drain_stderr() -> None:
-                if proc is None or proc.stderr is None:
+                if proc is None or proc.stderr is None:  # pragma: no cover
                     return
                 try:
                     for chunk in proc.stderr:
@@ -220,7 +220,7 @@ class SkillRunner:
             timed_out = {"hit": False}
 
             def _on_timeout() -> None:
-                if proc is None:
+                if proc is None:  # pragma: no cover
                     return
                 # Don't flip the flag if the child already exited cleanly —
                 # prevents a race where the read loop finishes right as the
@@ -230,7 +230,7 @@ class SkillRunner:
                 timed_out["hit"] = True
                 try:
                     proc.kill()
-                except Exception:
+                except Exception:  # pragma: no cover
                     pass
 
             watchdog = threading.Timer(self.timeout, _on_timeout)

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -1,8 +1,36 @@
-"""Skill runner — executes Claude Code skills and captures output."""
+"""Skill runner — executes Claude Code skills and captures output.
+
+Stream-JSON parser notes
+------------------------
+This module invokes the Claude CLI with
+``--output-format stream-json --verbose`` and parses its NDJSON output
+line-by-line. Each line is a JSON object with a ``type`` field. The schema
+below reflects the Anthropic CLI streaming format (verified live against
+``claude`` 2.1.x):
+
+- ``{"type": "system", ...}``                 — init / hook / misc events
+- ``{"type": "assistant", "message": {..., "content": [blocks]}}``
+    Each block in ``message.content`` has a ``type``. For ``type == "text"``
+    the block carries a ``text`` field. Tool-use blocks and other block
+    types are ignored for the purposes of ``SkillResult.output``.
+- ``{"type": "result", ..., "usage": {"input_tokens": N, "output_tokens": M}}``
+    The final line of a successful run. Carries aggregate token usage.
+
+Malformed lines (``json.JSONDecodeError``) are logged to stderr and
+skipped, never aborting the run. A missing ``result`` message leaves
+token counts at 0 and emits a warning but still yields a ``SkillResult``.
+
+Every exit path from ``_invoke`` is wrapped in ``try/finally`` so that
+``SkillResult.duration_seconds`` is set for success, timeout, missing
+binary, and any other error path (DEC-005).
+"""
 
 from __future__ import annotations
 
+import json
 import subprocess
+import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -30,6 +58,9 @@ class SkillResult:
     duration_seconds: float = 0.0
     error: str | None = None
     outputs: dict[str, str] = field(default_factory=dict)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    raw_messages: list[dict] = field(default_factory=list)
 
     @property
     def succeeded(self) -> bool:
@@ -110,45 +141,7 @@ class SkillRunner:
         prompt = f"/{skill_name}"
         if args:
             prompt += f" {args}"
-
-        import time
-
-        start = time.monotonic()
-        try:
-            result = subprocess.run(
-                [self.claude_bin, "-p", prompt],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout,
-                cwd=str(self.project_dir),
-            )
-            duration = time.monotonic() - start
-            return SkillResult(
-                output=result.stdout,
-                exit_code=result.returncode,
-                skill_name=skill_name,
-                args=args,
-                duration_seconds=duration,
-                error=result.stderr if result.returncode != 0 else None,
-            )
-        except subprocess.TimeoutExpired:
-            duration = time.monotonic() - start
-            return SkillResult(
-                output="",
-                exit_code=-1,
-                skill_name=skill_name,
-                args=args,
-                duration_seconds=duration,
-                error=f"Timed out after {self.timeout}s",
-            )
-        except FileNotFoundError:
-            return SkillResult(
-                output="",
-                exit_code=-1,
-                skill_name=skill_name,
-                args=args,
-                error=f"Claude CLI not found: {self.claude_bin}",
-            )
+        return self._invoke(prompt=prompt, skill_name=skill_name, args=args)
 
     def run_raw(self, prompt: str) -> SkillResult:
         """Run a raw prompt without skill prefix for baseline comparison.
@@ -159,41 +152,127 @@ class SkillRunner:
         Returns:
             SkillResult with skill_name="__baseline__"
         """
-        import time
+        return self._invoke(prompt=prompt, skill_name="__baseline__", args=prompt)
 
+    # ------------------------------------------------------------------ #
+    # Stream-json Popen implementation                                    #
+    # ------------------------------------------------------------------ #
+
+    def _invoke(self, *, prompt: str, skill_name: str, args: str) -> SkillResult:
+        """Run ``claude`` with stream-json output and parse the NDJSON stream.
+
+        Uses ``try/finally`` so ``duration_seconds`` is populated on every
+        exit path (success, timeout, CalledProcessError, FileNotFoundError).
+        """
         start = time.monotonic()
+        raw_messages: list[dict] = []
+        text_chunks: list[str] = []
+        input_tokens = 0
+        output_tokens = 0
+        saw_result = False
+        result: SkillResult | None = None
+        proc: subprocess.Popen | None = None
         try:
-            result = subprocess.run(
-                [self.claude_bin, "-p", prompt],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout,
-                cwd=str(self.project_dir),
+            try:
+                proc = subprocess.Popen(
+                    [
+                        self.claude_bin,
+                        "-p",
+                        prompt,
+                        "--output-format",
+                        "stream-json",
+                        "--verbose",
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    cwd=str(self.project_dir),
+                )
+            except FileNotFoundError:
+                result = SkillResult(
+                    output="",
+                    exit_code=-1,
+                    skill_name=skill_name,
+                    args=args,
+                    error=f"Claude CLI not found: {self.claude_bin}",
+                )
+                return result
+
+            try:
+                if proc.stdout is not None:
+                    for raw_line in proc.stdout:
+                        line = raw_line.strip()
+                        if not line:
+                            continue
+                        try:
+                            msg = json.loads(line)
+                        except json.JSONDecodeError as exc:
+                            print(
+                                "clauditor.runner: skipping malformed "
+                                f"stream-json line: {exc}",
+                                file=sys.stderr,
+                            )
+                            continue
+
+                        raw_messages.append(msg)
+                        mtype = msg.get("type")
+                        if mtype == "assistant":
+                            message = msg.get("message") or {}
+                            for block in message.get("content", []) or []:
+                                if (
+                                    isinstance(block, dict)
+                                    and block.get("type") == "text"
+                                ):
+                                    text_chunks.append(block.get("text", ""))
+                        elif mtype == "result":
+                            saw_result = True
+                            usage = msg.get("usage") or {}
+                            input_tokens = int(usage.get("input_tokens", 0) or 0)
+                            output_tokens = int(
+                                usage.get("output_tokens", 0) or 0
+                            )
+
+                returncode = proc.wait(timeout=self.timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                result = SkillResult(
+                    output="\n".join(text_chunks),
+                    exit_code=-1,
+                    skill_name=skill_name,
+                    args=args,
+                    error="timeout",
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    raw_messages=raw_messages,
+                )
+                return result
+
+            stderr_text = ""
+            if proc.stderr is not None:
+                try:
+                    stderr_text = proc.stderr.read() or ""
+                except Exception:
+                    stderr_text = ""
+
+            if not saw_result:
+                print(
+                    "clauditor.runner: stream-json ended without a 'result' "
+                    "message; token usage unavailable",
+                    file=sys.stderr,
+                )
+
+            result = SkillResult(
+                output="\n".join(text_chunks),
+                exit_code=returncode,
+                skill_name=skill_name,
+                args=args,
+                error=stderr_text if returncode != 0 and stderr_text else None,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                raw_messages=raw_messages,
             )
+            return result
+        finally:
             duration = time.monotonic() - start
-            return SkillResult(
-                output=result.stdout,
-                exit_code=result.returncode,
-                skill_name="__baseline__",
-                args=prompt,
-                duration_seconds=duration,
-                error=result.stderr if result.returncode != 0 else None,
-            )
-        except subprocess.TimeoutExpired:
-            duration = time.monotonic() - start
-            return SkillResult(
-                output="",
-                exit_code=-1,
-                skill_name="__baseline__",
-                args=prompt,
-                duration_seconds=duration,
-                error=f"Timed out after {self.timeout}s",
-            )
-        except FileNotFoundError:
-            return SkillResult(
-                output="",
-                exit_code=-1,
-                skill_name="__baseline__",
-                args=prompt,
-                error=f"Claude CLI not found: {self.claude_bin}",
-            )
+            if result is not None:
+                result.duration_seconds = duration

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -320,6 +320,30 @@ class SkillRunner:
             )
             return result
         finally:
+            # Defensive cleanup: if an unexpected exception escaped the
+            # inner try, the subprocess could still be running. Always try
+            # to reap it so we never leak a claude process. Swallow all
+            # cleanup errors — duration must still be set below.
+            if proc is not None and proc.poll() is None:
+                try:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=1)
+                    except Exception:
+                        try:
+                            proc.kill()
+                            proc.wait(timeout=1)
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
+            if proc is not None:
+                for stream in (proc.stdout, proc.stderr):
+                    try:
+                        if stream is not None and hasattr(stream, "close"):
+                            stream.close()
+                    except Exception:
+                        pass
             duration = time.monotonic() - start
             if result is not None:
                 result.duration_seconds = duration

--- a/src/clauditor/triggers.py
+++ b/src/clauditor/triggers.py
@@ -23,6 +23,8 @@ class TriggerResult:
     passed: bool  # expected == predicted
     confidence: float  # 0.0-1.0
     reasoning: str
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 @dataclass
@@ -33,6 +35,8 @@ class TriggerReport:
     skill_description: str
     results: list[TriggerResult]
     model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     @property
     def passed(self) -> bool:
@@ -185,6 +189,8 @@ async def classify_query(
         max_tokens=1024,
         messages=[{"role": "user", "content": prompt}],
     )
+    input_tokens = getattr(getattr(response, "usage", None), "input_tokens", 0)
+    output_tokens = getattr(getattr(response, "usage", None), "output_tokens", 0)
 
     if not response.content or not hasattr(response.content[0], "text"):
         return TriggerResult(
@@ -194,6 +200,8 @@ async def classify_query(
             passed=not expected,
             confidence=0.0,
             reasoning="LLM response contained no text content",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
         )
 
     response_text = response.content[0].text
@@ -206,6 +214,8 @@ async def classify_query(
         passed=expected == predicted,
         confidence=confidence,
         reasoning=reasoning,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
     )
 
 
@@ -255,10 +265,13 @@ async def test_triggers(
     ]
 
     results = await asyncio.gather(*tasks)
+    results_list = list(results)
 
     return TriggerReport(
         skill_name=eval_spec.skill_name,
         skill_description=eval_spec.description,
-        results=list(results),
+        results=results_list,
         model=model,
+        input_tokens=sum(r.input_tokens for r in results_list),
+        output_tokens=sum(r.output_tokens for r in results_list),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ clauditor_grader, or clauditor_triggers -- those are defined by the pytest plugi
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -19,6 +20,70 @@ from clauditor.schemas import (
     FieldRequirement,
     SectionRequirement,
 )
+
+
+class _FakePopen:
+    """Minimal ``subprocess.Popen`` stand-in for stream-json runner tests.
+
+    Exposes a ``stdout`` that yields the provided NDJSON lines (each
+    terminated by ``\\n``), a ``stderr`` mock with ``.read() == ""``, and
+    ``wait``/``kill`` methods. The ``returncode`` is set on construction
+    and returned from ``wait``.
+    """
+
+    def __init__(self, lines: list[str], returncode: int = 0):
+        body = "\n".join(lines)
+        if body and not body.endswith("\n"):
+            body += "\n"
+        self.stdout = io.StringIO(body)
+        self.stderr = MagicMock()
+        self.stderr.read.return_value = ""
+        self.returncode = returncode
+        self.kill_called = False
+
+    def wait(self, timeout=None):  # noqa: ARG002 — timeout ignored for fake
+        return self.returncode
+
+    def kill(self):
+        self.kill_called = True
+
+
+def make_fake_skill_stream(
+    text: str,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    extra_messages: list[dict] | None = None,
+) -> _FakePopen:
+    """Build a ``_FakePopen`` emitting a realistic stream-json sequence.
+
+    Produces:
+      1. one assistant message with a single ``text`` block containing ``text``
+      2. any ``extra_messages`` verbatim, in order
+      3. a final ``result`` message carrying token usage
+    """
+    messages: list[dict] = [
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
+            },
+        }
+    ]
+    if extra_messages:
+        messages.extend(extra_messages)
+    messages.append(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        }
+    )
+    return _FakePopen([json.dumps(m) for m in messages])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,16 +36,29 @@ class _FakePopen:
         if body and not body.endswith("\n"):
             body += "\n"
         self.stdout = io.StringIO(body)
-        self.stderr = MagicMock()
-        self.stderr.read.return_value = ""
+        # iter(()) makes `for chunk in proc.stderr:` a no-op drain loop.
+        self.stderr = iter(())
         self.returncode = returncode
         self.kill_called = False
+        self._killed = False
 
     def wait(self, timeout=None):  # noqa: ARG002 — timeout ignored for fake
         return self.returncode
 
     def kill(self):
         self.kill_called = True
+        self._killed = True
+        # After kill, poll reports a non-None exit signal.
+        if self.returncode == 0:
+            self.returncode = -9
+
+    def poll(self) -> int | None:
+        # Immediate-timer tests want poll() to report "still running" so the
+        # watchdog sets timed_out=True. Production code only calls poll from
+        # the watchdog callback; returning None mimics a live child.
+        if self._killed:
+            return self.returncode
+        return None
 
 
 def make_fake_skill_stream(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,10 @@ class _FakePopen:
     """Minimal ``subprocess.Popen`` stand-in for stream-json runner tests.
 
     Exposes a ``stdout`` that yields the provided NDJSON lines (each
-    terminated by ``\\n``), a ``stderr`` mock with ``.read() == ""``, and
-    ``wait``/``kill`` methods. The ``returncode`` is set on construction
-    and returned from ``wait``.
+    terminated by ``\\n``), a ``stderr`` that is an empty iterator (so the
+    runner's background ``for chunk in proc.stderr`` drain loop is a
+    no-op), plus ``wait``/``kill``/``poll`` methods. The ``returncode`` is
+    set on construction and returned from ``wait``.
     """
 
     def __init__(self, lines: list[str], returncode: int = 0):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1477,3 +1477,183 @@ class TestCmdGradeHistory:
         assert rc == 0
         history_path = tmp_path / ".clauditor" / "history.jsonl"
         assert not history_path.exists()
+
+
+class TestCmdExtractHistory:
+    """cmd_extract appends a history record with command=extract (US-005)."""
+
+    def test_extract_appends_history(self, tmp_path, monkeypatch):
+        """--output path records skill=0, grader=tokens from AssertionSet."""
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        results = AssertionSet(
+            results=[
+                AssertionResult(
+                    name="section:Results:count",
+                    passed=True,
+                    message="ok",
+                    kind="count",
+                )
+            ],
+            input_tokens=500,
+            output_tokens=200,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        assert history_path.exists()
+        lines = [ln for ln in history_path.read_text().splitlines() if ln]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["skill"] == "test-skill"
+        assert record["schema_version"] == 2
+        assert record["command"] == "extract"
+        assert record["pass_rate"] is None
+        assert record["mean_score"] is None
+        metrics = record["metrics"]
+        # --output path -> no skill run -> skill tokens 0
+        assert metrics["skill"]["input_tokens"] == 0
+        assert metrics["skill"]["output_tokens"] == 0
+        assert metrics["grader"]["input_tokens"] == 500
+        assert metrics["grader"]["output_tokens"] == 200
+        assert "quality" not in metrics
+        assert "triggers" not in metrics
+        assert metrics["total"]["total"] == 700
+
+    def test_extract_live_run_records_skill_and_grader_tokens(
+        self, tmp_path, monkeypatch
+    ):
+        """Live skill run records skill tokens + grader tokens; total=850."""
+        monkeypatch.chdir(tmp_path)
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output="some skill output",
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=2.5,
+            input_tokens=100,
+            output_tokens=50,
+        )
+        results = AssertionSet(
+            results=[
+                AssertionResult(
+                    name="section:Results:count",
+                    passed=True,
+                    message="ok",
+                    kind="count",
+                )
+            ],
+            input_tokens=500,
+            output_tokens=200,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md"])
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        record = json.loads(history_path.read_text().splitlines()[0])
+        assert record["command"] == "extract"
+        metrics = record["metrics"]
+        assert metrics["skill"]["input_tokens"] == 100
+        assert metrics["skill"]["output_tokens"] == 50
+        assert metrics["grader"]["input_tokens"] == 500
+        assert metrics["grader"]["output_tokens"] == 200
+        assert metrics["total"]["total"] == 850
+        assert metrics["duration_seconds"] == 2.5
+        assert "quality" not in metrics
+        assert "triggers" not in metrics
+
+
+class TestCmdValidateHistory:
+    """cmd_validate appends a history record with command=validate (US-005)."""
+
+    def test_validate_live_run_appends_history(self, tmp_path, monkeypatch):
+        """Layer 1 live run records skill tokens only; pass_rate from assertions."""
+        monkeypatch.chdir(tmp_path)
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output="hello world output",
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=1.5,
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        assert history_path.exists()
+        lines = [ln for ln in history_path.read_text().splitlines() if ln]
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["skill"] == "test-skill"
+        assert record["schema_version"] == 2
+        assert record["command"] == "validate"
+        # Layer 1 pass_rate is 1.0 (the "contains hello" assertion passes)
+        assert record["pass_rate"] == 1.0
+        assert record["mean_score"] is None
+        metrics = record["metrics"]
+        assert metrics["skill"]["input_tokens"] == 100
+        assert metrics["skill"]["output_tokens"] == 50
+        assert metrics["duration_seconds"] == 1.5
+        assert "grader" not in metrics
+        assert "quality" not in metrics
+        assert "triggers" not in metrics
+        assert metrics["total"]["total"] == 150
+
+    def test_validate_with_output_file_records_zeros(
+        self, tmp_path, monkeypatch
+    ):
+        """--output path records zero skill tokens/duration."""
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hello world content")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        record = json.loads(history_path.read_text().splitlines()[0])
+        assert record["command"] == "validate"
+        metrics = record["metrics"]
+        assert metrics["skill"]["input_tokens"] == 0
+        assert metrics["skill"]["output_tokens"] == 0
+        assert metrics["duration_seconds"] == 0.0
+        assert "grader" not in metrics

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ import json
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from clauditor.assertions import AssertionResult, AssertionSet
 from clauditor.cli import main
 from clauditor.quality_grader import GradingReport, GradingResult
@@ -1270,6 +1272,225 @@ class TestCmdTrend:
         out = capsys.readouterr().out
         data_lines = [ln for ln in out.splitlines() if "\t" in ln]
         assert len(data_lines) == 5
+
+
+class TestCmdTrendCommandFilter:
+    """cmd_trend --command filter (US-006)."""
+
+    def _seed(self, path, skill="test-skill"):
+        from clauditor import history
+
+        for i in range(3):
+            history.append_record(
+                skill=skill,
+                pass_rate=0.5 + i * 0.1,
+                mean_score=0.6,
+                metrics={},
+                command="grade",
+                path=path,
+            )
+        for i in range(2):
+            history.append_record(
+                skill=skill,
+                pass_rate=None,
+                mean_score=None,
+                metrics={"skill": {"input_tokens": 100 + i}},
+                command="extract",
+                path=path,
+            )
+
+    def test_default_is_grade(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl")
+        rc = main(["trend", "test-skill", "--metric", "pass_rate"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data_lines = [ln for ln in out.splitlines() if "\t" in ln]
+        assert len(data_lines) == 3
+
+    def test_command_all_unions(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl")
+        rc = main(
+            ["trend", "test-skill", "--metric", "pass_rate", "--command", "all"]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        data_lines = [ln for ln in out.splitlines() if "\t" in ln]
+        # extract records have pass_rate=None so resolve_path returns None;
+        # only the 3 grade records land in the output.
+        assert len(data_lines) == 3
+
+    def test_command_extract_none_values(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl")
+        rc = main(
+            [
+                "trend",
+                "test-skill",
+                "--metric",
+                "pass_rate",
+                "--command",
+                "extract",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "pass_rate" in err
+
+
+class TestCmdTrendDottedPath:
+    """cmd_trend dotted-path resolution (US-006)."""
+
+    def test_dotted_nested_metric(self, tmp_path, monkeypatch, capsys):
+        from clauditor import history
+
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".clauditor" / "history.jsonl"
+        for tok in (500, 600, 700):
+            history.append_record(
+                skill="test-skill",
+                pass_rate=0.8,
+                mean_score=0.7,
+                metrics={"grader": {"input_tokens": tok}},
+                command="grade",
+                path=path,
+            )
+        rc = main(["trend", "test-skill", "--metric", "grader.input_tokens"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data_lines = [ln for ln in out.splitlines() if "\t" in ln]
+        assert len(data_lines) == 3
+        assert "500" in out
+        assert "600" in out
+        assert "700" in out
+        # Sparkline line present
+        from clauditor.history import SPARK_GLYPHS
+
+        spark = out.splitlines()[-1]
+        assert spark
+        assert all(c in SPARK_GLYPHS for c in spark)
+
+
+class TestCmdTrendListMetrics:
+    """cmd_trend --list-metrics (US-006)."""
+
+    def _seed_full(self, path, skill="test-skill"):
+        from clauditor import history
+
+        history.append_record(
+            skill=skill,
+            pass_rate=0.8,
+            mean_score=0.7,
+            metrics={
+                "skill": {"input_tokens": 100, "output_tokens": 50},
+                "grader": {"input_tokens": 500, "output_tokens": 200},
+                "total": {
+                    "input_tokens": 900,
+                    "output_tokens": 400,
+                    "total": 1300,
+                },
+                "duration_seconds": 2.5,
+            },
+            command="grade",
+            path=path,
+        )
+        history.append_record(
+            skill=skill,
+            pass_rate=None,
+            mean_score=None,
+            metrics={
+                "skill": {"input_tokens": 80, "output_tokens": 30},
+                "duration_seconds": 1.2,
+            },
+            command="extract",
+            path=path,
+        )
+
+    def test_list_metrics_default_grade(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed_full(tmp_path / ".clauditor" / "history.jsonl")
+        rc = main(["trend", "test-skill", "--list-metrics"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if ln]
+        assert lines == sorted(lines)
+        assert "pass_rate" in lines
+        assert "mean_score" in lines
+        assert "skill.input_tokens" in lines
+        assert "grader.input_tokens" in lines
+        assert "total.total" in lines
+        assert "duration_seconds" in lines
+
+    def test_list_metrics_command_extract(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed_full(tmp_path / ".clauditor" / "history.jsonl")
+        rc = main(
+            ["trend", "test-skill", "--list-metrics", "--command", "extract"]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if ln]
+        # Extract record had null pass_rate/mean_score, so those are absent
+        assert "pass_rate" not in lines
+        assert "mean_score" not in lines
+        assert "skill.input_tokens" in lines
+        assert "duration_seconds" in lines
+        # And no grader bucket in extract seed
+        assert "grader.input_tokens" not in lines
+
+    def test_list_metrics_command_all(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        self._seed_full(tmp_path / ".clauditor" / "history.jsonl")
+        rc = main(
+            ["trend", "test-skill", "--list-metrics", "--command", "all"]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if ln]
+        # Union includes grade-only grader plus extract fields
+        assert "pass_rate" in lines
+        assert "grader.input_tokens" in lines
+        assert "skill.input_tokens" in lines
+        assert "duration_seconds" in lines
+
+    def test_list_metrics_empty_exits_1(self, tmp_path, monkeypatch, capsys):
+        from clauditor import history
+
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".clauditor" / "history.jsonl"
+        history.append_record(
+            skill="test-skill",
+            pass_rate=None,
+            mean_score=None,
+            metrics={},
+            command="grade",
+            path=path,
+        )
+        rc = main(["trend", "test-skill", "--list-metrics"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "no metric paths" in err
+
+
+class TestCmdTrendMutuallyExclusive:
+    def test_metric_and_list_metrics_conflict(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            main(
+                [
+                    "trend",
+                    "test-skill",
+                    "--metric",
+                    "pass_rate",
+                    "--list-metrics",
+                ]
+            )
+
+    def test_neither_required(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            main(["trend", "test-skill"])
 
 
 class TestCmdGradeHistory:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1590,6 +1590,107 @@ class TestCmdGradeHistory:
         assert "grader" not in metrics
         assert "triggers" not in metrics
 
+    def test_grade_variance_rolls_tokens_into_history_and_grade_json(
+        self, tmp_path, monkeypatch
+    ):
+        """cmd_grade --variance N: variance-run skill + grader tokens must
+        be summed into metrics in BOTH history.jsonl and .grade.json."""
+        from clauditor.quality_grader import VarianceReport
+
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        # Primary grade report: 500/200 grader tokens
+        primary_report = GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="c",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
+                )
+            ],
+            duration_seconds=1.0,
+            input_tokens=500,
+            output_tokens=200,
+        )
+
+        # Variance: 3 more runs with 100/50 grader tokens each, 10/5 skill
+        # tokens each, 0.5s skill duration each = totals 300/150 grader,
+        # 30/15 skill, 1.5s skill duration.
+        variance_report = VarianceReport(
+            skill_name="test-skill",
+            n_runs=3,
+            reports=[],
+            score_mean=1.0,
+            score_stddev=0.0,
+            pass_rate_mean=1.0,
+            stability=1.0,
+            input_tokens=300,
+            output_tokens=150,
+            skill_input_tokens=30,
+            skill_output_tokens=15,
+            skill_duration_seconds=1.5,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=primary_report,
+            ),
+            patch(
+                "clauditor.quality_grader.measure_variance",
+                new_callable=AsyncMock,
+                return_value=variance_report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--variance",
+                    "3",
+                    "--save",
+                ]
+            )
+
+        assert rc == 0
+
+        # Check history.jsonl
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        record = json.loads(history_path.read_text().splitlines()[0])
+        history_metrics = record["metrics"]
+
+        # Primary --output run: skill tokens 0. Variance adds 30/15.
+        assert history_metrics["skill"]["input_tokens"] == 30
+        assert history_metrics["skill"]["output_tokens"] == 15
+        # Quality: primary 500/200 + variance 300/150 = 800/350
+        assert history_metrics["quality"]["input_tokens"] == 800
+        assert history_metrics["quality"]["output_tokens"] == 350
+        # Total: skill 30+15 + quality 800+350 = 1195
+        assert history_metrics["total"]["total"] == 1195
+        # Skill duration: --output path 0.0 + variance 1.5 = 1.5
+        assert history_metrics["duration_seconds"] == pytest.approx(1.5)
+
+        # Check .grade.json mirrors history
+        grade_path = tmp_path / ".clauditor" / "test-skill.grade.json"
+        assert grade_path.exists()
+        grade_data = json.loads(grade_path.read_text())
+        grade_metrics = grade_data["metrics"]
+        assert grade_metrics == history_metrics
+
     def test_grade_save_writes_metrics_to_grade_json(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1214,6 +1214,7 @@ class TestCmdTrend:
                 pass_rate=0.5 + i * 0.1,
                 mean_score=0.6 + i * 0.05,
                 metrics={"count": i + 1},
+                command="grade",
                 path=path,
             )
 
@@ -1316,3 +1317,163 @@ class TestCmdGradeHistory:
         assert record["skill"] == "test-skill"
         assert record["pass_rate"] == 1.0
         assert record["mean_score"] == 0.9
+        assert record["schema_version"] == 2
+        assert record["command"] == "grade"
+
+    def test_grade_history_records_metrics(self, tmp_path, monkeypatch):
+        """cmd_grade records real bucketed metrics in history.jsonl."""
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="c",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
+                )
+            ],
+            duration_seconds=1.0,
+            input_tokens=500,
+            output_tokens=200,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        record = json.loads(history_path.read_text().splitlines()[0])
+        metrics = record["metrics"]
+        # --output path -> no skill run -> skill tokens 0
+        assert metrics["skill"]["input_tokens"] == 0
+        assert metrics["skill"]["output_tokens"] == 0
+        assert metrics["quality"]["input_tokens"] == 500
+        assert metrics["quality"]["output_tokens"] == 200
+        assert metrics["total"]["total"] == 700
+        assert "grader" not in metrics
+        assert "triggers" not in metrics
+
+    def test_grade_save_writes_metrics_to_grade_json(
+        self, tmp_path, monkeypatch
+    ):
+        """--save writes metrics into the .grade.json report."""
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some output")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="c",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
+                )
+            ],
+            duration_seconds=1.0,
+            input_tokens=300,
+            output_tokens=100,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--save",
+                ]
+            )
+
+        assert rc == 0
+        save_path = tmp_path / ".clauditor" / "test-skill.grade.json"
+        assert save_path.exists()
+        data = json.loads(save_path.read_text())
+        assert "metrics" in data
+        assert data["metrics"]["quality"]["input_tokens"] == 300
+        assert data["metrics"]["quality"]["output_tokens"] == 100
+        assert data["metrics"]["total"]["total"] == 400
+
+        # Round-trip through GradingReport.from_json
+        rt = GradingReport.from_json(save_path.read_text())
+        assert rt.metrics is not None
+        assert rt.metrics["quality"]["input_tokens"] == 300
+
+    def test_grade_only_criterion_still_skips_history(
+        self, tmp_path, monkeypatch
+    ):
+        """--only-criterion must not write a history record (regression #18)."""
+        monkeypatch.chdir(tmp_path)
+
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some output")
+
+        eval_spec = _make_eval_spec(grading_criteria=["foo bar", "baz"])
+        spec = _make_spec(eval_spec=eval_spec)
+        report = GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="foo bar",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--only-criterion",
+                    "foo",
+                ]
+            )
+
+        assert rc == 0
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        assert not history_path.exists()

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -579,7 +579,7 @@ class TestExtractAndGrade:
                 ]
             }
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -598,7 +598,7 @@ class TestExtractAndGrade:
             }
         }
         wrapped = f"```json\n{json.dumps(data)}\n```"
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=wrapped)]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -617,7 +617,7 @@ class TestExtractAndGrade:
             }
         }
         wrapped = f"```\n{json.dumps(data)}\n```"
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=wrapped)]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -627,7 +627,7 @@ class TestExtractAndGrade:
 
     @pytest.mark.asyncio
     async def test_json_parse_failure(self):
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text="not valid json at all")]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -654,7 +654,7 @@ class TestExtractAndGrade:
                 ]
             }
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -693,7 +693,7 @@ class TestExtractAndGrade:
                 },
             ]
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -717,7 +717,7 @@ class TestExtractAndGrade:
                 {"note": "LLM added this unsolicited"},
             ],
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -740,7 +740,7 @@ class TestExtractAndGrade:
                 ],
             }
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -756,7 +756,7 @@ class TestExtractAndGrade:
                 {"name": "CDM", "address": "X", "website": "Y"},
             ],
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -769,7 +769,7 @@ class TestExtractAndGrade:
     @pytest.mark.asyncio
     async def test_json_parse_failure_leaves_raw_data_none(self):
         """US-005: unparseable response keeps raw_data=None and evidence."""
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text="not valid json at all")]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -779,6 +779,28 @@ class TestExtractAndGrade:
         assert len(parse_failures) == 1
         assert parse_failures[0].raw_data is None
         assert parse_failures[0].evidence == "not valid json at all"
+
+    @pytest.mark.asyncio
+    async def test_captures_token_usage(self):
+        """extract_and_grade propagates SDK usage into the AssertionSet."""
+        data = {
+            "Venues": {
+                "default": [
+                    {"name": "A", "address": "B", "website": "C"},
+                    {"name": "D", "address": "E", "website": "F"},
+                ]
+            }
+        }
+        mock_response = MagicMock(
+            usage=MagicMock(input_tokens=500, output_tokens=200)
+        )
+        mock_response.content = [MagicMock(text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("some output", _make_spec())
+        assert result.input_tokens == 500
+        assert result.output_tokens == 200
 
     @pytest.mark.asyncio
     async def test_non_failure_result_has_no_raw_data(self):
@@ -791,7 +813,7 @@ class TestExtractAndGrade:
                 ]
             }
         }
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [MagicMock(text=json.dumps(data))]
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,15 +2,27 @@
 
 from __future__ import annotations
 
-from clauditor.history import SPARK_GLYPHS, append_record, read_records, sparkline
+import pytest
+
+from clauditor.history import (
+    SCHEMA_VERSION,
+    SPARK_GLYPHS,
+    append_record,
+    read_records,
+    sparkline,
+)
 
 
 class TestAppendAndRead:
     def test_round_trip(self, tmp_path):
         path = tmp_path / "history.jsonl"
-        append_record("skill-a", 0.8, 0.75, {"foo": 1}, path=path)
-        append_record("skill-b", 0.5, None, {}, path=path)
-        append_record("skill-a", 0.9, 0.85, {"foo": 2}, path=path)
+        append_record(
+            "skill-a", 0.8, 0.75, {"foo": 1}, command="grade", path=path
+        )
+        append_record("skill-b", 0.5, None, {}, command="grade", path=path)
+        append_record(
+            "skill-a", 0.9, 0.85, {"foo": 2}, command="grade", path=path
+        )
 
         all_records = read_records(path=path)
         assert len(all_records) == 3
@@ -18,6 +30,8 @@ class TestAppendAndRead:
         assert all_records[0]["pass_rate"] == 0.8
         assert all_records[0]["mean_score"] == 0.75
         assert all_records[0]["metrics"] == {"foo": 1}
+        assert all_records[0]["schema_version"] == SCHEMA_VERSION
+        assert all_records[0]["command"] == "grade"
         assert "ts" in all_records[0]
 
         a_records = read_records(skill="skill-a", path=path)
@@ -26,7 +40,7 @@ class TestAppendAndRead:
 
     def test_append_creates_parent_dir(self, tmp_path):
         path = tmp_path / "nested" / "dir" / "history.jsonl"
-        append_record("s", 1.0, 1.0, {}, path=path)
+        append_record("s", 1.0, 1.0, {}, command="grade", path=path)
         assert path.exists()
         assert len(read_records(path=path)) == 1
 
@@ -37,15 +51,27 @@ class TestAppendAndRead:
 
     def test_corrupt_line_skipped_with_warning(self, tmp_path, capsys):
         path = tmp_path / "history.jsonl"
-        append_record("s", 0.5, 0.5, {}, path=path)
+        append_record("s", 0.5, 0.5, {}, command="grade", path=path)
         with path.open("a", encoding="utf-8") as f:
             f.write("{not valid json\n")
-        append_record("s", 0.7, 0.7, {}, path=path)
+        append_record("s", 0.7, 0.7, {}, command="grade", path=path)
 
         records = read_records(path=path)
         assert len(records) == 2
         err = capsys.readouterr().err
         assert "corrupt history line" in err
+
+    def test_append_record_requires_command(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(TypeError):
+            append_record("s", 1.0, 1.0, {}, path=path)  # type: ignore[call-arg]
+
+    def test_schema_version_v2_written(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        append_record("s", 1.0, 1.0, {"k": 1}, command="grade", path=path)
+        records = read_records(path=path)
+        assert records[0]["schema_version"] == 2
+        assert records[0]["command"] == "grade"
 
 
 class TestSparkline:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -8,9 +8,103 @@ from clauditor.history import (
     SCHEMA_VERSION,
     SPARK_GLYPHS,
     append_record,
+    collect_metric_paths,
     read_records,
+    resolve_path,
     sparkline,
 )
+
+
+class TestResolvePath:
+    def test_top_level_pass_rate(self):
+        assert resolve_path({"pass_rate": 0.5, "metrics": {}}, "pass_rate") == 0.5
+
+    def test_top_level_mean_score(self):
+        assert (
+            resolve_path({"mean_score": 0.75, "metrics": {}}, "mean_score")
+            == 0.75
+        )
+
+    def test_nested_grader_input_tokens(self):
+        rec = {"metrics": {"grader": {"input_tokens": 500}}}
+        assert resolve_path(rec, "grader.input_tokens") == 500
+
+    def test_nested_total_total(self):
+        rec = {"metrics": {"total": {"total": 1300}}}
+        assert resolve_path(rec, "total.total") == 1300
+
+    def test_duration_seconds_nested(self):
+        rec = {"metrics": {"duration_seconds": 2.5}}
+        assert resolve_path(rec, "duration_seconds") == 2.5
+
+    def test_missing_path_returns_none(self):
+        assert resolve_path({"metrics": {}}, "nonexistent.path") is None
+
+    def test_non_numeric_returns_none(self):
+        rec = {"metrics": {"grader": {"input_tokens": "oops"}}}
+        assert resolve_path(rec, "grader.input_tokens") is None
+
+    def test_missing_intermediate_returns_none(self):
+        rec = {"metrics": {"grader": {}}}
+        assert resolve_path(rec, "grader.input_tokens") is None
+
+    def test_empty_record_pass_rate_none(self):
+        assert resolve_path({}, "pass_rate") is None
+
+    def test_pass_rate_none_value(self):
+        assert resolve_path({"pass_rate": None, "metrics": {}}, "pass_rate") is None
+
+    def test_dict_leaf_returns_none(self):
+        rec = {"metrics": {"grader": {"input_tokens": 5}}}
+        assert resolve_path(rec, "grader") is None
+
+    def test_non_dict_record(self):
+        assert resolve_path("not a dict", "pass_rate") is None  # type: ignore[arg-type]
+
+    def test_bool_not_numeric(self):
+        rec = {"metrics": {"flag": True}}
+        assert resolve_path(rec, "flag") is None
+
+
+class TestCollectMetricPaths:
+    def test_v1_flat_record(self):
+        rec = {"pass_rate": 0.8, "mean_score": 0.7, "metrics": {}}
+        assert collect_metric_paths(rec) == {"pass_rate", "mean_score"}
+
+    def test_v1_flat_record_only_pass_rate(self):
+        rec = {"pass_rate": 0.8, "mean_score": None, "metrics": {}}
+        assert collect_metric_paths(rec) == {"pass_rate"}
+
+    def test_v2_nested_record(self):
+        rec = {
+            "pass_rate": 0.8,
+            "mean_score": 0.7,
+            "metrics": {
+                "skill": {"input_tokens": 100, "output_tokens": 50},
+                "grader": {"input_tokens": 500, "output_tokens": 200},
+                "total": {
+                    "input_tokens": 900,
+                    "output_tokens": 400,
+                    "total": 1300,
+                },
+                "duration_seconds": 2.5,
+            },
+        }
+        paths = collect_metric_paths(rec)
+        assert "pass_rate" in paths
+        assert "mean_score" in paths
+        assert "skill.input_tokens" in paths
+        assert "skill.output_tokens" in paths
+        assert "grader.input_tokens" in paths
+        assert "total.total" in paths
+        assert "total.input_tokens" in paths
+        assert "duration_seconds" in paths
+
+    def test_empty_record(self):
+        assert collect_metric_paths({}) == set()
+
+    def test_non_dict(self):
+        assert collect_metric_paths("nope") == set()  # type: ignore[arg-type]
 
 
 class TestAppendAndRead:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -167,6 +167,21 @@ class TestAppendAndRead:
         assert records[0]["schema_version"] == 2
         assert records[0]["command"] == "grade"
 
+    def test_append_record_rejects_invalid_command(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(ValueError, match="command must be one of"):
+            append_record(
+                "s", 1.0, 1.0, {}, command="bogus", path=path  # type: ignore[arg-type]
+            )
+        with pytest.raises(ValueError):
+            append_record(
+                "s", 1.0, 1.0, {}, command="GRADE", path=path  # type: ignore[arg-type]
+            )
+        # Valid values still work.
+        for cmd in ("grade", "extract", "validate"):
+            append_record("s", None, None, {}, command=cmd, path=path)
+        assert len(read_records(path=path)) == 3
+
 
 class TestSparkline:
     def test_empty(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,89 @@
+"""Tests for clauditor.metrics — TokenUsage and build_metrics()."""
+from __future__ import annotations
+
+from clauditor.metrics import TokenUsage, build_metrics
+
+
+class TestTokenUsage:
+    def test_to_dict_shape(self):
+        tu = TokenUsage(input_tokens=10, output_tokens=20)
+        assert tu.to_dict() == {"input_tokens": 10, "output_tokens": 20}
+
+    def test_total_property(self):
+        tu = TokenUsage(input_tokens=10, output_tokens=20)
+        assert tu.total == 30
+
+    def test_defaults_zero(self):
+        tu = TokenUsage()
+        assert tu.input_tokens == 0
+        assert tu.output_tokens == 0
+        assert tu.total == 0
+        assert tu.to_dict() == {"input_tokens": 0, "output_tokens": 0}
+
+
+class TestBuildMetrics:
+    def test_skill_only(self):
+        m = build_metrics(skill=TokenUsage(100, 50), duration_seconds=1.0)
+        assert "skill" in m
+        assert "grader" not in m
+        assert "quality" not in m
+        assert "triggers" not in m
+        assert m["skill"] == {"input_tokens": 100, "output_tokens": 50}
+        assert m["total"] == {"input_tokens": 100, "output_tokens": 50, "total": 150}
+        assert m["duration_seconds"] == 1.0
+
+    def test_all_four_buckets(self):
+        m = build_metrics(
+            skill=TokenUsage(100, 50),
+            duration_seconds=2.5,
+            grader=TokenUsage(500, 200),
+            quality=TokenUsage(300, 100),
+            triggers=TokenUsage(40, 10),
+        )
+        assert m["skill"] == {"input_tokens": 100, "output_tokens": 50}
+        assert m["grader"] == {"input_tokens": 500, "output_tokens": 200}
+        assert m["quality"] == {"input_tokens": 300, "output_tokens": 100}
+        assert m["triggers"] == {"input_tokens": 40, "output_tokens": 10}
+        # sums
+        in_sum = 100 + 500 + 300 + 40
+        out_sum = 50 + 200 + 100 + 10
+        assert m["total"] == {
+            "input_tokens": in_sum,
+            "output_tokens": out_sum,
+            "total": in_sum + out_sum,
+        }
+        assert m["duration_seconds"] == 2.5
+
+    def test_zero_token_skill(self):
+        m = build_metrics(skill=TokenUsage(0, 0), duration_seconds=0.1)
+        assert m["skill"] == {"input_tokens": 0, "output_tokens": 0}
+        assert m["total"]["total"] == 0
+        assert m["total"]["input_tokens"] == 0
+        assert m["total"]["output_tokens"] == 0
+
+    def test_duration_flows_through(self):
+        m = build_metrics(skill=TokenUsage(1, 1), duration_seconds=1.5)
+        assert m["duration_seconds"] == 1.5
+
+    def test_grader_only(self):
+        """cmd_extract case: skill + grader, no quality/triggers."""
+        m = build_metrics(
+            skill=TokenUsage(100, 50),
+            duration_seconds=2.0,
+            grader=TokenUsage(500, 200),
+        )
+        assert set(m.keys()) == {"skill", "grader", "total", "duration_seconds"}
+        assert m["total"]["total"] == 850
+
+    def test_zero_bucket_is_present_when_explicitly_passed(self):
+        """None is the absence signal; TokenUsage(0, 0) is still presence."""
+        m = build_metrics(
+            skill=TokenUsage(10, 5),
+            duration_seconds=1.0,
+            grader=TokenUsage(0, 0),
+        )
+        assert "grader" in m
+        assert m["grader"] == {"input_tokens": 0, "output_tokens": 0}
+        assert "quality" not in m
+        assert "triggers" not in m
+        assert m["total"]["total"] == 15

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -826,9 +826,16 @@ class TestMeasureVariance:
             output_tokens=50,
         )
 
+        # Use real attrs (not MagicMock defaults) so skill-side token
+        # aggregation is actually verifiable — MagicMock would silently
+        # return MagicMock instances for arithmetic and the test would
+        # pass while storing nonsense.
         mock_result = MagicMock()
         mock_result.output = "some output"
         mock_result.succeeded = True
+        mock_result.input_tokens = 10
+        mock_result.output_tokens = 5
+        mock_result.duration_seconds = 1.5
 
         mock_spec = MagicMock()
         mock_spec.skill_name = "test-skill"
@@ -846,8 +853,13 @@ class TestMeasureVariance:
         ):
             vr = await measure_variance(mock_spec, n_runs=3)
 
+        # Grader (Layer 3) tokens aggregated across the 3 internal runs
         assert vr.input_tokens == 300
         assert vr.output_tokens == 150
+        # Skill (subprocess) tokens aggregated across the 3 skill runs
+        assert vr.skill_input_tokens == 30
+        assert vr.skill_output_tokens == 15
+        assert vr.skill_duration_seconds == pytest.approx(4.5)
 
     @pytest.mark.asyncio
     async def test_measure_variance_no_eval_spec(self):

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -234,6 +234,35 @@ class TestGradingReportSerialization:
         assert restored.thresholds.min_mean_score == pytest.approx(0.6)
         assert restored.passed == original.passed
 
+    def test_token_fields_roundtrip(self):
+        """input_tokens/output_tokens survive JSON round-trip."""
+        original = GradingReport(
+            skill_name="tokens",
+            results=_make_results([True]),
+            model="claude-sonnet-4-6",
+            input_tokens=500,
+            output_tokens=200,
+        )
+        raw = original.to_json()
+        data = json.loads(raw)
+        assert data["input_tokens"] == 500
+        assert data["output_tokens"] == 200
+
+        restored = GradingReport.from_json(raw)
+        assert restored.input_tokens == 500
+        assert restored.output_tokens == 200
+
+    def test_token_fields_default_when_missing(self):
+        """Missing token fields in legacy grade.json files default to 0."""
+        data = json.dumps({
+            "skill_name": "legacy",
+            "model": "claude-sonnet-4-6",
+            "results": [],
+        })
+        restored = GradingReport.from_json(data)
+        assert restored.input_tokens == 0
+        assert restored.output_tokens == 0
+
     def test_no_thresholds_roundtrip(self):
         """Report without thresholds omits them from JSON."""
         original = GradingReport(
@@ -384,7 +413,7 @@ class TestGradeQuality:
             },
         ]
 
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [
             MagicMock(text=json.dumps(grading_data))
         ]
@@ -411,7 +440,7 @@ class TestGradeQuality:
     async def test_parse_failure_returns_failed_report(self):
         spec = _make_spec()
 
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [
             MagicMock(text="I cannot parse this as valid output")
         ]
@@ -444,7 +473,7 @@ class TestGradeQuality:
             },
         ]
 
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [
             MagicMock(text=f"```json\n{json.dumps(grading_data)}\n```")
         ]
@@ -474,7 +503,7 @@ class TestGradeQuality:
             },
         ]
 
-        mock_response = MagicMock()
+        mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
         mock_response.content = [
             MagicMock(text=json.dumps(grading_data))
         ]
@@ -494,6 +523,30 @@ class TestGradeQuality:
         user_message = call_kwargs["messages"][0]["content"]
         assert "THE SKILL OUTPUT" in user_message
         assert call_kwargs["model"] == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_captures_token_usage(self):
+        """grade_quality propagates SDK usage into the GradingReport."""
+        spec = _make_spec()
+        grading_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "e",
+                "reasoning": "r",
+            },
+        ]
+        mock_response = MagicMock(
+            usage=MagicMock(input_tokens=500, output_tokens=200)
+        )
+        mock_response.content = [MagicMock(text=json.dumps(grading_data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await grade_quality("some output", spec)
+        assert report.input_tokens == 500
+        assert report.output_tokens == 200
 
 
 def _make_grading_report(
@@ -753,6 +806,48 @@ class TestMeasureVariance:
             vr = await measure_variance(mock_spec, n_runs=2)
 
         assert vr.min_stability == 0.8
+
+    @pytest.mark.asyncio
+    async def test_measure_variance_aggregates_tokens(self):
+        """Tokens across the internal grade_quality runs are summed."""
+        mock_report = GradingReport(
+            skill_name="test-skill",
+            results=[
+                GradingResult(
+                    criterion="Is clear",
+                    passed=True,
+                    score=0.9,
+                    evidence="e",
+                    reasoning="r",
+                )
+            ],
+            model="claude-sonnet-4-6",
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+        mock_result = MagicMock()
+        mock_result.output = "some output"
+        mock_result.succeeded = True
+
+        mock_spec = MagicMock()
+        mock_spec.skill_name = "test-skill"
+        mock_spec.run.return_value = mock_result
+        mock_spec.eval_spec = EvalSpec(
+            skill_name="test-skill",
+            grading_criteria=["Is clear"],
+            variance=VarianceConfig(n_runs=3, min_stability=0.8),
+        )
+
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new_callable=AsyncMock,
+            return_value=mock_report,
+        ):
+            vr = await measure_variance(mock_spec, n_runs=3)
+
+        assert vr.input_tokens == 300
+        assert vr.output_tokens == 150
 
     @pytest.mark.asyncio
     async def test_measure_variance_no_eval_spec(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,9 @@
 """Tests for SkillRunner."""
 
 import importlib
+import json
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -11,28 +12,38 @@ import clauditor.runner as _runner_mod
 importlib.reload(_runner_mod)
 
 from clauditor.runner import SkillResult, SkillRunner  # noqa: E402
+from tests.conftest import _FakePopen, make_fake_skill_stream  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# SkillRunner.run_raw
+# ---------------------------------------------------------------------------
 
 
 class TestRunRaw:
     def test_run_raw_returns_baseline_skill_name(self):
-        runner = SkillRunner(project_dir="/tmp", claude_bin="echo")
-        result = runner.run_raw("test prompt")
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=make_fake_skill_stream("hi"),
+        ):
+            result = runner.run_raw("test prompt")
         assert result.skill_name == "__baseline__"
 
     def test_run_raw_passes_prompt_directly(self):
         """Verify run_raw sends the prompt without a skill prefix."""
         runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                stdout="some output", stderr="", returncode=0
-            )
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("some output")
             result = runner.run_raw("find me activities in Seattle")
-            mock_run.assert_called_once()
-            cmd = mock_run.call_args[0][0]
+            mock_popen.assert_called_once()
+            cmd = mock_popen.call_args[0][0]
             assert cmd == [
                 "claude",
                 "-p",
                 "find me activities in Seattle",
+                "--output-format",
+                "stream-json",
+                "--verbose",
             ]
             assert result.skill_name == "__baseline__"
             assert result.args == "find me activities in Seattle"
@@ -40,22 +51,25 @@ class TestRunRaw:
 
     def test_run_raw_handles_timeout(self):
         runner = SkillRunner(project_dir="/tmp", timeout=1, claude_bin="claude")
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired("claude", 1),
-        ):
+        fake = make_fake_skill_stream("partial")
+        fake.wait = lambda timeout=None: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired("claude", 1)
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
             result = runner.run_raw("test prompt")
-            assert result.exit_code == -1
-            assert result.skill_name == "__baseline__"
-            assert "Timed out" in result.error
+        assert result.exit_code == -1
+        assert result.skill_name == "__baseline__"
+        assert result.error == "timeout"
 
     def test_run_raw_handles_missing_binary(self):
         runner = SkillRunner(project_dir="/tmp", claude_bin="nonexistent-binary")
-        with patch("subprocess.run", side_effect=FileNotFoundError):
+        with patch(
+            "clauditor.runner.subprocess.Popen", side_effect=FileNotFoundError
+        ):
             result = runner.run_raw("test prompt")
-            assert result.exit_code == -1
-            assert result.skill_name == "__baseline__"
-            assert "not found" in result.error
+        assert result.exit_code == -1
+        assert result.skill_name == "__baseline__"
+        assert "not found" in result.error
 
 
 # ---------------------------------------------------------------------------
@@ -164,22 +178,27 @@ class TestSkillResultAssertions:
 
 
 # ---------------------------------------------------------------------------
-# SkillRunner.run()
+# SkillRunner.run() — covered more thoroughly in TestStreamJsonRunner
 # ---------------------------------------------------------------------------
 
 
 class TestSkillRunnerRun:
     def test_runner_run_success(self):
         runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
-        with patch("clauditor.runner.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                stdout="skill output", stderr="", returncode=0
-            )
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("skill output")
             result = runner.run("my-skill", "some args")
 
-            mock_run.assert_called_once()
-            cmd = mock_run.call_args[0][0]
-            assert cmd == ["claude", "-p", "/my-skill some args"]
+            mock_popen.assert_called_once()
+            cmd = mock_popen.call_args[0][0]
+            assert cmd == [
+                "claude",
+                "-p",
+                "/my-skill some args",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+            ]
             assert result.output == "skill output"
             assert result.exit_code == 0
             assert result.skill_name == "my-skill"
@@ -188,35 +207,33 @@ class TestSkillRunnerRun:
 
     def test_runner_run_success_no_args(self):
         runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
-        with patch("clauditor.runner.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                stdout="output", stderr="", returncode=0
-            )
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("output")
             runner.run("my-skill")
-            cmd = mock_run.call_args[0][0]
-            assert cmd == ["claude", "-p", "/my-skill"]
+            cmd = mock_popen.call_args[0][0]
+            assert cmd[:3] == ["claude", "-p", "/my-skill"]
 
     def test_runner_run_timeout(self):
         runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")
-        with patch(
-            "clauditor.runner.subprocess.run",
-            side_effect=subprocess.TimeoutExpired("claude", 5),
-        ):
+        fake = make_fake_skill_stream("partial")
+        fake.wait = lambda timeout=None: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired("claude", 5)
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
             result = runner.run("my-skill")
-            assert result.exit_code == -1
-            assert "Timed out" in result.error
-            assert result.output == ""
+        assert result.exit_code == -1
+        assert result.error == "timeout"
 
     def test_runner_run_not_found(self):
         runner = SkillRunner(project_dir="/tmp", claude_bin="missing-bin")
         with patch(
-            "clauditor.runner.subprocess.run",
+            "clauditor.runner.subprocess.Popen",
             side_effect=FileNotFoundError,
         ):
             result = runner.run("my-skill")
-            assert result.exit_code == -1
-            assert "not found" in result.error
-            assert result.output == ""
+        assert result.exit_code == -1
+        assert "not found" in result.error
+        assert result.output == ""
 
 
 # ---------------------------------------------------------------------------
@@ -261,3 +278,174 @@ class TestSkillResultOutputs:
         )
         result.assert_contains("hello world")
         result.assert_not_contains("completely different text")
+
+
+# ---------------------------------------------------------------------------
+# Stream-JSON runner — new Popen-based behavior
+# ---------------------------------------------------------------------------
+
+
+class TestStreamJsonRunner:
+    def test_single_assistant_message_single_text_block(self):
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=make_fake_skill_stream(
+                "hello", input_tokens=100, output_tokens=50
+            ),
+        ):
+            result = runner.run("skill")
+        assert result.output == "hello"
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+        assert result.exit_code == 0
+        assert result.duration_seconds >= 0
+
+    def test_two_assistant_messages_joined_with_newline(self):
+        extra = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "second"}],
+                },
+            }
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=make_fake_skill_stream("first", extra_messages=extra),
+        ):
+            result = runner.run("skill")
+        assert result.output == "first\nsecond"
+
+    def test_assistant_text_and_tool_use_only_text_included(self):
+        lines = [
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "visible"},
+                            {
+                                "type": "tool_use",
+                                "id": "t1",
+                                "name": "Bash",
+                                "input": {"command": "ls"},
+                            },
+                        ],
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 5, "output_tokens": 7},
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen", return_value=_FakePopen(lines)
+        ):
+            result = runner.run("skill")
+        assert result.output == "visible"
+        assert result.input_tokens == 5
+        assert result.output_tokens == 7
+
+    def test_missing_result_message_defaults_tokens_to_zero(self, capsys):
+        lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "only text"}],
+                    },
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen", return_value=_FakePopen(lines)
+        ):
+            result = runner.run("skill")
+        assert isinstance(result, SkillResult)
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
+        assert result.output == "only text"
+        captured = capsys.readouterr()
+        assert "without a 'result'" in captured.err
+
+    def test_malformed_json_line_skipped_with_warning(self, capsys):
+        lines = [
+            "this is not json",
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "survived"}],
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 1, "output_tokens": 2},
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen", return_value=_FakePopen(lines)
+        ):
+            result = runner.run("skill")
+        assert result.output == "survived"
+        assert result.input_tokens == 1
+        assert result.output_tokens == 2
+        captured = capsys.readouterr()
+        assert "malformed" in captured.err
+
+    def test_timeout_sets_duration_and_kills_process(self):
+        runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")
+        fake = make_fake_skill_stream("partial")
+
+        def _raise(timeout=None):  # noqa: ARG001
+            raise subprocess.TimeoutExpired("claude", 5)
+
+        fake.wait = _raise
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            result = runner.run("skill")
+        assert result.error == "timeout"
+        assert result.exit_code == -1
+        assert result.duration_seconds >= 0
+        assert fake.kill_called is True
+
+    def test_file_not_found_sets_duration(self):
+        """DEC-005: duration must be set even on FileNotFoundError."""
+        runner = SkillRunner(project_dir="/tmp", claude_bin="missing")
+        with patch(
+            "clauditor.runner.subprocess.Popen", side_effect=FileNotFoundError
+        ):
+            result = runner.run("skill")
+        assert result.exit_code == -1
+        assert "not found" in result.error
+        assert result.duration_seconds >= 0
+
+    def test_raw_messages_populated(self):
+        extra = [
+            {"type": "system", "subtype": "ping"},
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=make_fake_skill_stream("x", extra_messages=extra),
+        ):
+            result = runner.run("skill")
+        # assistant + system + result == 3 messages
+        assert len(result.raw_messages) == 3
+        types = [m.get("type") for m in result.raw_messages]
+        assert types == ["assistant", "system", "result"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,7 +2,6 @@
 
 import importlib
 import json
-import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -52,10 +51,24 @@ class TestRunRaw:
     def test_run_raw_handles_timeout(self):
         runner = SkillRunner(project_dir="/tmp", timeout=1, claude_bin="claude")
         fake = make_fake_skill_stream("partial")
-        fake.wait = lambda timeout=None: (_ for _ in ()).throw(
-            subprocess.TimeoutExpired("claude", 1)
-        )
-        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+
+        # Simulate the watchdog firing immediately by patching threading.Timer
+        # to invoke the callback on .start() before any stdout is read.
+        class _ImmediateTimer:
+            def __init__(self, interval, function, args=None, kwargs=None):
+                self.function = function
+                self.daemon = True
+
+            def start(self):
+                self.function()
+
+            def cancel(self):
+                pass
+
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            patch("clauditor.runner.threading.Timer", _ImmediateTimer),
+        ):
             result = runner.run_raw("test prompt")
         assert result.exit_code == -1
         assert result.skill_name == "__baseline__"
@@ -216,10 +229,22 @@ class TestSkillRunnerRun:
     def test_runner_run_timeout(self):
         runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")
         fake = make_fake_skill_stream("partial")
-        fake.wait = lambda timeout=None: (_ for _ in ()).throw(
-            subprocess.TimeoutExpired("claude", 5)
-        )
-        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+
+        class _ImmediateTimer:
+            def __init__(self, interval, function, args=None, kwargs=None):
+                self.function = function
+                self.daemon = True
+
+            def start(self):
+                self.function()
+
+            def cancel(self):
+                pass
+
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            patch("clauditor.runner.threading.Timer", _ImmediateTimer),
+        ):
             result = runner.run("my-skill")
         assert result.exit_code == -1
         assert result.error == "timeout"
@@ -413,16 +438,59 @@ class TestStreamJsonRunner:
         runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")
         fake = make_fake_skill_stream("partial")
 
-        def _raise(timeout=None):  # noqa: ARG001
-            raise subprocess.TimeoutExpired("claude", 5)
+        class _ImmediateTimer:
+            def __init__(self, interval, function, args=None, kwargs=None):
+                self.function = function
+                self.daemon = True
 
-        fake.wait = _raise
-        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            def start(self):
+                self.function()
+
+            def cancel(self):
+                pass
+
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            patch("clauditor.runner.threading.Timer", _ImmediateTimer),
+        ):
             result = runner.run("skill")
         assert result.error == "timeout"
         assert result.exit_code == -1
         assert result.duration_seconds >= 0
         assert fake.kill_called is True
+
+    def test_timeout_watchdog_skips_if_child_already_exited(self):
+        """Watchdog race: if the child exits cleanly before the timer fires,
+        _on_timeout should bail out without setting timed_out[hit] and the
+        run should return a success result, not a bogus timeout."""
+        runner = SkillRunner(project_dir="/tmp", timeout=5, claude_bin="claude")
+        fake = make_fake_skill_stream("done", input_tokens=1, output_tokens=2)
+        # Simulate "child already exited" by pre-killing the fake. poll()
+        # will return a non-None returncode so _on_timeout early-returns.
+        fake._killed = True
+        fake.returncode = 0
+
+        class _ImmediateTimer:
+            def __init__(self, interval, function, args=None, kwargs=None):
+                self.function = function
+                self.daemon = True
+
+            def start(self):
+                self.function()
+
+            def cancel(self):
+                pass
+
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            patch("clauditor.runner.threading.Timer", _ImmediateTimer),
+        ):
+            result = runner.run("skill")
+        # _on_timeout was called but returned early (poll() was not None);
+        # the run completes normally and we get a success result, not a
+        # false timeout.
+        assert result.error != "timeout"
+        assert result.output == "done"
 
     def test_file_not_found_sets_duration(self):
         """DEC-005: duration must be set even on FileNotFoundError."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -517,3 +517,322 @@ class TestStreamJsonRunner:
         assert len(result.raw_messages) == 3
         types = [m.get("type") for m in result.raw_messages]
         assert types == ["assistant", "system", "result"]
+
+
+class TestStreamJsonDefensiveBranches:
+    """Cover defensive branches added in #21 so codecov/patch is green."""
+
+    def test_non_dict_json_line_is_skipped(self):
+        """runner.py:258 — JSON scalar/array lines are not stream-json
+        messages; skip without crashing."""
+        lines = [
+            "123",  # bare scalar
+            "[1, 2, 3]",  # bare array
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "survived"}]
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 1, "output_tokens": 2},
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=_FakePopen(lines),
+        ):
+            result = runner.run("skill")
+        assert result.output == "survived"
+        assert result.input_tokens == 1
+
+    def test_assistant_content_non_list_is_skipped(self):
+        """runner.py:266 — assistant message with non-list content."""
+        lines = [
+            json.dumps(
+                {"type": "assistant", "message": {"content": "oops string"}}
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "real one"}]
+                    },
+                }
+            ),
+            json.dumps({"type": "result", "usage": {}}),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=_FakePopen(lines),
+        ):
+            result = runner.run("skill")
+        assert result.output == "real one"
+
+    def test_usage_input_tokens_non_numeric_defaults_to_zero(self):
+        """runner.py:283-284 — ValueError on int() cast for input_tokens."""
+        lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hi"}]},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": "bogus", "output_tokens": 50},
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=_FakePopen(lines),
+        ):
+            result = runner.run("skill")
+        assert result.input_tokens == 0
+        assert result.output_tokens == 50
+
+    def test_usage_output_tokens_non_numeric_defaults_to_zero(self):
+        """runner.py:289-290 — ValueError on int() cast for output_tokens."""
+        lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hi"}]},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 10, "output_tokens": {"not": "int"}},
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=_FakePopen(lines),
+        ):
+            result = runner.run("skill")
+        assert result.input_tokens == 10
+        assert result.output_tokens == 0
+
+    def test_stderr_drain_collects_chunks(self):
+        """runner.py:211 — stderr chunks are accumulated by the drain thread."""
+        fake = make_fake_skill_stream("ok")
+        fake.stderr = iter(["warning: something\n", "more diagnostic\n"])
+        # Return a nonzero exit code so stderr is surfaced in result.error.
+        fake.returncode = 1
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen", return_value=fake
+        ):
+            result = runner.run("skill")
+        assert "warning: something" in (result.error or "")
+        assert "more diagnostic" in (result.error or "")
+
+    def test_stderr_drain_exception_is_swallowed(self):
+        """runner.py:212-213 — exception while iterating stderr must not
+        crash the run. Replace _FakePopen.stderr with a raising iterator."""
+
+        class _RaisingIter:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise RuntimeError("stderr blew up")
+
+        fake = make_fake_skill_stream("ok")
+        fake.stderr = _RaisingIter()
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen", return_value=fake
+        ):
+            result = runner.run("skill")
+        # The run completed successfully despite the stderr drain exception.
+        assert result.output == "ok"
+        assert result.exit_code == 0
+
+    def test_outer_finally_reaps_leaked_subprocess(self):
+        """runner.py:338-345, 353-354 — if an unexpected exception escapes
+        the inner try, the outer finally must terminate/kill/close the
+        child so no process leaks."""
+        fake = make_fake_skill_stream("ok")
+        # Force the wait step to raise an unexpected exception.
+        original_wait = fake.wait
+        call_count = {"n": 0}
+
+        def _explode_once(timeout=None):  # noqa: ARG001
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("boom inside parsing")
+            return original_wait(timeout=timeout)
+
+        fake.wait = _explode_once
+        # Track whether terminate + close were called.
+        fake.terminate_called = False
+
+        def _terminate():
+            fake.terminate_called = True
+            fake._killed = True
+            fake.returncode = -15
+
+        fake.terminate = _terminate
+
+        stdout_closed = {"hit": False}
+        original_stdout = fake.stdout
+
+        def _close_stdout():
+            stdout_closed["hit"] = True
+            original_stdout.close()
+
+        fake.stdout.close = _close_stdout
+
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            runner.run("skill")
+        # Defensive cleanup fired: terminate was called and stdout closed.
+        assert fake.terminate_called is True
+        assert stdout_closed["hit"] is True
+
+    def test_blank_lines_in_stream_are_skipped(self):
+        """runner.py:245 — blank lines between NDJSON messages are ignored."""
+        lines = [
+            "",
+            "   ",
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hi"}]},
+                }
+            ),
+            "",
+            json.dumps(
+                {
+                    "type": "result",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                }
+            ),
+        ]
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor.runner.subprocess.Popen",
+            return_value=_FakePopen(lines),
+        ):
+            result = runner.run("skill")
+        assert result.output == "hi"
+        assert result.input_tokens == 1
+
+    def test_cleanup_terminate_succeeds_but_wait_raises(self):
+        """runner.py:340-345 — terminate() succeeds but proc.wait(timeout=1)
+        raises, so the kill() + wait() fallback runs."""
+        fake = make_fake_skill_stream("ok")
+
+        call_log = {"terminate": 0, "kill": 0, "wait_during_cleanup": 0}
+
+        def _boom_wait(timeout=None):
+            # The first wait (in the read loop) raises the real error.
+            # Subsequent waits are from cleanup — the first cleanup wait
+            # raises TimeoutExpired so kill() runs; the second succeeds.
+            call_log["wait_during_cleanup"] += 1
+            if call_log["wait_during_cleanup"] == 1:
+                raise RuntimeError("parse failure")
+            if call_log["wait_during_cleanup"] == 2:
+                # terminate() was called, but cleanup wait times out.
+                raise RuntimeError("cleanup wait timeout")
+            return 0
+
+        fake.wait = _boom_wait
+
+        def _terminate():
+            call_log["terminate"] += 1
+            fake._killed = False  # still alive after terminate
+
+        def _kill():
+            call_log["kill"] += 1
+            fake._killed = True
+
+        fake.terminate = _terminate
+        fake.kill = _kill
+
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            pytest.raises(RuntimeError, match="parse failure"),
+        ):
+            runner.run("skill")
+        assert call_log["terminate"] == 1
+        assert call_log["kill"] == 1  # kill fallback ran after terminate-wait raised
+
+    def test_cleanup_wait_after_kill_also_raises(self):
+        """runner.py:344-345 — kill() + wait(timeout=1) cascade: if the
+        wait AFTER kill also raises, the innermost except swallows it
+        and the original exception still propagates."""
+        fake = make_fake_skill_stream("ok")
+
+        cleanup_wait_calls = {"n": 0}
+
+        def _always_boom_wait(timeout=None):  # noqa: ARG001
+            # First call = main run's wait in the read loop
+            if cleanup_wait_calls["n"] == 0:
+                cleanup_wait_calls["n"] = 1
+                raise RuntimeError("parse failure")
+            # Every subsequent call (cleanup waits) also raises
+            cleanup_wait_calls["n"] += 1
+            raise RuntimeError(f"cleanup wait #{cleanup_wait_calls['n']} boom")
+
+        fake.wait = _always_boom_wait
+        # Don't let terminate mark the child as dead, so cleanup proceeds.
+        fake.terminate = lambda: None
+        fake.kill = lambda: None
+
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            pytest.raises(RuntimeError, match="parse failure"),
+        ):
+            runner.run("skill")
+        # Three wait() calls total: main loop + after terminate + after kill.
+        assert cleanup_wait_calls["n"] >= 3
+
+    def test_cleanup_terminate_exception_is_swallowed(self):
+        """runner.py:340-347 — if terminate() itself raises, the kill
+        fallback still runs and the run's exception propagates."""
+        fake = make_fake_skill_stream("ok")
+
+        def _boom_wait(timeout=None):  # noqa: ARG001
+            raise RuntimeError("parse failure")
+
+        fake.wait = _boom_wait
+
+        def _terminate_raises():
+            raise RuntimeError("terminate failed")
+
+        fake.terminate = _terminate_raises
+        kill_called = {"hit": False}
+
+        def _kill():
+            kill_called["hit"] = True
+
+        fake.kill = _kill
+
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with (
+            patch("clauditor.runner.subprocess.Popen", return_value=fake),
+            pytest.raises(RuntimeError, match="parse failure"),
+        ):
+            runner.run("skill")
+        # terminate raised, but the outer handler swallowed it; the
+        # original RuntimeError from wait still propagated.

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -66,7 +66,7 @@ def _mock_client(response_text: str) -> AsyncMock:
     client = AsyncMock()
     mock_content = MagicMock()
     mock_content.text = response_text
-    mock_response = MagicMock()
+    mock_response = MagicMock(usage=MagicMock(input_tokens=500, output_tokens=200))
     mock_response.content = [mock_content]
     client.messages.create = AsyncMock(return_value=mock_response)
     return client
@@ -281,6 +281,17 @@ class TestClassifyQuery:
         assert result.confidence == 0.0
 
     @pytest.mark.asyncio
+    async def test_captures_token_usage(self):
+        client = _mock_client(
+            '{"triggered": true, "confidence": 0.9, "reasoning": "ok"}'
+        )
+        result = await classify_query(
+            "skill", "desc", "query", True, client, "test-model"
+        )
+        assert result.input_tokens == 500
+        assert result.output_tokens == 200
+
+    @pytest.mark.asyncio
     async def test_calls_client_with_correct_model(self):
         client = _mock_client(
             '{"triggered": true, "confidence": 0.9, "reasoning": "ok"}'
@@ -332,6 +343,26 @@ class TestTestTriggers:
         report = await run_test_triggers(spec, model="test-model")
         assert len(report.results) == 3
         assert report.model == "test-model"
+
+    @pytest.mark.asyncio
+    async def test_aggregates_token_usage(self, monkeypatch):
+        """TriggerReport sums tokens across all classify_query calls."""
+        spec = _make_eval_spec(
+            should_trigger=["a", "b"],
+            should_not_trigger=["c"],
+        )
+        mock_client = _mock_client(
+            '{"triggered": true, "confidence": 0.9, "reasoning": "yes"}'
+        )
+        mock_cls = MagicMock(return_value=mock_client)
+        import anthropic
+
+        monkeypatch.setattr(anthropic, "AsyncAnthropic", mock_cls)
+
+        report = await run_test_triggers(spec)
+        # 3 queries × 500/200 per mock
+        assert report.input_tokens == 1500
+        assert report.output_tokens == 600
 
     @pytest.mark.asyncio
     async def test_parallel_execution(self, monkeypatch):


### PR DESCRIPTION
## Summary
Super plan for #21 — Capture timing and token usage per skill run so `clauditor trend` can render real efficiency metrics.

**Phase:** detailing (awaiting approval)
**Stories:** 6 implementation stories + Quality Gate + Patterns & Memory
**Decisions:** 16 decisions captured (DEC-001 through DEC-016)

## Scope
Wire timing + tokens through to both `.grade.json` (per-run detail) and `.clauditor/history.jsonl` (longitudinal), following the agentskills.io eval spec. Pre-production — breaking changes OK.

**Big moves:**
- `runner.run()` switches to `subprocess.Popen` with `claude -p --output-format stream-json --verbose` for true line-at-a-time streaming (prereq for #24 transcripts)
- `SkillResult.output` becomes the concatenation of assistant-message text blocks (not raw stdout)
- Token buckets: \`skill\`, \`grader\`, \`quality\`, \`triggers\` — each with \`{input_tokens, output_tokens}\`
- All three commands (\`grade\`, \`extract\`, \`validate\`) record history with a \`command\` discriminator
- \`cmd_trend\` grows dotted-path metric resolution, \`--command\` filter, \`--list-metrics\`
- History schema version bumped to 2 (old rows transparently skipped for v2-only keys)

**Deferred (intentional):** separate \`timing.json\` file — punted to #22 where it naturally fits into per-iteration workspace dirs. Avoids a temporary path convention.

## Plan document
See \`plans/super/21-timing-tokens.md\` for the full plan.

## Next steps
- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)