### PR TITLE
#22: Per-iteration workspace layout for eval runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ the count failure and any per-entry failures.
 ## Migration notes
 
 - **`clauditor grade --save` has been removed.** Every `grade` run is now persisted to `.clauditor/iteration-N/<skill>/` automatically. Drop `--save` from scripts and CI; use `--iteration N` / `--force` if you need to target a specific slot.
-- **Legacy `.clauditor/<skill>.grade.json` files are ignored.** The canonical grade report is `.clauditor/iteration-N/<skill>/grading.json`. Old files on disk are left alone but no longer read by `compare` or `trend`.
+- **Legacy `.clauditor/<skill>.grade.json` files are ignored by auto-discovery.** The canonical grade report is `.clauditor/iteration-N/<skill>/grading.json`, and `grade --diff` / `cmd_trend` only look at the new layout. You can still pass a legacy `.grade.json` explicitly to `clauditor compare` (e.g. `compare old.grade.json new.grade.json`), but clauditor no longer writes that format.
 - **`history.jsonl` is now schema v3** with `iteration` and `workspace_path` fields on `grade` records. Mixed v2/v3 files continue to load.
 - **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ clauditor implements (and in places extends) the skill evaluation workflow descr
 | Rubric quality grading | **Layer 3** — `quality_grader.py`, per-criterion scoring + variance measurement |
 | With-skill vs without-skill baseline | `compare_ab()` Python API (`clauditor.comparator`) |
 | Regression diff between runs | `clauditor compare <before> <after>` |
-| Timing + token capture | `SkillResult.input_tokens/output_tokens/duration_seconds`, persisted to `history.jsonl` and `.grade.json` under nested bucket keys (`skill`, `grader`, `quality`, `triggers`, `total`) |
-| Longitudinal history | `.clauditor/history.jsonl` schema v2 + `clauditor trend --metric <dotted.path>` with ASCII sparklines |
+| Timing + token capture | `SkillResult.input_tokens/output_tokens/duration_seconds`, persisted to `history.jsonl` and `.clauditor/iteration-N/<skill>/grading.json` under nested bucket keys (`skill`, `grader`, `quality`, `triggers`, `total`) |
+| Longitudinal history | `.clauditor/history.jsonl` schema v3 + `clauditor trend --metric <dotted.path>` with ASCII sparklines |
+| Per-iteration workspace | `.clauditor/iteration-N/<skill>/` with `grading.json`, `timing.json`, and `run-*/output.{txt,jsonl}` captures |
 
 **Beyond the spec**, clauditor adds: trigger precision testing (`triggers.py`), a strict/extract `FORMAT_REGISTRY` invariant for canonical types, tiered section extraction (top-3 restaurants require more fields than the next 7), a reusable pytest plugin, and an `AssertionResult.kind` enum for programmatic filtering.
 
-**Deliberately out of scope**: per-iteration workspace dirs, automated with/without pair runs, blind A/B judges, human-feedback capture, and LLM-driven skill improvement proposers. These are tracked as follow-up issues (#22–#27).
+**Deliberately out of scope**: automated with/without pair runs, blind A/B judges, human-feedback capture, and LLM-driven skill improvement proposers. These are tracked as follow-up issues (#23–#27).
 
 ## Install
 
@@ -231,19 +232,56 @@ Define rubric criteria in your eval spec:
 ```bash
 clauditor grade .claude/commands/my-skill.md
 clauditor grade .claude/commands/my-skill.md --json
-clauditor grade .claude/commands/my-skill.md --dry-run   # Print prompt, no API call
-clauditor grade .claude/commands/my-skill.md --save       # Persist results to .clauditor/
-clauditor grade .claude/commands/my-skill.md --diff       # Compare against prior saved results
+clauditor grade .claude/commands/my-skill.md --dry-run      # Print prompt, no API call
+clauditor grade .claude/commands/my-skill.md --iteration 5  # Write to iteration-5/ explicitly
+clauditor grade .claude/commands/my-skill.md --iteration 5 --force  # Overwrite existing iteration-5/
+clauditor grade .claude/commands/my-skill.md --diff         # Compare against prior iteration
 ```
 
-Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--save` to persist results for regression tracking, and `--diff` to compare against a prior run (flags regressions where a criterion's score drops by more than 0.1).
+Every `grade` run is persisted to `.clauditor/iteration-N/<skill>/` — there is no opt-in `--save`. By default the iteration number auto-increments to the next free slot. Pass `--iteration N` to target a specific slot; if `iteration-N/` already exists the command errors unless you also pass `--force` to overwrite.
+
+Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--diff` to compare against a prior iteration (flags regressions where a criterion's score drops by more than 0.1).
+
+#### Iteration workspace layout
+
+`.clauditor/` is anchored at the repository root (the nearest ancestor of your CWD containing `.git/` or `.claude/`), so `grade` from any subdirectory writes to the same place. Each run produces:
+
+```
+.clauditor/
+  iteration-1/
+    my-skill/
+      grading.json        # full GradingReport
+      timing.json         # skill name, iteration, n_runs, token + duration metrics
+      run-0/
+        output.txt        # rendered text blocks
+        output.jsonl      # raw stream-json events
+  iteration-2/
+    my-skill/
+      grading.json
+      timing.json
+      run-0/
+        output.txt
+        output.jsonl
+      run-1/              # additional runs appear under --variance N
+        output.txt
+        output.jsonl
+  history.jsonl
+```
 
 #### Regression Comparison
 
-Diffs two saved grade reports (from `--save`) or two captured outputs, printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression.
+Diffs two grade reports, printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression. `compare` accepts three input forms:
 
 ```bash
+# 1. Numeric iteration refs (preferred — pairs with auto-incremented iterations)
+clauditor compare --skill my-skill --from 1 --to 2
+
+# 2. Iteration directory paths
+clauditor compare .clauditor/iteration-1/my-skill .clauditor/iteration-2/my-skill
+
+# 3. Legacy grade-report files
 clauditor compare before.grade.json after.grade.json
+
 # Or re-grade two raw captures against a spec:
 clauditor compare before.txt after.txt --spec <skill.md>
 ```
@@ -336,12 +374,15 @@ clauditor validate <skill.md> --json   # JSON output for CI
 clauditor run <skill-name> --args "…"  # Run skill, print output
 clauditor extract <skill.md>           # Layer 2 schema extraction
 clauditor extract <skill.md> --dry-run # Print extraction prompt only
-clauditor grade <skill.md>             # Layer 3 quality grading
-clauditor grade <skill.md> --variance 3  # Variance measurement
-clauditor grade <skill.md> --only-criterion clarity  # Run a subset (repeatable, substring match)
-clauditor grade <skill.md> --save      # Persist results to .clauditor/
-clauditor grade <skill.md> --diff      # Compare against prior results
-clauditor compare before.grade.json after.grade.json  # Diff two saved grade reports
+clauditor grade <skill.md>                             # Layer 3 quality grading (auto-increments iteration)
+clauditor grade <skill.md> --variance 3                # Variance measurement
+clauditor grade <skill.md> --only-criterion clarity    # Run a subset (repeatable, substring match)
+clauditor grade <skill.md> --iteration 5               # Write to .clauditor/iteration-5/<skill>/
+clauditor grade <skill.md> --iteration 5 --force       # Overwrite an existing iteration-5/
+clauditor grade <skill.md> --diff                      # Compare against prior iteration
+clauditor compare --skill <skill> --from 1 --to 2      # Diff two iterations by number
+clauditor compare .clauditor/iteration-1/<skill> .clauditor/iteration-2/<skill>  # Diff by directory
+clauditor compare before.grade.json after.grade.json   # Diff two legacy grade reports
 clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
 clauditor trend <skill> --metric total.total     # Tab-separated history + ASCII sparkline
 clauditor trend <skill> --list-metrics           # List available metric paths
@@ -353,14 +394,16 @@ clauditor doctor                       # Report environment diagnostics
 
 ### Persistent metric history
 
-Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Records are schema v2 with a `command` discriminator and a nested `metrics` dict:
+Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Records are schema v3 with a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`. Legacy v2 records still read cleanly.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "command": "grade",
   "ts": "2026-04-13T15:00:00+00:00",
   "skill": "find-restaurants",
+  "iteration": 4,
+  "workspace_path": ".clauditor/iteration-4/find-restaurants",
   "pass_rate": 0.83,
   "mean_score": 0.75,
   "metrics": {
@@ -521,6 +564,13 @@ the count failure and any per-entry failures.
 > `FieldRequirement` has been removed. Migrate by renaming `pattern` to
 > `format` — inline regexes work as before; registered names are now the
 > preferred ergonomics.
+
+## Migration notes
+
+- **`clauditor grade --save` has been removed.** Every `grade` run is now persisted to `.clauditor/iteration-N/<skill>/` automatically. Drop `--save` from scripts and CI; use `--iteration N` / `--force` if you need to target a specific slot.
+- **Legacy `.clauditor/<skill>.grade.json` files are ignored.** The canonical grade report is `.clauditor/iteration-N/<skill>/grading.json`. Old files on disk are left alone but no longer read by `compare` or `trend`.
+- **`history.jsonl` is now schema v3** with `iteration` and `workspace_path` fields on `grade` records. Mixed v2/v3 files continue to load.
+- **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
 
 ## License
 

--- a/plans/super/22-iteration-workspace.md
+++ b/plans/super/22-iteration-workspace.md
@@ -9,8 +9,8 @@ sessions: 1
 
 ## Meta
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/22
-- **Phase:** discovery (complete) → architecture (next)
-- **Branch:** dev (no worktree yet — pre-PR planning on dev)
+- **Phase:** devolved (all stories merged; Quality Gate + Patterns & Memory complete)
+- **Branch:** feature/22-iteration-workspace
 
 ## Context
 

--- a/plans/super/22-iteration-workspace.md
+++ b/plans/super/22-iteration-workspace.md
@@ -1,0 +1,216 @@
+---
+ticket: 22
+title: Per-iteration workspace layout for eval runs
+phase: detailing
+sessions: 1
+---
+
+# 22 — Per-iteration workspace layout for eval runs
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/22
+- **Phase:** discovery (complete) → architecture (next)
+- **Branch:** dev (no worktree yet — pre-PR planning on dev)
+
+## Context
+
+Today `clauditor grade <skill>` writes a single `.clauditor/<skill>.grade.json`, overwritten each run. Skill stdout lives only in memory. We want each run preserved as `iteration-N/` so users can re-inspect, re-grade, and root-cause regressions.
+
+## Discovery findings
+
+- `cmd_grade` (cli.py:130–363) writes `.clauditor/<skill>.grade.json` under `--save`, overwrites each run.
+- Skill stdout is in-memory only (`SkillResult.output`, runner.py:55) — never persisted today.
+- Timing/tokens (#21) already embedded in `.grade.json` and `history.jsonl` — no separate `timing.json` exists.
+- `clauditor compare` reads `.txt` or `.grade.json` via `_load_assertion_set` (cli.py:366–405, comparator.py).
+- `history.jsonl` schema v2: `{schema_version, command, ts, skill, pass_rate, mean_score, metrics}`.
+- README flags per-iteration workspace as deliberately out of scope until #22.
+- No `.claude/rules/`, no `workflow-project.md`, pre-production (no backwards-compat constraint).
+
+## Scoping decisions (Phase 1)
+
+- **DEC-001 — Iteration numbering:** Hybrid. Auto-increment by default (scan `.clauditor/iteration-*`, pick max+1); `--iteration N` overrides. Rationale: ergonomic default, explicit escape hatch.
+- **DEC-002 — `--save` flag:** Remove it. Every `grade` run writes `iteration-N/` and appends to `history.jsonl`. Rationale: pre-production, no users to break; the point of #22 is "stop losing runs." Add `--no-save` later if clutter appears.
+- **DEC-003 — Directory layout:** Simplified. `.clauditor/iteration-N/<skill>/{output.txt, grading.json, timing.json}`. No with/without split (that's #23). Rationale: matches today's single-run model; extensible for #23.
+- **DEC-004 — `compare` inputs:** Dual mode. Accept iteration dirs (`compare .clauditor/iteration-1 .clauditor/iteration-2`) OR short numeric refs (`compare --skill foo 1 2`). Rationale: dirs for explicit cross-skill use; numbers for common same-skill case.
+- **DEC-005 — history.jsonl iteration field:** Add `iteration: N` and `workspace_path: ".clauditor/iteration-N/<skill>"`. Bump to schema v3. Rationale: trend queries can link back to raw artifacts.
+
+## Architecture Review (Phase 2)
+
+| Area | Rating | Finding |
+|---|---|---|
+| Concurrent grade runs | blocker→resolved | TOCTOU on auto-increment; history.jsonl append not atomic. Fix: DEC-006. |
+| `compare` numeric refs | blocker→resolved | `compare` positional args parse as paths. Fix: DEC-007. |
+| Partial writes | concern→resolved | 3-file sequence non-atomic. Fix: DEC-012 (tmp+rename). |
+| `--iteration N` collision | concern→resolved | DEC-008 (error + `--force`). |
+| Path resolution (CWD-relative) | concern→resolved | DEC-009 (walk-up repo root). |
+| history.jsonl v2→v3 | concern→resolved | DEC-013 (graceful mixed readback). |
+| Disk usage | pass | `SkillResult.output` already in memory. |
+| Other commands (trend/doctor/extract/init/pytest_plugin) | pass | None read `.grade.json`. |
+| Variance semantics | resolved | DEC-011 (per-run subdirs + aggregated grading.json). |
+| Tests | concern | ~21 refs in test_cli.py, ~4 methods to rewrite, ~8–10 new cases. |
+
+## Refinement Log (Phase 3)
+
+### Decisions
+
+- **DEC-001 — Iteration numbering.** Auto-increment by default (scan `.clauditor/iteration-*`, pick max+1); `--iteration N` overrides. _Phase 1._
+- **DEC-002 — Remove `--save` flag.** Every `grade` run persists. Pre-production; the point of #22 is "stop losing runs." _Phase 1._
+- **DEC-003 — Workspace layout.** `.clauditor/iteration-N/<skill>/` containing aggregated `grading.json` + `timing.json` at the skill level, and `run-K/{output.txt, output.jsonl}` per variance run. Single-run grade still uses `run-0/` for consistency. _Phase 1 + Q11._
+- **DEC-004 — `compare` inputs.** Dual: file or directory paths (auto-detected), OR `--skill foo --from N --to M` for same-skill numeric refs. _Phase 1 + Q7._
+- **DEC-005 — history.jsonl schema v3.** Add `iteration` and `workspace_path` fields. _Phase 1._
+- **DEC-006 — Concurrency (Q6=A).** Optimistic atomic `mkdir(iteration-N)`, catch `FileExistsError`, retry with N+1. Wrap `history.append_record()` in `fcntl.flock` on `.clauditor/.lock`. No global lock on the grade run.
+- **DEC-007 — `compare` shape (Q7=A).** Auto-detect: if positional arg is a dir, read `grading.json` from within; if file, current behavior. Alternate form: `--skill foo --from N --to M`. No new subcommand.
+- **DEC-008 — Collision policy (Q8).** `--iteration N` where `iteration-N/` exists → hard error with message "iteration-N already exists; use --force to overwrite". `--force` required to replace.
+- **DEC-009 — Repo-root resolution (Q9).** Walk up from CWD looking for `.git/` or `.claude/`; use the first match as repo root. Anchor `.clauditor/` there. If neither found, fall back to CWD with a warning.
+- **DEC-010 — Output artifacts (Q10=C).** Write both `output.txt` (rendered text blocks — what `SkillResult.output` already produces) and `output.jsonl` (raw stream-json events, one JSON object per line).
+- **DEC-011 — Variance layout (Q11=C).** Each variance run gets its own `run-K/` subdir with `output.txt` + `output.jsonl`. Aggregated `grading.json` + `timing.json` sit at `iteration-N/<skill>/` level. Single-run grade uses `run-0/` (always, for consistency).
+- **DEC-012 — Atomic writes (Q12=B).** Write to `iteration-N-tmp/` (repo-root-relative), atomic `rename()` to `iteration-N/` on success. On exception: `shutil.rmtree` the tmp dir.
+- **DEC-013 — Schema bump (Q13=A).** `SCHEMA_VERSION = 3`. `history.read_records()` tolerates v2 records (missing `iteration`/`workspace_path` → None). `cmd_trend` gets an explicit `rec.get("schema_version", 2)` guard before touching new fields.
+- **DEC-014 — `--force` semantics (Q14=A).** `--force` does `shutil.rmtree(iteration-N)` first, then writes fresh. Clean slate; no mixed state from prior run.
+- **DEC-015 — Legacy `.grade.json` (Q15=A).** Ignore existing `.clauditor/<skill>.grade.json`. Not deleted, not migrated. Users can clean manually. Pre-production, low-friction.
+
+### Implications for runner.py
+
+- **DEC-010 requires capturing raw stream-json.** Today `SkillResult.output` is only the concatenated text; the raw events are parsed and discarded. US-003 adds a field (e.g. `stream_events: list[dict]`) populated during stream parsing.
+
+## Detailed Breakdown (Phase 4)
+
+### US-001 — Repo-root detection helper
+- **Description:** Add a `resolve_clauditor_dir()` utility that walks up from CWD looking for `.git/` or `.claude/` and returns `<repo_root>/.clauditor`. Falls back to `Path.cwd() / ".clauditor"` with a single-line warning when neither marker is found.
+- **Traces to:** DEC-009
+- **Files:** `src/clauditor/paths.py` (new, ~40 LOC), `src/clauditor/cli.py` (replace `Path(".clauditor")` call sites), `src/clauditor/history.py` (use helper for default path)
+- **Acceptance:**
+  - `resolve_clauditor_dir()` returns the same path whether invoked from repo root or a nested subdir of a repo
+  - Fallback path triggered only when no `.git`/`.claude` ancestor exists
+  - `uv run pytest tests/test_paths.py -v` passes
+  - `uv run ruff check src/ tests/` clean
+- **Done when:** `cli.py` and `history.py` no longer contain `Path(".clauditor")` literals
+- **Depends on:** none
+- **TDD:**
+  - `test_resolve_from_repo_root` — CWD = repo root with `.git/` → returns `<root>/.clauditor`
+  - `test_resolve_from_nested_subdir` — CWD = deep subdir → still returns `<root>/.clauditor`
+  - `test_resolve_with_claude_only` — `.claude/` but no `.git/` still anchors root
+  - `test_resolve_no_markers_fallback` — emits warning, returns `cwd/.clauditor`
+
+### US-002 — Iteration workspace allocator
+- **Description:** Pure library module (`workspace.py`) that given a clauditor dir, skill name, and optional explicit iteration, allocates an iteration slot: scans existing `iteration-*` dirs, picks `max+1` or honors `--iteration`, handles `FileExistsError` retry (DEC-006), creates the `iteration-N-tmp/<skill>/` staging path, and returns an object with `finalize()` (atomic rename per DEC-012) and `abort()` (rmtree tmp).
+- **Traces to:** DEC-001, DEC-006, DEC-008, DEC-012, DEC-014
+- **Files:** `src/clauditor/workspace.py` (new, ~120 LOC), `tests/test_workspace.py` (new)
+- **Acceptance:**
+  - Auto-increment handles gaps (iteration-1, -3 present → N=4)
+  - Concurrent allocation via threaded test: two allocators never return the same N
+  - `--iteration 5` when `iteration-5/` exists raises `IterationExistsError` with clear message
+  - `--iteration 5 --force` removes existing `iteration-5/` (rmtree) before allocation
+  - Crash between allocation and finalize leaves no `iteration-N/` — only an orphan `iteration-N-tmp/` that a future run can safely ignore
+  - `abort()` removes the tmp dir cleanly
+- **Done when:** `test_workspace.py` covers all 6 cases; 80% branch coverage for the module
+- **Depends on:** US-001
+- **TDD:**
+  - `test_auto_increment_empty` (N=1)
+  - `test_auto_increment_with_gaps` (N jumps over gaps)
+  - `test_explicit_iteration_no_collision`
+  - `test_explicit_iteration_collision_raises`
+  - `test_force_replaces_existing`
+  - `test_concurrent_allocation_threaded` (2 threads, distinct N values)
+  - `test_finalize_atomic_rename`
+  - `test_abort_removes_tmp`
+
+### US-003 — Runner captures raw stream events
+- **Description:** Extend `SkillResult` with a `stream_events: list[dict]` field populated by `runner.py` during stream-json parsing. Every `{"type": ...}` object from the CLI's stream-json output is appended. Preserves existing `output` field (rendered text blocks) unchanged.
+- **Traces to:** DEC-010
+- **Files:** `src/clauditor/runner.py` (add field + populate in stream parser), `src/clauditor/schemas.py` (if `SkillResult` lives there — check), `tests/test_runner.py` (extend existing tests)
+- **Acceptance:**
+  - `SkillResult.output` unchanged from pre-story behavior
+  - `SkillResult.stream_events` contains every JSON object emitted on stdout, in order
+  - Non-JSON lines in stdout are ignored (not crashed on)
+  - Existing runner tests still pass unchanged
+- **Done when:** New field is populated and a new test asserts round-trip of a captured stream
+- **Depends on:** none (independent)
+- **TDD:**
+  - `test_stream_events_populated` — mock subprocess emits 3 JSON lines; field has 3 dicts
+  - `test_stream_events_skips_non_json` — garbage line between JSON objects doesn't crash
+  - `test_output_field_still_renders_text_blocks` — no regression
+
+### US-004 — Rewrite `cmd_grade` for iteration workspace
+- **Description:** Replace `--save`-gated single-file write with always-on iteration workspace. Remove `--save` flag. Add `--iteration N` and `--force`. Wire variance to per-run subdirs. Uses `workspace.py` allocator and writes `run-K/output.txt`, `run-K/output.jsonl`, aggregated `grading.json`, and aggregated `timing.json`. Single grade run uses `run-0/`. Prints iteration path on completion.
+- **Traces to:** DEC-002, DEC-003, DEC-010, DEC-011, DEC-012, DEC-014
+- **Files:** `src/clauditor/cli.py` (cmd_grade 130–363, argparse 457–579), `src/clauditor/quality_grader.py` (if `GradingReport.to_json()` needs a `timing.json`-only split), `tests/test_cli.py` (rewrite `TestCmdGradeSaveDiff`, `TestCmdGrade`, `TestCmdGradeHistory`)
+- **Acceptance:**
+  - `clauditor grade foo` with no flags writes `.clauditor/iteration-1/foo/{grading.json,timing.json,run-0/output.txt,run-0/output.jsonl}`
+  - Second invocation writes `iteration-2/`
+  - `--iteration 5` creates `iteration-5/`; re-running without `--force` errors
+  - `--iteration 5 --force` overwrites (clean slate)
+  - `--variance 3` writes `run-0/`, `run-1/`, `run-2/` under one iteration dir
+  - `--save` flag removed (argparse rejects it)
+  - Crash mid-grade leaves no `iteration-N/` (only an orphan tmp dir)
+  - `uv run ruff check src/ tests/` clean
+  - `uv run pytest --cov=clauditor --cov-report=term-missing` ≥80% and passes
+- **Done when:** Grade command writes the new layout; `--save` is gone; all updated tests green
+- **Depends on:** US-001, US-002, US-003
+- **TDD:**
+  - `test_grade_writes_iteration_one_when_empty`
+  - `test_grade_auto_increments_across_runs`
+  - `test_grade_iteration_explicit_collision_errors`
+  - `test_grade_iteration_force_overwrites`
+  - `test_grade_variance_produces_run_subdirs`
+  - `test_grade_save_flag_removed` (argparse rejects)
+  - `test_grade_crash_leaves_no_iteration_dir` (exception between allocate and finalize)
+
+### US-005 — history.jsonl schema v3
+- **Description:** Bump `SCHEMA_VERSION = 3` in `history.py`. Extend `append_record()` signature with `iteration: int` and `workspace_path: str` parameters. Add `fcntl.flock` on `.clauditor/.lock` around the append (DEC-006). Update `read_records()` to tolerate v2 records (missing new fields → None). Add explicit `schema_version` guard in `cmd_trend` before accessing new fields.
+- **Traces to:** DEC-005, DEC-006, DEC-013
+- **Files:** `src/clauditor/history.py` (schema, append_record, read_records, lock), `src/clauditor/cli.py` (cmd_grade passes new fields; cmd_trend guards), `tests/test_history.py`, `tests/test_cli.py` (trend tests)
+- **Acceptance:**
+  - New records written with `schema_version: 3` and include `iteration` + `workspace_path`
+  - Reading a file with mixed v2/v3 records returns all of them without error
+  - `cmd_trend` renders sparklines over mixed history without crashing
+  - Concurrent `append_record()` from two processes produces two well-formed lines (no interleaving)
+- **Done when:** Mixed-schema fixture file reads cleanly; concurrent append test passes
+- **Depends on:** US-002 (needs `workspace_path` from allocator)
+- **TDD:**
+  - `test_append_v3_record_shape`
+  - `test_read_mixed_v2_v3_records`
+  - `test_trend_over_mixed_schema`
+  - `test_concurrent_append_no_interleave` (2 processes via `multiprocessing`)
+
+### US-006 — `compare` auto-detects iteration dirs
+- **Description:** Rewrite `_load_assertion_set()` (cli.py:366–405) so that positional args to `compare` can be iteration dirs: if the path is a directory, resolve to `<dir>/grading.json`. Existing `.txt`/`.grade.json` file support preserved. Add `--skill NAME --from N --to M` alternate form that resolves to `.clauditor/iteration-N/<skill>/` / `...-M/<skill>/`. Mutually exclusive with positional args.
+- **Traces to:** DEC-004, DEC-007
+- **Files:** `src/clauditor/cli.py` (cmd_compare subparser 993–1001; `_load_assertion_set`, `_file_kind`), `src/clauditor/comparator.py` (if any `.grade.json` assumptions leak there), `tests/test_cli.py` / `tests/test_comparator.py`
+- **Acceptance:**
+  - `compare .clauditor/iteration-1/foo .clauditor/iteration-2/foo` reads `grading.json` from each dir and diffs
+  - `compare --skill foo --from 1 --to 2` resolves to the same paths under the repo-root-anchored `.clauditor`
+  - Legacy `compare old.grade.json new.grade.json` still works unchanged
+  - Passing positional args AND `--skill/--from/--to` errors with clear message
+  - Missing `grading.json` inside a supplied dir errors with a clear "no grading.json found" message
+- **Done when:** Three compare modes (file, dir, numeric refs) all tested; legacy mode not regressed
+- **Depends on:** US-001 (repo-root), US-004 (iteration dirs exist to compare against)
+- **TDD:**
+  - `test_compare_two_iteration_dirs`
+  - `test_compare_numeric_refs`
+  - `test_compare_legacy_grade_json_files` (regression)
+  - `test_compare_positional_and_numeric_conflict_errors`
+  - `test_compare_dir_missing_grading_json_errors`
+
+### US-007 — Update README and docs
+- **Description:** Update `README.md` to remove the "deliberately out of scope: per-iteration workspace dirs" line, document the new layout with an example tree, show the two `compare` forms, and note the `--save` removal. Add a short section on iteration numbering and `--force`. No `docs/` deep-dive.
+- **Traces to:** DEC-002, DEC-003, DEC-004, DEC-007, DEC-008, DEC-014
+- **Files:** `README.md`
+- **Acceptance:**
+  - Example tree matches actual layout produced by US-004
+  - Both compare forms shown
+  - `--save` deprecation noted in changelog / breaking-changes section
+  - `uv run ruff check src/ tests/` still clean (no code changes, but sanity)
+- **Done when:** README reflects the new behavior; grep finds no stale references to `--save` or the old `.grade.json` path
+- **Depends on:** US-004, US-006
+
+### Quality Gate
+- **Description:** Run code reviewer 4 times over the full changeset. Fix every real bug found each pass. Run CodeRabbit if available. Run `uv run ruff check src/ tests/` and `uv run pytest --cov=clauditor --cov-report=term-missing` — both must pass with ≥80% coverage.
+- **Depends on:** US-001..US-007
+
+### Patterns & Memory
+- **Description:** Capture any patterns learned (e.g., repo-root resolution helper, workspace allocator idiom, atomic-write-via-tmp-dir pattern, schema-version guard pattern) in a short note. If a `.claude/rules/` directory is created for this project, add an entry; otherwise note in `bd remember`.
+- **Depends on:** Quality Gate
+
+## Beads Manifest
+_Populated at devolve time._

--- a/plans/super/22-iteration-workspace.md
+++ b/plans/super/22-iteration-workspace.md
@@ -1,7 +1,7 @@
 ---
 ticket: 22
 title: Per-iteration workspace layout for eval runs
-phase: detailing
+phase: devolved
 sessions: 1
 ---
 
@@ -213,4 +213,21 @@ Today `clauditor grade <skill>` writes a single `.clauditor/<skill>.grade.json`,
 - **Depends on:** Quality Gate
 
 ## Beads Manifest
-_Populated at devolve time._
+
+- **Epic:** `clauditor-yng` — #22: Per-iteration workspace layout for eval runs
+- **PR:** https://github.com/wjduenow/clauditor/pull/31
+- **Branch:** `feature/22-iteration-workspace`
+
+| Task | Story | Depends on |
+|---|---|---|
+| `clauditor-yng.1` | US-001 Repo-root detection helper | — |
+| `clauditor-yng.2` | US-002 Iteration workspace allocator | .1 |
+| `clauditor-yng.3` | US-003 Runner captures raw stream events | — |
+| `clauditor-yng.4` | US-004 Rewrite cmd_grade | .1, .2, .3 |
+| `clauditor-yng.5` | US-005 history.jsonl schema v3 | .2 |
+| `clauditor-yng.6` | US-006 compare auto-detect dirs | .1, .4 |
+| `clauditor-yng.7` | US-007 README update | .4, .6 |
+| `clauditor-yng.8` | Quality Gate | .4, .5, .6, .7 |
+| `clauditor-yng.9` | Patterns & Memory | .8 |
+
+Ready at devolve time: `.1`, `.3` (parallelizable immediately), plus the epic row.

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -238,6 +238,12 @@ def cmd_grade(args: argparse.Namespace) -> int:
     except IterationExistsError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
+    except InvalidSkillNameError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     try:
         return _cmd_grade_with_workspace(
@@ -247,6 +253,12 @@ def cmd_grade(args: argparse.Namespace) -> int:
             clauditor_dir=clauditor_dir,
             workspace=workspace,
         )
+    except IterationExistsError as exc:
+        # Raised by workspace.finalize() when a concurrent peer won the
+        # rename race. The staging dir has already been aborted inside
+        # finalize(); surface a clean error instead of a traceback.
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     finally:
         # workspace.finalized is set to True inside finalize(); any other
         # exit path (early return on skill failure, exception mid-write,
@@ -1280,11 +1292,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_grade.add_argument(
         "--iteration",
-        type=int,
+        type=_positive_int,
         default=None,
         metavar="N",
         help=(
-            "Explicit iteration index. Defaults to auto-increment "
+            "Explicit iteration index (>= 1). Defaults to auto-increment "
             "(scan .clauditor/iteration-* and pick max+1)."
         ),
     )
@@ -1351,15 +1363,15 @@ def main(argv: list[str] | None = None) -> int:
         "--from",
         dest="from_iter",
         default=None,
-        type=int,
-        help="Baseline iteration number (requires --skill)",
+        type=_positive_int,
+        help="Baseline iteration number >= 1 (requires --skill)",
     )
     p_compare.add_argument(
         "--to",
         dest="to_iter",
         default=None,
-        type=int,
-        help="Candidate iteration number (requires --skill)",
+        type=_positive_int,
+        help="Candidate iteration number >= 1 (requires --skill)",
     )
 
     # triggers

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from clauditor import history
 from clauditor.assertions import AssertionSet, run_assertions
+from clauditor.paths import resolve_clauditor_dir
 from clauditor.runner import SkillRunner
 from clauditor.spec import SkillSpec
 
@@ -251,7 +252,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
 
     # --diff: compare against prior results
     # Use stderr for human output when --json is set to keep stdout valid JSON
-    save_dir = Path(".clauditor")
+    save_dir = resolve_clauditor_dir()
     save_path = save_dir / f"{spec.skill_name}.grade.json"
     diff_out = sys.stderr if args.json else sys.stdout
 

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -10,8 +10,13 @@ from pathlib import Path
 from clauditor import history
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.paths import resolve_clauditor_dir
-from clauditor.runner import SkillRunner
+from clauditor.runner import SkillResult, SkillRunner
 from clauditor.spec import SkillSpec
+from clauditor.workspace import (
+    IterationExistsError,
+    IterationWorkspace,
+    allocate_iteration,
+)
 
 
 def _positive_int(value: str) -> int:
@@ -128,10 +133,29 @@ def cmd_run(args: argparse.Namespace) -> int:
     return result.exit_code
 
 
-def cmd_grade(args: argparse.Namespace) -> int:
-    """Run Layer 3 quality grading against a skill's output."""
-    import asyncio
+def _write_run_dir(
+    run_dir: Path, output_text: str, stream_events: list[dict]
+) -> None:
+    """Write ``output.txt`` and ``output.jsonl`` to a ``run-K/`` subdir.
 
+    ``stream_events`` is one JSON object per line. Empty list yields an
+    empty ``output.jsonl`` (the file still exists for layout consistency).
+    """
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "output.txt").write_text(output_text, encoding="utf-8")
+    lines = [json.dumps(ev) for ev in stream_events]
+    body = ("\n".join(lines) + "\n") if lines else ""
+    (run_dir / "output.jsonl").write_text(body, encoding="utf-8")
+
+
+def cmd_grade(args: argparse.Namespace) -> int:
+    """Run Layer 3 quality grading against a skill's output.
+
+    Always writes a per-iteration workspace under
+    ``.clauditor/iteration-N/<skill>/`` containing ``grading.json``,
+    ``timing.json`` and one ``run-K/`` subdir per skill invocation
+    (DEC-002, DEC-003, DEC-010, DEC-011, DEC-012, DEC-014).
+    """
     spec = SkillSpec.from_file(args.skill, eval_path=args.eval)
 
     if not spec.eval_spec:
@@ -180,47 +204,210 @@ def cmd_grade(args: argparse.Namespace) -> int:
         print(f"Prompt:\n{prompt}")
         return 0
 
-    # Get output
-    skill_result = None
+    # Allocate the iteration workspace early so that a collision
+    # (--iteration N already exists) fails before we make any LLM calls.
+    clauditor_dir = resolve_clauditor_dir()
+    try:
+        workspace = allocate_iteration(
+            clauditor_dir,
+            spec.skill_name,
+            iteration=getattr(args, "iteration", None),
+            force=getattr(args, "force", False),
+        )
+    except IterationExistsError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        return _cmd_grade_with_workspace(
+            args=args,
+            spec=spec,
+            model=model,
+            clauditor_dir=clauditor_dir,
+            workspace=workspace,
+        )
+    except Exception:
+        workspace.abort()
+        raise
+
+
+def _cmd_grade_with_workspace(
+    *,
+    args: argparse.Namespace,
+    spec: SkillSpec,
+    model: str,
+    clauditor_dir: Path,
+    workspace: IterationWorkspace,
+) -> int:
+    """Body of cmd_grade that runs inside an allocated iteration workspace."""
+    import asyncio
+
+    from clauditor.metrics import TokenUsage, build_metrics
+    from clauditor.quality_grader import (
+        GradingReport,
+        grade_quality,
+    )
+
+    n_variance = int(args.variance) if args.variance else 0
+    total_runs = 1 + n_variance
+
+    # Collect a (output_text, stream_events) tuple per run plus the
+    # corresponding skill-side token / duration totals.
+    run_outputs: list[tuple[str, list[dict]]] = []
+    skill_input_total = 0
+    skill_output_total = 0
+    skill_duration_total = 0.0
+
+    # Run 0: primary. Honors --output (no subprocess) when provided.
+    primary_skill_result: SkillResult | None = None
     if args.output:
-        output = Path(args.output).read_text()
+        primary_text = Path(args.output).read_text()
+        run_outputs.append((primary_text, []))
     else:
-        print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
-        skill_result = spec.run()
-        if not skill_result.succeeded:
+        print(
+            f"Running /{spec.skill_name} {spec.eval_spec.test_args}..."
+        )
+        primary_skill_result = spec.run()
+        if not primary_skill_result.succeeded:
             print(
-                f"ERROR: Skill failed: {skill_result.error}", file=sys.stderr
+                f"ERROR: Skill failed: {primary_skill_result.error}",
+                file=sys.stderr,
             )
             return 1
-        output = skill_result.output
-
-    # Grade (and optionally measure variance in a single event loop)
-    from clauditor.quality_grader import grade_quality
-
-    async def _run_grade():
-        report = await grade_quality(
-            output, spec.eval_spec, model,
-            thresholds=spec.eval_spec.grade_thresholds,
+        primary_text = primary_skill_result.output
+        run_outputs.append(
+            (primary_text, list(primary_skill_result.stream_events))
         )
-        variance_report = None
-        if args.variance:
-            from clauditor.quality_grader import measure_variance
+        skill_input_total += primary_skill_result.input_tokens
+        skill_output_total += primary_skill_result.output_tokens
+        skill_duration_total += primary_skill_result.duration_seconds
 
-            variance_report = await measure_variance(
-                spec, args.variance, model
+    # Variance runs: always invoke the skill subprocess (variance against
+    # a fixed --output file would be meaningless).
+    for _ in range(n_variance):
+        variance_result = spec.run()
+        if not variance_result.succeeded:
+            print(
+                f"ERROR: Variance skill run failed: {variance_result.error}",
+                file=sys.stderr,
             )
-        return report, variance_report
+            return 1
+        run_outputs.append(
+            (variance_result.output, list(variance_result.stream_events))
+        )
+        skill_input_total += variance_result.input_tokens
+        skill_output_total += variance_result.output_tokens
+        skill_duration_total += variance_result.duration_seconds
 
-    report, variance_report = asyncio.run(_run_grade())
+    # Grade every run's output. Primary report drives the exit code; the
+    # rest contribute to variance stats and aggregated token counts.
+    async def _grade_all() -> list[GradingReport]:
+        return list(
+            await asyncio.gather(
+                *[
+                    grade_quality(
+                        text,
+                        spec.eval_spec,
+                        model,
+                        thresholds=spec.eval_spec.grade_thresholds,
+                    )
+                    for text, _ev in run_outputs
+                ]
+            )
+        )
+
+    reports = asyncio.run(_grade_all())
+    primary_report = reports[0]
+    variance_reports = reports[1:]
+
+    # Build a VarianceReport when --variance was passed so the JSON /
+    # human summary continues to surface stability statistics.
+    variance_report = None
+    if n_variance >= 1:
+        from clauditor.quality_grader import VarianceReport
+
+        scores = [r.mean_score for r in reports]
+        score_mean = sum(scores) / len(scores)
+        score_stddev = (
+            sum((s - score_mean) ** 2 for s in scores) / len(scores)
+        ) ** 0.5
+        pass_rate_mean = sum(r.pass_rate for r in reports) / len(reports)
+        stability = sum(1 for r in reports if r.passed) / len(reports)
+        min_stability = 0.8
+        if spec.eval_spec.variance is not None:
+            min_stability = spec.eval_spec.variance.min_stability
+        variance_report = VarianceReport(
+            skill_name=spec.skill_name,
+            n_runs=total_runs,
+            reports=reports,
+            score_mean=score_mean,
+            score_stddev=score_stddev,
+            pass_rate_mean=pass_rate_mean,
+            stability=stability,
+            min_stability=min_stability,
+            model=model,
+            input_tokens=sum(r.input_tokens for r in variance_reports),
+            output_tokens=sum(r.output_tokens for r in variance_reports),
+            skill_input_tokens=0,  # all skill totals already aggregated above
+            skill_output_tokens=0,
+            skill_duration_seconds=0.0,
+        )
+
+    # Aggregate quality (Layer 3 grader) tokens across every run.
+    quality_input_total = sum(r.input_tokens for r in reports)
+    quality_output_total = sum(r.output_tokens for r in reports)
+
+    metrics_dict = build_metrics(
+        skill=TokenUsage(
+            input_tokens=skill_input_total,
+            output_tokens=skill_output_total,
+        ),
+        duration_seconds=skill_duration_total,
+        quality=TokenUsage(
+            input_tokens=quality_input_total,
+            output_tokens=quality_output_total,
+        ),
+    )
+    primary_report.metrics = metrics_dict
+
+    # ------------------------------------------------------------------ #
+    # Write workspace files (DEC-012: stage in tmp_path, then finalize)  #
+    # ------------------------------------------------------------------ #
+    skill_dir = workspace.tmp_path
+    for idx, (text, events) in enumerate(run_outputs):
+        _write_run_dir(skill_dir / f"run-{idx}", text, events)
+
+    (skill_dir / "grading.json").write_text(
+        primary_report.to_json(), encoding="utf-8"
+    )
+
+    timing_payload: dict = {
+        "skill": spec.skill_name,
+        "iteration": workspace.iteration,
+        "n_runs": total_runs,
+        "metrics": metrics_dict,
+    }
+    (skill_dir / "timing.json").write_text(
+        json.dumps(timing_payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+    workspace.finalize()
+
+    # ------------------------------------------------------------------ #
+    # Report to the user                                                  #
+    # ------------------------------------------------------------------ #
+    final_skill_dir = workspace.final_path
 
     if args.json:
         data: dict = {
             "skill": spec.skill_name,
             "model": model,
+            "iteration": workspace.iteration,
+            "workspace": str(final_skill_dir),
             "grade": {
-                "passed": report.passed,
-                "pass_rate": report.pass_rate,
-                "mean_score": report.mean_score,
+                "passed": primary_report.passed,
+                "pass_rate": primary_report.pass_rate,
+                "mean_score": primary_report.mean_score,
                 "results": [
                     {
                         "criterion": r.criterion,
@@ -229,7 +416,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
                         "evidence": r.evidence,
                         "reasoning": r.reasoning,
                     }
-                    for r in report.results
+                    for r in primary_report.results
                 ],
             },
             "variance": None,
@@ -246,122 +433,137 @@ def cmd_grade(args: argparse.Namespace) -> int:
         print(json.dumps(data, indent=2))
     else:
         print(f"Quality Grade: {spec.skill_name} ({model})")
-        print(report.summary())
+        print(primary_report.summary())
         if variance_report:
             print(f"\n{variance_report.summary()}")
+        print(f"\nWorkspace: {final_skill_dir}")
 
-    # --diff: compare against prior results
-    # Use stderr for human output when --json is set to keep stdout valid JSON
-    save_dir = resolve_clauditor_dir()
-    save_path = save_dir / f"{spec.skill_name}.grade.json"
+    # --diff: compare against the previous iteration's grading.json,
+    # if any. Output goes to stderr in --json mode so stdout stays
+    # parseable.
     diff_out = sys.stderr if args.json else sys.stdout
-
-    if args.diff:
-        if save_path.exists():
-            from clauditor.quality_grader import GradingReport
-
-            prior = GradingReport.from_json(save_path.read_text())
-            prior_by_name = {r.criterion: r for r in prior.results}
-            current_by_name = {r.criterion: r for r in report.results}
-            common = set(prior_by_name) & set(current_by_name)
-            regressions = []
-            print("\nDiff vs prior results:", file=diff_out)
-            print(
-                f"  {'Criterion':<40} {'Prior':>6} {'Current':>8} {'Delta':>6}",
-                file=diff_out,
-            )
-            print(
-                f"  {'-'*40} {'-'*6} {'-'*8} {'-'*6}", file=diff_out
-            )
-            for name in sorted(common):
-                p_score = prior_by_name[name].score
-                c_score = current_by_name[name].score
-                delta = c_score - p_score
-                is_regression = (
-                    delta < -0.1
-                    or (prior_by_name[name].passed and not current_by_name[name].passed)
-                )
-                marker = " REGRESSION" if is_regression else ""
-                line = (
-                    f"  {name:<40} {p_score:>6.2f}"
-                    f" {c_score:>8.2f} {delta:>+6.2f}{marker}"
-                )
-                print(line, file=diff_out)
-                if is_regression:
-                    regressions.append(name)
-            if regressions:
-                print(
-                    f"\n  {len(regressions)} regression(s) detected.", file=diff_out
-                )
-            else:
-                print("\n  No regressions detected.", file=diff_out)
+    if getattr(args, "diff", False):
+        prior_path = _find_prior_grading_json(
+            clauditor_dir, spec.skill_name, workspace.iteration
+        )
+        if prior_path is not None:
+            _print_grade_diff(prior_path, primary_report, diff_out)
         else:
             print(
-                f"\nWARNING: No prior results at {save_path}. "
-                "Run with --save first to establish a baseline.",
+                "\nWARNING: No prior iteration grading.json found "
+                f"for skill '{spec.skill_name}'.",
                 file=sys.stderr,
             )
-
-    # Build the canonical bucketed metrics dict (US-004). For --output
-    # runs there's no skill subprocess, so skill tokens/duration are zero.
-    # When --variance N was passed, the variance path runs the skill N
-    # additional times and makes N additional Layer 3 grader calls — those
-    # must be included so longitudinal trends reflect the real cost.
-    from clauditor.metrics import TokenUsage, build_metrics
-
-    base_skill_input = getattr(skill_result, "input_tokens", 0) or 0
-    base_skill_output = getattr(skill_result, "output_tokens", 0) or 0
-    base_skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
-    base_quality_input = report.input_tokens
-    base_quality_output = report.output_tokens
-
-    if variance_report is not None:
-        base_skill_input += variance_report.skill_input_tokens
-        base_skill_output += variance_report.skill_output_tokens
-        base_skill_duration += variance_report.skill_duration_seconds
-        base_quality_input += variance_report.input_tokens
-        base_quality_output += variance_report.output_tokens
-
-    skill_tokens = TokenUsage(
-        input_tokens=base_skill_input,
-        output_tokens=base_skill_output,
-    )
-    quality_tokens = TokenUsage(
-        input_tokens=base_quality_input,
-        output_tokens=base_quality_output,
-    )
-    metrics_dict = build_metrics(
-        skill=skill_tokens,
-        duration_seconds=base_skill_duration,
-        quality=quality_tokens,
-    )
-    report.metrics = metrics_dict
-
-    if args.save:
-        save_dir.mkdir(parents=True, exist_ok=True)
-        save_path.write_text(report.to_json())
-        print(f"\nGrade report saved to {save_path}", file=diff_out)
 
     # Append a history record for trendability (US-006). Skip when
     # --only-criterion is set: partial-criterion runs would silently
     # corrupt longitudinal pass_rate/mean_score trends.
     if not getattr(args, "only_criterion", None):
+        workspace_rel = _relative_to_repo(clauditor_dir, final_skill_dir)
         try:
             history.append_record(
                 skill=spec.skill_name,
-                pass_rate=report.pass_rate,
-                mean_score=report.mean_score,
+                pass_rate=primary_report.pass_rate,
+                mean_score=primary_report.mean_score,
                 metrics=metrics_dict,
                 command="grade",
+                iteration=workspace.iteration,
+                workspace_path=workspace_rel,
             )
         except Exception as e:  # pragma: no cover - defensive
             print(f"WARNING: failed to append history: {e}", file=sys.stderr)
 
     # Determine exit code
-    passed = report.passed
+    passed = primary_report.passed
     if variance_report:
         passed = passed and variance_report.passed
     return 0 if passed else 1
+
+
+def _relative_to_repo(clauditor_dir: Path, final_skill_dir: Path) -> str:
+    """Return ``final_skill_dir`` as a path relative to the repo root.
+
+    The repo root is ``clauditor_dir.parent`` (DEC-009). Falls back to the
+    absolute path if the directories are not related (defensive — should
+    not happen in practice).
+    """
+    repo_root = clauditor_dir.parent
+    try:
+        return str(final_skill_dir.relative_to(repo_root))
+    except ValueError:  # pragma: no cover - defensive
+        return str(final_skill_dir)
+
+
+def _find_prior_grading_json(
+    clauditor_dir: Path, skill: str, current_iteration: int
+) -> Path | None:
+    """Return the most recent prior ``grading.json`` for ``skill``, if any.
+
+    Scans ``iteration-*`` siblings of ``iteration-<current>``, picks the
+    highest index strictly less than ``current_iteration`` whose
+    ``<skill>/grading.json`` exists.
+    """
+    if not clauditor_dir.exists():
+        return None
+    import re as _re
+
+    pattern = _re.compile(r"^iteration-(\d+)$")
+    candidates: list[int] = []
+    for child in clauditor_dir.iterdir():
+        if not child.is_dir():
+            continue
+        m = pattern.match(child.name)
+        if m is None:
+            continue
+        idx = int(m.group(1))
+        if idx >= current_iteration:
+            continue
+        if (child / skill / "grading.json").exists():
+            candidates.append(idx)
+    if not candidates:
+        return None
+    best = max(candidates)
+    return clauditor_dir / f"iteration-{best}" / skill / "grading.json"
+
+
+def _print_grade_diff(prior_path: Path, current_report, out) -> None:
+    """Print a per-criterion diff against ``prior_path``'s GradingReport."""
+    from clauditor.quality_grader import GradingReport
+
+    prior = GradingReport.from_json(prior_path.read_text())
+    prior_by_name = {r.criterion: r for r in prior.results}
+    current_by_name = {r.criterion: r for r in current_report.results}
+    common = set(prior_by_name) & set(current_by_name)
+    regressions: list[str] = []
+    print(f"\nDiff vs prior results ({prior_path}):", file=out)
+    print(
+        f"  {'Criterion':<40} {'Prior':>6} {'Current':>8} {'Delta':>6}",
+        file=out,
+    )
+    print(f"  {'-'*40} {'-'*6} {'-'*8} {'-'*6}", file=out)
+    for name in sorted(common):
+        p_score = prior_by_name[name].score
+        c_score = current_by_name[name].score
+        delta = c_score - p_score
+        is_regression = (
+            delta < -0.1
+            or (
+                prior_by_name[name].passed
+                and not current_by_name[name].passed
+            )
+        )
+        marker = " REGRESSION" if is_regression else ""
+        line = (
+            f"  {name:<40} {p_score:>6.2f}"
+            f" {c_score:>8.2f} {delta:>+6.2f}{marker}"
+        )
+        print(line, file=out)
+        if is_regression:
+            regressions.append(name)
+    if regressions:
+        print(f"\n  {len(regressions)} regression(s) detected.", file=out)
+    else:
+        print("\n  No regressions detected.", file=out)
 
 
 def _load_assertion_set(
@@ -974,10 +1176,27 @@ def main(argv: list[str] | None = None) -> int:
         help="Run N times with variance measurement",
     )
     p_grade.add_argument(
-        "--save", action="store_true", help="Save grade report to .clauditor/"
+        "--iteration",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Explicit iteration index. Defaults to auto-increment "
+            "(scan .clauditor/iteration-* and pick max+1)."
+        ),
     )
     p_grade.add_argument(
-        "--diff", action="store_true", help="Compare against prior grade results"
+        "--force",
+        action="store_true",
+        help=(
+            "With --iteration N, remove the existing iteration-N/ "
+            "directory before writing (clean slate)."
+        ),
+    )
+    p_grade.add_argument(
+        "--diff",
+        action="store_true",
+        help="Compare against the previous iteration's grading.json",
     )
     p_grade.add_argument(
         "--only-criterion",

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -13,9 +13,11 @@ from clauditor.paths import resolve_clauditor_dir
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.spec import SkillSpec
 from clauditor.workspace import (
+    InvalidSkillNameError,
     IterationExistsError,
     IterationWorkspace,
     allocate_iteration,
+    validate_skill_name,
 )
 
 
@@ -166,9 +168,28 @@ def cmd_grade(args: argparse.Namespace) -> int:
         print("ERROR: No grading_criteria defined in eval spec", file=sys.stderr)
         return 1
 
-    # --only-criterion: filter criteria before LLM call (token savings)
+    # --only-criterion: filter criteria before LLM call (token savings).
+    # Partial runs produce a subset grading.json and must not publish an
+    # iteration workspace (the partial report would later be misused as a
+    # baseline). Reject combinations that would either destroy existing
+    # iteration state or interact confusingly with diffing.
     only = getattr(args, "only_criterion", None)
     if only:
+        conflict = []
+        if getattr(args, "iteration", None) is not None:
+            conflict.append("--iteration")
+        if getattr(args, "force", False):
+            conflict.append("--force")
+        if getattr(args, "diff", False):
+            conflict.append("--diff")
+        if conflict:
+            print(
+                "ERROR: --only-criterion cannot be combined with "
+                + ", ".join(conflict)
+                + " (partial runs are not persisted to the iteration workspace)",
+                file=sys.stderr,
+            )
+            return 2
         needles = [s.lower() for s in only]
         original = list(spec.eval_spec.grading_criteria)
 
@@ -226,9 +247,15 @@ def cmd_grade(args: argparse.Namespace) -> int:
             clauditor_dir=clauditor_dir,
             workspace=workspace,
         )
-    except Exception:
-        workspace.abort()
-        raise
+    finally:
+        # workspace.finalized is set to True inside finalize(); any other
+        # exit path (early return on skill failure, exception mid-write,
+        # --only-criterion partial run) leaves the staging dir behind,
+        # so we clean it up here. --only-criterion in particular must NOT
+        # publish a partial grading.json that later runs would mistake
+        # for a baseline.
+        if not workspace.finalized:
+            workspace.abort()
 
 
 def _cmd_grade_with_workspace(
@@ -318,7 +345,6 @@ def _cmd_grade_with_workspace(
 
     reports = asyncio.run(_grade_all())
     primary_report = reports[0]
-    variance_reports = reports[1:]
 
     # Build a VarianceReport when --variance was passed so the JSON /
     # human summary continues to surface stability statistics.
@@ -336,6 +362,10 @@ def _cmd_grade_with_workspace(
         min_stability = 0.8
         if spec.eval_spec.variance is not None:
             min_stability = spec.eval_spec.variance.min_stability
+        # Token / duration fields cover *all* runs (primary + variance),
+        # matching the pre-#22 measure_variance() contract — downstream
+        # cost accounting reads these for the full n_runs, not just
+        # non-primary. See review Pass 1 bug 4.
         variance_report = VarianceReport(
             skill_name=spec.skill_name,
             n_runs=total_runs,
@@ -346,11 +376,11 @@ def _cmd_grade_with_workspace(
             stability=stability,
             min_stability=min_stability,
             model=model,
-            input_tokens=sum(r.input_tokens for r in variance_reports),
-            output_tokens=sum(r.output_tokens for r in variance_reports),
-            skill_input_tokens=0,  # all skill totals already aggregated above
-            skill_output_tokens=0,
-            skill_duration_seconds=0.0,
+            input_tokens=sum(r.input_tokens for r in reports),
+            output_tokens=sum(r.output_tokens for r in reports),
+            skill_input_tokens=skill_input_total,
+            skill_output_tokens=skill_output_total,
+            skill_duration_seconds=skill_duration_total,
         )
 
     # Aggregate quality (Layer 3 grader) tokens across every run.
@@ -373,37 +403,46 @@ def _cmd_grade_with_workspace(
     # ------------------------------------------------------------------ #
     # Write workspace files (DEC-012: stage in tmp_path, then finalize)  #
     # ------------------------------------------------------------------ #
-    skill_dir = workspace.tmp_path
-    for idx, (text, events) in enumerate(run_outputs):
-        _write_run_dir(skill_dir / f"run-{idx}", text, events)
+    # --only-criterion runs grade a filtered subset of criteria. That
+    # partial report must NOT land in iteration-N/<skill>/grading.json
+    # where --diff / compare / _find_prior_grading_json would later pick
+    # it up as a misleading baseline. Skip the entire write+finalize step;
+    # the outer finally block will abort() the staging dir.
+    only_criterion = bool(getattr(args, "only_criterion", None))
 
-    (skill_dir / "grading.json").write_text(
-        primary_report.to_json(), encoding="utf-8"
-    )
+    if not only_criterion:
+        skill_dir = workspace.tmp_path
+        for idx, (text, events) in enumerate(run_outputs):
+            _write_run_dir(skill_dir / f"run-{idx}", text, events)
 
-    timing_payload: dict = {
-        "skill": spec.skill_name,
-        "iteration": workspace.iteration,
-        "n_runs": total_runs,
-        "metrics": metrics_dict,
-    }
-    (skill_dir / "timing.json").write_text(
-        json.dumps(timing_payload, indent=2) + "\n", encoding="utf-8"
-    )
+        (skill_dir / "grading.json").write_text(
+            primary_report.to_json(), encoding="utf-8"
+        )
 
-    workspace.finalize()
+    if not only_criterion:
+        timing_payload: dict = {
+            "skill": spec.skill_name,
+            "iteration": workspace.iteration,
+            "n_runs": total_runs,
+            "metrics": metrics_dict,
+        }
+        (skill_dir / "timing.json").write_text(
+            json.dumps(timing_payload, indent=2) + "\n", encoding="utf-8"
+        )
+
+        workspace.finalize()
 
     # ------------------------------------------------------------------ #
     # Report to the user                                                  #
     # ------------------------------------------------------------------ #
-    final_skill_dir = workspace.final_path
+    final_skill_dir = workspace.final_path if workspace.finalized else None
 
     if args.json:
         data: dict = {
             "skill": spec.skill_name,
             "model": model,
-            "iteration": workspace.iteration,
-            "workspace": str(final_skill_dir),
+            "iteration": workspace.iteration if final_skill_dir else None,
+            "workspace": str(final_skill_dir) if final_skill_dir else None,
             "grade": {
                 "passed": primary_report.passed,
                 "pass_rate": primary_report.pass_rate,
@@ -436,7 +475,8 @@ def _cmd_grade_with_workspace(
         print(primary_report.summary())
         if variance_report:
             print(f"\n{variance_report.summary()}")
-        print(f"\nWorkspace: {final_skill_dir}")
+        if final_skill_dir is not None:
+            print(f"\nWorkspace: {final_skill_dir}")
 
     # --diff: compare against the previous iteration's grading.json,
     # if any. Output goes to stderr in --json mode so stdout stays
@@ -620,8 +660,10 @@ def _load_assertion_set(
 def _file_kind(path: Path) -> str:
     """Return a coarse file-kind label for mismatch detection.
 
-    Directories containing a ``grading.json`` are treated as the
-    ``grade.json`` kind so they diff uniformly with saved grade reports.
+    Directories are treated as the ``grade.json`` kind so they diff
+    uniformly with saved grade reports; the eventual ``grading.json``
+    lookup in :func:`_load_assertion_set` surfaces a precise
+    ``no grading.json found in <path>`` error when the dir is empty.
     """
     if path.is_dir():
         return "grade.json"
@@ -662,6 +704,17 @@ def cmd_compare(args: argparse.Namespace) -> int:
             print(
                 "ERROR: --skill, --from, and --to must all be provided "
                 "together",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            validate_skill_name(skill)
+        except InvalidSkillNameError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        if from_iter < 1 or to_iter < 1:
+            print(
+                "ERROR: --from and --to must be >= 1",
                 file=sys.stderr,
             )
             return 2

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -579,6 +579,11 @@ def _load_assertion_set(
     from clauditor.assertions import AssertionResult
     from clauditor.quality_grader import GradingReport
 
+    if path.is_dir():
+        grading = path / "grading.json"
+        if not grading.is_file():
+            raise ValueError(f"no grading.json found in {path}")
+        path = grading
     suffix = "".join(path.suffixes)
     if path.suffix == ".txt":
         if not spec_path:
@@ -590,7 +595,11 @@ def _load_assertion_set(
             raise ValueError(f"No eval spec found for {spec_path}")
         output = path.read_text()
         return run_assertions(output, spec.eval_spec.assertions)
-    if suffix.endswith(".grade.json") or path.name.endswith(".grade.json"):
+    if (
+        suffix.endswith(".grade.json")
+        or path.name.endswith(".grade.json")
+        or path.name == "grading.json"
+    ):
         report = GradingReport.from_json(path.read_text())
         results = [
             AssertionResult(
@@ -609,7 +618,15 @@ def _load_assertion_set(
 
 
 def _file_kind(path: Path) -> str:
-    """Return a coarse file-kind label for mismatch detection."""
+    """Return a coarse file-kind label for mismatch detection.
+
+    Directories containing a ``grading.json`` are treated as the
+    ``grade.json`` kind so they diff uniformly with saved grade reports.
+    """
+    if path.is_dir():
+        return "grade.json"
+    if path.name == "grading.json":
+        return "grade.json"
     if path.name.endswith(".grade.json"):
         return "grade.json"
     if path.suffix == ".txt":
@@ -626,8 +643,41 @@ def cmd_compare(args: argparse.Namespace) -> int:
     """
     from clauditor.comparator import diff_assertion_sets
 
-    before_path = Path(args.before)
-    after_path = Path(args.after)
+    skill = getattr(args, "skill", None)
+    from_iter = getattr(args, "from_iter", None)
+    to_iter = getattr(args, "to_iter", None)
+    numeric_form = any(v is not None for v in (skill, from_iter, to_iter))
+    positional_form = args.before is not None or args.after is not None
+
+    if numeric_form and positional_form:
+        print(
+            "ERROR: cannot combine positional paths with "
+            "--skill/--from/--to",
+            file=sys.stderr,
+        )
+        return 2
+
+    if numeric_form:
+        if skill is None or from_iter is None or to_iter is None:
+            print(
+                "ERROR: --skill, --from, and --to must all be provided "
+                "together",
+                file=sys.stderr,
+            )
+            return 2
+        clauditor_dir = resolve_clauditor_dir()
+        before_path = clauditor_dir / f"iteration-{from_iter}" / skill
+        after_path = clauditor_dir / f"iteration-{to_iter}" / skill
+    else:
+        if args.before is None or args.after is None:
+            print(
+                "ERROR: compare requires two positional paths or "
+                "--skill/--from/--to",
+                file=sys.stderr,
+            )
+            return 2
+        before_path = Path(args.before)
+        after_path = Path(args.after)
 
     before_kind = _file_kind(before_path)
     after_kind = _file_kind(after_path)
@@ -1217,8 +1267,18 @@ def main(argv: list[str] | None = None) -> int:
             "(.txt) or saved grade reports (.grade.json)"
         ),
     )
-    p_compare.add_argument("before", help="Baseline file (.txt or .grade.json)")
-    p_compare.add_argument("after", help="Candidate file (.txt or .grade.json)")
+    p_compare.add_argument(
+        "before",
+        nargs="?",
+        default=None,
+        help="Baseline file, iteration dir (.txt or .grade.json or dir)",
+    )
+    p_compare.add_argument(
+        "after",
+        nargs="?",
+        default=None,
+        help="Candidate file, iteration dir (.txt or .grade.json or dir)",
+    )
     p_compare.add_argument(
         "--spec",
         default=None,
@@ -1228,6 +1288,25 @@ def main(argv: list[str] | None = None) -> int:
         "--eval",
         default=None,
         help="Path to eval.json (auto-discovered if omitted)",
+    )
+    p_compare.add_argument(
+        "--skill",
+        default=None,
+        help="Skill name (used with --from/--to to resolve iteration dirs)",
+    )
+    p_compare.add_argument(
+        "--from",
+        dest="from_iter",
+        default=None,
+        type=int,
+        help="Baseline iteration number (requires --skill)",
+    )
+    p_compare.add_argument(
+        "--to",
+        dest="to_iter",
+        default=None,
+        type=int,
+        help="Candidate iteration number (requires --skill)",
     )
 
     # triggers

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -59,6 +59,9 @@ SPARK_GLYPHS = "_.-=#"
 SCHEMA_VERSION = 3
 
 
+_FLOCK_UNSUPPORTED_WARNED = False
+
+
 @contextlib.contextmanager
 def _file_lock(lock_path: Path) -> Iterator[None]:
     """Acquire an exclusive ``fcntl.flock`` on ``lock_path``.
@@ -66,16 +69,39 @@ def _file_lock(lock_path: Path) -> Iterator[None]:
     Creates the lockfile (and its parent dir) if missing. The lock is
     released when the context exits. Use this only to serialize the
     short ``history.jsonl`` append — do not hold it across other work.
+
+    On filesystems that do not implement advisory locking (WSL2
+    ``/mnt/*`` drvfs, some NFSv3 mounts, 9p shares) ``fcntl.flock``
+    raises ``OSError`` (typically ``ENOLCK`` or ``EINVAL``). Rather
+    than losing the history append entirely we fall back to an
+    unlocked context and warn once per process — concurrent appends
+    may theoretically interleave, but a single-writer history is still
+    better than silent data loss.
     """
+    global _FLOCK_UNSUPPORTED_WARNED
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # ``open(..., "a")`` creates the file if missing without truncating
     # an existing one and gives us a writable fd flock can lock.
     with lock_path.open("a") as lock_fd:
-        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        except OSError as exc:
+            if not _FLOCK_UNSUPPORTED_WARNED:
+                print(
+                    f"WARNING: fcntl.flock unsupported on {lock_path} "
+                    f"({exc}); history appends will be unlocked",
+                    file=sys.stderr,
+                )
+                _FLOCK_UNSUPPORTED_WARNED = True
+            yield
+            return
         try:
             yield
         finally:
-            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
 
 
 def append_record(

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -6,26 +6,39 @@ Appends a JSON line per grade run to ``.clauditor/history.jsonl`` so the
 ASCII-only (DEC-014): the sparkline uses ``"_.-=#"`` glyphs — no Unicode
 block characters.
 
-Schema v2 (US-004): each record is a JSON object with the following
+Schema v3 (US-005): each record is a JSON object with the following
 top-level keys:
 
-- ``schema_version``: int, always ``2``
+- ``schema_version``: int, always ``3``
 - ``command``: one of ``"grade"``, ``"extract"``, ``"validate"``
 - ``ts``: ISO-8601 UTC timestamp
 - ``skill``: skill name
 - ``pass_rate``: float or None
 - ``mean_score``: float or None
 - ``metrics``: dict (canonical bucketed metrics from ``clauditor.metrics``)
+- ``iteration``: int or None — Ralph iteration number, when known
+- ``workspace_path``: str or None — workspace dir for this run, when known
 
-v1 records (no ``schema_version``, no ``command``) may still exist on disk
-and are returned as-is by :func:`read_records`.
+The two new v3 fields (``iteration``, ``workspace_path``) are always
+written, even when ``None``, so the on-disk record shape is predictable.
+
+v2 records (``schema_version: 2``, no iteration/workspace_path) and v1
+records (no ``schema_version``, no ``command``) may still exist on disk
+and are returned as-is by :func:`read_records`. Callers must use
+``record.get("iteration")``-style access to tolerate missing keys.
+
+Concurrent appends from multiple processes are serialized via a
+``fcntl.flock`` exclusive lock on ``<history_dir>/.lock``.
 """
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import math
 import sys
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
@@ -43,7 +56,26 @@ def _default_path() -> Path:
         return _DEFAULT_PATH
     return resolve_clauditor_dir() / "history.jsonl"
 SPARK_GLYPHS = "_.-=#"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
+
+
+@contextlib.contextmanager
+def _file_lock(lock_path: Path) -> Iterator[None]:
+    """Acquire an exclusive ``fcntl.flock`` on ``lock_path``.
+
+    Creates the lockfile (and its parent dir) if missing. The lock is
+    released when the context exits. Use this only to serialize the
+    short ``history.jsonl`` append — do not hold it across other work.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # ``open(..., "a")`` creates the file if missing without truncating
+    # an existing one and gives us a writable fd flock can lock.
+    with lock_path.open("a") as lock_fd:
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
 
 
 def append_record(
@@ -54,6 +86,8 @@ def append_record(
     *,
     command: Literal["grade", "extract", "validate"],
     path: Path | None = None,
+    iteration: int | None = None,
+    workspace_path: str | None = None,
 ) -> None:
     """Append one history record for a grade run.
 
@@ -63,7 +97,13 @@ def append_record(
 
     ``command`` is required (keyword-only) and identifies which clauditor
     subcommand produced the record. Every written record includes
-    ``schema_version: 2`` at the top level.
+    ``schema_version: 3`` at the top level along with the v3 fields
+    ``iteration`` and ``workspace_path`` (always present, possibly
+    ``None``).
+
+    Concurrent appends from multiple processes are serialized via an
+    ``fcntl.flock`` exclusive lock on ``<history_parent>/.lock`` so each
+    JSONL line is written atomically without interleaving.
     """
     if command not in ("grade", "extract", "validate"):
         raise ValueError(
@@ -80,9 +120,14 @@ def append_record(
         "pass_rate": pass_rate,
         "mean_score": mean_score,
         "metrics": metrics,
+        "iteration": iteration,
+        "workspace_path": workspace_path,
     }
-    with path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(record) + "\n")
+    line = json.dumps(record) + "\n"
+    lock_path = path.parent / ".lock"
+    with _file_lock(lock_path):
+        with path.open("a", encoding="utf-8") as f:
+            f.write(line)
 
 
 def read_records(

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -34,10 +34,26 @@ Concurrent appends from multiple processes are serialized via a
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import json
 import math
 import sys
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    # fcntl is POSIX-only. On Windows we fall back to a no-op lock so
+    # the module can still be imported; concurrent history appends may
+    # theoretically interleave but the rest of clauditor continues to
+    # work.
+    class _FcntlFallback:
+        LOCK_EX = 0
+        LOCK_UN = 0
+
+        @staticmethod
+        def flock(_fd: int, _operation: int) -> None:
+            return None
+
+    fcntl = _FcntlFallback()  # type: ignore[assignment]
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -55,9 +71,10 @@ def _default_path() -> Path:
     if _DEFAULT_PATH is not None:
         return _DEFAULT_PATH
     return resolve_clauditor_dir() / "history.jsonl"
+
+
 SPARK_GLYPHS = "_.-=#"
 SCHEMA_VERSION = 3
-
 
 _FLOCK_UNSUPPORTED_WARNED = False
 

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -30,7 +30,18 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
-_DEFAULT_PATH = Path(".clauditor/history.jsonl")
+from clauditor.paths import resolve_clauditor_dir
+
+# Module-level override, monkeypatched by tests. When ``None``, the
+# default path is resolved lazily via :func:`resolve_clauditor_dir` so
+# the lookup honors the caller's current working directory.
+_DEFAULT_PATH: Path | None = None
+
+
+def _default_path() -> Path:
+    if _DEFAULT_PATH is not None:
+        return _DEFAULT_PATH
+    return resolve_clauditor_dir() / "history.jsonl"
 SPARK_GLYPHS = "_.-=#"
 SCHEMA_VERSION = 2
 
@@ -59,7 +70,7 @@ def append_record(
             f"command must be one of 'grade', 'extract', 'validate'; got {command!r}"
         )
     if path is None:
-        path = _DEFAULT_PATH
+        path = _default_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     record = {
         "schema_version": SCHEMA_VERSION,
@@ -85,7 +96,7 @@ def read_records(
     time so tests can monkeypatch the module attribute.
     """
     if path is None:
-        path = _DEFAULT_PATH
+        path = _default_path()
     if not path.exists():
         return []
 

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -24,10 +24,28 @@ def resolve_clauditor_dir() -> Path:
     of ``.git`` or ``.claude``. Returns ``<that_dir>/.clauditor``. If no
     ancestor contains a marker, emits a single-line warning to stderr and
     returns ``Path.cwd() / ".clauditor"``.
+
+    The user's home directory is only accepted as a match via the
+    ``.git`` marker, never ``.claude``. A stray ``~/.claude`` (common:
+    Claude Code's user config directory) would otherwise cause any
+    clauditor invocation run from a project lacking ``.git`` to write
+    iterations into ``~/.clauditor`` and contaminate unrelated work.
     """
+    try:
+        home = Path.home().resolve()
+    except (RuntimeError, OSError):
+        home = None
+
     cwd = Path.cwd()
     for candidate in (cwd, *cwd.parents):
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        at_home = home is not None and resolved == home
         for marker in _MARKERS:
+            if at_home and marker == ".claude":
+                continue
             if (candidate / marker).exists():
                 return candidate / _CLAUDITOR_DIRNAME
     print(

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -1,0 +1,37 @@
+"""Repo-root detection helpers for clauditor.
+
+Provides :func:`resolve_clauditor_dir` which walks up from the current
+working directory looking for a ``.git/`` or ``.claude/`` marker and
+returns ``<repo_root>/.clauditor``. If no marker is found, falls back to
+``Path.cwd() / ".clauditor"`` and emits a single-line warning to stderr.
+
+Traces to DEC-009 (see ``plans/super/22-iteration-workspace.md``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_MARKERS = (".git", ".claude")
+_CLAUDITOR_DIRNAME = ".clauditor"
+
+
+def resolve_clauditor_dir() -> Path:
+    """Return the ``.clauditor`` directory anchored at the nearest repo root.
+
+    Walks up from :func:`Path.cwd` looking for a directory containing any
+    of ``.git`` or ``.claude``. Returns ``<that_dir>/.clauditor``. If no
+    ancestor contains a marker, emits a single-line warning to stderr and
+    returns ``Path.cwd() / ".clauditor"``.
+    """
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        for marker in _MARKERS:
+            if (candidate / marker).exists():
+                return candidate / _CLAUDITOR_DIRNAME
+    print(
+        f"WARNING: no .git/.claude ancestor found; using {cwd / _CLAUDITOR_DIRNAME}",
+        file=sys.stderr,
+    )
+    return cwd / _CLAUDITOR_DIRNAME

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -62,6 +62,7 @@ class SkillResult:
     input_tokens: int = 0
     output_tokens: int = 0
     raw_messages: list[dict] = field(default_factory=list)
+    stream_events: list[dict] = field(default_factory=list)
 
     @property
     def succeeded(self) -> bool:
@@ -167,6 +168,7 @@ class SkillRunner:
         """
         start = time.monotonic()
         raw_messages: list[dict] = []
+        stream_events: list[dict] = []
         text_chunks: list[str] = []
         input_tokens = 0
         output_tokens = 0
@@ -258,6 +260,8 @@ class SkillRunner:
                             continue
 
                         raw_messages.append(msg)
+                        if "type" in msg:
+                            stream_events.append(msg)
                         mtype = msg.get("type")
                         if mtype == "assistant":
                             message = msg.get("message") or {}
@@ -306,6 +310,7 @@ class SkillRunner:
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     raw_messages=raw_messages,
+                    stream_events=stream_events,
                 )
                 return result
 
@@ -325,6 +330,7 @@ class SkillRunner:
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 raw_messages=raw_messages,
+                stream_events=stream_events,
             )
             return result
         finally:

--- a/src/clauditor/workspace.py
+++ b/src/clauditor/workspace.py
@@ -20,17 +20,38 @@ from dataclasses import dataclass
 from pathlib import Path
 
 __all__ = [
+    "InvalidSkillNameError",
     "IterationExistsError",
     "IterationWorkspace",
     "allocate_iteration",
+    "validate_skill_name",
 ]
 
 _ITERATION_RE = re.compile(r"^iteration-(\d+)$")
+_SKILL_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _MAX_AUTO_RETRIES = 100
 
 
 class IterationExistsError(Exception):
     """Raised when an explicit ``iteration=N`` collides and ``force`` is False."""
+
+
+class InvalidSkillNameError(ValueError):
+    """Raised when a skill name contains characters unsafe for path joining."""
+
+
+def validate_skill_name(skill: str) -> str:
+    """Reject skill names that could escape the clauditor directory.
+
+    Accepts alphanumerics plus ``_ . -``. Rejects empty strings, path
+    separators, parent references (``..``), and leading dots that could
+    otherwise collide with hidden dirs. Returns the validated name.
+    """
+    if not skill or skill in {".", ".."} or not _SKILL_NAME_RE.match(skill):
+        raise InvalidSkillNameError(
+            f"invalid skill name for workspace path: {skill!r}"
+        )
+    return skill
 
 
 @dataclass
@@ -48,6 +69,7 @@ class IterationWorkspace:
     iteration: int
     final_path: Path
     tmp_path: Path
+    finalized: bool = False
 
     @property
     def _tmp_parent(self) -> Path:
@@ -63,8 +85,22 @@ class IterationWorkspace:
         Uses :func:`os.rename` on the ``iteration-N-tmp`` → ``iteration-N``
         parent directories (they are peers under ``clauditor_dir``, so the
         rename is atomic on POSIX).
+
+        If a concurrent peer finalized the same iteration index between our
+        allocation scan and this call, the rename raises ``OSError``
+        (``ENOTEMPTY``); we clean up the staging dir and surface the race as
+        an :class:`IterationExistsError` so the caller sees a consistent
+        failure mode rather than a bare OSError.
         """
-        os.rename(self._tmp_parent, self._final_parent)
+        try:
+            os.rename(self._tmp_parent, self._final_parent)
+        except OSError as exc:
+            self.abort()
+            raise IterationExistsError(
+                f"iteration-{self.iteration} was finalized by a concurrent "
+                f"writer; staging dir discarded"
+            ) from exc
+        self.finalized = True
 
     def abort(self) -> None:
         """Remove the staging directory. Safe if it's already gone."""
@@ -115,6 +151,7 @@ def allocate_iteration(
         RuntimeError: Auto-increment could not find a free slot within the
             retry cap (pathological contention).
     """
+    validate_skill_name(skill)
     clauditor_dir.mkdir(parents=True, exist_ok=True)
 
     if iteration is not None:
@@ -125,6 +162,10 @@ def allocate_iteration(
 def _allocate_explicit(
     clauditor_dir: Path, skill: str, iteration: int, *, force: bool
 ) -> IterationWorkspace:
+    if iteration < 1:
+        raise ValueError(
+            f"iteration must be >= 1, got {iteration}"
+        )
     final_parent = clauditor_dir / f"iteration-{iteration}"
     tmp_parent = clauditor_dir / f"iteration-{iteration}-tmp"
 
@@ -135,7 +176,9 @@ def _allocate_explicit(
             )
         shutil.rmtree(final_parent)
 
-    # --force may also mean a prior aborted run left an orphan tmp dir.
+    # Orphan tmp dirs are stage-only junk from a crashed prior run — always
+    # clear them regardless of --force so explicit --iteration N doesn't
+    # crash with a bare FileExistsError.
     if tmp_parent.exists():
         shutil.rmtree(tmp_parent)
 

--- a/src/clauditor/workspace.py
+++ b/src/clauditor/workspace.py
@@ -13,6 +13,7 @@ See ``plans/super/22-iteration-workspace.md``.
 
 from __future__ import annotations
 
+import errno
 import os
 import re
 import shutil
@@ -44,10 +45,16 @@ def validate_skill_name(skill: str) -> str:
     """Reject skill names that could escape the clauditor directory.
 
     Accepts alphanumerics plus ``_ . -``. Rejects empty strings, path
-    separators, parent references (``..``), and leading dots that could
-    otherwise collide with hidden dirs. Returns the validated name.
+    separators, parent references (``..``), and any name beginning with
+    a dot (to avoid collisions with hidden directories like ``.lock``
+    or ``.git`` siblings under ``.clauditor/``). Returns the validated
+    name.
     """
-    if not skill or skill in {".", ".."} or not _SKILL_NAME_RE.match(skill):
+    if (
+        not skill
+        or skill.startswith(".")
+        or not _SKILL_NAME_RE.match(skill)
+    ):
         raise InvalidSkillNameError(
             f"invalid skill name for workspace path: {skill!r}"
         )
@@ -95,6 +102,12 @@ class IterationWorkspace:
         try:
             os.rename(self._tmp_parent, self._final_parent)
         except OSError as exc:
+            # Only a concurrent-peer race produces ENOTEMPTY / EEXIST
+            # (the target directory was populated by another writer).
+            # Surface permission, disk-full, and read-only-fs errors
+            # unchanged so the caller sees the real failure.
+            if exc.errno not in (errno.ENOTEMPTY, errno.EEXIST):
+                raise
             self.abort()
             raise IterationExistsError(
                 f"iteration-{self.iteration} was finalized by a concurrent "

--- a/src/clauditor/workspace.py
+++ b/src/clauditor/workspace.py
@@ -1,0 +1,183 @@
+"""Iteration workspace allocator for clauditor grade runs.
+
+Allocates an ``iteration-N/`` slot under ``.clauditor/`` for a given skill.
+Writes stage to ``iteration-N-tmp/<skill>/`` first; callers invoke
+:meth:`IterationWorkspace.finalize` to atomically rename the staging dir
+into place, or :meth:`IterationWorkspace.abort` to discard it.
+
+Traces to DEC-001 (auto-increment + explicit override), DEC-006 (optimistic
+concurrent allocation), DEC-008 (collision policy), DEC-012 (atomic
+tmp+rename writes), DEC-014 (``--force`` clean-slate semantics).
+See ``plans/super/22-iteration-workspace.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "IterationExistsError",
+    "IterationWorkspace",
+    "allocate_iteration",
+]
+
+_ITERATION_RE = re.compile(r"^iteration-(\d+)$")
+_MAX_AUTO_RETRIES = 100
+
+
+class IterationExistsError(Exception):
+    """Raised when an explicit ``iteration=N`` collides and ``force`` is False."""
+
+
+@dataclass
+class IterationWorkspace:
+    """Handle for an allocated iteration slot.
+
+    Attributes:
+        iteration: The numeric iteration index.
+        final_path: Target path ``<clauditor_dir>/iteration-N/<skill>/``.
+            Does not exist until :meth:`finalize` is called.
+        tmp_path: Staging path ``<clauditor_dir>/iteration-N-tmp/<skill>/``
+            where callers should write artifacts.
+    """
+
+    iteration: int
+    final_path: Path
+    tmp_path: Path
+
+    @property
+    def _tmp_parent(self) -> Path:
+        return self.tmp_path.parent
+
+    @property
+    def _final_parent(self) -> Path:
+        return self.final_path.parent
+
+    def finalize(self) -> None:
+        """Atomically promote the tmp dir to its final location.
+
+        Uses :func:`os.rename` on the ``iteration-N-tmp`` → ``iteration-N``
+        parent directories (they are peers under ``clauditor_dir``, so the
+        rename is atomic on POSIX).
+        """
+        os.rename(self._tmp_parent, self._final_parent)
+
+    def abort(self) -> None:
+        """Remove the staging directory. Safe if it's already gone."""
+        shutil.rmtree(self._tmp_parent, ignore_errors=True)
+
+
+def _scan_existing_iterations(clauditor_dir: Path) -> set[int]:
+    """Return the set of iteration indices already present under ``clauditor_dir``.
+
+    Considers only real ``iteration-N/`` directories (not ``-tmp`` siblings
+    and not malformed names).
+    """
+    if not clauditor_dir.exists():
+        return set()
+    found: set[int] = set()
+    for child in clauditor_dir.iterdir():
+        if not child.is_dir():
+            continue
+        match = _ITERATION_RE.match(child.name)
+        if match is not None:
+            found.add(int(match.group(1)))
+    return found
+
+
+def allocate_iteration(
+    clauditor_dir: Path,
+    skill: str,
+    *,
+    iteration: int | None = None,
+    force: bool = False,
+) -> IterationWorkspace:
+    """Allocate an iteration workspace slot for ``skill`` under ``clauditor_dir``.
+
+    Args:
+        clauditor_dir: The ``.clauditor`` directory (created if missing).
+        skill: Skill name; becomes a subdirectory inside the iteration dir.
+        iteration: Explicit iteration index. ``None`` means auto-increment.
+        force: If True and an explicit ``iteration`` dir already exists,
+            ``shutil.rmtree`` it before allocation.
+
+    Returns:
+        An :class:`IterationWorkspace` whose ``tmp_path`` already exists and
+        is ready to be written into.
+
+    Raises:
+        IterationExistsError: ``iteration=N`` given, ``iteration-N/`` exists,
+            and ``force`` is False.
+        RuntimeError: Auto-increment could not find a free slot within the
+            retry cap (pathological contention).
+    """
+    clauditor_dir.mkdir(parents=True, exist_ok=True)
+
+    if iteration is not None:
+        return _allocate_explicit(clauditor_dir, skill, iteration, force=force)
+    return _allocate_auto(clauditor_dir, skill)
+
+
+def _allocate_explicit(
+    clauditor_dir: Path, skill: str, iteration: int, *, force: bool
+) -> IterationWorkspace:
+    final_parent = clauditor_dir / f"iteration-{iteration}"
+    tmp_parent = clauditor_dir / f"iteration-{iteration}-tmp"
+
+    if final_parent.exists():
+        if not force:
+            raise IterationExistsError(
+                f"iteration-{iteration} already exists; use --force to overwrite"
+            )
+        shutil.rmtree(final_parent)
+
+    # --force may also mean a prior aborted run left an orphan tmp dir.
+    if tmp_parent.exists():
+        shutil.rmtree(tmp_parent)
+
+    tmp_parent.mkdir(exist_ok=False)
+    tmp_path = tmp_parent / skill
+    tmp_path.mkdir(parents=True, exist_ok=False)
+    return IterationWorkspace(
+        iteration=iteration,
+        final_path=final_parent / skill,
+        tmp_path=tmp_path,
+    )
+
+
+def _allocate_auto(clauditor_dir: Path, skill: str) -> IterationWorkspace:
+    existing = _scan_existing_iterations(clauditor_dir)
+    candidate = (max(existing) + 1) if existing else 1
+
+    for _ in range(_MAX_AUTO_RETRIES):
+        final_parent = clauditor_dir / f"iteration-{candidate}"
+        tmp_parent = clauditor_dir / f"iteration-{candidate}-tmp"
+
+        # Skip slots whose final dir already exists (another worker won).
+        if final_parent.exists():
+            candidate += 1
+            continue
+
+        try:
+            tmp_parent.mkdir(exist_ok=False)
+        except FileExistsError:
+            # Peer racing on the same slot — try the next one.
+            candidate += 1
+            continue
+
+        tmp_path = tmp_parent / skill
+        tmp_path.mkdir(parents=True, exist_ok=False)
+        return IterationWorkspace(
+            iteration=candidate,
+            final_path=final_parent / skill,
+            tmp_path=tmp_path,
+        )
+
+    raise RuntimeError(
+        f"allocate_iteration: exceeded {_MAX_AUTO_RETRIES} retries scanning "
+        f"for a free iteration slot under {clauditor_dir}"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1273,6 +1273,48 @@ class TestCmdTrend:
         data_lines = [ln for ln in out.splitlines() if "\t" in ln]
         assert len(data_lines) == 5
 
+    def test_trend_over_mixed_schema(self, tmp_path, monkeypatch, capsys):
+        """cmd_trend renders cleanly over mixed v2 and v3 history (US-005)."""
+        import json as _json
+
+        from clauditor import history
+
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".clauditor" / "history.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # One v2 record (no iteration/workspace_path).
+        v2_rec = {
+            "schema_version": 2,
+            "command": "grade",
+            "ts": "2026-01-01T00:00:00+00:00",
+            "skill": "test-skill",
+            "pass_rate": 0.4,
+            "mean_score": 0.5,
+            "metrics": {},
+        }
+        with path.open("w", encoding="utf-8") as f:
+            f.write(_json.dumps(v2_rec) + "\n")
+
+        # One v3 record via the API.
+        history.append_record(
+            "test-skill",
+            0.9,
+            0.8,
+            {},
+            command="grade",
+            path=path,
+            iteration=1,
+            workspace_path="ws/1",
+        )
+
+        rc = main(["trend", "test-skill", "--metric", "pass_rate"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Both records should appear in the trend output.
+        assert "0.4" in out
+        assert "0.9" in out
+
 
 class TestCmdTrendCommandFilter:
     """cmd_trend --command filter (US-006)."""
@@ -1538,7 +1580,7 @@ class TestCmdGradeHistory:
         assert record["skill"] == "test-skill"
         assert record["pass_rate"] == 1.0
         assert record["mean_score"] == 0.9
-        assert record["schema_version"] == 2
+        assert record["schema_version"] == 3
         assert record["command"] == "grade"
 
     def test_grade_history_records_metrics(self, tmp_path, monkeypatch):
@@ -1843,7 +1885,7 @@ class TestCmdExtractHistory:
         assert len(lines) == 1
         record = json.loads(lines[0])
         assert record["skill"] == "test-skill"
-        assert record["schema_version"] == 2
+        assert record["schema_version"] == 3
         assert record["command"] == "extract"
         assert record["pass_rate"] is None
         assert record["mean_score"] is None
@@ -1941,7 +1983,7 @@ class TestCmdValidateHistory:
         assert len(lines) == 1
         record = json.loads(lines[0])
         assert record["skill"] == "test-skill"
-        assert record["schema_version"] == 2
+        assert record["schema_version"] == 3
         assert record["command"] == "validate"
         # Layer 1 pass_rate is 1.0 (the "contains hello" assertion passes)
         assert record["pass_rate"] == 1.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -379,6 +379,71 @@ class TestOnlyCriterion:
         assert rc == 0
         assert spec.eval_spec.grading_criteria == ["foo"]
 
+    @pytest.mark.parametrize(
+        "extra,label",
+        [
+            (["--iteration", "3"], "--iteration"),
+            (["--force"], "--force"),
+            (["--diff"], "--diff"),
+        ],
+    )
+    def test_only_criterion_rejects_conflicting_flags(
+        self, tmp_path, monkeypatch, capsys, extra, label
+    ):
+        """--only-criterion + --iteration/--force/--diff is a hard error.
+
+        Pass 3 bug 1/2 regression guard: these combinations could either
+        destroy the existing iteration-N baseline (--force) or report a
+        confusing diff against an abandoned slot (--diff).
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        output_file = tmp_path / "o.txt"
+        output_file.write_text("out")
+        eval_spec = _make_eval_spec(grading_criteria=["foo", "bar"])
+        spec = _make_spec(eval_spec=eval_spec)
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--only-criterion",
+                    "foo",
+                    *extra,
+                ]
+            )
+        assert rc == 2
+        assert label in capsys.readouterr().err
+
+    def test_only_criterion_does_not_publish_iteration_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """--only-criterion must not leave an iteration-N/ dir on disk.
+
+        A partial grading.json from a filtered run would otherwise be
+        picked up later as a bogus baseline by --diff / compare /
+        _find_prior_grading_json. Pass 2 bug 2 regression guard.
+        """
+        (tmp_path / ".git").mkdir()
+        rc, _mock, _spec = self._run(
+            tmp_path,
+            ["foo", "bar"],
+            ["--only-criterion", "foo"],
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0
+        clauditor_dir = tmp_path / ".clauditor"
+        if clauditor_dir.exists():
+            iteration_dirs = sorted(clauditor_dir.glob("iteration-*"))
+            final_dirs = [
+                d for d in iteration_dirs if not d.name.endswith("-tmp")
+            ]
+            assert final_dirs == [], (
+                f"--only-criterion unexpectedly published {final_dirs}"
+            )
+
 
 class TestCmdGradeSaveDiff:
     """Tests for the iteration workspace layout (US-004) and --diff."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,8 +187,9 @@ class TestCmdGrade:
             duration_seconds=1.0,
         )
 
-    def test_grade_with_output(self, tmp_path):
+    def test_grade_with_output(self, tmp_path, monkeypatch):
         """Grades pre-captured output, returns 0 when passed."""
+        monkeypatch.chdir(tmp_path)
         output_file = tmp_path / "output.txt"
         output_file.write_text("some skill output")
 
@@ -242,8 +243,9 @@ class TestCmdGrade:
         assert "Model:" in out
         assert "Prompt:" in out
 
-    def test_grade_failed(self, tmp_path):
+    def test_grade_failed(self, tmp_path, monkeypatch):
         """Returns 1 when grading fails."""
+        monkeypatch.chdir(tmp_path)
         output_file = tmp_path / "output.txt"
         output_file.write_text("bad output")
 
@@ -283,7 +285,9 @@ class TestOnlyCriterion:
             duration_seconds=1.0,
         )
 
-    def _run(self, tmp_path, criteria, extra_args):
+    def _run(self, tmp_path, criteria, extra_args, monkeypatch=None):
+        if monkeypatch is not None:
+            monkeypatch.chdir(tmp_path)
         output_file = tmp_path / "o.txt"
         output_file.write_text("out")
         eval_spec = _make_eval_spec(grading_criteria=list(criteria))
@@ -298,12 +302,13 @@ class TestOnlyCriterion:
             )
         return rc, mock_grade, spec
 
-    def test_single_substring_filters(self, tmp_path):
+    def test_single_substring_filters(self, tmp_path, monkeypatch):
         """--only-criterion foo keeps only matching criteria."""
         rc, mock_grade, spec = self._run(
             tmp_path,
             ["foo bar", "baz qux", "other foo"],
             ["--only-criterion", "foo"],
+            monkeypatch=monkeypatch,
         )
         assert rc == 0
         assert spec.eval_spec.grading_criteria == ["foo bar", "other foo"]
@@ -312,12 +317,13 @@ class TestOnlyCriterion:
         passed_spec = mock_grade.call_args.args[1]
         assert passed_spec.grading_criteria == ["foo bar", "other foo"]
 
-    def test_multiple_substrings_union(self, tmp_path):
+    def test_multiple_substrings_union(self, tmp_path, monkeypatch):
         """Multiple --only-criterion flags use OR semantics."""
         rc, mock_grade, spec = self._run(
             tmp_path,
             ["alpha", "beta", "gamma", "alphabeta"],
             ["--only-criterion", "alpha", "--only-criterion", "gamma"],
+            monkeypatch=monkeypatch,
         )
         assert rc == 0
         assert spec.eval_spec.grading_criteria == ["alpha", "gamma", "alphabeta"]
@@ -354,25 +360,28 @@ class TestOnlyCriterion:
         # Grader must NOT have been called
         mock_grade.assert_not_called()
 
-    def test_no_flag_passes_all(self, tmp_path):
+    def test_no_flag_passes_all(self, tmp_path, monkeypatch):
         """Without --only-criterion, all criteria are passed through."""
         rc, mock_grade, spec = self._run(
-            tmp_path, ["one", "two", "three"], []
+            tmp_path, ["one", "two", "three"], [], monkeypatch=monkeypatch
         )
         assert rc == 0
         assert spec.eval_spec.grading_criteria == ["one", "two", "three"]
 
-    def test_case_insensitive(self, tmp_path):
+    def test_case_insensitive(self, tmp_path, monkeypatch):
         """--only-criterion FOO matches criterion 'foo'."""
         rc, _mock, spec = self._run(
-            tmp_path, ["foo", "bar"], ["--only-criterion", "FOO"]
+            tmp_path,
+            ["foo", "bar"],
+            ["--only-criterion", "FOO"],
+            monkeypatch=monkeypatch,
         )
         assert rc == 0
         assert spec.eval_spec.grading_criteria == ["foo"]
 
 
 class TestCmdGradeSaveDiff:
-    """Tests for --save and --diff flags on the grade subcommand."""
+    """Tests for the iteration workspace layout (US-004) and --diff."""
 
     def _make_grading_report(self, skill_name="test-skill", passed=True, score=0.9):
         return GradingReport(
@@ -390,192 +399,322 @@ class TestCmdGradeSaveDiff:
             duration_seconds=1.0,
         )
 
-    def test_save_creates_file(self, tmp_path):
-        """--save writes JSON to .clauditor/."""
+    def _patch_grade(self, spec, report):
+        return (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        )
+
+    def test_grade_writes_iteration_one_when_empty(self, tmp_path, monkeypatch):
+        """An empty .clauditor/ allocates iteration-1 with the full layout."""
+        monkeypatch.chdir(tmp_path)
         output_file = tmp_path / "output.txt"
         output_file.write_text("some skill output")
 
-        eval_spec = _make_eval_spec()
-        spec = _make_spec(eval_spec=eval_spec)
+        spec = _make_spec(eval_spec=_make_eval_spec())
         report = self._make_grading_report()
 
-        import os
-
-        orig_dir = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            with (
-                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
-                patch(
-                    "clauditor.quality_grader.grade_quality",
-                    new_callable=AsyncMock,
-                    return_value=report,
-                ),
-            ):
-                rc = main(
-                    ["grade", "skill.md", "--output", str(output_file), "--save"]
-                )
-
-            assert rc == 0
-            save_path = tmp_path / ".clauditor" / "test-skill.grade.json"
-            assert save_path.exists()
-            data = json.loads(save_path.read_text())
-            assert data["skill_name"] == "test-skill"
-        finally:
-            os.chdir(orig_dir)
-
-    def test_save_creates_directory(self, tmp_path):
-        """.clauditor/ is created if missing."""
-        output_file = tmp_path / "output.txt"
-        output_file.write_text("some skill output")
-
-        eval_spec = _make_eval_spec()
-        spec = _make_spec(eval_spec=eval_spec)
-        report = self._make_grading_report()
-
-        import os
-
-        orig_dir = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            assert not (tmp_path / ".clauditor").exists()
-            with (
-                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
-                patch(
-                    "clauditor.quality_grader.grade_quality",
-                    new_callable=AsyncMock,
-                    return_value=report,
-                ),
-            ):
-                main(["grade", "skill.md", "--output", str(output_file), "--save"])
-
-            assert (tmp_path / ".clauditor").is_dir()
-        finally:
-            os.chdir(orig_dir)
-
-    def test_diff_shows_regressions(self, tmp_path, capsys):
-        """--diff with prior results shows regression table."""
-        output_file = tmp_path / "output.txt"
-        output_file.write_text("some skill output")
-
-        eval_spec = _make_eval_spec()
-        spec = _make_spec(eval_spec=eval_spec)
-
-        # Prior report: high score
-        prior_report = self._make_grading_report(score=0.9, passed=True)
-        # Current report: low score (regression)
-        current_report = self._make_grading_report(score=0.5, passed=False)
-
-        import os
-
-        orig_dir = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            # Write prior results
-            save_dir = tmp_path / ".clauditor"
-            save_dir.mkdir()
-            (save_dir / "test-skill.grade.json").write_text(prior_report.to_json())
-
-            with (
-                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
-                patch(
-                    "clauditor.quality_grader.grade_quality",
-                    new_callable=AsyncMock,
-                    return_value=current_report,
-                ),
-            ):
-                main(["grade", "skill.md", "--output", str(output_file), "--diff"])
-
-            out = capsys.readouterr().out
-            assert "REGRESSION" in out
-            assert "1 regression(s) detected" in out
-        finally:
-            os.chdir(orig_dir)
-
-    def test_diff_no_prior_warns(self, tmp_path, capsys):
-        """--diff without prior results warns, doesn't error."""
-        output_file = tmp_path / "output.txt"
-        output_file.write_text("some skill output")
-
-        eval_spec = _make_eval_spec()
-        spec = _make_spec(eval_spec=eval_spec)
-        report = self._make_grading_report()
-
-        import os
-
-        orig_dir = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            with (
-                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
-                patch(
-                    "clauditor.quality_grader.grade_quality",
-                    new_callable=AsyncMock,
-                    return_value=report,
-                ),
-            ):
-                rc = main(
-                    ["grade", "skill.md", "--output", str(output_file), "--diff"]
-                )
-
-            assert rc == 0
-            err = capsys.readouterr().err
-            assert "WARNING" in err
-            assert "No prior results" in err
-        finally:
-            os.chdir(orig_dir)
-
-    def test_save_and_diff_together(self, tmp_path, capsys):
-        """Both --save and --diff work in sequence."""
-        output_file = tmp_path / "output.txt"
-        output_file.write_text("some skill output")
-
-        eval_spec = _make_eval_spec()
-        spec = _make_spec(eval_spec=eval_spec)
-
-        prior_report = self._make_grading_report(score=0.8, passed=True)
-        current_report = self._make_grading_report(score=0.85, passed=True)
-
-        import os
-
-        orig_dir = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            # Write prior results
-            save_dir = tmp_path / ".clauditor"
-            save_dir.mkdir()
-            (save_dir / "test-skill.grade.json").write_text(prior_report.to_json())
-
-            with (
-                patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
-                patch(
-                    "clauditor.quality_grader.grade_quality",
-                    new_callable=AsyncMock,
-                    return_value=current_report,
-                ),
-            ):
-                rc = main(
-                    [
-                        "grade",
-                        "skill.md",
-                        "--output",
-                        str(output_file),
-                        "--diff",
-                        "--save",
-                    ]
-                )
-
-            assert rc == 0
-            out = capsys.readouterr().out
-            # Diff ran (no regressions since score improved)
-            assert "No regressions detected" in out
-            # Save ran — file updated with current results
-            saved = json.loads(
-                (save_dir / "test-skill.grade.json").read_text()
+        s_patch, g_patch = self._patch_grade(spec, report)
+        with s_patch, g_patch:
+            rc = main(
+                ["grade", "skill.md", "--output", str(output_file)]
             )
-            assert saved["results"][0]["score"] == 0.85
-        finally:
-            os.chdir(orig_dir)
+
+        assert rc == 0
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        assert skill_dir.is_dir()
+        assert (skill_dir / "grading.json").is_file()
+        assert (skill_dir / "timing.json").is_file()
+        assert (skill_dir / "run-0" / "output.txt").is_file()
+        assert (skill_dir / "run-0" / "output.jsonl").is_file()
+        assert (
+            (skill_dir / "run-0" / "output.txt").read_text()
+            == "some skill output"
+        )
+        # No tmp dir should remain after a successful finalize.
+        assert not (tmp_path / ".clauditor" / "iteration-1-tmp").exists()
+        # grading.json round-trips through GradingReport
+        rt = GradingReport.from_json(
+            (skill_dir / "grading.json").read_text()
+        )
+        assert rt.skill_name == "test-skill"
+        # timing.json holds metrics
+        timing = json.loads((skill_dir / "timing.json").read_text())
+        assert timing["iteration"] == 1
+        assert "metrics" in timing
+
+    def test_grade_auto_increments_across_runs(self, tmp_path, monkeypatch):
+        """Two runs in a row produce iteration-1/ then iteration-2/."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        report = self._make_grading_report()
+
+        s, g = self._patch_grade(spec, report)
+        with s, g:
+            assert main(
+                ["grade", "skill.md", "--output", str(output_file)]
+            ) == 0
+            assert main(
+                ["grade", "skill.md", "--output", str(output_file)]
+            ) == 0
+
+        assert (tmp_path / ".clauditor" / "iteration-1" / "test-skill").is_dir()
+        assert (tmp_path / ".clauditor" / "iteration-2" / "test-skill").is_dir()
+
+    def test_grade_iteration_explicit_collision_errors(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Re-running --iteration N without --force errors non-zero."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        report = self._make_grading_report()
+
+        s, g = self._patch_grade(spec, report)
+        with s, g:
+            assert main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--iteration",
+                    "5",
+                ]
+            ) == 0
+            rc2 = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--iteration",
+                    "5",
+                ]
+            )
+        assert rc2 != 0
+        err = capsys.readouterr().err
+        assert "iteration-5" in err
+        assert "--force" in err
+
+    def test_grade_iteration_force_overwrites(self, tmp_path, monkeypatch):
+        """--force replaces an existing iteration-N/ cleanly."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("first")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        first_report = self._make_grading_report(score=0.9)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=first_report,
+            ),
+        ):
+            assert main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--iteration",
+                    "5",
+                ]
+            ) == 0
+
+        # Second run with different content + --force
+        output_file.write_text("second")
+        second_report = self._make_grading_report(score=0.55)
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=second_report,
+            ),
+        ):
+            assert main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--iteration",
+                    "5",
+                    "--force",
+                ]
+            ) == 0
+
+        skill_dir = tmp_path / ".clauditor" / "iteration-5" / "test-skill"
+        assert (skill_dir / "run-0" / "output.txt").read_text() == "second"
+        rt = GradingReport.from_json((skill_dir / "grading.json").read_text())
+        assert rt.results[0].score == 0.55
+
+    def test_grade_variance_produces_run_subdirs(self, tmp_path, monkeypatch):
+        """--variance N produces N+1 run-K/ subdirs under one iteration."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("primary text")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+
+        # Variance runs invoke spec.run() — return distinct outputs.
+        spec.run.side_effect = [
+            SkillResult(
+                output=f"variance run {i}",
+                exit_code=0,
+                skill_name="test-skill",
+                args="",
+                duration_seconds=0.5,
+                input_tokens=10,
+                output_tokens=5,
+                stream_events=[{"type": "result", "i": i}],
+            )
+            for i in range(2)
+        ]
+
+        report = self._make_grading_report()
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--variance",
+                    "2",
+                ]
+            )
+        assert rc == 0
+
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        for k in (0, 1, 2):
+            assert (skill_dir / f"run-{k}" / "output.txt").is_file()
+            assert (skill_dir / f"run-{k}" / "output.jsonl").is_file()
+        assert (
+            (skill_dir / "run-0" / "output.txt").read_text() == "primary text"
+        )
+        assert (
+            (skill_dir / "run-1" / "output.txt").read_text() == "variance run 0"
+        )
+        assert (
+            (skill_dir / "run-2" / "output.txt").read_text() == "variance run 1"
+        )
+        # Single grading.json at the skill level (not per-run)
+        assert (skill_dir / "grading.json").is_file()
+
+    def test_grade_save_flag_removed(self, tmp_path, monkeypatch, capsys):
+        """argparse rejects --save with an unrecognized argument error."""
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            main(["grade", "skill.md", "--save"])
+        err = capsys.readouterr().err
+        assert "--save" in err or "unrecognized" in err
+
+    def test_grade_crash_leaves_no_iteration_dir(self, tmp_path, monkeypatch):
+        """An exception mid-write must not leave a finalized iteration-N/."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        boom = AsyncMock(side_effect=RuntimeError("kaboom"))
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch("clauditor.quality_grader.grade_quality", boom),
+            pytest.raises(RuntimeError),
+        ):
+            main(["grade", "skill.md", "--output", str(output_file)])
+
+        # iteration-1/ must not exist (only an orphan tmp dir is allowed).
+        assert not (tmp_path / ".clauditor" / "iteration-1").exists()
+
+    def test_grade_diff_shows_regression_against_prior_iteration(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--diff compares against the most recent prior iteration's grading.json."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+
+        prior_report = self._make_grading_report(score=0.9, passed=True)
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=prior_report,
+            ),
+        ):
+            assert main(
+                ["grade", "skill.md", "--output", str(output_file)]
+            ) == 0
+
+        current_report = self._make_grading_report(score=0.4, passed=False)
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=current_report,
+            ),
+        ):
+            main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--diff",
+                ]
+            )
+        out = capsys.readouterr().out
+        assert "REGRESSION" in out
+
+    def test_grade_diff_no_prior_warns(self, tmp_path, monkeypatch, capsys):
+        """--diff with no prior iteration warns, does not error."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        report = self._make_grading_report()
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--diff",
+                ]
+            )
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "No prior iteration" in err
 
 
 class TestCmdCompare:
@@ -1632,13 +1771,11 @@ class TestCmdGradeHistory:
         assert "grader" not in metrics
         assert "triggers" not in metrics
 
-    def test_grade_variance_rolls_tokens_into_history_and_grade_json(
+    def test_grade_variance_rolls_tokens_into_history_and_grading_json(
         self, tmp_path, monkeypatch
     ):
-        """cmd_grade --variance N: variance-run skill + grader tokens must
-        be summed into metrics in BOTH history.jsonl and .grade.json."""
-        from clauditor.quality_grader import VarianceReport
-
+        """--variance N: skill + grader tokens across all runs roll up into
+        both history.jsonl metrics and the iteration's grading.json."""
         monkeypatch.chdir(tmp_path)
 
         output_file = tmp_path / "output.txt"
@@ -1646,9 +1783,25 @@ class TestCmdGradeHistory:
 
         eval_spec = _make_eval_spec()
         spec = _make_spec(eval_spec=eval_spec)
+        # Each variance run: 10 in / 5 out skill tokens, 0.5s duration.
+        spec.run.side_effect = [
+            SkillResult(
+                output=f"v{i}",
+                exit_code=0,
+                skill_name="test-skill",
+                args="",
+                duration_seconds=0.5,
+                input_tokens=10,
+                output_tokens=5,
+                stream_events=[],
+            )
+            for i in range(3)
+        ]
 
-        # Primary grade report: 500/200 grader tokens
-        primary_report = GradingReport(
+        # Each grade_quality call returns the same per-run report shape:
+        # 200 in / 100 out grader tokens. Total runs = 1 primary + 3 variance
+        # = 4 grader calls -> quality totals 800 / 400.
+        per_run_report = GradingReport(
             skill_name="test-skill",
             model="claude-sonnet-4-6",
             results=[
@@ -1661,26 +1814,8 @@ class TestCmdGradeHistory:
                 )
             ],
             duration_seconds=1.0,
-            input_tokens=500,
-            output_tokens=200,
-        )
-
-        # Variance: 3 more runs with 100/50 grader tokens each, 10/5 skill
-        # tokens each, 0.5s skill duration each = totals 300/150 grader,
-        # 30/15 skill, 1.5s skill duration.
-        variance_report = VarianceReport(
-            skill_name="test-skill",
-            n_runs=3,
-            reports=[],
-            score_mean=1.0,
-            score_stddev=0.0,
-            pass_rate_mean=1.0,
-            stability=1.0,
-            input_tokens=300,
-            output_tokens=150,
-            skill_input_tokens=30,
-            skill_output_tokens=15,
-            skill_duration_seconds=1.5,
+            input_tokens=200,
+            output_tokens=100,
         )
 
         with (
@@ -1688,12 +1823,7 @@ class TestCmdGradeHistory:
             patch(
                 "clauditor.quality_grader.grade_quality",
                 new_callable=AsyncMock,
-                return_value=primary_report,
-            ),
-            patch(
-                "clauditor.quality_grader.measure_variance",
-                new_callable=AsyncMock,
-                return_value=variance_report,
+                return_value=per_run_report,
             ),
         ):
             rc = main(
@@ -1704,39 +1834,32 @@ class TestCmdGradeHistory:
                     str(output_file),
                     "--variance",
                     "3",
-                    "--save",
                 ]
             )
 
         assert rc == 0
 
-        # Check history.jsonl
         history_path = tmp_path / ".clauditor" / "history.jsonl"
         record = json.loads(history_path.read_text().splitlines()[0])
-        history_metrics = record["metrics"]
+        m = record["metrics"]
+        # Primary --output -> skill 0/0/0.0; variance: 3 * (10/5/0.5) = 30/15/1.5
+        assert m["skill"]["input_tokens"] == 30
+        assert m["skill"]["output_tokens"] == 15
+        assert m["duration_seconds"] == pytest.approx(1.5)
+        # Quality: 4 grader calls * 200/100 = 800/400
+        assert m["quality"]["input_tokens"] == 800
+        assert m["quality"]["output_tokens"] == 400
+        assert m["total"]["total"] == 30 + 15 + 800 + 400
 
-        # Primary --output run: skill tokens 0. Variance adds 30/15.
-        assert history_metrics["skill"]["input_tokens"] == 30
-        assert history_metrics["skill"]["output_tokens"] == 15
-        # Quality: primary 500/200 + variance 300/150 = 800/350
-        assert history_metrics["quality"]["input_tokens"] == 800
-        assert history_metrics["quality"]["output_tokens"] == 350
-        # Total: skill 30+15 + quality 800+350 = 1195
-        assert history_metrics["total"]["total"] == 1195
-        # Skill duration: --output path 0.0 + variance 1.5 = 1.5
-        assert history_metrics["duration_seconds"] == pytest.approx(1.5)
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        grade_data = json.loads((skill_dir / "grading.json").read_text())
+        assert grade_data["metrics"] == m
+        timing = json.loads((skill_dir / "timing.json").read_text())
+        assert timing["metrics"] == m
+        assert timing["n_runs"] == 4
 
-        # Check .grade.json mirrors history
-        grade_path = tmp_path / ".clauditor" / "test-skill.grade.json"
-        assert grade_path.exists()
-        grade_data = json.loads(grade_path.read_text())
-        grade_metrics = grade_data["metrics"]
-        assert grade_metrics == history_metrics
-
-    def test_grade_save_writes_metrics_to_grade_json(
-        self, tmp_path, monkeypatch
-    ):
-        """--save writes metrics into the .grade.json report."""
+    def test_grade_writes_metrics_to_grading_json(self, tmp_path, monkeypatch):
+        """grading.json carries the same metrics dict as history.jsonl."""
         monkeypatch.chdir(tmp_path)
 
         output_file = tmp_path / "output.txt"
@@ -1770,28 +1893,67 @@ class TestCmdGradeHistory:
             ),
         ):
             rc = main(
-                [
-                    "grade",
-                    "skill.md",
-                    "--output",
-                    str(output_file),
-                    "--save",
-                ]
+                ["grade", "skill.md", "--output", str(output_file)]
             )
 
         assert rc == 0
-        save_path = tmp_path / ".clauditor" / "test-skill.grade.json"
-        assert save_path.exists()
-        data = json.loads(save_path.read_text())
-        assert "metrics" in data
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        grading_path = skill_dir / "grading.json"
+        assert grading_path.exists()
+        data = json.loads(grading_path.read_text())
         assert data["metrics"]["quality"]["input_tokens"] == 300
         assert data["metrics"]["quality"]["output_tokens"] == 100
         assert data["metrics"]["total"]["total"] == 400
 
-        # Round-trip through GradingReport.from_json
-        rt = GradingReport.from_json(save_path.read_text())
+        rt = GradingReport.from_json(grading_path.read_text())
         assert rt.metrics is not None
         assert rt.metrics["quality"]["input_tokens"] == 300
+
+    def test_grade_history_record_has_iteration_and_workspace_path(
+        self, tmp_path, monkeypatch
+    ):
+        """history.jsonl records carry iteration + workspace_path (schema v3)."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        report = GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="c",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            assert main(
+                ["grade", "skill.md", "--output", str(output_file)]
+            ) == 0
+
+        history_path = tmp_path / ".clauditor" / "history.jsonl"
+        record = json.loads(history_path.read_text().splitlines()[0])
+        assert record["iteration"] == 1
+        assert record["workspace_path"] is not None
+        assert record["workspace_path"].endswith(
+            "iteration-1/test-skill"
+        ) or record["workspace_path"].endswith(
+            "iteration-1\\test-skill"
+        )
 
     def test_grade_only_criterion_still_skips_history(
         self, tmp_path, monkeypatch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -685,6 +685,271 @@ class TestCmdGradeSaveDiff:
         # Single grading.json at the skill level (not per-run)
         assert (skill_dir / "grading.json").is_file()
 
+    def test_grade_primary_skill_subprocess_path(
+        self, tmp_path, monkeypatch
+    ):
+        """No --output: cmd_grade runs the skill subprocess and captures
+        its stream_events + token totals into run-0/ and metrics.
+
+        Covers the primary-run branch (306-322).
+        """
+        monkeypatch.chdir(tmp_path)
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run = MagicMock(
+            return_value=SkillResult(
+                output="primary output",
+                exit_code=0,
+                skill_name="test-skill",
+                args="",
+                stream_events=[
+                    {"type": "assistant", "text": "primary output"}
+                ],
+                input_tokens=100,
+                output_tokens=50,
+                duration_seconds=1.5,
+            )
+        )
+        report = self._make_grading_report()
+        s, g = self._patch_grade(spec, report)
+        with s, g:
+            rc = main(["grade", "skill.md"])
+        assert rc == 0
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        assert (skill_dir / "run-0" / "output.txt").read_text() == (
+            "primary output"
+        )
+        # stream_events serialized to output.jsonl
+        jsonl_lines = [
+            line
+            for line in (skill_dir / "run-0" / "output.jsonl")
+            .read_text()
+            .splitlines()
+            if line.strip()
+        ]
+        assert len(jsonl_lines) == 1
+        assert json.loads(jsonl_lines[0])["type"] == "assistant"
+        # timing.json has skill bucket tokens
+        timing = json.loads((skill_dir / "timing.json").read_text())
+        metrics = timing["metrics"]
+        assert metrics["skill"]["input_tokens"] == 100
+        assert metrics["skill"]["output_tokens"] == 50
+
+    def test_grade_primary_skill_failure_returns_1(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """If the primary skill subprocess fails, grade exits 1 with error.
+
+        The workspace staging dir must be aborted (not finalized).
+        """
+        monkeypatch.chdir(tmp_path)
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run = MagicMock(
+            return_value=SkillResult(
+                output="",
+                exit_code=1,
+                skill_name="test-skill",
+                args="",
+                error="skill blew up",
+            )
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["grade", "skill.md"])
+        assert rc == 1
+        assert "skill blew up" in capsys.readouterr().err
+        # No iteration-N/ should remain.
+        clauditor_dir = tmp_path / ".clauditor"
+        if clauditor_dir.exists():
+            assert list(clauditor_dir.glob("iteration-*/")) == []
+
+    def test_grade_variance_run_failure_returns_1(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """If a variance subrun fails, grade exits 1 with error.
+
+        Covers the variance-run failure branch (329-333).
+        """
+        monkeypatch.chdir(tmp_path)
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        # First call succeeds (primary), second fails (variance run 1).
+        spec.run = MagicMock(
+            side_effect=[
+                SkillResult(
+                    output="primary",
+                    exit_code=0,
+                    skill_name="test-skill",
+                    args="",
+                    stream_events=[],
+                    input_tokens=10,
+                    output_tokens=5,
+                    duration_seconds=0.5,
+                ),
+                SkillResult(
+                    output="",
+                    exit_code=1,
+                    skill_name="test-skill",
+                    args="",
+                    error="variance kaboom",
+                ),
+            ]
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["grade", "skill.md", "--variance", "1"])
+        assert rc == 1
+        assert "variance kaboom" in capsys.readouterr().err.lower()
+        # No iteration-N/ should remain.
+        clauditor_dir = tmp_path / ".clauditor"
+        if clauditor_dir.exists():
+            assert list(clauditor_dir.glob("iteration-*/")) == []
+
+    def test_grade_invalid_skill_name_errors(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Path-traversal skill names surface as a clean error from cmd_grade.
+
+        Covers the InvalidSkillNameError catch in cmd_grade (PR review).
+        """
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        # SkillSpec.from_file returns a spec whose skill_name is unsafe.
+        spec = _make_spec(
+            skill_name="../evil", eval_spec=_make_eval_spec()
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(
+                ["grade", "skill.md", "--output", str(output_file)]
+            )
+        assert rc == 2
+        assert "invalid skill name" in capsys.readouterr().err
+
+    def test_grade_programmatic_value_error_caught(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """cmd_grade converts allocate_iteration ValueError to exit 2.
+
+        argparse rejects --iteration<1 at the CLI boundary, but the
+        programmatic path (direct call with a crafted Namespace) can
+        still reach the allocator; cmd_grade's `except ValueError`
+        branch surfaces the error cleanly.
+        """
+        import argparse
+
+        from clauditor.cli import cmd_grade
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        output_file = tmp_path / "o.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        ns = argparse.Namespace(
+            skill="skill.md",
+            eval=None,
+            output=str(output_file),
+            model=None,
+            variance=None,
+            dry_run=False,
+            iteration=0,  # invalid — triggers ValueError in allocator
+            force=False,
+            only_criterion=None,
+            diff=False,
+            json=False,
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = cmd_grade(ns)
+        assert rc == 2
+        assert "iteration must be" in capsys.readouterr().err
+
+    def test_grade_iteration_zero_rejected_by_argparse(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--iteration 0 is rejected at argparse (uses _positive_int)."""
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            main(["grade", "skill.md", "--iteration", "0"])
+        err = capsys.readouterr().err
+        assert "--iteration" in err or "must be" in err or "invalid" in err
+
+    def test_grade_finalize_race_surfaces_clean_error(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Concurrent finalize() race produces exit 1, not a traceback.
+
+        Covers the IterationExistsError catch around
+        _cmd_grade_with_workspace.
+        """
+        import errno as _errno
+
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        report = self._make_grading_report()
+
+        enotempty = OSError(_errno.ENOTEMPTY, "Directory not empty")
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+            patch(
+                "clauditor.workspace.os.rename", side_effect=enotempty
+            ),
+        ):
+            rc = main(
+                ["grade", "skill.md", "--output", str(output_file)]
+            )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "finalized by a concurrent writer" in err
+
+    def test_grade_json_variance_output_shape(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--json --variance emits a populated data.variance sub-object.
+
+        Covers the `if variance_report:` JSON branch (475-483).
+        """
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "o.txt"
+        output_file.write_text("hi")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        # Variance runs call spec.run() — return a real SkillResult so
+        # the stream_events and token accounting paths don't blow up.
+        spec.run = MagicMock(
+            return_value=SkillResult(
+                output="variance run",
+                exit_code=0,
+                skill_name="test-skill",
+                args="",
+                stream_events=[],
+                input_tokens=5,
+                output_tokens=3,
+                duration_seconds=0.1,
+            )
+        )
+        report = self._make_grading_report()
+        s, g = self._patch_grade(spec, report)
+        with s, g:
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--output",
+                    str(output_file),
+                    "--variance",
+                    "2",
+                    "--json",
+                ]
+            )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["variance"] is not None
+        assert payload["variance"]["n_runs"] == 3
+        assert "score_mean" in payload["variance"]
+        assert "stability" in payload["variance"]
+
     def test_grade_save_flag_removed(self, tmp_path, monkeypatch, capsys):
         """argparse rejects --save with an unrecognized argument error."""
         monkeypatch.chdir(tmp_path)
@@ -1021,6 +1286,33 @@ class TestCmdCompareNumericRefs:
         assert rc == 2
         err = capsys.readouterr().err
         assert "cannot combine" in err or "--skill" in err
+
+    def test_compare_numeric_refs_partial_args_error(self, tmp_path, capsys):
+        """--skill without --from/--to errors with clear message."""
+        rc = main(["compare", "--skill", "foo", "--from", "1"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "all be provided together" in err
+
+    def test_compare_missing_positional_args_error(self, tmp_path, capsys):
+        """No positional paths and no --skill: clear error."""
+        rc = main(["compare"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "positional paths" in err or "--skill" in err
+
+    def test_compare_invalid_skill_name_in_numeric_form(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--skill with path-traversal name surfaces a clean error."""
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            ["compare", "--skill", "../evil", "--from", "1", "--to", "2"]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "invalid skill name" in err
 
     def test_compare_legacy_grade_json_files(self, tmp_path, capsys):
         """Regression: legacy two .grade.json file form still works."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -836,6 +836,157 @@ class TestCmdCompare:
         assert "Mismatched" in err
 
 
+class TestCmdCompareIterationDirs:
+    """compare auto-detects iteration directory layouts (clauditor-yng.6)."""
+
+    def _make_grading_json(self, dir_path, criterion_passes):
+        dir_path.mkdir(parents=True, exist_ok=True)
+        results = [
+            GradingResult(
+                criterion=c,
+                passed=p,
+                score=0.9 if p else 0.3,
+                evidence="",
+                reasoning="",
+            )
+            for c, p in criterion_passes.items()
+        ]
+        report = GradingReport(
+            skill_name=dir_path.name,
+            model="test-model",
+            results=results,
+            duration_seconds=0.0,
+        )
+        (dir_path / "grading.json").write_text(report.to_json())
+        return dir_path
+
+    def test_compare_two_iteration_dirs(self, tmp_path, capsys):
+        before_dir = self._make_grading_json(
+            tmp_path / ".clauditor" / "iteration-1" / "foo",
+            {"c1": True, "c2": True},
+        )
+        after_dir = self._make_grading_json(
+            tmp_path / ".clauditor" / "iteration-2" / "foo",
+            {"c1": True, "c2": False},
+        )
+        rc = main(["compare", str(before_dir), str(after_dir)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "[REGRESSION]" in out
+        assert "c2" in out
+
+    def test_compare_dir_missing_grading_json_errors(self, tmp_path, capsys):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        rc = main(["compare", str(empty_dir), str(other)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "no grading.json found" in err
+
+
+class TestCmdCompareNumericRefs:
+    """compare --skill/--from/--to numeric ref form (clauditor-yng.6)."""
+
+    def _make_grading_json(self, dir_path, criterion_passes):
+        dir_path.mkdir(parents=True, exist_ok=True)
+        results = [
+            GradingResult(
+                criterion=c,
+                passed=p,
+                score=0.9 if p else 0.3,
+                evidence="",
+                reasoning="",
+            )
+            for c, p in criterion_passes.items()
+        ]
+        report = GradingReport(
+            skill_name=dir_path.name,
+            model="test-model",
+            results=results,
+            duration_seconds=0.0,
+        )
+        (dir_path / "grading.json").write_text(report.to_json())
+
+    def test_compare_numeric_refs(self, tmp_path, monkeypatch, capsys):
+        # Set up a fake repo root marker so resolve_clauditor_dir() finds it.
+        (tmp_path / ".git").mkdir()
+        self._make_grading_json(
+            tmp_path / ".clauditor" / "iteration-1" / "foo",
+            {"c1": True, "c2": True},
+        )
+        self._make_grading_json(
+            tmp_path / ".clauditor" / "iteration-2" / "foo",
+            {"c1": True, "c2": False},
+        )
+        monkeypatch.chdir(tmp_path)
+        rc = main(["compare", "--skill", "foo", "--from", "1", "--to", "2"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "[REGRESSION]" in out
+        assert "c2" in out
+
+    def test_compare_positional_and_numeric_conflict_errors(
+        self, tmp_path, capsys
+    ):
+        before = tmp_path / "before.grade.json"
+        after = tmp_path / "after.grade.json"
+        report = GradingReport(
+            skill_name="x",
+            model="m",
+            results=[],
+            duration_seconds=0.0,
+        )
+        before.write_text(report.to_json())
+        after.write_text(report.to_json())
+        rc = main(
+            [
+                "compare",
+                str(before),
+                str(after),
+                "--skill",
+                "foo",
+                "--from",
+                "1",
+                "--to",
+                "2",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "cannot combine" in err or "--skill" in err
+
+    def test_compare_legacy_grade_json_files(self, tmp_path, capsys):
+        """Regression: legacy two .grade.json file form still works."""
+        before = tmp_path / "before.grade.json"
+        after = tmp_path / "after.grade.json"
+        for p, passes in [
+            (before, {"c1": True}),
+            (after, {"c1": True}),
+        ]:
+            report = GradingReport(
+                skill_name=p.stem,
+                model="test-model",
+                results=[
+                    GradingResult(
+                        criterion=c,
+                        passed=v,
+                        score=0.9 if v else 0.3,
+                        evidence="",
+                        reasoning="",
+                    )
+                    for c, v in passes.items()
+                ],
+                duration_seconds=0.0,
+            )
+            p.write_text(report.to_json())
+        rc = main(["compare", str(before), str(after)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "no flips" in out
+
+
 class TestCmdGradeCompareFlagRemoved:
     """US-003: the legacy --compare flag on grade is gone."""
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -287,6 +287,12 @@ class TestConcurrentAppend:
         path.parent.mkdir(parents=True, exist_ok=True)
 
         n = 8
+        # Use fork: it's reliable under pytest+coverage, cheap, and this
+        # test is Linux-only (pyproject.toml pins clauditor to Linux).
+        # spawn hangs under pytest-cov due to the child needing to
+        # re-import coverage machinery before any user code runs.
+        if not hasattr(__import__("os"), "fork"):
+            pytest.skip("fork multiprocessing required for this test")
         ctx = multiprocessing.get_context("fork")
         with ctx.Pool(4) as pool:
             pool.map(

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -310,6 +311,46 @@ class TestConcurrentAppend:
             assert isinstance(rec["iteration"], int)
             seen_iters.add(rec["iteration"])
         assert seen_iters == set(range(n))
+
+
+class TestFileLockFallback:
+    """Coverage for _file_lock's fallback path on filesystems without flock."""
+
+    def test_flock_oserror_falls_back_to_unlocked_append(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """If fcntl.flock raises OSError, append still succeeds with warn.
+
+        Simulates WSL2 /mnt/* drvfs / NFSv3 environments where advisory
+        locking is unsupported.
+        """
+        import clauditor.history as history_mod
+
+        # Reset the module-level warn-once flag so the warning fires.
+        monkeypatch.setattr(history_mod, "_FLOCK_UNSUPPORTED_WARNED", False)
+
+        path = tmp_path / ".clauditor" / "history.jsonl"
+
+        def _raise(*_a, **_k):
+            raise OSError("flock unsupported on this fs")
+
+        with patch.object(history_mod.fcntl, "flock", side_effect=_raise):
+            append_record(
+                skill="foo",
+                pass_rate=1.0,
+                mean_score=0.9,
+                metrics={},
+                command="grade",
+                path=path,
+                iteration=1,
+                workspace_path=".clauditor/iteration-1/foo",
+            )
+
+        records = read_records(path=path)
+        assert len(records) == 1
+        assert records[0]["schema_version"] == 3
+        err = capsys.readouterr().err
+        assert "fcntl.flock unsupported" in err
 
 
 class TestSparkline:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from clauditor.history import (
@@ -160,12 +162,14 @@ class TestAppendAndRead:
         with pytest.raises(TypeError):
             append_record("s", 1.0, 1.0, {}, path=path)  # type: ignore[call-arg]
 
-    def test_schema_version_v2_written(self, tmp_path):
+    def test_schema_version_v3_written(self, tmp_path):
         path = tmp_path / "history.jsonl"
         append_record("s", 1.0, 1.0, {"k": 1}, command="grade", path=path)
         records = read_records(path=path)
-        assert records[0]["schema_version"] == 2
+        assert records[0]["schema_version"] == 3
         assert records[0]["command"] == "grade"
+        assert records[0]["iteration"] is None
+        assert records[0]["workspace_path"] is None
 
     def test_append_record_rejects_invalid_command(self, tmp_path):
         path = tmp_path / "history.jsonl"
@@ -181,6 +185,125 @@ class TestAppendAndRead:
         for cmd in ("grade", "extract", "validate"):
             append_record("s", None, None, {}, command=cmd, path=path)
         assert len(read_records(path=path)) == 3
+
+
+class TestAppendV3:
+    """Schema v3: iteration + workspace_path fields (US-005)."""
+
+    def test_append_v3_record_shape(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        append_record(
+            "s",
+            0.9,
+            0.8,
+            {"k": 1},
+            command="grade",
+            path=path,
+            iteration=3,
+            workspace_path=".clauditor/iteration-3/foo",
+        )
+        records = read_records(path=path)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["schema_version"] == 3
+        assert rec["iteration"] == 3
+        assert rec["workspace_path"] == ".clauditor/iteration-3/foo"
+
+    def test_append_v3_defaults_none(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        append_record("s", 1.0, 1.0, {}, command="grade", path=path)
+        rec = read_records(path=path)[0]
+        assert rec["iteration"] is None
+        assert rec["workspace_path"] is None
+
+
+class TestReadMixedSchema:
+    """Reading mixed v2 and v3 history files (US-005)."""
+
+    def test_read_mixed_v2_v3_records(self, tmp_path):
+        import json as _json
+
+        path = tmp_path / "history.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        v2_record = {
+            "schema_version": 2,
+            "command": "grade",
+            "ts": "2026-01-01T00:00:00+00:00",
+            "skill": "skill-a",
+            "pass_rate": 0.5,
+            "mean_score": 0.6,
+            "metrics": {},
+        }
+        with path.open("w", encoding="utf-8") as f:
+            f.write(_json.dumps(v2_record) + "\n")
+
+        # Append a v3 record via the API.
+        append_record(
+            "skill-a",
+            0.9,
+            0.85,
+            {},
+            command="grade",
+            path=path,
+            iteration=2,
+            workspace_path="ws/2",
+        )
+
+        records = read_records(path=path)
+        assert len(records) == 2
+        assert records[0]["schema_version"] == 2
+        assert records[0].get("iteration") is None
+        assert records[0].get("workspace_path") is None
+        assert records[1]["schema_version"] == 3
+        assert records[1]["iteration"] == 2
+        assert records[1]["workspace_path"] == "ws/2"
+
+
+def _concurrent_writer(args):
+    # Top-level so multiprocessing can pickle it.
+    from clauditor.history import append_record as _append
+
+    path_str, idx = args
+    _append(
+        f"skill-{idx}",
+        float(idx) / 10,
+        None,
+        {"i": idx},
+        command="grade",
+        path=Path(path_str),
+        iteration=idx,
+        workspace_path=f"ws/{idx}",
+    )
+
+
+class TestConcurrentAppend:
+    """fcntl.flock serializes concurrent append_record across processes."""
+
+    def test_concurrent_append_no_interleave(self, tmp_path):
+        import json as _json
+        import multiprocessing
+
+        path = tmp_path / ".clauditor" / "history.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        n = 8
+        ctx = multiprocessing.get_context("fork")
+        with ctx.Pool(4) as pool:
+            pool.map(
+                _concurrent_writer,
+                [(str(path), i) for i in range(n)],
+            )
+
+        with path.open("r", encoding="utf-8") as f:
+            lines = [ln for ln in f.readlines() if ln.strip()]
+        assert len(lines) == n
+        seen_iters = set()
+        for line in lines:
+            rec = _json.loads(line)  # would raise if interleaved/corrupt
+            assert rec["schema_version"] == 3
+            assert isinstance(rec["iteration"], int)
+            seen_iters.add(rec["iteration"])
+        assert seen_iters == set(range(n))
 
 
 class TestSparkline:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,40 @@
+"""Tests for repo-root detection in clauditor.paths."""
+
+import importlib
+
+import clauditor.paths as _paths_mod
+
+importlib.reload(_paths_mod)
+
+from clauditor.paths import resolve_clauditor_dir  # noqa: E402
+
+
+class TestResolveClauditorDir:
+    def test_resolve_from_repo_root(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+        assert resolve_clauditor_dir() == tmp_path / ".clauditor"
+
+    def test_resolve_from_nested_subdir(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        assert resolve_clauditor_dir() == tmp_path / ".clauditor"
+
+    def test_resolve_with_claude_only(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude").mkdir()
+        nested = tmp_path / "x" / "y"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        assert resolve_clauditor_dir() == tmp_path / ".clauditor"
+
+    def test_resolve_no_markers_fallback(self, tmp_path, monkeypatch, capsys):
+        # tmp_path lives under /tmp which has no .git/.claude ancestors.
+        sub = tmp_path / "proj"
+        sub.mkdir()
+        monkeypatch.chdir(sub)
+        result = resolve_clauditor_dir()
+        assert result == sub / ".clauditor"
+        captured = capsys.readouterr()
+        assert "clauditor" in (captured.err + captured.out).lower()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -38,3 +38,26 @@ class TestResolveClauditorDir:
         assert result == sub / ".clauditor"
         captured = capsys.readouterr()
         assert "clauditor" in (captured.err + captured.out).lower()
+
+    def test_home_dir_claude_marker_is_ignored(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``~/.claude`` must not be treated as a repo-root marker.
+
+        Pass 3 bug 6 regression guard: a user's global Claude Code config
+        directory would otherwise cause every clauditor invocation from a
+        project without .git to write iterations into ``~/.clauditor``.
+        """
+        fake_home = tmp_path / "home"
+        (fake_home / ".claude").mkdir(parents=True)
+        project = fake_home / "project" / "nested"
+        project.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.chdir(project)
+
+        result = resolve_clauditor_dir()
+        # Should NOT resolve to ~/.clauditor (which would be
+        # fake_home / ".clauditor"). Instead it falls back to the
+        # current working directory because no valid marker was found.
+        assert result != fake_home / ".clauditor"
+        assert result == project / ".clauditor"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -836,3 +836,94 @@ class TestStreamJsonDefensiveBranches:
             runner.run("skill")
         # terminate raised, but the outer handler swallowed it; the
         # original RuntimeError from wait still propagated.
+
+
+class TestStreamEvents:
+    """Tests for SkillResult.stream_events capture (US-003 / DEC-010)."""
+
+    def test_stream_events_populated(self):
+        """Mock subprocess emits 3 JSON lines -> 3 dicts in order."""
+        messages = [
+            {"type": "system", "subtype": "init"},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "usage": {"input_tokens": 7, "output_tokens": 3},
+            },
+        ]
+        fake = _FakePopen([json.dumps(m) for m in messages])
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            result = runner.run("skill")
+
+        assert len(result.stream_events) == 3
+        assert result.stream_events == messages
+        # order preserved
+        assert [e["type"] for e in result.stream_events] == [
+            "system",
+            "assistant",
+            "result",
+        ]
+
+    def test_stream_events_skips_non_json(self):
+        """Non-JSON lines are ignored; stream_events only contains dicts."""
+        messages = [
+            {"type": "system", "subtype": "init"},
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hi"}],
+                },
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        ]
+        lines = [
+            json.dumps(messages[0]),
+            "this is not json at all",
+            json.dumps(messages[1]),
+            "{broken json",
+            json.dumps(messages[2]),
+        ]
+        fake = _FakePopen(lines)
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            result = runner.run("skill")
+
+        assert len(result.stream_events) == 3
+        assert result.stream_events == messages
+
+    def test_output_field_still_renders_text_blocks(self):
+        """Regression: SkillResult.output is unchanged by stream_events work."""
+        fake = make_fake_skill_stream("the quick brown fox")
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            result = runner.run("skill")
+
+        assert result.output == "the quick brown fox"
+        assert result.exit_code == 0
+        # stream_events contains assistant + result (2 entries from the helper)
+        assert len(result.stream_events) == 2
+        assert result.stream_events[0]["type"] == "assistant"
+        assert result.stream_events[-1]["type"] == "result"
+
+    def test_stream_events_default_empty_list(self):
+        """SkillResult default factory gives each instance its own list."""
+        a = SkillResult(output="", exit_code=0, skill_name="x", args="")
+        b = SkillResult(output="", exit_code=0, skill_name="y", args="")
+        assert a.stream_events == []
+        a.stream_events.append({"type": "foo"})
+        assert b.stream_events == []

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 
 from clauditor.workspace import (
+    InvalidSkillNameError,
     IterationExistsError,
     IterationWorkspace,
     allocate_iteration,
+    validate_skill_name,
 )
 
 
@@ -125,3 +127,73 @@ class TestConcurrent:
         iterations = sorted(ws.iteration for ws in results)
         assert iterations == list(range(1, n_threads + 1))
         assert len(set(iterations)) == n_threads
+
+
+class TestSkillNameValidation:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            ".",
+            "..",
+            "../evil",
+            "foo/bar",
+            "/abs",
+            "with space",
+            "has\\backslash",
+        ],
+    )
+    def test_rejects_unsafe_names(self, tmp_path: Path, bad: str) -> None:
+        with pytest.raises(InvalidSkillNameError):
+            validate_skill_name(bad)
+        with pytest.raises(InvalidSkillNameError):
+            allocate_iteration(tmp_path, bad)
+
+    @pytest.mark.parametrize(
+        "good", ["foo", "foo-bar", "foo_bar.v2", "Abc123"]
+    )
+    def test_accepts_safe_names(self, tmp_path: Path, good: str) -> None:
+        assert validate_skill_name(good) == good
+        ws = allocate_iteration(tmp_path, good)
+        assert ws.iteration == 1
+
+
+class TestExplicitIterationRobustness:
+    def test_rejects_non_positive_iteration(self, tmp_path: Path) -> None:
+        for bad in (0, -1, -99):
+            with pytest.raises(ValueError, match="iteration must be >= 1"):
+                allocate_iteration(tmp_path, "foo", iteration=bad)
+
+    def test_clears_orphan_tmp_from_prior_crash(self, tmp_path: Path) -> None:
+        # Prior crashed run left iteration-5-tmp behind. Rerunning
+        # --iteration 5 should succeed without --force (tmp is junk).
+        orphan = tmp_path / "iteration-5-tmp" / "foo"
+        orphan.mkdir(parents=True)
+        (orphan / "stale.txt").write_text("junk")
+
+        ws = allocate_iteration(tmp_path, "foo", iteration=5)
+        assert ws.iteration == 5
+        assert ws.tmp_path.is_dir()
+        assert not (ws.tmp_path / "stale.txt").exists()
+
+
+class TestFinalizeConcurrentRace:
+    def test_finalize_raises_iteration_exists_when_target_occupied(
+        self, tmp_path: Path
+    ) -> None:
+        # Simulate a concurrent peer that finalized iteration-1 between our
+        # allocation and our finalize() — populate the destination with
+        # a non-empty dir so os.rename raises ENOTEMPTY on Linux.
+        ws = allocate_iteration(tmp_path, "foo")
+        racer_final = tmp_path / "iteration-1" / "foo"
+        racer_final.mkdir(parents=True)
+        (racer_final / "race.txt").write_text("from peer")
+
+        with pytest.raises(IterationExistsError):
+            ws.finalize()
+
+        # After the race, the caller's staging dir is cleaned up.
+        assert not (tmp_path / "iteration-1-tmp").exists()
+        # The peer's finalized data is untouched.
+        assert (racer_final / "race.txt").read_text() == "from peer"
+        assert ws.finalized is False

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,127 @@
+"""Tests for clauditor.workspace — iteration workspace allocator."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from clauditor.workspace import (
+    IterationExistsError,
+    IterationWorkspace,
+    allocate_iteration,
+)
+
+
+class TestAllocateIteration:
+    def test_allocate_empty_clauditor_dir_returns_iteration_one(
+        self, tmp_path: Path
+    ) -> None:
+        ws = allocate_iteration(tmp_path, "foo")
+        assert ws.iteration == 1
+        assert ws.final_path == tmp_path / "iteration-1" / "foo"
+        assert ws.tmp_path.is_dir()
+        assert ws.tmp_path == tmp_path / "iteration-1-tmp" / "foo"
+
+    def test_allocate_with_gaps_skips_to_max_plus_one(self, tmp_path: Path) -> None:
+        (tmp_path / "iteration-1").mkdir()
+        (tmp_path / "iteration-3").mkdir()
+        ws = allocate_iteration(tmp_path, "foo")
+        assert ws.iteration == 4
+
+    def test_allocate_ignores_non_iteration_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "iteration-foo").mkdir()
+        (tmp_path / "iteration-2-tmp").mkdir()
+        (tmp_path / "something-else").mkdir()
+        ws = allocate_iteration(tmp_path, "foo")
+        assert ws.iteration == 1
+
+    def test_allocate_explicit_iteration_no_collision(self, tmp_path: Path) -> None:
+        ws = allocate_iteration(tmp_path, "foo", iteration=5)
+        assert ws.iteration == 5
+        assert ws.tmp_path.is_dir()
+
+    def test_allocate_explicit_iteration_collision_raises_without_force(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "iteration-5").mkdir()
+        with pytest.raises(IterationExistsError, match="iteration-5"):
+            allocate_iteration(tmp_path, "foo", iteration=5)
+
+    def test_allocate_explicit_iteration_force_replaces_existing(
+        self, tmp_path: Path
+    ) -> None:
+        existing = tmp_path / "iteration-5"
+        existing.mkdir()
+        (existing / "stale.txt").write_text("stale")
+        ws = allocate_iteration(tmp_path, "foo", iteration=5, force=True)
+        assert ws.iteration == 5
+        assert not (existing / "stale.txt").exists()
+        assert ws.tmp_path.is_dir()
+
+    def test_allocate_force_when_no_existing(self, tmp_path: Path) -> None:
+        ws = allocate_iteration(tmp_path, "foo", iteration=2, force=True)
+        assert ws.iteration == 2
+
+
+class TestFinalize:
+    def test_finalize_atomic_rename(self, tmp_path: Path) -> None:
+        ws = allocate_iteration(tmp_path, "foo")
+        (ws.tmp_path / "grading.json").write_text("{}")
+        ws.finalize()
+        assert ws.final_path.is_dir()
+        assert (ws.final_path / "grading.json").read_text() == "{}"
+        assert not (tmp_path / "iteration-1-tmp").exists()
+
+    def test_finalize_multiple_iterations(self, tmp_path: Path) -> None:
+        ws1 = allocate_iteration(tmp_path, "foo")
+        ws1.finalize()
+        ws2 = allocate_iteration(tmp_path, "foo")
+        ws2.finalize()
+        assert (tmp_path / "iteration-1" / "foo").is_dir()
+        assert (tmp_path / "iteration-2" / "foo").is_dir()
+
+
+class TestAbort:
+    def test_abort_removes_tmp(self, tmp_path: Path) -> None:
+        ws = allocate_iteration(tmp_path, "foo")
+        assert (tmp_path / "iteration-1-tmp").exists()
+        ws.abort()
+        assert not (tmp_path / "iteration-1-tmp").exists()
+
+    def test_abort_safe_when_already_gone(self, tmp_path: Path) -> None:
+        ws = allocate_iteration(tmp_path, "foo")
+        ws.abort()
+        ws.abort()  # Should not raise.
+
+
+class TestConcurrent:
+    def test_concurrent_allocation_threaded(self, tmp_path: Path) -> None:
+        n_threads = 5
+        barrier = threading.Barrier(n_threads)
+        results: list[IterationWorkspace] = []
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                ws = allocate_iteration(tmp_path, "foo")
+                with lock:
+                    results.append(ws)
+            except BaseException as exc:  # pragma: no cover - defensive
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert len(results) == n_threads
+        iterations = sorted(ws.iteration for ws in results)
+        assert iterations == list(range(1, n_threads + 1))
+        assert len(set(iterations)) == n_threads

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import errno
 import threading
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -175,6 +177,97 @@ class TestExplicitIterationRobustness:
         assert ws.iteration == 5
         assert ws.tmp_path.is_dir()
         assert not (ws.tmp_path / "stale.txt").exists()
+
+
+class TestScanMissingDir:
+    def test_scan_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        """_scan_existing_iterations should return empty set if dir absent."""
+        from clauditor.workspace import _scan_existing_iterations
+
+        missing = tmp_path / "does-not-exist"
+        assert _scan_existing_iterations(missing) == set()
+
+
+class TestAutoRetryExhaustion:
+    def test_auto_allocation_raises_after_max_retries(
+        self, tmp_path: Path
+    ) -> None:
+        """_allocate_auto raises RuntimeError after _MAX_AUTO_RETRIES.
+
+        Simulates persistent contention by making every tmp_parent.mkdir
+        raise FileExistsError so the loop never converges.
+        """
+        from clauditor import workspace as ws_mod
+
+        real_mkdir = Path.mkdir
+        call_count = {"n": 0}
+
+        def fake_mkdir(self, *args, **kwargs):
+            # Let the initial clauditor_dir.mkdir(parents=True,
+            # exist_ok=True) and the per-iteration skill-subdir mkdir
+            # succeed. Only sabotage tmp_parent.mkdir(exist_ok=False).
+            if "-tmp" in self.name and kwargs.get("exist_ok") is False:
+                call_count["n"] += 1
+                raise FileExistsError(self)
+            return real_mkdir(self, *args, **kwargs)
+
+        with (
+            patch.object(ws_mod, "_MAX_AUTO_RETRIES", 3),
+            patch.object(Path, "mkdir", fake_mkdir),
+        ):
+            with pytest.raises(RuntimeError, match="exceeded 3 retries"):
+                allocate_iteration(tmp_path, "foo")
+        assert call_count["n"] == 3
+
+    def test_auto_allocation_skips_finalized_peer(
+        self, tmp_path: Path
+    ) -> None:
+        """Auto loop increments past an existing iteration-N dir.
+
+        Coverage for the final_parent.exists() → candidate+=1 branch
+        in _allocate_auto. Forces the branch by injecting an extra
+        iteration directory AFTER the initial scan: the scan picks
+        candidate=N+1 but by the time the loop runs we've raced in a
+        peer N+1, so the first iteration of the loop must skip it.
+        """
+        (tmp_path / "iteration-5").mkdir()
+
+        # Patch _scan_existing_iterations to return {5} so the loop
+        # starts at candidate=6; then create iteration-6 on disk so
+        # the loop's exists() check triggers the skip branch.
+        from clauditor import workspace as ws_mod
+
+        original_scan = ws_mod._scan_existing_iterations
+
+        def scan_then_race(dir_):
+            result = original_scan(dir_)
+            (tmp_path / "iteration-6").mkdir(exist_ok=True)
+            return result
+
+        with patch.object(
+            ws_mod, "_scan_existing_iterations", side_effect=scan_then_race
+        ):
+            ws = allocate_iteration(tmp_path, "foo")
+        assert ws.iteration == 7
+
+
+class TestFinalizeNonRaceError:
+    def test_finalize_reraises_permission_error(
+        self, tmp_path: Path
+    ) -> None:
+        """finalize() must re-raise OSErrors other than ENOTEMPTY/EEXIST.
+
+        Pass 1 review follow-up: a permission-denied rename should
+        surface as the real error, not be relabeled as
+        IterationExistsError.
+        """
+        ws = allocate_iteration(tmp_path, "foo")
+        eacces = OSError(errno.EACCES, "permission denied")
+        with patch("clauditor.workspace.os.rename", side_effect=eacces):
+            with pytest.raises(OSError) as exc_info:
+                ws.finalize()
+        assert exc_info.value.errno == errno.EACCES
+        assert ws.finalized is False
 
 
 class TestFinalizeConcurrentRace:


### PR DESCRIPTION
## Summary
Implements issue #22 — replaces the single `.clauditor/<skill>.grade.json` file with a per-iteration workspace at `.clauditor/iteration-N/<skill>/{grading.json, timing.json, run-K/{output.txt, output.jsonl}}`. Every `clauditor grade` run is now preserved so you can re-inspect, re-grade, and root-cause regressions after the fact.

## What changed
- **Always-on iteration workspace.** `--save` removed; each grade run auto-increments to the next `iteration-N/` slot (or honors `--iteration N` with `--force` to overwrite).
- **New runner capture.** `SkillResult.stream_events` preserves raw stream-json events alongside the rendered text; `output.jsonl` + `output.txt` are emitted per run.
- **Variance layout.** `--variance N` emits `run-0/` through `run-N/` under one iteration dir, with an aggregated `grading.json` + `timing.json` at the skill level.
- **Repo-root resolution.** `.clauditor/` is now anchored by walking up from CWD for `.git` / `.claude`, so running `grade` from a subdirectory lands in the right place. `~/.claude` is deliberately ignored at the home boundary to avoid cross-repo contamination.
- **`compare` accepts three input forms.** Legacy `.grade.json` files (explicit paths), iteration directory paths, or `--skill NAME --from N --to M` numeric refs.
- **`history.jsonl` schema v3.** Adds `iteration` + `workspace_path`. Mixed v2/v3 files continue to load. Concurrent appends serialized via `fcntl.flock` with graceful fallback on filesystems that do not support advisory locking.
- **Atomic staging.** All writes land in `iteration-N-tmp/` and are atomically renamed on success; crashes leave only the tmp dir (auto-cleaned by the next run).

## Review history
- **Planning phase** (super-plan): 15 decisions (DEC-001..DEC-015), 7 implementation stories + Quality Gate + Patterns & Memory tracked via beads (`clauditor-yng`).
- **4 internal code-review passes** fixed 11 real bugs (early-return leaks, finalize race, path traversal, variance token regression, `--only-criterion` partial baseline leak, orphan tmp handling, `$HOME/.claude` contamination, `fcntl.flock` fallback, etc.).
- **CodeRabbit local review** (`coderabbit review --base dev`) surfaced 8 findings: 4 addressed in code, 2 in docs, 2 skipped (already handled / not applicable).
- **GitHub Copilot PR review** comments addressed in `fc37cd1`: conditional `fcntl` import, argparse `_positive_int` on `--iteration`/`--from`/`--to`, `cmd_grade` catches `InvalidSkillNameError`/`ValueError`/`IterationExistsError` from the allocator and finalize, E305 blank line, README wording clarified.

## Test + coverage
- **769 tests passing**, total coverage **95.86%** (workspace.py 100%, runner.py 100%, paths.py 83%, history.py 91%, cli.py 94%).
- Full suite green on ruff + pytest across 3.11 / 3.12 / 3.13.

## Plan document
See `plans/super/22-iteration-workspace.md` for the decision log and Beads Manifest.
