### PR TITLE
#23: Input files support on eval specs (plan)

### DIFF
--- a/.claude/rules/path-validation.md
+++ b/.claude/rules/path-validation.md
@@ -1,0 +1,49 @@
+# Rule: Validating user-provided filesystem paths
+
+When an `EvalSpec` field (or any other config-loaded field) accepts a
+filesystem path from a user-authored JSON/YAML file, validate it with the
+following recipe. This is a tight, security-positive check that rejects
+absolute paths, `..` traversal, symlink-target escape, directories, sockets,
+FIFOs, and broken symlinks in one go.
+
+## The pattern
+
+```python
+spec_dir = path.parent.resolve()
+
+if not isinstance(entry, str) or entry == "":
+    raise ValueError(f"{field}[{i}]={entry!r} — must be a non-empty string")
+if Path(entry).is_absolute():
+    raise ValueError(f"{field}[{i}]={entry!r} — absolute paths not allowed")
+try:
+    candidate = (path.parent / entry).resolve(strict=True)
+except FileNotFoundError as e:
+    raise ValueError(
+        f"{field}[{i}]={entry!r} — file not found under {spec_dir}"
+    ) from e
+if not candidate.is_relative_to(spec_dir):
+    raise ValueError(f"{field}[{i}]={entry!r} — escapes spec directory")
+if not candidate.is_file():
+    raise ValueError(f"{field}[{i}]={entry!r} — not a regular file")
+```
+
+## Why each step matters
+
+- `isinstance(entry, str)` + non-empty: rejects nulls, numbers, lists, and
+  empty strings before any filesystem call.
+- `is_absolute()`: blocks `/etc/passwd`-style escapes before resolution.
+- `resolve(strict=True)`: normalizes `..`, follows symlinks to their real
+  target, AND raises `FileNotFoundError` if the target does not exist. This
+  is the load-bearing step — without `strict=True` you would silently accept
+  dangling symlinks.
+- `is_relative_to(spec_dir)`: containment check that runs against the
+  *resolved* target, so a symlink pointing outside the spec dir is rejected
+  even when the symlink itself lives inside.
+- `is_file()`: rejects directories (including a `"."` entry), sockets,
+  FIFOs, character devices, etc. Combined with the strict resolve, also
+  rejects broken symlinks.
+
+## Canonical implementation
+
+`src/clauditor/schemas.py` — `EvalSpec.from_file()`, the `input_files`
+validation block. Reuse this recipe verbatim for any new path-bearing field.

--- a/.claude/rules/subprocess-cwd.md
+++ b/.claude/rules/subprocess-cwd.md
@@ -1,0 +1,41 @@
+# Rule: CWD override on subprocess wrappers
+
+When a long-lived subprocess wrapper (like `SkillRunner`) needs to let
+callers swap the working directory for a single invocation without
+disturbing existing call sites, use a keyword-only `cwd` parameter that
+defaults to the wrapper's configured project dir.
+
+## The pattern
+
+```python
+class SkillRunner:
+    def __init__(self, project_dir: Path, ...):
+        self.project_dir = project_dir
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        cwd: Path | None = None,
+        ...,
+    ) -> RunResult:
+        effective_cwd = cwd if cwd is not None else self.project_dir
+        # ... pass effective_cwd into the subprocess spawn ...
+```
+
+## Why this shape
+
+- **Keyword-only** (`*,`): forces call sites to be explicit and prevents
+  positional-argument ambiguity if the signature grows.
+- **`None` sentinel + default-to-self.project_dir**: every pre-existing
+  call site keeps working with zero changes. Only new callers that need
+  staging dirs, tempdirs, or sibling worktrees pass `cwd=`.
+- **Resolution at call time, not init**: the wrapper is reusable across
+  many runs against different CWDs (e.g. variance reps in different
+  staging dirs).
+
+## Canonical implementation
+
+`src/clauditor/runner.py` — `SkillRunner.run()`. Caller example: see
+`spec.py` where `effective_cwd` (staging dir when `input_files` are
+declared) is threaded through to `runner.run(..., cwd=effective_cwd)`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ clauditor implements (and in places extends) the skill evaluation workflow descr
 
 | agentskills.io concept | clauditor |
 |---|---|
-| Test case (prompt + expected + files) | `.eval.json` with `test_args`, `sections`, `fields`, `grading_criteria` |
+| Test case (prompt + expected + files) | `.eval.json` with `test_args`, `input_files`, `sections`, `fields`, `grading_criteria` |
 | Deterministic assertions | **Layer 1** — `assertions.py`, `FORMAT_REGISTRY` (20 canonical types), strict/extract invariants |
 | LLM-judged structural checks | **Layer 2** — `grader.py`, tiered schema extraction with per-tier field requirements |
 | Rubric quality grading | **Layer 3** — `quality_grader.py`, per-criterion scoring + variance measurement |
@@ -455,6 +455,38 @@ Place `<skill-name>.eval.json` alongside your `.claude/commands/<skill-name>.md`
 
 **File-based output:** Many skills save results to files instead of printing to stdout. Use `output_file` for skills that write to one known path (e.g., `research/results.md`). Use `output_files` with glob patterns for skills that produce multiple files (e.g., `["research/*.md"]`). If both are set, `output_file` takes precedence. When set, clauditor reads the file(s) after running the skill instead of capturing stdout.
 
+### Input files
+
+Some skills need sample inputs — a CSV to clean, a log file to summarize, a PDF to extract. Declare them with `input_files` and clauditor will stage them into each variance run's working directory before invoking the skill:
+
+```json
+{
+  "skill_name": "csv-cleaner",
+  "test_args": "--strict",
+  "input_files": ["fixtures/sales.csv"]
+}
+```
+
+At grade time, `fixtures/sales.csv` is copied (via `shutil.copy2`) into `.clauditor/iteration-N/csv-cleaner/run-K/inputs/sales.csv` for each of the `variance.n_runs` runs, and the skill's subprocess is launched with that `inputs/` directory as its CWD. So `/csv-cleaner --strict` sees `sales.csv` as a plain basename in its own current directory — no path wrangling required. Each `run-K` gets its own fresh copy, so a skill that mutates its input in one run does not affect the next.
+
+Rules enforced at spec-load time (`EvalSpec.from_file`):
+
+- **Paths are relative to the eval spec's parent directory**, not the repo root. An `input_files` entry of `fixtures/sales.csv` next to `my-skill.eval.json` resolves to `<spec-dir>/fixtures/sales.csv`. This intentionally differs from `output_files`, which globs relative to the skill's working directory.
+- **Absolute paths are rejected.** Use a relative path under the spec directory.
+- **Source containment is enforced.** The resolved path (including symlink targets) must live under the spec's parent directory. Escapes via `..` or symlinks pointing outside the spec tree raise `ValueError`.
+- **Missing files fail loudly.** Paths are resolved with `Path.resolve(strict=True)` — a typo fails at load, not at grade time.
+- **Destinations are flattened to basenames.** `input_files: ["data/sales.csv"]` stages as `run-K/inputs/sales.csv`, not `run-K/inputs/data/sales.csv`. Two entries that would flatten to the same basename (e.g. `a/data.csv` and `b/data.csv`) raise `ValueError` at load.
+- **Collision guard with `output_files`.** Any literal `output_files` pattern whose basename matches an `input_files` basename raises `ValueError` at load. If your skill mutates `sales.csv` in place and you want to capture the result, either declare the output under a different basename / subdirectory in `output_files`, or read the post-run file back from the persisted `iteration-N/<skill>/run-K/inputs/` directory after grading.
+- **No file-size cap.** Files are copied verbatim — eval specs are author-controlled, so keep fixtures reasonable.
+
+**Captured-output mode:** `clauditor grade --output <file>` reads a pre-captured output file instead of running the skill. In that mode, staging is skipped. If a spec declares `input_files` and `--output` is passed, clauditor prints `WARNING: --output bypasses the runner; input_files declaration is ignored.` to stderr and continues.
+
+**Persistence:** staged inputs are preserved post-finalize under `.clauditor/iteration-N/<skill>/run-K/inputs/` alongside `output.txt` and `output.jsonl`, so you can inspect exactly what the skill saw (and what it did to the files) after each run.
+
+**Pytest plugin:** the `clauditor_spec` fixture transparently stages `input_files` into `tmp_path` when a loaded spec declares them, so existing tests need zero changes.
+
+**Security / trust model:** Eval specs are developer-authored and run with the repo owner's filesystem access. Clauditor resolves `input_files` paths under the spec's parent directory, enforces source containment, and rejects absolute paths — but the underlying assumption is that eval specs live in a repo you already trust. Do not run clauditor against eval specs from untrusted sources without reviewing them first.
+
 A complete eval spec with all three layers:
 
 ```json
@@ -462,6 +494,7 @@ A complete eval spec with all three layers:
   "skill_name": "find-kid-activities",
   "description": "Finds kid-friendly activities near a location",
   "test_args": "\"Cupertino, CA\" --ages 4-6 --count 5 --depth quick",
+  "input_files": ["fixtures/sample-venues.csv"],
 
   "assertions": [
     {"type": "contains", "value": "Venues"},

--- a/examples/.claude/commands/example-skill.eval.json
+++ b/examples/.claude/commands/example-skill.eval.json
@@ -2,6 +2,9 @@
   "skill_name": "find-kid-activities",
   "description": "Validates /find-kid-activities produces venues and events with required fields",
   "test_args": "\"Cupertino, CA\" --dates today --distance 15mi --ages 4-6 --cost \"Free, $\" --type both --category any --count 5 --depth quick",
+  "input_files": [
+    "sample-input.txt"
+  ],
   "assertions": [
     {
       "type": "contains",

--- a/examples/.claude/commands/sample-input.txt
+++ b/examples/.claude/commands/sample-input.txt
@@ -1,0 +1,3 @@
+sample input row 1
+sample input row 2
+sample input row 3

--- a/plans/super/23-eval-input-files.md
+++ b/plans/super/23-eval-input-files.md
@@ -1,0 +1,433 @@
+# Super Plan — GH-23: Input Files Support on Eval Specs
+
+## Meta
+
+- **Ticket:** [clauditor#23](https://github.com/wjduenow/clauditor/issues/23)
+- **Title:** Input files support on eval specs
+- **Branch:** `feature/23-eval-input-files`
+- **Phase:** detailing
+- **Sessions:** 1
+- **Last session:** 2026-04-13
+
+---
+
+## Ticket Summary
+
+The [agentskills.io spec](https://agentskills.io/skill-creation/evaluating-skills) allows test cases to declare `files: ["evals/files/sales_2025.csv"]` — input files the skill operates on. Clauditor's `EvalSpec` only has `test_args: str`; there is no formal way to declare input files. This blocks evaluating file-transforming skills (data cleaners, PDF extractors, code refactorers) and forces users to hand-place files in cwd before `clauditor grade`, with no cleanup or isolation guarantees.
+
+**Done when:** an eval spec with `"input_files": ["sales_2025.csv"]` runs successfully and the skill sees `sales_2025.csv` in its working directory.
+
+---
+
+## Discovery Findings
+
+### Codebase landscape (from Codebase Scout)
+
+| Area | Location | Relevant today |
+| --- | --- | --- |
+| `EvalSpec` schema | `src/clauditor/schemas.py:108-220` | JSON loader via `EvalSpec.from_file(path)`. No input-file field. No relative-path context — receives only `Path`. |
+| Spec composition | `src/clauditor/spec.py:41-65` | `SkillSpec.from_file()` auto-discovers sibling `<skill>.eval.json`. Spec file path *is* available here for relative resolution. |
+| Runner invocation | `src/clauditor/runner.py:180-193` | `subprocess.Popen([claude_bin, "-p", prompt, ...])` with `cwd=str(self.project_dir)`. `project_dir` defaults to `Path.cwd()`. No scratch-dir or staging layer. |
+| Iteration workspace | `src/clauditor/workspace.py:141-239` | `allocate_iteration()` returns an `IterationWorkspace` with `tmp_path` (staging) and `final_path`; `finalize()` atomic-renames, `abort()` removes tmp. Per-run subdirs live at `iteration-N/<skill>/run-K/`. |
+| Repo-root detection | `src/clauditor/paths.py:20-56` | `resolve_clauditor_dir()` walks up for `.git`/`.claude` marker. |
+| CLI `grade` entry | `src/clauditor/cli.py:153-380` | Allocates workspace early (`_cmd_grade_with_workspace`), calls `spec.run()` at ~line 311. Natural place to stage input files is *after* workspace allocation and *before* `spec.run()`. |
+| Pytest plugin | `src/clauditor/pytest_plugin.py:85-185` | Exposes `clauditor_runner`, `clauditor_spec`, `clauditor_grader`, `clauditor_triggers`, `clauditor_capture` factory fixtures. No `clauditor_input_files` today. |
+| Captured-output mode | `tests/eval/captured/` | Directory pattern documented (`<skill>.txt`) but no files yet; `--output <file>` CLI flag bypasses runner entirely (`cli.py:307`). |
+| Example eval spec | `examples/.claude/commands/example-skill.eval.json` | Canonical schema shape; no input_files today. |
+
+### Relevant prior decisions (from plan #22, merged in PR #31)
+
+- **DEC-003** — Workspace layout: `.clauditor/iteration-N/<skill>/run-K/` with aggregated `grading.json`+`timing.json` at the skill level.
+- **DEC-011** — Single-run uses `run-0/` for structural consistency with variance mode.
+- **DEC-012** — Atomic writes: tmp+rename. All staging lives under `.clauditor/iteration-N-tmp/<skill>/`, finalized by `os.rename()`.
+- **DEC-014** — `--force` semantics: clean-slate `rmtree` before rewriting an iteration.
+- **DEC-009** — Repo-root resolution: walk up from CWD for `.git`/`.claude` markers; `$HOME/.claude` deliberately excluded.
+
+### Rules constraints (from Convention Checker)
+
+- **No `.claude/rules/` directory, no `workflow-project.md`** — project is pre-production, no backwards-compatibility or versioning constraints.
+- **Quality gate convention** (from plan #22): 4× code reviewer passes + CodeRabbit + ruff + pytest ≥80% coverage.
+- **Test conventions** (CLAUDE.md): class-based tests, `asyncio_mode = "strict"`, `importlib.reload()` for plugin-loaded modules, `tmp_path` over raw `tempfile`.
+
+### Ambiguities / open questions
+
+1. **Staging location** — inside the iteration workspace (finalized alongside `run-K/output.txt`), or in a throwaway tmpdir outside the workspace?
+2. **Persistence after finalize** — after a successful run, do we keep a copy of the input files inside `iteration-N/<skill>/` (so a re-grade can re-run the exact same inputs), or delete them on success?
+3. **CWD vs. arg interpolation** — does the skill see files by name in its CWD (`sales_2025.csv`), or do we rewrite `test_args` with absolute paths?
+4. **Mutation semantics** — if the skill modifies an input file (data cleaner, code refactorer), is the modified file captured as output? Related to `output_files` glob.
+5. **Subdirectory structure** — if `input_files: ["data/sales.csv", "data/refunds.csv"]`, are relative subdirs preserved in staging?
+6. **Captured-output mode interaction** — `clauditor grade --output captured.txt` bypasses the runner entirely. Does `input_files` validation still fire? (Probably no-op; files aren't staged since no run happens.)
+7. **Pytest plugin surface** — transparent inside `clauditor_spec` factory, or a new `clauditor_input_files` fixture for explicit staging?
+8. **Missing-file behavior at spec load** — hard error (abort spec load), or defer to run-time?
+9. **Variance runs** — do all N runs share the same staged input files (single copy), or does each `run-K/` get a fresh copy in case the skill mutates them?
+10. **`--keep-workspace` flag** — the ticket mentions it as a cleanup override, but iteration workspaces are already persistent post-merge of PR #31. Is the flag still needed, or does it collapse into existing iteration-persistence semantics?
+
+---
+
+## Proposed scope (for refinement)
+
+- Add `EvalSpec.input_files: list[str]` (default `[]`).
+- `EvalSpec.from_file(path)` becomes `EvalSpec.from_file(path)` with internal resolution: input_files paths resolved relative to `path.parent`, validated to exist at load time, and stored as absolute paths on the spec.
+- `SkillSpec.run()` stages input files into the iteration workspace's per-run scratch area before invoking the runner.
+- `SkillRunner` CWD is set to the staging dir so the skill sees files by plain name.
+- Staged files are copied (not symlinked) so the skill can mutate them freely.
+- Pytest plugin: transparent — `clauditor_spec` factory handles staging automatically.
+- CLI: no new flag required (question 10 above to confirm).
+- Captured-output mode: `--output <file>` bypasses runner → no staging needed; validation still fires at spec load.
+
+---
+
+## Scoping questions
+
+**Q1 — Staging location & persistence after finalize.** Where do staged input files live on disk and what happens after a successful run?
+
+- **A.** Stage into `iteration-N-tmp/<skill>/run-K/inputs/`. On finalize, files persist inside `iteration-N/<skill>/run-K/inputs/` alongside `output.txt`. Pro: re-grade and post-mortem can see exactly what the skill saw. Con: iterations get heavier if inputs are large.
+- **B.** Stage into a throwaway `tempfile.mkdtemp()` dir outside `.clauditor/`. Cleaned up on success. Pro: keeps `.clauditor/` small. Con: can't re-run the exact inputs later.
+- **C.** Stage into `iteration-N-tmp/<skill>/inputs/` (skill-level, shared across runs). On finalize, persisted at `iteration-N/<skill>/inputs/`. Pro: one copy shared across variance runs. Con: mutation in run-0 affects run-1.
+- **D.** Hybrid — stage per-run (like A) but only persist if user passes `--keep-inputs`. Default is cleanup-on-finalize.
+
+**Q2 — CWD vs. absolute-path arg rewriting.** How does the skill reference the staged files?
+
+- **A.** CWD is set to the staging dir. The skill sees `sales_2025.csv` as a plain filename. `test_args` stays as-is. (Matches agentskills.io spec wording: "files the skill operates on".)
+- **B.** CWD stays at repo root (current behavior). Clauditor rewrites `test_args` by substituting `{{input_files[0]}}` tokens with absolute paths. Pro: explicit, no CWD magic. Con: requires new templating and breaks `test_args` opacity.
+- **C.** CWD is set to the staging dir *and* `{{input_files[0]}}` tokens are supported for cases where the skill expects absolute paths. Hybrid.
+
+**Q3 — Mutation & output capture.** If the skill mutates an input file (e.g. a CSV cleaner rewrites `sales.csv`), how is the result captured?
+
+- **A.** No special handling. If the user wants to capture the mutated file, they declare it in `output_files: ["sales.csv"]` — `output_files` already globs against CWD. The staging dir being CWD makes this work naturally.
+- **B.** Auto-snapshot: clauditor diffs each input file before/after and records `input_files_mutated: [...]` in `grading.json`.
+- **C.** Files are staged read-only (`chmod a-w`); any mutation attempt is a spec failure.
+
+**Q4 — Missing-file behavior at spec load.** A spec declares `input_files: ["missing.csv"]` and the file doesn't exist relative to the spec dir.
+
+- **A.** Hard error at `EvalSpec.from_file()` — matches existing fail-fast pattern (`FORMAT_REGISTRY`, regex compile).
+- **B.** Warn at load, hard error at run time (when staging would happen).
+- **C.** Silently skip missing files, stage whatever is present.
+
+**Q5 — Variance runs: shared or per-run staging?** With `variance.n_runs=5` and a mutating skill:
+
+- **A.** Per-run fresh copy: each `run-K/inputs/` gets its own copy of the declared input files. Guarantees run independence. (Pairs with Q1-A.)
+- **B.** Shared copy at skill level: all runs share one `inputs/` dir. Faster, less disk, but mutation in run-0 contaminates run-1..run-N. (Pairs with Q1-C.)
+- **C.** Shared copy, but snapshot+restore between runs (re-copy from the spec's source dir before each run). Middle ground.
+
+**Q6 — Pytest plugin surface.** How does `input_files` work inside `pytest` tests that call `clauditor_spec` / `clauditor_runner` directly?
+
+- **A.** Transparent: the `clauditor_spec` factory stages files into `tmp_path` automatically when the loaded eval spec has `input_files`. Tests get no new fixture.
+- **B.** Explicit: add `clauditor_input_files(spec)` factory that returns the staging dir path; tests wire it into `runner.project_dir` manually.
+- **C.** Both — transparent default, but `clauditor_input_files` exposed for tests that want to pre-seed mutated input files.
+
+---
+
+## Architecture Review
+
+### Ratings
+
+| Area | Rating | Headline |
+| --- | --- | --- |
+| Security — source path traversal | **blocker** | `input_files: ["../../../etc/passwd"]` resolves cleanly via `Path.resolve()`. Must enforce containment. |
+| Security — destination path traversal | **blocker** | Subdir preservation (`data/../../escape.csv`) could write outside the staging root. |
+| Security — absolute paths | concern | `/etc/passwd` as an entry is technically valid today. Least-surprise: reject. |
+| Security — symlinks | concern | `shutil.copy2` follows symlinks by default. Copy content (not the symlink) and accept the small supply-chain risk, OR `follow_symlinks=False`. |
+| Security — file size / DoS | concern | No size cap. Acceptable for pre-production / author-trusted specs. Document. |
+| Security — trust model | pass | README already frames specs as developer-authored; plan #13 echoes it. Add one-line trust note. |
+| Data model — field placement | pass | Insert `input_files: list[str]` after `test_args`, mirrors `output_file`/`output_files` naming. |
+| Data model — storage type | pass | Keep as `list[str]` (not `list[Path]`) for JSON round-trip parity with `output_files`. |
+| Data model — path resolution timing | concern | Resolve + validate at **load time** in `EvalSpec.from_file()`, diverging intentionally from `output_files` (which stays CWD-relative, resolved at run time). Needs a DEC to document. |
+| Data model — backward compat | pass | `history.py` v3 doesn't embed specs; `data.get("input_files", [])` default makes old specs load cleanly. |
+| API — `output_files` glob collision | concern | If CWD is staging dir with inputs pre-copied, `output_files: ["*.csv"]` can match un-mutated inputs. Needs docs warning + ideally spec-load guard. |
+| API — field name bikeshed | pass | `input_files` wins (parallel with `output_file`/`output_files`). |
+| API — pytest fixture surface | pass | Transparent staging inside `clauditor_spec` factory; uses `tmp_path`. |
+| Observability — logging | concern | Project uses `print()` (no logger). Staging should emit one stdout line per run matching `cli.py:62` informational style. |
+| Observability — error messages | pass | Follow existing `ClassName(field=X): problem. solution-hint.` pattern (schemas.py:32-46). |
+| Testing — file organization | pass | `TestEvalSpecInputFiles` in `test_schemas.py`, `TestStageInputs` in `test_workspace.py`, fixture test in `test_pytest_plugin.py`. Class-based, `tmp_path`-based. |
+| Testing — coverage gate | concern | ~16-18 test cases needed to stay above 80%. Enumerated below. |
+| Performance | pass | File copies are O(N·M) for N runs × M files. Acceptable; same disk cost as per-run output capture. |
+
+### Key findings
+
+**Blocker 1 — source path traversal (security).** `Path("/specdir") / "../../../etc/passwd"` resolved via `Path.resolve()` yields `/etc/passwd` — no error, full escape. Fix: at load time, compute `resolved = (spec_dir / entry).resolve()` and assert `resolved.is_relative_to(spec_dir)` (Python 3.9+). Anything failing that check is a `ValueError` at load. Same pattern clauditor uses for skill-name validation (workspace.py:32-61 regex-only tokens).
+
+**Blocker 2 — destination path traversal (security).** If we preserve subdir structure (`input_files: ["data/sales.csv"]` → `run-K/inputs/data/sales.csv`), a malicious entry `data/../../escape.csv` could mkdir outside the staging root. Fix: after source-side containment check passes, derive the destination path using only `entry.name` (flatten) OR validate each path component against `^[A-Za-z0-9_.-]+$` (the same regex workspace uses for skill names). Recommendation: **flatten** — simpler, no collision surface, unless the user genuinely needs subdir structure.
+
+**Concern 1 — absolute paths.** `input_files: ["/etc/passwd"]`. `Path.resolve()` is identity on absolutes. Cleanest policy: **reject `.is_absolute()` at load time**, because (a) absolute paths would bypass source containment, (b) they are non-portable across checkouts, (c) easy to add later if someone needs repo-absolute paths with an explicit `root:` field.
+
+**Concern 2 — symlinks.** If `inputs/sales.csv` is a symlink to `~/.ssh/id_rsa`, `shutil.copy2` happily copies the private key. Two options: (a) `follow_symlinks=False` — copies the symlink itself, skill sees a broken link (the target isn't staged); (b) resolve the symlink, check that the *real* target is also inside the spec dir. Recommendation: **(b)** — call `resolved.resolve(strict=True)` and apply the same containment check. Matches user intent (the author put a symlink there on purpose, so the target should be colocated).
+
+**Concern 3 — `output_files` glob collision (API).** With CWD=staging dir and `output_files: ["*.csv"]`, un-mutated inputs match the glob. Fix: (a) docs warning in README and example; (b) optional spec-load guard that raises if any `output_files` glob matches an `input_files` entry name. The guard is cheap — do it.
+
+**Concern 4 — resolution-timing divergence.** `output_files` stays relative-to-CWD (resolved at run time against `runner.project_dir`). `input_files` resolves at load time against the spec file's parent. This is a deliberate split: outputs are runtime artifacts, inputs are pre-existing static assets. Needs a DEC entry so future readers aren't confused.
+
+**Concern 5 — file size DoS.** No cap today. Eval specs are author-controlled; acceptable. Document in README ("input files are copied without size limits") and leave a `max_input_bytes` field as future work. Not a blocker for pre-production.
+
+**Concern 6 — staging logging.** Follow cli.py:62 pattern: one info line per run, `Staged 3 input file(s) into run-0/inputs/`. Written to stdout, no prefix. Error path follows schemas.py:32-46 style: `EvalSpec(skill_name='foo'): input_files[1]='missing.csv' not found under {spec_dir}`.
+
+**Concern 7 — test coverage.** 16-18 test cases enumerated in the testing review, broken down by module: 3 in `test_schemas.py` (field parse, defaults, to_dict round-trip), 4 in `test_spec.py` (load-time validation: missing / absolute / traversal / happy), 5 in `test_workspace.py` (stage_inputs helper), 2 in `test_runner.py` (CWD swap), 2 in `test_cli.py` (grade integration + variance), 2 in `test_pytest_plugin.py` (transparent fixture staging + captured-output bypass).
+
+---
+
+## Refinement Log
+
+### Decisions
+
+- **DEC-001 — Schema field.** Add `input_files: list[str] = field(default_factory=list)` to `EvalSpec` immediately after `test_args`. Stored as `list[str]` (absolute path strings post-resolve), not `list[Path]`, for JSON round-trip parity with `output_files`. **Why:** matches `output_file`/`output_files` naming and serialization style; keeps `to_dict()` trivial. **How to apply:** `schemas.py:122`.
+
+- **DEC-002 — Load-time resolution.** `EvalSpec.from_file(path)` resolves each `input_files` entry against `path.parent`, validates existence, and stores the absolute path string. Diverges intentionally from `output_files` (which stays CWD-relative, resolved at run time) because inputs are pre-existing static assets while outputs are runtime artifacts. **Why:** fail-fast UX — typos surface at spec load, not mid-grade. **How to apply:** `schemas.py:EvalSpec.from_file`.
+
+- **DEC-003 — Source containment (B1).** Each resolved entry must satisfy `resolved.is_relative_to(spec_dir)`. Violations raise `ValueError` with the `EvalSpec(skill_name=…): input_files[i]=… escapes spec dir` format. **Why:** prevents `../../../etc/passwd` escape. **How to apply:** part of `from_file` validation; test in `test_schemas.py` with `TestEvalSpecInputFiles::test_path_traversal_rejected`.
+
+- **DEC-004 — Reject absolute paths (C1, R2-A).** Entries where `Path(entry).is_absolute()` raise `ValueError` at load. **Why:** portable specs, no surprise staging of system files. **How to apply:** checked before `resolve()` in `from_file`.
+
+- **DEC-005 — Symlink policy (C2, R3-A).** Resolve each entry with `resolve(strict=True)`, then apply the containment check to the real target. If the symlink target lives outside the spec dir, raise `ValueError`. Staged content is the target's bytes. **Why:** intentional symlinks are fine; escape via symlink is not. **How to apply:** reuse the containment check from DEC-003.
+
+- **DEC-006 — Flatten subdirs (B2, R1-A).** `input_files: ["data/sales.csv"]` is staged as `run-K/inputs/sales.csv` — the destination uses `Path(entry).name` only. Duplicate basenames across entries raise `ValueError` at spec load. **Why:** eliminates destination-traversal surface entirely; simpler mental model. **How to apply:** basename-collision check lives next to DEC-003/004.
+
+- **DEC-007 — Staging layout.** Files land in `.clauditor/iteration-N-tmp/<skill>/run-K/inputs/<basename>`. On `workspace.finalize()` the atomic rename persists them at `iteration-N/<skill>/run-K/inputs/<basename>`. **Why:** matches DEC-003/012 from plan #22 (tmp+rename, per-run artifacts); re-grade can reuse the exact input bytes. **How to apply:** new `workspace.stage_inputs(run_tmp_dir, abs_paths)` helper.
+
+- **DEC-008 — CWD = staging dir (Q2-A).** `SkillRunner` is invoked with `cwd=<run-K/inputs absolute path>`. `test_args` is never rewritten. **Why:** matches agentskills.io wording ("files the skill operates on"); zero templating surface. **How to apply:** `SkillSpec.run()` passes a per-run project_dir to `runner.run()`, or a new `cwd=` kwarg on `runner.run()`.
+
+- **DEC-009 — `output_files` collision guard (C3, R4-B).** At spec load, if any `output_files` pattern literally matches an `input_files` basename, raise `ValueError`. Plus a README/example warning. **Why:** staging dir = CWD means stale input globs are a silent footgun. **How to apply:** check in `EvalSpec.from_file` after both fields are parsed.
+
+- **DEC-010 — Variance fresh copies (Q5-A, R5-A).** Each `run-K/inputs/` is populated by re-copying from the spec-dir source (absolute path stored on the spec). No intermediate master cache. **Why:** simplest code path, guaranteed pristine inputs, negligible disk cost. **How to apply:** `stage_inputs()` is called once per run inside the variance loop in `cli._cmd_grade_with_workspace`.
+
+- **DEC-011 — Captured-output mode (R6-C).** `EvalSpec.from_file` validation still fires in `--output <file>` mode (fail-fast). At the CLI layer, if `--output` is combined with a non-empty `input_files`, print a warning to stderr and skip staging (no run happens). **Why:** spec correctness shouldn't depend on how the user invokes grade; warning tells them the declaration is inert in this mode. **How to apply:** warning lives in `cli.cmd_grade` where `--output` is handled.
+
+- **DEC-012 — Pytest fixture transparent staging (Q6-A).** The `clauditor_spec` factory stages `input_files` into `tmp_path / "inputs/"` and wires that as the runner's `cwd`. No new fixture. Tests that want explicit control can still build their own `SkillSpec` by hand. **Why:** smallest public surface; mirrors the CLI's behavior so tests match production. **How to apply:** extend `pytest_plugin.py:clauditor_spec`.
+
+- **DEC-013 — Mutation capture via existing `output_files` (Q3-A).** No auto-diff, no read-only staging. If a user wants to capture a mutated input, they declare it in `output_files` — but because of DEC-009, the spec-load guard will force them to rename so it can't collide with the input basename. **Why:** reuses existing machinery; simpler than diffing. **How to apply:** documented in README + example spec.
+
+- **DEC-014 — No file-size cap.** Staged files are copied without size checks. Documented in README as "input files are copied without size limits". Future work: optional `max_input_bytes` field. **Why:** pre-production, author-trusted specs; matches existing "no output size limit" posture. **How to apply:** docs only.
+
+- **DEC-015 — Logging style.** One stdout line per run: `Staged N input file(s) into run-K/inputs/`. No prefix, matches `cli.py:62`. Errors follow `EvalSpec(skill_name='foo'): input_files[1]='missing.csv' — <reason>` pattern (schemas.py:32-46). **Why:** house style consistency.
+
+- **DEC-016 — Trust model note in README.** One-paragraph addition stating eval specs are developer-authored and run with the repo owner's filesystem access. **Why:** makes the "author-trusted" assumption explicit so downstream consumers (e.g. public example galleries) know the review bar.
+
+### Session notes
+
+- All 6 scoping questions and 6 refinement questions answered in one session (2026-04-13) with user accepting every recommendation.
+- No rules in `.claude/rules/`; no `workflow-project.md`. Pre-production posture — no backward-compat shims needed.
+- Architecture review surfaced 2 blockers (both path-traversal flavors) and 7 concerns; all resolved by DEC-003..DEC-009 + docs.
+
+---
+
+## Detailed Breakdown
+
+Layering follows the natural clauditor stack: schema → workspace helper → spec/runner glue → CLI integration → pytest plugin → docs → quality gate → patterns.
+
+### US-001 — `EvalSpec.input_files` field + load-time validation
+
+**Description.** Add the `input_files` field to `EvalSpec` and implement full load-time validation in `EvalSpec.from_file()`: reject absolute paths, resolve against `path.parent`, enforce source containment (including symlink targets), flatten destinations, detect duplicate basenames, and enforce the `output_files` collision guard.
+
+**Traces to.** DEC-001, DEC-002, DEC-003, DEC-004, DEC-005, DEC-006, DEC-009, DEC-015 (error-message style).
+
+**Acceptance criteria.**
+- `EvalSpec` has `input_files: list[str] = field(default_factory=list)` declared after `test_args`.
+- `EvalSpec.from_file(path)` stores absolute path strings in `input_files`.
+- Relative entries are resolved against `path.parent`.
+- Each of these conditions raises `ValueError` with an informative message citing `skill_name` and the offending index: absolute path entry; entry that escapes the spec dir via `..`; entry whose symlink target escapes the spec dir; missing file; two entries with the same basename; any `output_files` pattern literal-matching an input basename.
+- Old specs without an `input_files` key load cleanly (default `[]`).
+- `to_dict()` round-trips the field.
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥80% coverage.
+
+**Done when.** All new tests green; coverage gate met; `test_schemas.py::TestEvalSpecInputFiles` covers every `ValueError` branch above.
+
+**Files.**
+- `src/clauditor/schemas.py` — add field at ~L122; extend `EvalSpec.from_file` with validation block; extend `to_dict`.
+- `tests/test_schemas.py` — new `TestEvalSpecInputFiles` class.
+
+**Depends on.** none.
+
+**TDD.**
+- `test_input_files_defaults_to_empty_list` — spec without the key loads with `[]`.
+- `test_relative_paths_resolved_against_spec_dir` — `"sales.csv"` → absolute under spec dir.
+- `test_absolute_path_rejected` — `"/etc/passwd"` raises `ValueError`.
+- `test_path_traversal_rejected` — `"../../../etc/passwd"` raises.
+- `test_symlink_target_outside_spec_dir_rejected` — symlink in spec dir → target outside → raises.
+- `test_symlink_target_inside_spec_dir_accepted` — link to sibling file works.
+- `test_missing_input_file_raises_valueerror_at_load` — mention of `input_files[i]` and filename.
+- `test_duplicate_basenames_across_entries_rejected` — `["a/sales.csv", "b/sales.csv"]` raises.
+- `test_output_files_collision_guard_rejects_overlap` — `input_files: ["x.csv"]`, `output_files: ["x.csv"]` raises.
+- `test_to_dict_roundtrip_preserves_input_files`.
+
+---
+
+### US-002 — `workspace.stage_inputs()` helper
+
+**Description.** Add a pure helper that, given a run-scoped destination directory and a list of absolute source paths, copies each source to `<dest>/<basename>` with `shutil.copy2`, creating `dest` if needed. No path parsing or validation — that's US-001's job. Returns the list of destination paths.
+
+**Traces to.** DEC-007, DEC-010 (fresh copies), DEC-013 (no special read-only handling).
+
+**Acceptance criteria.**
+- New `stage_inputs(run_dir: Path, sources: list[Path]) -> list[Path]` in `src/clauditor/workspace.py`.
+- Creates `run_dir / "inputs"` if missing.
+- Empty `sources` → no-op, returns `[]`, does not create the `inputs/` dir.
+- Preserves file content and mtime (`copy2`).
+- Raises `FileNotFoundError` with a clear message if a source no longer exists (unlikely post-US-001, but defensive).
+- `uv run pytest tests/test_workspace.py` passes; `uv run ruff` clean.
+
+**Done when.** `tests/test_workspace.py::TestStageInputs` covers empty / single / multiple / missing-source / destination-creation cases, all green; function has 100% line coverage.
+
+**Files.**
+- `src/clauditor/workspace.py` — append new helper (no changes to `allocate_iteration`).
+- `tests/test_workspace.py` — new `TestStageInputs` class using `tmp_path`.
+
+**Depends on.** US-001 (for typing consistency, not strictly required to compile — the helper is freestanding).
+
+**TDD.**
+- `test_stage_inputs_empty_list_is_noop` — no dir created.
+- `test_stage_inputs_single_file_copies_and_preserves_mtime`.
+- `test_stage_inputs_multiple_files`.
+- `test_stage_inputs_creates_inputs_subdir`.
+- `test_stage_inputs_missing_source_raises`.
+
+---
+
+### US-003 — `SkillRunner` cwd override + `SkillSpec.run()` staging hook
+
+**Description.** Allow `SkillRunner.run()` (or `_invoke`) to accept a per-call `cwd` override. Update `SkillSpec.run()` to detect a non-empty `input_files`, stage them via `stage_inputs()` into a per-run directory passed in by the caller, and invoke the runner with `cwd` pointed at that `inputs/` directory. When `input_files` is empty, preserve today's behavior exactly (runner uses `project_dir`).
+
+**Traces to.** DEC-007, DEC-008.
+
+**Acceptance criteria.**
+- `SkillRunner.run(skill_name, args, *, cwd: Path | None = None)` — when `cwd` is `None`, uses `self.project_dir` (current behavior, unchanged).
+- `SkillSpec.run()` accepts an optional `run_dir: Path | None` kwarg; if provided and `input_files` is non-empty, stages inputs into `run_dir / "inputs"` and passes that as `cwd` to the runner.
+- When `run_dir` is `None` or `input_files` is empty, behavior is bit-for-bit identical to today.
+- One stdout info line per staging call: `Staged N input file(s) into <relative path>` (DEC-015).
+- Existing runner/spec tests still pass (no regression).
+- `ruff` clean; coverage ≥80%.
+
+**Done when.** New tests cover both the cwd-override path (via Popen mock assertion on the `cwd=` kwarg) and the staging integration in `SkillSpec.run()`.
+
+**Files.**
+- `src/clauditor/runner.py` — add `cwd` kwarg to `run()`/`_invoke`; thread to `Popen(..., cwd=...)`.
+- `src/clauditor/spec.py` — extend `SkillSpec.run()` signature; call `stage_inputs` when appropriate; emit info log.
+- `tests/test_runner.py` — extend `TestSkillRunnerRun` with `test_run_uses_cwd_override_when_passed`.
+- `tests/test_spec.py` — new `TestSkillSpecRunWithInputFiles` covering empty / populated / log-line assertions.
+
+**Depends on.** US-001, US-002.
+
+**TDD.**
+- `test_runner_default_cwd_is_project_dir` (regression guard).
+- `test_runner_cwd_override_passed_to_popen`.
+- `test_skillspec_run_with_empty_input_files_uses_project_dir`.
+- `test_skillspec_run_with_input_files_stages_and_sets_cwd`.
+- `test_skillspec_run_emits_staged_log_line`.
+
+---
+
+### US-004 — CLI `grade` integration + variance fresh copies + captured-output warning
+
+**Description.** Wire US-003 into `cli._cmd_grade_with_workspace`. For each run in the variance loop, compute the tmp run directory (`iteration-N-tmp/<skill>/run-K/`), pass it to `spec.run()` so inputs are re-staged fresh per run (DEC-010). When `--output <file>` is combined with a non-empty `input_files`, emit a stderr warning and skip staging entirely (DEC-011). After `workspace.finalize()`, the staged inputs live at their final persistent path.
+
+**Traces to.** DEC-007, DEC-010, DEC-011.
+
+**Acceptance criteria.**
+- Single-run and variance modes both pass a per-run directory to `spec.run()`.
+- `iteration-N/<skill>/run-K/inputs/` contains the staged input files after `finalize()`.
+- In variance mode, each `run-K/inputs/` is a separately-copied, independently-writable directory (mutation in run-0 doesn't affect run-1).
+- `clauditor grade --output captured.txt` on a spec with `input_files` prints `WARNING: --output bypasses the runner; input_files declaration is ignored.` to stderr and does not attempt to stage.
+- Existing non-input_files grade flows unchanged (regression guard).
+- `ruff` clean; coverage ≥80%.
+
+**Done when.** CLI tests assert the per-run staging paths on disk, the variance isolation, and the captured-output warning text.
+
+**Files.**
+- `src/clauditor/cli.py` — inside the variance loop in `_cmd_grade_with_workspace`, thread `run_dir` into `spec.run()`; add the `--output` + `input_files` warning branch in `cmd_grade`.
+- `tests/test_cli.py` — extend `TestCmdGrade` with two tests (see TDD below).
+
+**Depends on.** US-003.
+
+**TDD.**
+- `test_grade_stages_inputs_into_iteration_run_dir_on_finalize` — run a fake skill end-to-end with one input file, assert `iteration-1/<skill>/run-0/inputs/sales.csv` exists with correct bytes.
+- `test_grade_variance_stages_inputs_per_run` — `variance.n_runs=3`, mutate input in each fake run, assert each `run-K/inputs/sales.csv` holds its own copy.
+- `test_grade_captured_output_mode_warns_and_skips_staging` — `--output captured.txt` with `input_files: ["x.csv"]` prints the warning and does not create any `inputs/` dir.
+
+---
+
+### US-005 — Pytest plugin transparent staging
+
+**Description.** Extend the `clauditor_spec` fixture factory in `pytest_plugin.py` so that when a loaded `SkillSpec` has non-empty `input_files`, the factory automatically stages them into `tmp_path / "inputs/"` and arranges for `SkillSpec.run()` to use that directory as the runner cwd. No new fixture; tests see the feature transparently.
+
+**Traces to.** DEC-012.
+
+**Acceptance criteria.**
+- `clauditor_spec(skill_path, eval_path=None)` returns a `SkillSpec` whose subsequent `.run()` call stages inputs into the test's `tmp_path`.
+- Tests that don't touch `input_files` see zero behavior change (regression).
+- Captured-output fixture path (`clauditor_capture`) is unaffected.
+- `ruff` clean; fixture is covered by at least one pytester-style integration test and one direct unit test.
+
+**Done when.** `tests/test_pytest_plugin.py` has new tests demonstrating the transparent staging and a non-regression test for the existing fixture behavior.
+
+**Files.**
+- `src/clauditor/pytest_plugin.py` — extend the `clauditor_spec` factory.
+- `tests/test_pytest_plugin.py` — new tests under `TestPytestPlugin`.
+
+**Depends on.** US-003.
+
+**TDD.**
+- `test_clauditor_spec_fixture_stages_input_files_into_tmp_path` (pytester).
+- `test_clauditor_spec_fixture_without_input_files_is_unchanged` (regression).
+
+---
+
+### US-006 — Docs: README, example eval spec, trust-model note
+
+**Description.** Update README and the example eval spec to document `input_files`: placement in the field list, semantics (CWD, flattening, containment, symlink handling), the `output_files` collision guard, the captured-output mode warning, the no-size-limit disclaimer, and a one-paragraph trust-model note. Update the agentskills.io alignment table to mark this gap closed.
+
+**Traces to.** DEC-006 (flatten), DEC-008 (CWD), DEC-009 (collision guard), DEC-011 (captured-output), DEC-013 (mutation via output_files), DEC-014 (size), DEC-016 (trust note).
+
+**Acceptance criteria.**
+- README has a dedicated `input_files` subsection with a small worked example (CSV cleaner skill).
+- README mentions: relative-to-spec-dir resolution, flatten-to-basename, containment, symlink target check, reject absolute, `output_files` collision, captured-output warning, no size limit.
+- README trust-model paragraph states specs are author-controlled.
+- `examples/.claude/commands/example-skill.eval.json` gains an `input_files` entry (or a separate example file is added) demonstrating the feature.
+- Agentskills.io alignment gap #5 marked closed.
+- No code changes in this story — docs only.
+
+**Done when.** `git diff` shows only README + example JSON + (optional) `docs/` updates.
+
+**Files.**
+- `README.md`
+- `examples/.claude/commands/example-skill.eval.json` (or a sibling example).
+
+**Depends on.** US-001..US-005 (docs describe behavior that must exist).
+
+---
+
+### US-Q — Quality Gate
+
+**Description.** Run the code reviewer over the full changeset 4 times in sequence, fixing every real bug each pass. Then run CodeRabbit (`coderabbit review --base dev`) and address findings. Finally re-run `uv run ruff check src/ tests/` and `uv run pytest --cov=clauditor --cov-report=term-missing`; confirm ≥80% coverage and green.
+
+**Traces to.** Project convention from plan #22 Quality Gate.
+
+**Acceptance criteria.**
+- 4 code-review passes completed; all real bugs fixed (not stylistic nits unless they reflect a real rule).
+- CodeRabbit findings triaged (addressed / explicitly skipped with reason).
+- `ruff` clean, `pytest` green, coverage ≥80%.
+- Commit history shows the review passes as distinct fixup commits.
+
+**Done when.** Final review pass turns up zero real bugs and all gates are green.
+
+**Depends on.** US-001..US-006.
+
+---
+
+### US-P — Patterns & Memory
+
+**Description.** Capture any new patterns or gotchas learned during implementation. Candidates: the source-containment pattern for user-provided paths (reusable for any future field that accepts filesystem paths); the CWD-override idiom on `SkillRunner`; the load-time-vs-run-time resolution split; any new test helpers that emerged.
+
+**Traces to.** DEC-003 (containment pattern — reusable), DEC-008 (cwd override idiom).
+
+**Acceptance criteria.**
+- `.claude/rules/` updated or created with at least a path-containment rule if no equivalent exists.
+- `docs/` or a `bd remember` entry captures the load-vs-run-time resolution decision so the next person touching `EvalSpec` doesn't re-debate it.
+- No code changes unless a refactor naturally falls out.
+
+**Depends on.** US-Q.
+
+
+---
+
+## Beads Manifest
+
+*(pending — Phase 7)*

--- a/plans/super/23-eval-input-files.md
+++ b/plans/super/23-eval-input-files.md
@@ -5,7 +5,7 @@
 - **Ticket:** [clauditor#23](https://github.com/wjduenow/clauditor/issues/23)
 - **Title:** Input files support on eval specs
 - **Branch:** `feature/23-eval-input-files`
-- **Phase:** detailing
+- **Phase:** devolved
 - **Sessions:** 1
 - **Last session:** 2026-04-13
 
@@ -430,4 +430,17 @@ Layering follows the natural clauditor stack: schema → workspace helper → sp
 
 ## Beads Manifest
 
-*(pending — Phase 7)*
+- **Epic:** `clauditor-5o9` — #23: Input files support on eval specs
+- **Draft PR:** https://github.com/wjduenow/clauditor/pull/32
+- **Branch / worktree:** `feature/23-eval-input-files` at repo root
+- **Tasks (parent = epic):**
+  - `clauditor-5o9.1` — US-001 — EvalSpec.input_files field + load-time validation *(no deps, ready)*
+  - `clauditor-5o9.2` — US-002 — workspace.stage_inputs() pure copy helper *(blocked by .1)*
+  - `clauditor-5o9.3` — US-003 — SkillRunner cwd override + SkillSpec.run() staging hook *(blocked by .1, .2)*
+  - `clauditor-5o9.4` — US-004 — CLI grade integration, variance fresh copies, captured-output warning *(blocked by .3)*
+  - `clauditor-5o9.5` — US-005 — Pytest plugin transparent staging *(blocked by .3)*
+  - `clauditor-5o9.6` — US-006 — Docs: README, example eval spec, trust-model note *(blocked by .1..5)*
+  - `clauditor-5o9.7` — Quality Gate — code review x4 + CodeRabbit + ruff + pytest *(blocked by .1..6)*
+  - `clauditor-5o9.8` — Patterns & Memory *(blocked by .7, priority 4)*
+- **Parallel-safe at start:** `clauditor-5o9.1` only (everything else depends on it).
+- **After US-001 lands:** `.2` unblocks; then `.3`; then `.4` and `.5` run in parallel.

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -300,13 +300,21 @@ def _cmd_grade_with_workspace(
     # Run 0: primary. Honors --output (no subprocess) when provided.
     primary_skill_result: SkillResult | None = None
     if args.output:
+        if spec.eval_spec is not None and spec.eval_spec.input_files:
+            print(
+                "WARNING: --output bypasses the runner; "
+                "input_files declaration is ignored.",
+                file=sys.stderr,
+            )
         primary_text = Path(args.output).read_text()
         run_outputs.append((primary_text, []))
     else:
         print(
             f"Running /{spec.skill_name} {spec.eval_spec.test_args}..."
         )
-        primary_skill_result = spec.run()
+        primary_skill_result = spec.run(
+            run_dir=workspace.tmp_path / "run-0",
+        )
         if not primary_skill_result.succeeded:
             print(
                 f"ERROR: Skill failed: {primary_skill_result.error}",
@@ -323,8 +331,15 @@ def _cmd_grade_with_workspace(
 
     # Variance runs: always invoke the skill subprocess (variance against
     # a fixed --output file would be meaningless).
-    for _ in range(n_variance):
-        variance_result = spec.run()
+    for variance_idx in range(n_variance):
+        # In captured-output mode, skip run_dir threading so input_files
+        # staging is suppressed (warning already printed above).
+        variance_run_dir = (
+            None
+            if args.output
+            else workspace.tmp_path / f"run-{variance_idx + 1}"
+        )
+        variance_result = spec.run(run_dir=variance_run_dir)
         if not variance_result.succeeded:
             print(
                 f"ERROR: Variance skill run failed: {variance_result.error}",

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -93,12 +93,19 @@ def clauditor_runner(request: pytest.FixtureRequest) -> SkillRunner:
 
 
 @pytest.fixture
-def clauditor_spec(request: pytest.FixtureRequest):
+def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
     """Fixture factory for loading SkillSpecs.
 
     Usage:
         def test_skill(clauditor_spec):
             spec = clauditor_spec(".claude/commands/my-skill.md")
+
+    When the loaded spec declares non-empty ``eval_spec.input_files``, the
+    returned ``SkillSpec`` has its ``.run`` method transparently wrapped so
+    that calls without an explicit ``run_dir`` use a stable subdirectory
+    under pytest's ``tmp_path``. This causes the declared input files to be
+    staged automatically. Specs with no ``input_files`` are returned
+    unmodified (zero behavior change).
     """
     runner = SkillRunner(
         project_dir=request.config.getoption("--clauditor-project-dir"),
@@ -107,7 +114,23 @@ def clauditor_spec(request: pytest.FixtureRequest):
     )
 
     def _factory(skill_path: str | Path, eval_path: str | Path | None = None):
-        return SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
+        spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
+        if spec.eval_spec is not None and spec.eval_spec.input_files:
+            original_run = spec.run
+            default_run_dir = tmp_path / "clauditor_run"
+
+            def _run_with_default_run_dir(
+                args: str | None = None,
+                *,
+                run_dir: Path | None = None,
+            ):
+                if run_dir is None:
+                    default_run_dir.mkdir(parents=True, exist_ok=True)
+                    run_dir = default_run_dir
+                return original_run(args, run_dir=run_dir)
+
+            spec.run = _run_with_default_run_dir  # type: ignore[method-assign]
+        return spec
 
     return _factory
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -117,7 +117,7 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
         spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
         if spec.eval_spec is not None and spec.eval_spec.input_files:
             original_run = spec.run
-            default_run_dir = tmp_path / "clauditor_run"
+            default_run_dir = tmp_path / f"clauditor_run_{id(spec)}"
 
             def _run_with_default_run_dir(
                 args: str | None = None,

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -130,12 +130,20 @@ class SkillRunner:
         self.timeout = timeout
         self.claude_bin = claude_bin
 
-    def run(self, skill_name: str, args: str = "") -> SkillResult:
+    def run(
+        self,
+        skill_name: str,
+        args: str = "",
+        *,
+        cwd: Path | None = None,
+    ) -> SkillResult:
         """Run a skill and capture its output.
 
         Args:
             skill_name: Name of the skill (e.g., "find-kid-activities")
             args: Pre-filled arguments to skip interactive prompts
+            cwd: Optional override for the subprocess working directory.
+                When ``None``, falls back to ``self.project_dir``.
 
         Returns:
             SkillResult with captured output
@@ -143,7 +151,7 @@ class SkillRunner:
         prompt = f"/{skill_name}"
         if args:
             prompt += f" {args}"
-        return self._invoke(prompt=prompt, skill_name=skill_name, args=args)
+        return self._invoke(prompt=prompt, skill_name=skill_name, args=args, cwd=cwd)
 
     def run_raw(self, prompt: str) -> SkillResult:
         """Run a raw prompt without skill prefix for baseline comparison.
@@ -160,7 +168,14 @@ class SkillRunner:
     # Stream-json Popen implementation                                    #
     # ------------------------------------------------------------------ #
 
-    def _invoke(self, *, prompt: str, skill_name: str, args: str) -> SkillResult:
+    def _invoke(
+        self,
+        *,
+        prompt: str,
+        skill_name: str,
+        args: str,
+        cwd: Path | None = None,
+    ) -> SkillResult:
         """Run ``claude`` with stream-json output and parse the NDJSON stream.
 
         Uses ``try/finally`` so ``duration_seconds`` is populated on every
@@ -189,7 +204,7 @@ class SkillRunner:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
-                    cwd=str(self.project_dir),
+                    cwd=str(cwd) if cwd is not None else str(self.project_dir),
                 )
             except FileNotFoundError:
                 result = SkillResult(

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -115,6 +115,7 @@ class EvalSpec:
     skill_name: str
     description: str = ""
     test_args: str = ""  # Pre-filled args to skip interactive Q&A
+    input_files: list[str] = field(default_factory=list)  # Resolved absolute paths
     assertions: list[dict] = field(default_factory=list)  # Layer 1 checks
     sections: list[SectionRequirement] = field(default_factory=list)  # Layer 2 schema
     grading_criteria: list[str] = field(default_factory=list)  # Layer 3 rubric
@@ -131,6 +132,51 @@ class EvalSpec:
         path = Path(path)
         with open(path) as f:
             data = json.load(f)
+
+        skill_name = data.get("skill_name", path.stem)
+        spec_dir = path.parent.resolve()
+        raw_input_files = data.get("input_files", [])
+        resolved_input_files: list[str] = []
+        input_basenames: list[str] = []
+        for i, entry in enumerate(raw_input_files):
+            if Path(entry).is_absolute():
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"input_files[{i}]={entry!r} — absolute paths not allowed"
+                )
+            try:
+                candidate = (path.parent / entry).resolve(strict=True)
+            except FileNotFoundError as e:
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"input_files[{i}]={entry!r} — file not found under {spec_dir}"
+                ) from e
+            if not candidate.is_relative_to(spec_dir):
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"input_files[{i}]={entry!r} — escapes spec directory"
+                )
+            resolved_input_files.append(str(candidate))
+            input_basenames.append(candidate.name)
+        for i, name_i in enumerate(input_basenames):
+            for j in range(i + 1, len(input_basenames)):
+                if input_basenames[j] == name_i:
+                    raise ValueError(
+                        f"EvalSpec(skill_name={skill_name!r}): "
+                        f"input_files entries {i} and {j} share destination "
+                        f"basename {name_i!r}"
+                    )
+
+        raw_output_files = data.get("output_files", [])
+        input_basename_set = set(input_basenames)
+        for pat in raw_output_files:
+            pat_name = Path(pat).name
+            if pat_name in input_basename_set:
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"output_files pattern {pat!r} collides with "
+                    f"input_files basename {pat_name!r}"
+                )
 
         sections = []
         for s in data.get("sections", []):
@@ -205,9 +251,10 @@ class EvalSpec:
             )
 
         return cls(
-            skill_name=data.get("skill_name", path.stem),
+            skill_name=skill_name,
             description=data.get("description", ""),
             test_args=data.get("test_args", ""),
+            input_files=resolved_input_files,
             assertions=data.get("assertions", []),
             sections=sections,
             grading_criteria=data.get("grading_criteria", []),
@@ -225,6 +272,7 @@ class EvalSpec:
             "skill_name": self.skill_name,
             "description": self.description,
             "test_args": self.test_args,
+            "input_files": self.input_files,
             "assertions": self.assertions,
             "sections": [
                 {

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -139,6 +139,11 @@ class EvalSpec:
         resolved_input_files: list[str] = []
         input_basenames: list[str] = []
         for i, entry in enumerate(raw_input_files):
+            if not isinstance(entry, str) or entry == "":
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"input_files[{i}]={entry!r} — must be a non-empty string"
+                )
             if Path(entry).is_absolute():
                 raise ValueError(
                     f"EvalSpec(skill_name={skill_name!r}): "
@@ -155,6 +160,11 @@ class EvalSpec:
                 raise ValueError(
                     f"EvalSpec(skill_name={skill_name!r}): "
                     f"input_files[{i}]={entry!r} — escapes spec directory"
+                )
+            if not candidate.is_file():
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"input_files[{i}]={entry!r} — not a regular file"
                 )
             resolved_input_files.append(str(candidate))
             input_basenames.append(candidate.name)

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -135,6 +135,13 @@ class EvalSpec:
 
         skill_name = data.get("skill_name", path.stem)
         spec_dir = path.parent.resolve()
+        # Path resolution split (intentional): `input_files` are pre-existing
+        # static assets and resolve HERE at load time, relative to the spec
+        # file's parent dir, with strict source-containment. `output_files`
+        # are runtime artifacts and resolve at run time against the runner's
+        # effective CWD (staging dir when inputs are declared, else
+        # project_dir) — see `spec.py` `_collect_outputs` / `effective_cwd`.
+        # Any new path-bearing field must pick a side of this split.
         raw_input_files = data.get("input_files", [])
         resolved_input_files: list[str] = []
         input_basenames: list[str] = []

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -101,7 +101,11 @@ class SkillSpec:
         # Read output from files if eval spec specifies file-based output
         # Only read files on successful runs to avoid stale output
         if self.eval_spec and result.succeeded:
-            base_dir = self.runner.project_dir
+            base_dir = (
+                effective_cwd
+                if effective_cwd is not None
+                else self.runner.project_dir
+            )
             if self.eval_spec.output_file:
                 file_path = base_dir / self.eval_spec.output_file
                 if file_path.exists():
@@ -126,7 +130,9 @@ class SkillSpec:
     def evaluate(self, output: str | None = None) -> AssertionSet:
         """Run Layer 1 assertions from the eval spec against output.
 
-        If output is None, runs the skill first to get output.
+        If output is None, runs the skill first to get output. Note that this
+        path does not stage ``input_files`` — for that, call ``run(run_dir=...)``
+        directly (the CLI and pytest plugin do this for you).
         """
         if not self.eval_spec:
             raise ValueError(

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.schemas import EvalSpec
+from clauditor.workspace import stage_inputs
 
 
 class SkillSpec:
@@ -64,17 +65,38 @@ class SkillSpec:
 
         return cls(skill_path=skill_path, eval_spec=eval_spec, runner=runner)
 
-    def run(self, args: str | None = None) -> SkillResult:
+    def run(
+        self,
+        args: str | None = None,
+        *,
+        run_dir: Path | None = None,
+    ) -> SkillResult:
         """Run the skill and return captured output.
 
         If args is None and an eval spec exists, uses the eval spec's test_args.
+
+        If ``run_dir`` is provided and the eval spec declares non-empty
+        ``input_files``, those files are staged into ``run_dir / "inputs"``
+        and the subprocess runs with that directory as its CWD.
         """
         run_args = (
             args
             if args is not None
             else (self.eval_spec.test_args if self.eval_spec else "")
         )
-        result = self.runner.run(self.skill_name, run_args)
+
+        effective_cwd: Path | None = None
+        if (
+            run_dir is not None
+            and self.eval_spec is not None
+            and self.eval_spec.input_files
+        ):
+            sources = [Path(p) for p in self.eval_spec.input_files]
+            stage_inputs(run_dir, sources)
+            effective_cwd = run_dir / "inputs"
+            print(f"Staged {len(sources)} input file(s) into {effective_cwd}")
+
+        result = self.runner.run(self.skill_name, run_args, cwd=effective_cwd)
 
         # Read output from files if eval spec specifies file-based output
         # Only read files on successful runs to avoid stale output

--- a/src/clauditor/workspace.py
+++ b/src/clauditor/workspace.py
@@ -25,6 +25,7 @@ __all__ = [
     "IterationExistsError",
     "IterationWorkspace",
     "allocate_iteration",
+    "stage_inputs",
     "validate_skill_name",
 ]
 
@@ -237,3 +238,37 @@ def _allocate_auto(clauditor_dir: Path, skill: str) -> IterationWorkspace:
         f"allocate_iteration: exceeded {_MAX_AUTO_RETRIES} retries scanning "
         f"for a free iteration slot under {clauditor_dir}"
     )
+
+
+def stage_inputs(run_dir: Path, sources: list[Path]) -> list[Path]:
+    """Copy input files into ``run_dir / "inputs"`` and return destinations.
+
+    Pure helper: trusts its inputs. Path parsing, containment checks, and
+    symlink resolution are performed upstream at spec load time (US-001);
+    this function does no validation of its own.
+
+    Contract:
+        - If ``sources`` is empty, returns ``[]`` and does **not** create
+          the ``inputs/`` subdirectory (no-op).
+        - Otherwise creates ``run_dir / "inputs"`` if needed and copies
+          each source to ``<run_dir>/inputs/<source.name>`` via
+          :func:`shutil.copy2` (preserving mtime).
+        - Returns destination paths in the same order as ``sources``.
+
+    Raises:
+        FileNotFoundError: If any source path does not exist.
+    """
+    if not sources:
+        return []
+    inputs_dir = run_dir / "inputs"
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    destinations: list[Path] = []
+    for src in sources:
+        if not src.exists():
+            raise FileNotFoundError(
+                f"stage_inputs: source file not found: {src}"
+            )
+        dest = inputs_dir / src.name
+        shutil.copy2(src, dest)
+        destinations.append(dest)
+    return destinations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -387,10 +387,16 @@ class TestCmdGradeInputFilesStaging:
 
         assert rc == 0
         skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        staged_paths = []
         for k in (0, 1, 2):
             staged = skill_dir / f"run-{k}" / "inputs" / "sales.csv"
             assert staged.is_file(), f"run-{k} missing staged input"
             assert staged.read_bytes() == source.read_bytes()
+            staged_paths.append(staged)
+        # Independence: mutating run-0's copy must not affect run-1 / run-2.
+        staged_paths[0].write_bytes(b"tampered")
+        assert staged_paths[1].read_bytes() == source.read_bytes()
+        assert staged_paths[2].read_bytes() == source.read_bytes()
 
     def test_grade_captured_output_mode_with_input_files_warns(  # noqa: E501
         self, tmp_path, monkeypatch, capsys

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,6 +266,175 @@ class TestCmdGrade:
         assert rc == 1
 
 
+class TestCmdGradeInputFilesStaging:
+    """Tests for US-004: CLI threads run_dir to spec.run so eval input_files
+    are staged per-run, and captured-output mode warns + skips staging."""
+
+    def _make_grading_report(self, passed=True):
+        return GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    criterion="Is the output relevant?",
+                    passed=passed,
+                    score=0.9,
+                    evidence="e",
+                    reasoning="r",
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+    def _staging_spec(self, eval_spec, outputs):
+        """Build a MagicMock SkillSpec whose .run() mirrors the real
+        SkillSpec.run: when run_dir is passed and eval_spec.input_files
+        is non-empty, call stage_inputs(run_dir, [...]). Returns
+        ``outputs`` popped per-call as SkillResults."""
+        from pathlib import Path as _Path
+
+        from clauditor.workspace import stage_inputs
+
+        spec = _make_spec(eval_spec=eval_spec)
+        outputs_iter = iter(outputs)
+
+        def _run(args=None, *, run_dir=None):
+            if run_dir is not None and eval_spec.input_files:
+                stage_inputs(
+                    run_dir, [_Path(p) for p in eval_spec.input_files]
+                )
+            return next(outputs_iter)
+
+        spec.run = MagicMock(side_effect=_run)
+        return spec
+
+    def _ok_result(self, text="ok"):
+        return SkillResult(
+            output=text,
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=0.1,
+            input_tokens=1,
+            output_tokens=1,
+            stream_events=[{"type": "assistant", "text": text}],
+        )
+
+    def test_grade_stages_input_files_into_iteration_run_dir_on_finalize(
+        self, tmp_path, monkeypatch
+    ):
+        """Primary (non --output) grade threads run_dir so input_files
+        are staged under iteration-1/<skill>/run-0/inputs/."""
+        monkeypatch.chdir(tmp_path)
+        source = tmp_path / "sales.csv"
+        source.write_bytes(b"date,amount\n2024-01-01,100\n")
+
+        eval_spec = _make_eval_spec(input_files=[str(source)])
+        spec = self._staging_spec(eval_spec, [self._ok_result("primary")])
+        report = self._make_grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        staged = (
+            tmp_path
+            / ".clauditor"
+            / "iteration-1"
+            / "test-skill"
+            / "run-0"
+            / "inputs"
+            / "sales.csv"
+        )
+        assert staged.is_file()
+        assert staged.read_bytes() == source.read_bytes()
+
+    def test_grade_variance_stages_inputs_per_run(
+        self, tmp_path, monkeypatch
+    ):
+        """--variance 2 stages input_files into every run-K dir."""
+        monkeypatch.chdir(tmp_path)
+        source = tmp_path / "sales.csv"
+        source.write_bytes(b"k,v\na,1\n")
+
+        eval_spec = _make_eval_spec(input_files=[str(source)])
+        spec = self._staging_spec(
+            eval_spec,
+            [
+                self._ok_result("primary"),
+                self._ok_result("variance 1"),
+                self._ok_result("variance 2"),
+            ],
+        )
+        report = self._make_grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--variance", "2"])
+
+        assert rc == 0
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        for k in (0, 1, 2):
+            staged = skill_dir / f"run-{k}" / "inputs" / "sales.csv"
+            assert staged.is_file(), f"run-{k} missing staged input"
+            assert staged.read_bytes() == source.read_bytes()
+
+    def test_grade_captured_output_mode_with_input_files_warns(  # noqa: E501
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--output <file> + non-empty input_files prints a stderr warning
+        and does NOT create any inputs/ dir under the iteration workspace."""
+        monkeypatch.chdir(tmp_path)
+        source = tmp_path / "sales.csv"
+        source.write_bytes(b"k,v\na,1\n")
+        captured = tmp_path / "captured.txt"
+        captured.write_text("pre-captured skill output")
+
+        eval_spec = _make_eval_spec(input_files=[str(source)])
+        # Captured-output mode does not invoke spec.run for the primary.
+        spec = self._staging_spec(eval_spec, [])
+        report = self._make_grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                ["grade", "skill.md", "--output", str(captured)]
+            )
+
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert (
+            "WARNING: --output bypasses the runner; "
+            "input_files declaration is ignored." in err
+        )
+        spec.run.assert_not_called()
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        assert skill_dir.is_dir()
+        # No inputs/ dir should exist under any run-K
+        assert not any(
+            p.name == "inputs" for p in skill_dir.rglob("inputs")
+        )
+
+
 class TestOnlyCriterion:
     """Tests for --only-criterion filter on the grade subcommand."""
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -369,9 +369,8 @@ class TestClauditorSpecInputFiles:
                     skill_name="my-skill",
                     args="--depth quick",
                 )
-                with patch(
-                    "clauditor.spec.SkillRunner.run",
-                    return_value=fake_result,
+                with patch.object(
+                    spec.runner, "run", return_value=fake_result,
                 ):
                     result = spec.run()
                 assert result.exit_code == 0

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -163,7 +163,7 @@ class TestPluginFunctionsDirect:
         assert runner.timeout == 60
         assert runner.claude_bin == "claude"
 
-    def test_spec_fixture_returns_callable(self):
+    def test_spec_fixture_returns_callable(self, tmp_path):
         """clauditor_spec fixture returns a callable factory."""
         request = MagicMock()
         request.config.getoption.side_effect = (
@@ -173,7 +173,7 @@ class TestPluginFunctionsDirect:
                 "--clauditor-claude-bin": "claude",
             }[opt]
         )
-        factory = clauditor_spec.__wrapped__(request)
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
         assert callable(factory)
 
     def test_capture_fixture_returns_path(self, tmp_path):
@@ -220,7 +220,7 @@ class TestPluginFunctionsDirect:
         with _pytest.raises(FileNotFoundError):
             path.read_text()
 
-    def test_spec_factory_calls_from_file(self):
+    def test_spec_factory_calls_from_file(self, tmp_path):
         """clauditor_spec factory delegates to SkillSpec.from_file."""
         from unittest.mock import patch
 
@@ -232,11 +232,148 @@ class TestPluginFunctionsDirect:
                 "--clauditor-claude-bin": "claude",
             }[opt]
         )
-        factory = clauditor_spec.__wrapped__(request)
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
         with patch(
             "clauditor.pytest_plugin.SkillSpec.from_file"
         ) as mock_from_file:
-            mock_from_file.return_value = MagicMock()
+            mock_spec = MagicMock()
+            mock_spec.eval_spec = None
+            mock_from_file.return_value = mock_spec
             result = factory("some/skill.md")
             mock_from_file.assert_called_once()
-            assert result is mock_from_file.return_value
+            assert result is mock_spec
+
+
+class TestClauditorSpecInputFiles:
+    """US-005: clauditor_spec fixture auto-stages input_files."""
+
+    def test_clauditor_spec_fixture_without_input_files_unchanged(self, tmp_path):
+        """When input_files is empty, spec.run is NOT wrapped."""
+        from unittest.mock import patch
+
+        from clauditor.spec import SkillSpec
+
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 180,
+                "--clauditor-claude-bin": "claude",
+            }[opt]
+        )
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # spec.run was NOT replaced
+        assert result.run is original_run
+
+    def test_clauditor_spec_fixture_wraps_run_when_input_files_present(
+        self, tmp_path
+    ):
+        """When input_files is non-empty, spec.run is wrapped with default run_dir."""
+        from unittest.mock import patch
+
+        from clauditor.spec import SkillSpec
+
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 180,
+                "--clauditor-claude-bin": "claude",
+            }[opt]
+        )
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = ["/abs/path/sales.csv"]
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+        original_run.return_value = "RESULT"
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # spec.run WAS replaced
+        assert result.run is not original_run
+
+        # Calling with no run_dir injects the default + creates the dir
+        ret = result.run()
+        assert ret == "RESULT"
+        original_run.assert_called_once()
+        call_kwargs = original_run.call_args.kwargs
+        assert call_kwargs["run_dir"] == tmp_path / "clauditor_run"
+        assert (tmp_path / "clauditor_run").exists()
+
+        # Explicit run_dir passed by caller overrides the default
+        original_run.reset_mock()
+        custom = tmp_path / "custom_dir"
+        result.run("arg", run_dir=custom)
+        original_run.assert_called_once_with("arg", run_dir=custom)
+
+    def test_clauditor_spec_fixture_stages_input_files_transparently(
+        self, pytester
+    ):
+        """End-to-end: pytester test uses clauditor_spec and input_files get staged."""
+        skill_dir = pytester.path / "skill_pkg"
+        (skill_dir / ".claude" / "commands").mkdir(parents=True)
+        skill_md = skill_dir / ".claude" / "commands" / "my-skill.md"
+        skill_md.write_text("# My Skill\n\nDoes things.\n")
+
+        (skill_dir / ".claude" / "commands" / "sales.csv").write_text(
+            "a,b\n1,2\n"
+        )
+
+        eval_json = skill_dir / ".claude" / "commands" / "my-skill.eval.json"
+        eval_json.write_text(
+            '{"test_args": "--depth quick",'
+            ' "input_files": ["sales.csv"],'
+            ' "assertions": []}'
+        )
+
+        pytester.makepyfile(f"""
+            from unittest.mock import patch
+
+            from clauditor.runner import SkillResult
+
+            SKILL = r"{skill_md}"
+
+            def test_staging(clauditor_spec):
+                spec = clauditor_spec(SKILL)
+                assert spec.eval_spec is not None
+                assert spec.eval_spec.input_files
+                from clauditor.spec import SkillSpec
+                assert not (
+                    getattr(spec.run, '__func__', None) is SkillSpec.run
+                )
+
+                fake_result = SkillResult(
+                    output="Staged 1 input file(s) into /tmp/x\\nOK",
+                    exit_code=0,
+                    skill_name="my-skill",
+                    args="--depth quick",
+                )
+                with patch(
+                    "clauditor.spec.SkillRunner.run",
+                    return_value=fake_result,
+                ):
+                    result = spec.run()
+                assert result.exit_code == 0
+        """)
+        result = pytester.runpytest_inprocess("-v")
+        result.assert_outcomes(passed=1)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -317,8 +317,9 @@ class TestClauditorSpecInputFiles:
         assert ret == "RESULT"
         original_run.assert_called_once()
         call_kwargs = original_run.call_args.kwargs
-        assert call_kwargs["run_dir"] == tmp_path / "clauditor_run"
-        assert (tmp_path / "clauditor_run").exists()
+        expected_dir = tmp_path / f"clauditor_run_{id(result)}"
+        assert call_kwargs["run_dir"] == expected_dir
+        assert expected_dir.exists()
 
         # Explicit run_dir passed by caller overrides the default
         original_run.reset_mock()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -261,6 +261,24 @@ class TestSkillRunnerRun:
         assert result.output == ""
 
 
+class TestSkillRunnerCwd:
+    """US-003: cwd override threads through to Popen."""
+
+    def test_runner_default_cwd_is_project_dir(self):
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("out")
+            runner.run("my-skill", "args")
+            assert mock_popen.call_args.kwargs["cwd"] == "/tmp"
+
+    def test_runner_cwd_override_passes_through_to_popen(self, tmp_path):
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("out")
+            runner.run("my-skill", "args", cwd=tmp_path)
+            assert mock_popen.call_args.kwargs["cwd"] == str(tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # SkillResult.outputs dict
 # ---------------------------------------------------------------------------

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -988,3 +988,123 @@ class TestTieredSections:
         assert tier.description == ""
         assert tier.min_entries == 0
         assert tier.fields == []
+
+
+class TestEvalSpecInputFiles:
+    def _write_spec(self, tmp_path, extra):
+        data = {"skill_name": "test-skill", **extra}
+        spec_path = tmp_path / "test.eval.json"
+        spec_path.write_text(json.dumps(data))
+        return spec_path
+
+    def test_input_files_defaults_to_empty_list(self, tmp_path):
+        spec_path = self._write_spec(tmp_path, {})
+        spec = EvalSpec.from_file(spec_path)
+        assert spec.input_files == []
+
+    def test_relative_paths_resolved_against_spec_dir(self, tmp_path):
+        sibling = tmp_path / "sales.csv"
+        sibling.write_text("a,b\n")
+        spec_path = self._write_spec(tmp_path, {"input_files": ["sales.csv"]})
+        spec = EvalSpec.from_file(spec_path)
+        assert len(spec.input_files) == 1
+        assert spec.input_files[0] == str(sibling.resolve())
+        from pathlib import Path
+        assert Path(spec.input_files[0]).is_absolute()
+
+    def test_multiple_entries_resolved(self, tmp_path):
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        f1 = tmp_path / "a" / "one.csv"
+        f2 = tmp_path / "b" / "two.csv"
+        f1.write_text("x")
+        f2.write_text("y")
+        spec_path = self._write_spec(
+            tmp_path, {"input_files": ["a/one.csv", "b/two.csv"]}
+        )
+        spec = EvalSpec.from_file(spec_path)
+        assert spec.input_files == [str(f1.resolve()), str(f2.resolve())]
+
+    def test_absolute_path_rejected(self, tmp_path):
+        spec_path = self._write_spec(
+            tmp_path, {"input_files": ["/etc/passwd"]}
+        )
+        with pytest.raises(ValueError, match="absolute"):
+            EvalSpec.from_file(spec_path)
+
+    def test_path_traversal_rejected(self, tmp_path):
+        subdir = tmp_path / "spec"
+        subdir.mkdir()
+        outside = tmp_path / "outside.csv"
+        outside.write_text("x")
+        spec_path = subdir / "test.eval.json"
+        spec_path.write_text(
+            json.dumps(
+                {"skill_name": "t", "input_files": ["../outside.csv"]}
+            )
+        )
+        with pytest.raises(ValueError, match="escapes"):
+            EvalSpec.from_file(spec_path)
+
+    def test_missing_input_file_raises_valueerror(self, tmp_path):
+        spec_path = self._write_spec(
+            tmp_path, {"input_files": ["nope.csv"]}
+        )
+        with pytest.raises(ValueError, match="not found"):
+            EvalSpec.from_file(spec_path)
+
+    def test_symlink_target_inside_spec_dir_accepted(self, tmp_path):
+        real = tmp_path / "real.csv"
+        real.write_text("data")
+        link = tmp_path / "link.csv"
+        link.symlink_to(real)
+        spec_path = self._write_spec(tmp_path, {"input_files": ["link.csv"]})
+        spec = EvalSpec.from_file(spec_path)
+        assert spec.input_files == [str(real.resolve())]
+
+    def test_symlink_target_outside_spec_dir_rejected(self, tmp_path):
+        spec_dir = tmp_path / "spec"
+        spec_dir.mkdir()
+        escape = tmp_path / "escape.csv"
+        escape.write_text("x")
+        link = spec_dir / "link.csv"
+        link.symlink_to(escape)
+        spec_path = spec_dir / "test.eval.json"
+        spec_path.write_text(
+            json.dumps({"skill_name": "t", "input_files": ["link.csv"]})
+        )
+        with pytest.raises(ValueError, match="escapes"):
+            EvalSpec.from_file(spec_path)
+
+    def test_duplicate_basenames_across_entries_rejected(self, tmp_path):
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        (tmp_path / "a" / "sales.csv").write_text("x")
+        (tmp_path / "b" / "sales.csv").write_text("y")
+        spec_path = self._write_spec(
+            tmp_path, {"input_files": ["a/sales.csv", "b/sales.csv"]}
+        )
+        with pytest.raises(ValueError, match="basename"):
+            EvalSpec.from_file(spec_path)
+
+    def test_output_files_collision_guard_rejects_overlap(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "sales.csv").write_text("x")
+        spec_path = self._write_spec(
+            tmp_path,
+            {
+                "input_files": ["data/sales.csv"],
+                "output_files": ["sales.csv"],
+            },
+        )
+        with pytest.raises(ValueError, match="collides"):
+            EvalSpec.from_file(spec_path)
+
+    def test_to_dict_roundtrip_preserves_input_files(self, tmp_path):
+        f = tmp_path / "data.csv"
+        f.write_text("x")
+        spec_path = self._write_spec(tmp_path, {"input_files": ["data.csv"]})
+        spec = EvalSpec.from_file(spec_path)
+        d = spec.to_dict()
+        assert "input_files" in d
+        assert d["input_files"] == [str(f.resolve())]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1108,3 +1108,25 @@ class TestEvalSpecInputFiles:
         d = spec.to_dict()
         assert "input_files" in d
         assert d["input_files"] == [str(f.resolve())]
+        # Loading the same spec twice yields the same in-memory state.
+        # (to_dict emits absolute paths for inspection, not as a re-loadable
+        # authoring format — by design, since from_file rejects absolute paths.)
+        reloaded = EvalSpec.from_file(spec_path)
+        assert reloaded.input_files == spec.input_files
+
+    @pytest.mark.parametrize("bad_entry", [None, 42, ["nested"], ""])
+    def test_non_string_or_empty_entry_rejected(self, tmp_path, bad_entry):
+        spec_path = self._write_spec(tmp_path, {"input_files": [bad_entry]})
+        with pytest.raises(ValueError, match="non-empty string"):
+            EvalSpec.from_file(spec_path)
+
+    def test_directory_entry_rejected(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        spec_path = self._write_spec(tmp_path, {"input_files": ["subdir"]})
+        with pytest.raises(ValueError, match="not a regular file"):
+            EvalSpec.from_file(spec_path)
+
+    def test_dot_entry_rejected_as_directory(self, tmp_path):
+        spec_path = self._write_spec(tmp_path, {"input_files": ["."]})
+        with pytest.raises(ValueError, match="not a regular file"):
+            EvalSpec.from_file(spec_path)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -209,6 +209,76 @@ class TestFileBasedOutput:
         assert result.outputs == {}
 
 
+class TestOutputFilesResolutionWithStagedInputs:
+    """When input_files is staged, output_files must glob from the staging CWD,
+    not the runner's project_dir — otherwise mutated outputs are lost."""
+
+    def test_output_files_resolves_against_staging_cwd(
+        self, tmp_path, mock_runner
+    ):
+        skill_dir = tmp_path / ".claude" / "commands"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "csv-cleaner.md").write_text("# CSV cleaner\n")
+        (skill_dir / "sales.csv").write_text("a,b\n1,2\n")
+        (skill_dir / "csv-cleaner.eval.json").write_text(
+            json.dumps(
+                {
+                    "skill_name": "csv-cleaner",
+                    "test_args": "",
+                    "assertions": [],
+                    "input_files": ["sales.csv"],
+                    "output_files": ["cleaned.csv"],
+                }
+            )
+        )
+
+        runner = mock_runner(output="stdout transcript")
+        runner.project_dir = tmp_path  # repo root, NOT the staging dir
+
+        run_dir = tmp_path / "iter-tmp" / "csv-cleaner" / "run-0"
+        run_dir.mkdir(parents=True)
+        cleaned_text = "header\nclean,row\n"
+
+        # Side-effect: the "skill" writes cleaned.csv into its staging CWD.
+        base_result = runner.run.return_value
+
+        def side_effect(skill_name, args, *, cwd=None):
+            assert cwd == run_dir / "inputs"
+            (cwd / "cleaned.csv").write_text(cleaned_text)
+            return base_result
+
+        runner.run.side_effect = side_effect
+
+        spec = SkillSpec.from_file(skill_dir / "csv-cleaner.md", runner=runner)
+        result = spec.run(run_dir=run_dir)
+
+        assert "cleaned.csv" in result.outputs
+        assert result.outputs["cleaned.csv"] == cleaned_text
+        assert result.output == cleaned_text
+
+    def test_output_files_without_input_files_still_uses_project_dir(
+        self, tmp_skill_file, mock_runner
+    ):
+        # Regression guard: pre-existing output_files behavior is unchanged
+        # when no input_files are declared.
+        eval_data = {
+            "skill_name": "glob-skill",
+            "test_args": "",
+            "assertions": [],
+            "output_files": ["out/*.txt"],
+        }
+        skill_path, _ = tmp_skill_file("glob-skill", eval_data=eval_data)
+        runner = mock_runner(output="stdout content")
+        project_dir = skill_path.parent
+        runner.project_dir = project_dir
+        (project_dir / "out").mkdir()
+        (project_dir / "out" / "a.txt").write_text("alpha")
+
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        result = spec.run()
+        assert result.outputs["out/a.txt"] == "alpha"
+
+
 class TestSkillSpecRunWithInputFiles:
     """US-003: run_dir staging hook for EvalSpec.input_files."""
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -63,7 +64,7 @@ class TestRun:
         runner = mock_runner(output="explicit output")
         spec = SkillSpec.from_file(skill_path, runner=runner)
         result = spec.run(args="--custom flag")
-        runner.run.assert_called_once_with("run-skill", "--custom flag")
+        runner.run.assert_called_once_with("run-skill", "--custom flag", cwd=None)
         assert result.output == "explicit output"
 
     def test_run_uses_eval_test_args_when_no_args(self, tmp_skill_file, mock_runner):
@@ -71,7 +72,7 @@ class TestRun:
         runner = mock_runner(output="eval args output")
         spec = SkillSpec.from_file(skill_path, runner=runner)
         spec.run()
-        runner.run.assert_called_once_with("run-skill", "--depth quick")
+        runner.run.assert_called_once_with("run-skill", "--depth quick", cwd=None)
 
     def test_run_uses_empty_string_when_no_eval_no_args(
         self, tmp_skill_file, mock_runner
@@ -80,7 +81,7 @@ class TestRun:
         runner = mock_runner(output="empty args output")
         spec = SkillSpec.from_file(skill_path, runner=runner)
         spec.run()
-        runner.run.assert_called_once_with("run-skill", "")
+        runner.run.assert_called_once_with("run-skill", "", cwd=None)
 
 
 class TestEvaluate:
@@ -206,6 +207,83 @@ class TestFileBasedOutput:
         result = spec.run()
         assert result.output == "just stdout"
         assert result.outputs == {}
+
+
+class TestSkillSpecRunWithInputFiles:
+    """US-003: run_dir staging hook for EvalSpec.input_files."""
+
+    def test_spec_run_without_run_dir_uses_project_dir(
+        self, tmp_skill_file, mock_runner
+    ):
+        skill_path = tmp_skill_file("no-rd-skill")
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run()
+        # cwd kwarg defaults to None (runner falls back to project_dir)
+        assert runner.run.call_args.kwargs.get("cwd") is None
+
+    def test_spec_run_with_empty_input_files_does_not_stage(
+        self, tmp_skill_file, mock_runner, tmp_path
+    ):
+        eval_data = {
+            "skill_name": "empty-inputs",
+            "test_args": "",
+            "assertions": [],
+            "input_files": [],
+        }
+        skill_path, _ = tmp_skill_file("empty-inputs", eval_data=eval_data)
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        with patch("clauditor.spec.stage_inputs") as mock_stage:
+            spec.run(run_dir=tmp_path / "run-0")
+        mock_stage.assert_not_called()
+        assert runner.run.call_args.kwargs.get("cwd") is None
+
+    def test_spec_run_with_input_files_stages_and_sets_cwd(
+        self, tmp_skill_file, mock_runner, tmp_path
+    ):
+        # Create sibling input files next to the skill
+        (tmp_path / "data1.txt").write_text("one")
+        (tmp_path / "data2.txt").write_text("two")
+        eval_data = {
+            "skill_name": "staging-skill",
+            "test_args": "",
+            "assertions": [],
+            "input_files": ["data1.txt", "data2.txt"],
+        }
+        skill_path, _ = tmp_skill_file("staging-skill", eval_data=eval_data)
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        run_dir = tmp_path / "run-0"
+        run_dir.mkdir()
+        spec.run(run_dir=run_dir)
+
+        assert (run_dir / "inputs" / "data1.txt").read_text() == "one"
+        assert (run_dir / "inputs" / "data2.txt").read_text() == "two"
+        assert runner.run.call_args.kwargs.get("cwd") == run_dir / "inputs"
+
+    def test_spec_run_with_input_files_emits_staged_log_line(
+        self, tmp_skill_file, mock_runner, tmp_path, capsys
+    ):
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        eval_data = {
+            "skill_name": "log-skill",
+            "test_args": "",
+            "assertions": [],
+            "input_files": ["a.txt", "b.txt"],
+        }
+        skill_path, _ = tmp_skill_file("log-skill", eval_data=eval_data)
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        run_dir = tmp_path / "run-1"
+        run_dir.mkdir()
+        spec.run(run_dir=run_dir)
+
+        captured = capsys.readouterr()
+        assert "Staged 2 input file(s)" in captured.out
 
 
 class TestFailedRunResult:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import os
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -14,6 +15,7 @@ from clauditor.workspace import (
     IterationExistsError,
     IterationWorkspace,
     allocate_iteration,
+    stage_inputs,
     validate_skill_name,
 )
 
@@ -290,3 +292,81 @@ class TestFinalizeConcurrentRace:
         # The peer's finalized data is untouched.
         assert (racer_final / "race.txt").read_text() == "from peer"
         assert ws.finalized is False
+
+
+class TestStageInputs:
+    def test_stage_inputs_empty_list_is_noop(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        result = stage_inputs(run_dir, [])
+        assert result == []
+        assert not (run_dir / "inputs").exists()
+
+    def test_stage_inputs_single_file_copies_content(
+        self, tmp_path: Path
+    ) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"hello world")
+
+        result = stage_inputs(run_dir, [src])
+
+        assert len(result) == 1
+        assert result[0] == run_dir / "inputs" / "source.txt"
+        assert result[0].read_bytes() == b"hello world"
+
+    def test_stage_inputs_preserves_mtime(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"content")
+        known_mtime = 1_600_000_000.0
+        os.utime(src, (known_mtime, known_mtime))
+
+        (dest,) = stage_inputs(run_dir, [src])
+
+        assert abs(dest.stat().st_mtime - known_mtime) < 1.0
+
+    def test_stage_inputs_multiple_files(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        sources = []
+        for name, payload in [("a.txt", b"A"), ("b.txt", b"B"), ("c.txt", b"C")]:
+            p = tmp_path / name
+            p.write_bytes(payload)
+            sources.append(p)
+
+        result = stage_inputs(run_dir, sources)
+
+        assert result == [
+            run_dir / "inputs" / "a.txt",
+            run_dir / "inputs" / "b.txt",
+            run_dir / "inputs" / "c.txt",
+        ]
+        assert result[0].read_bytes() == b"A"
+        assert result[1].read_bytes() == b"B"
+        assert result[2].read_bytes() == b"C"
+
+    def test_stage_inputs_creates_inputs_subdir_when_missing(
+        self, tmp_path: Path
+    ) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"x")
+        assert not (run_dir / "inputs").exists()
+
+        stage_inputs(run_dir, [src])
+
+        assert (run_dir / "inputs").is_dir()
+
+    def test_stage_inputs_missing_source_raises_filenotfounderror(
+        self, tmp_path: Path
+    ) -> None:
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        missing = tmp_path / "nope.txt"
+
+        with pytest.raises(FileNotFoundError, match="nope.txt"):
+            stage_inputs(run_dir, [missing])


### PR DESCRIPTION
## Summary
Super plan for #23 — add `EvalSpec.input_files: list[str]` so file-transforming skills (CSV cleaners, PDF extractors, code refactorers) can have input files staged into the runner's CWD before `clauditor grade` runs them.

**Phase:** detailing (awaiting approval)
**Stories:** 6 implementation + Quality Gate + Patterns & Memory
**Decisions:** 16 decisions captured (DEC-001..DEC-016)

## Highlights
- Load-time resolution & validation in `EvalSpec.from_file()` — diverges intentionally from `output_files` (inputs are pre-existing static assets; outputs are runtime artifacts).
- Source containment via `Path.is_relative_to(spec_dir)` after resolving symlink targets; absolute paths rejected; destinations flattened to basenames to eliminate destination-traversal surface.
- Per-run fresh copies in `iteration-N/<skill>/run-K/inputs/` (matches plan #22 tmp+rename workspace pattern).
- `output_files` collision guard at spec load to prevent the "stale input glob" footgun.
- `--output <file>` captured-output mode warns + skips staging.
- Pytest plugin stages transparently inside `clauditor_spec` factory.

## Architecture review
2 blockers resolved in the plan (source + destination path traversal), 7 concerns worked through (absolute paths, symlinks, collision guard, resolution-timing split, size cap, logging style, coverage gate).

## Plan document
See `plans/super/23-eval-input-files.md` for the full plan.

## Next steps
- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)