### PR TITLE
#26: Execution transcripts for root-cause analysis (plan)

### DIFF
--- a/.claude/rules/non-mutating-scrub.md
+++ b/.claude/rules/non-mutating-scrub.md
@@ -1,0 +1,98 @@
+# Rule: Scrubs applied just-before-I/O must be non-mutating
+
+When you add a transformation that cleans, redacts, or otherwise
+sanitizes a value right before writing it to disk / stderr / the network,
+the transformation function must return a **new** structure and leave
+the input untouched. The caller is then free to keep using the
+full-fidelity in-memory copy for anything else (debugging, further
+assertions, downstream graders) without worrying that the scrub already
+clobbered the data.
+
+## The pattern
+
+```python
+def redact(obj: Any) -> tuple[Any, int]:
+    """Return ``(scrubbed_copy, count)`` for a JSON-compatible value.
+
+    The input is never mutated; nested containers are rebuilt.
+    """
+    if isinstance(obj, dict):
+        new_dict = {}
+        total = 0
+        for key, value in obj.items():
+            if _is_sensitive_key(key):
+                new_dict[key] = _REDACTED
+                total += 1
+                continue
+            scrubbed, n = redact(value)
+            new_dict[key] = scrubbed
+            total += n
+        return new_dict, total
+    if isinstance(obj, (list, tuple)):
+        # ... rebuild list, never mutate the input sequence ...
+```
+
+At the call site:
+
+```python
+# Disk write gets scrubbed copy; in-memory SkillResult keeps the original.
+scrubbed_events, n = transcripts.redact(skill_result.stream_events)
+(run_dir / "output.jsonl").write_text(
+    "\n".join(json.dumps(ev) for ev in scrubbed_events) + "\n"
+)
+# skill_result.stream_events is untouched — downstream consumers can still
+# read the full-fidelity sequence.
+```
+
+## Why this shape
+
+- **Disk/memory separation**: the motivating requirement is DEC-010 —
+  "on disk scrubbed, in memory untouched". The non-mutating contract is
+  the single mechanism that makes this possible without duplicating the
+  serialization path. Callers get to pick which copy they want.
+- **Testability**: a non-mutating function has no hidden state. Tests can
+  pass in a fixture, assert the return value, AND `assert fixture ==
+  original` to prove the scrub did not mutate. The companion test in
+  `tests/test_transcripts.py::TestCombined::test_returns_new_object` is
+  the canonical shape.
+- **Recursive safety**: when the function is recursive (as redaction is,
+  walking nested JSON), mutation would need to be opt-out at every level
+  — easy to miss a branch. Build-new-structure is a single uniform
+  rule.
+- **Multiple call sites, no order coupling**: the slice printer
+  (`_print_failing_transcript_slice`) and the disk writer
+  (`_write_run_dir`) both apply `redact()` independently. If either
+  mutated, the other would silently get the already-scrubbed view. With a
+  non-mutating contract, they each see the full-fidelity data and
+  produce their own scrubbed copy.
+
+## What NOT to do
+
+- Do NOT implement an in-place variant "for performance" unless you have
+  measured evidence of a hotspot. The allocation overhead is trivial
+  against the JSONL serialization step that follows.
+- Do NOT return the input unchanged when nothing matched — return a new
+  structure anyway, so the non-mutating invariant holds for every
+  caller regardless of data. (An `_scrub_string` fast-path that returns
+  the same string when no regex matched is fine — strings are immutable,
+  so there is no mutation risk.)
+
+## Canonical implementation
+
+`src/clauditor/transcripts.py::redact` — recursive walk over
+JSON-compatible values, rebuilds every nested container. Callers in
+`src/clauditor/cli.py`:
+
+- `_write_run_dir` — scrubs `stream_events` and `output_text` before
+  writing `output.jsonl` / `output.txt`.
+- `_print_failing_transcript_slice` — scrubs a per-run slice before
+  printing to stderr; the caller's in-memory `SkillResult.stream_events`
+  stays untouched.
+
+## When this rule applies
+
+Any future transformation function whose purpose is "clean this value
+before it leaves the process" — redactors, normalizers, anonymizers,
+PII strippers, error-message sanitizers. Pure in-place mutations that
+never cross an I/O boundary (e.g. building up a result list inside a
+single function) are not covered.

--- a/.claude/rules/sidecar-during-staging.md
+++ b/.claude/rules/sidecar-during-staging.md
@@ -49,11 +49,45 @@ with allocate_iteration(...) as workspace:
 - Do NOT mutate the rendered `iteration-N/` dir after publication — it is
   treated as immutable by downstream readers (audit, compare, trend).
 
+## Skip-write flags must clean pre-staged subtrees
+
+When adding a "skip this particular write" flag like `--no-transcript`
+(which suppresses the `_write_run_dir` call that would have created
+`run-K/output.jsonl` / `output.txt`), do NOT just skip the write. The skill
+subprocess may have **already** populated `run-K/` with pre-staged
+subtrees *before* the skip point — the canonical example is
+`spec.run(run_dir=...)` copying `input_files` into `run-K/inputs/` before
+the skill ever produces its first stream event. Simply skipping
+`_write_run_dir` publishes a half-populated `run-K/` dir (only the
+staged inputs, no `output.jsonl`) into `iteration-N/<skill>/`, which
+violates the contract downstream readers expect ("`run-K/` exists ⇒
+transcript exists"). Hit this bug twice in QG for #26 — once on
+`cmd_validate`, once on `_cmd_grade_with_workspace`.
+
+**The fix**: inside the skip branch, `shutil.rmtree(skill_dir / f"run-{idx}", ignore_errors=True)`
+for every run-K directory, **before** `workspace.finalize()`. It's safe
+because the skill subprocess has already returned by this point, and
+`ignore_errors=True` tolerates the "nothing was staged" case.
+
+```python
+if not no_transcript:
+    for idx, (text, events) in enumerate(run_outputs):
+        _write_run_dir(skill_dir / f"run-{idx}", text, events, verbose=verbose)
+else:
+    # Scrub any run-K/ subtrees the skill already staged (e.g. inputs/)
+    # so the skip flag does not leak a half-populated run dir.
+    for idx in range(len(run_outputs)):
+        shutil.rmtree(skill_dir / f"run-{idx}", ignore_errors=True)
+```
+
 ## Canonical implementation
 
 `src/clauditor/cli.py` — `_cmd_grade_with_workspace` persistence slot inside
 the `if not only_criterion:` block, just before `workspace.finalize()`.
-`_run_baseline_phase` follows the same contract for `baseline_*.json`.
+`cmd_validate` follows the same contract for the single-run validate path.
+`_run_baseline_phase` follows the same contract for `baseline_*.json`. The
+skip-flag subtree-cleanup pattern lives at the same two call sites for
+`--no-transcript`.
 
 ## When this rule applies
 

--- a/.claude/rules/stream-json-schema.md
+++ b/.claude/rules/stream-json-schema.md
@@ -1,0 +1,101 @@
+# Rule: Defensive parsing of the `claude` stream-json NDJSON stream
+
+clauditor invokes `claude -p … --output-format stream-json --verbose` and
+reads the child's stdout line-by-line. The parser must treat every field
+as tolerated-if-missing, skip-and-warn on malformed lines, and never let a
+single bad message abort the run. The CLI's streaming format is a moving
+target — hard-failing on a missing field or an unknown `type` would turn
+every future CLI upgrade into a clauditor outage.
+
+## The pattern
+
+```python
+for raw_line in proc.stdout:
+    line = raw_line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except json.JSONDecodeError as exc:
+        print(
+            f"clauditor.runner: skipping malformed stream-json line: {exc}",
+            file=sys.stderr,
+        )
+        continue
+    if not isinstance(msg, dict):
+        continue  # scalar/array JSON is not a valid stream-json message
+
+    raw_messages.append(msg)
+    mtype = msg.get("type")
+
+    if mtype == "assistant":
+        message = msg.get("message") or {}
+        content = message.get("content") or []
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text_chunks.append(block.get("text", ""))
+
+    elif mtype == "result":
+        saw_result = True
+        usage = msg.get("usage") or {}
+        if isinstance(usage, dict):
+            try:
+                input_tokens = int(usage.get("input_tokens", 0) or 0)
+            except (TypeError, ValueError):
+                input_tokens = 0
+            try:
+                output_tokens = int(usage.get("output_tokens", 0) or 0)
+            except (TypeError, ValueError):
+                output_tokens = 0
+
+if not saw_result:
+    print(
+        "clauditor.runner: stream-json ended without a 'result' message; "
+        "token usage unavailable",
+        file=sys.stderr,
+    )
+```
+
+## Why this shape
+
+- **Skip + log, do not crash**: a single malformed line (truncated JSON,
+  partial flush, CLI bug) must not abort the run. The line is reported to
+  stderr so operators can triage, and the loop keeps reading.
+- **`msg.get(...) or {}` / `or []` guards**: every nested dict/list access
+  uses `.get` with a falsy-safe default. An `assistant` message without
+  `message.content`, or a `result` message without `usage`, degrades to
+  "no text captured" or "zero tokens" — not an exception.
+- **`isinstance` before recursion**: `content` might be a string, a dict,
+  or `None` in a broken build of the CLI. The `isinstance(content, list)`
+  guard is what keeps the parser from raising `TypeError` mid-stream.
+- **Defensive `int()` on token counts**: if the CLI ever emits
+  `"input_tokens": null` or a string, the `try/except (TypeError,
+  ValueError)` falls back to 0 instead of aborting. Token counts are
+  observability data, not correctness data — losing them should be a
+  warning, not a crash.
+- **`saw_result` flag + stderr warning on EOF**: a stream that ends
+  without a `result` message is suspicious but not fatal — the run still
+  produced output. Warn, return zero tokens, let the caller decide.
+- **Unknown `type` values pass through**: new message types added to the
+  CLI land in `raw_messages` / `stream_events` unchanged. They do not
+  contribute to `SkillResult.output`, but they also do not break anything.
+  Extending the parser for a new type is an additive change.
+
+## Canonical implementation
+
+`src/clauditor/runner.py::SkillRunner._invoke` — the `for raw_line in
+proc.stdout` loop. The human-readable schema reference lives at
+`docs/stream-json-schema.md` and enumerates every field clauditor reads,
+with concrete JSONL examples and an error-handling table.
+
+## When this rule applies
+
+Any future parser of an external streaming JSON format produced by a tool
+clauditor does not control. The defensive-read + skip-and-warn shape is
+not appropriate for internal sidecars clauditor *writes* and reads back —
+those use `schema_version` hard checks (see
+`.claude/rules/json-schema-version.md`). The distinction is trust: our
+own artifacts are versioned and validated; a third-party streaming
+format is parsed permissively.

--- a/README.md
+++ b/README.md
@@ -615,6 +615,12 @@ the count failure and any per-entry failures.
 - **`history.jsonl` is now schema v3** with `iteration` and `workspace_path` fields on `grade` records. Mixed v2/v3 files continue to load.
 - **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
 
+## Reference docs
+
+- [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — authoritative
+  reference for the `claude` stream-json NDJSON fields clauditor parses,
+  with examples and error-handling rules.
+
 ## License
 
 Apache 2.0

--- a/docs/stream-json-schema.md
+++ b/docs/stream-json-schema.md
@@ -107,7 +107,7 @@ to stderr and still returns a `SkillResult` with `input_tokens = 0` and
 
 Every exit path is wrapped in `try/finally` so that
 `SkillResult.duration_seconds` is populated for success, timeout, missing
-binary, and any other error path (DEC-005).
+binary, and any other error path.
 
 ## Canonical parser
 

--- a/docs/stream-json-schema.md
+++ b/docs/stream-json-schema.md
@@ -1,0 +1,117 @@
+# Stream-JSON schema contract
+
+clauditor invokes the Claude CLI with `--output-format stream-json --verbose`
+and parses its NDJSON output line-by-line. This document is the authoritative
+reference for which fields clauditor reads, which it tolerates missing, and
+how it handles malformed lines. The parser lives in
+`src/clauditor/runner.py::SkillRunner._invoke`.
+
+This schema reflects the Anthropic CLI streaming format as verified live
+against `claude` 2.1.x. If a future CLI version changes the shape, update
+this document and `.claude/rules/stream-json-schema.md` in the same commit.
+
+## Transport
+
+- Each line of `claude`'s stdout is one JSON object (NDJSON / JSON Lines).
+- The parser reads lines until EOF, then calls `proc.wait()` to collect the
+  exit code.
+- Blank lines are silently skipped.
+- Lines that fail `json.loads` are logged to stderr (prefix
+  `clauditor.runner: skipping malformed stream-json line:`) and skipped —
+  they never abort the run.
+- Values that parse as JSON but are not objects (scalars, arrays) are
+  defensively ignored.
+
+## Message shapes clauditor consumes
+
+Every message is a JSON object with a top-level `type` field. clauditor
+dispatches on `type` and only reads the fields documented below. Any
+unknown `type` is stored in `raw_messages` / `stream_events` for debugging
+but otherwise ignored.
+
+### `type: "system"`
+
+Init / hook / misc events from the CLI.
+
+```json
+{"type":"system","subtype":"init","session_id":"abc123","cwd":"/tmp/work"}
+```
+
+**Read by clauditor:** nothing beyond `type` — the message is appended to
+`raw_messages` and `stream_events`, but no fields are extracted. System
+events are forwarded to transcripts but do not affect `SkillResult.output`
+or token counts.
+
+### `type: "assistant"`
+
+Assistant turn with one or more content blocks.
+
+```json
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Here are 5 venues near you..."},{"type":"tool_use","id":"toolu_01","name":"WebSearch","input":{"query":"parks"}}]}}
+```
+
+**Required fields for text capture:**
+- `message` (object) — tolerated-if-missing (treated as `{}`).
+- `message.content` (list) — tolerated-if-missing / non-list
+  (message is skipped for text capture).
+- Each block in `message.content` must be a dict with `type == "text"` to
+  contribute to `SkillResult.output`. The block's `text` field is read
+  with `.get("text", "")`, so a text block missing its `text` field
+  contributes an empty string rather than raising.
+
+**Tolerated block types:** `tool_use`, `tool_result`, `thinking`, and any
+other block whose `type` is not `"text"` are skipped for the purposes of
+`SkillResult.output`. They are still present in `raw_messages` for
+downstream tooling (transcripts, debug dumps).
+
+Text chunks from every assistant message are joined with `\n` to form
+`SkillResult.output`.
+
+### `type: "result"`
+
+The final line of a successful run. Carries aggregate token usage.
+
+```json
+{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":1423,"output_tokens":512}}
+```
+
+**Required fields:** none are hard-required — every field is read
+defensively.
+- `usage` (object) — tolerated-if-missing (token counts stay at 0).
+- `usage.input_tokens` (int) — tolerated-if-missing / `None` / non-numeric
+  (falls back to 0 via a `try/except (TypeError, ValueError)` wrapper).
+- `usage.output_tokens` (int) — same defensive treatment.
+
+Seeing a `result` message flips an internal `saw_result` flag. If the
+stream ends without any `result` message, clauditor emits:
+
+```
+clauditor.runner: stream-json ended without a 'result' message; token usage unavailable
+```
+
+to stderr and still returns a `SkillResult` with `input_tokens = 0` and
+`output_tokens = 0`. Missing token data is a warning, not a fatal error.
+
+## Error handling summary
+
+| Condition | Behavior |
+|---|---|
+| `json.JSONDecodeError` on a line | Log to stderr, skip the line, keep reading |
+| Line parses as non-dict JSON | Silently skip |
+| `assistant` message without `message.content` list | Skip text capture for that message |
+| Text block missing `text` field | Contributes empty string |
+| `result` message with missing/broken `usage` | Token counts default to 0 |
+| No `result` message before EOF | Warn to stderr, return `SkillResult` with zero tokens |
+| Subprocess times out | Kill child, return `SkillResult(exit_code=-1, error="timeout")` with whatever text was captured so far |
+| `claude` binary not found | Return `SkillResult(exit_code=-1, error="Claude CLI not found: …")` |
+
+Every exit path is wrapped in `try/finally` so that
+`SkillResult.duration_seconds` is populated for success, timeout, missing
+binary, and any other error path (DEC-005).
+
+## Canonical parser
+
+`src/clauditor/runner.py::SkillRunner._invoke` is the single source of truth
+for all parsing logic. If you need to extend the schema (new message type,
+new field), update that function *and* this document *and*
+`.claude/rules/stream-json-schema.md` in the same commit.

--- a/plans/super/26-execution-transcripts.md
+++ b/plans/super/26-execution-transcripts.md
@@ -1,0 +1,740 @@
+# Super Plan: #26 — Capture execution transcripts for root-cause analysis
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/26
+- **Branch:** `feature/26-execution-transcripts`
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/26-execution-transcripts`
+- **Phase:** `detailing`
+- **PR:** _pending_
+- **Sessions:** 1
+- **Last session:** 2026-04-14
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What (as written):** Wire `clauditor grade my-skill --transcript` to produce a
+jsonl transcript alongside the grade report, with failing assertions referencing
+it. Persist stream-json to `.clauditor/transcripts/<skill>-<ts>.jsonl` (or iteration
+dirs once #22 lands), redact secrets, attach path as `AssertionResult.evidence`,
+`-v` prints relevant slice inline, document the schema.
+
+**Why:** The agentskills.io spec flags transcript capture as table-stakes for
+root-cause analysis. Without it, non-deterministic failures and token outliers
+can't be diagnosed after the fact without a manual rerun.
+
+### Codebase Findings — much of the ticket is already done
+
+Tickets #21 (timing+tokens) and #22 (iteration workspaces) landed a
+stream-json implementation that incidentally captured execution transcripts.
+Current state:
+
+**Already implemented:**
+- `runner.py::_invoke` invokes `claude -p --output-format stream-json --verbose`
+  and parses the NDJSON stream line-by-line
+  (`src/clauditor/runner.py:192–363`).
+- `SkillResult.stream_events: list[dict]` and `raw_messages: list[dict]` fields
+  carry the full transcript in memory
+  (`src/clauditor/runner.py:64–65`).
+- `cli.py::_write_run_dir` writes `output.txt` + `output.jsonl` to each
+  `run-K/` subdir inside the iteration workspace, one JSON object per line
+  (`src/clauditor/cli.py:155–167`).
+- `_cmd_grade_with_workspace` already invokes `_write_run_dir` for every
+  primary + variance run under `iteration-N/<skill>/run-K/output.jsonl`
+  (`src/clauditor/cli.py:560–561`). **Transcripts are persisted on every
+  grade run, not opt-in.**
+- Stream-json schema is documented in the `runner.py` module docstring
+  (lines 3–26) as a **parser contract** (the shapes the runner relies on:
+  `system` / `assistant{message.content[].text}` / `result{usage}`).
+- `AssertionResult.evidence: str | None` field exists
+  (`src/clauditor/assertions.py:29–56`) — currently holds matched text
+  snippets, e.g. first 5 URLs, first 100 chars of a regex match.
+
+**What the ticket still actually needs:**
+1. **Opt-in/opt-out control** — transcripts are written unconditionally
+   today. They are **tiny in the common case** (a skill invocation emits
+   a few dozen stream-json lines, typically <100 KB) but can grow
+   meaningfully with long tool-use chains. Question is whether to add an
+   opt-out to suppress them for CI/bulk runs, or leave always-on.
+2. **Assertion → transcript cross-reference** — `AssertionResult.evidence`
+   captures *matched content*, not a file pointer. Failing assertions have
+   no pointer back to the `run-K/output.jsonl` that produced the failing
+   output. Needed: a new field (or convention) so a failure row says
+   "see iteration-3/<skill>/run-0/output.jsonl".
+3. **Secret redaction** — no redaction happens today. `output.jsonl`
+   contains the raw stream; a skill that echoes `os.environ['OPENAI_KEY']`
+   would leak it to disk. The ticket explicitly calls this out.
+4. **`-v` prints transcript slice inline** — `cmd_grade` does not currently
+   print any transcript content on failure. On `-v`/verbose with a failed
+   assertion, dump the last N stream-json `assistant`/`tool_use` blocks
+   inline so users get context without opening the file.
+5. **Stream-json schema doc as a stable contract** — the docstring is
+   good but lives in runner.py. Promote to a dedicated doc under
+   `docs/` (or `.claude/rules/stream-json-schema.md`) so clauditor's
+   dependency on the Anthropic CLI format is explicit and versioned.
+6. **`cmd_validate` + `cmd_extract` transcript capture** — `cmd_validate`
+   (`cli.py:52`) runs a skill and prints output; it does **not** stage a
+   workspace and does **not** write `output.jsonl`. Decide whether #26
+   extends transcript capture to validate/extract, or stays grade-only
+   (where the iteration workspace already exists).
+7. **Ticket's suggested `.clauditor/transcripts/<skill>-<ts>.jsonl` path
+   is superseded** by #22's per-iteration layout. Transcripts should
+   stay inside `iteration-N/<skill>/run-K/output.jsonl`. Call this out
+   explicitly in the plan so the ticket's scope language doesn't mislead
+   later readers.
+
+### Convention Constraints
+
+From `.claude/rules/`:
+
+- **`sidecar-during-staging.md`** — any new per-iteration JSON artifact
+  MUST be written inside `workspace.tmp_path` BEFORE `workspace.finalize()`.
+  Applies to any new per-run redacted transcript files or summary files.
+- **`json-schema-version.md`** — any new *persisted* JSON file that may
+  evolve must carry `schema_version: 1` as its first key. `output.jsonl`
+  is NDJSON (Anthropic CLI's format), so this rule does NOT apply to it —
+  its schema is owned by upstream. Any NEW top-level sidecar we add
+  (e.g. a per-run `transcript_meta.json`) would be subject to the rule.
+- **`path-validation.md`** — applies if we add a user-authored redaction
+  config (patterns file).
+- **`subprocess-cwd.md`** — runner already follows the pattern.
+- **`monotonic-time-indirection.md`** / **`llm-judge-prompt-injection.md`**
+  / **`eval-spec-stable-ids.md`** / **`positional-id-zip-validation.md`**
+  — not directly applicable.
+
+Also: 80% coverage gate enforced; ruff clean; no TodoWrite / markdown TODOs
+(use beads); `bd` for all task tracking; `asyncio_mode = "strict"`.
+
+### Proposed Scope
+
+Treat #26 as a **thin finishing layer** on top of the #22 workspace. The
+big-ticket items are: redaction, assertion→transcript cross-refs, the
+verbose inline printer, and a stable schema doc. The opt-out flag and
+validate/extract coverage are design decisions that depend on the
+answers below.
+
+Ordering: redaction primitives → assertion cross-ref plumbing →
+verbose inline slice printer → optional validate/extract expansion →
+schema doc promotion → Quality Gate → Patterns & Memory.
+
+---
+
+## Scoping Questions
+
+**Q1 — Transcript on/off control**
+Today `output.jsonl` is written unconditionally inside every iteration run dir.
+The ticket asks for an opt-in `--transcript` flag. Given the current state:
+- **(A)** Leave always-on. Transcripts are small, already persisted, and
+  the iteration workspace is the natural home. Close the ticket's "opt-in"
+  scope as OBE. No flag added.
+- **(B)** Add an opt-out `--no-transcript` flag for users who want to skip
+  disk write entirely (CI / bulk variance runs). Default remains on.
+- **(C)** Add a `--transcript={full,redacted,off}` 3-way flag where `off`
+  skips disk write, `redacted` applies secret scrubbing (see Q3), and
+  `full` is the current raw capture (for local debugging only).
+- **(D)** Add opt-in `--transcript` per the ticket's original language —
+  default OFF, explicit flag to enable. Note: this is a **breaking change**
+  — tooling that already reads `run-K/output.jsonl` (audit, compare) may
+  silently lose data. Require careful review.
+
+**Q2 — Assertion → transcript cross-reference shape**
+When an assertion fails on run-K, how does the failure row point at
+`iteration-N/<skill>/run-K/output.jsonl`?
+- **(A)** Add a new optional `AssertionResult.transcript_path: str | None`
+  field (relative path from repo root). Populated only when the caller
+  passes the workspace layout; otherwise `None`.
+- **(B)** Overload the existing `AssertionResult.evidence: str | None`
+  field to hold the path when no substantive match exists. Ambiguous
+  and backwards-compatible.
+- **(C)** Add a new `transcript_ref` field on `AssertionSet` (the
+  container) instead of per-assertion. One pointer per run, applies to
+  all failing assertions in that set.
+- **(D)** (A) + (C): per-assertion optional path for richer UX (e.g.
+  different tool-use slice per failure), plus a set-level fallback.
+
+**Q3 — Secret redaction scope**
+"Redact secrets / known sensitive patterns before persisting" — what
+exactly do we redact?
+- **(A)** Minimal: redact values of common env-var names (`*_KEY`,
+  `*_TOKEN`, `*_SECRET`, `*_PASSWORD`) when they appear as JSON values
+  in stream events. Built-in list, no user config.
+- **(B)** Minimal + regex patterns: (A) plus a hardcoded set of
+  high-signal regexes (`sk-[A-Za-z0-9]{20,}`, `ghp_[A-Za-z0-9]{20,}`,
+  AWS key prefixes, `Bearer [A-Za-z0-9._-]{20,}`).
+- **(C)** (B) plus a user-authored
+  `.clauditor/redaction.json` (or field on `EvalSpec`) with additional
+  regex patterns. Apply `path-validation.md` rules if loaded from spec.
+- **(D)** (C) but opt-in: redaction only runs when the user passes
+  `--redact` or sets a spec field. Default behavior is raw capture
+  (explicit user contract).
+
+**Q4 — Verbose inline slice**
+`-v` on a failing grade should print transcript content inline. What
+content and how much?
+- **(A)** Last 5 `assistant` text blocks from the failed run's stream
+  (usually captures the model's final reasoning).
+- **(B)** All `tool_use` blocks from the failed run (captures *what the
+  skill did*, which is the root-cause-analysis case the ticket names).
+- **(C)** (A) + (B) interleaved in chronological order, capped at N KB
+  total.
+- **(D)** Dump the full `output.jsonl` contents up to a cap, with a
+  truncation marker. Simplest; lets the user grep themselves.
+
+**Q5 — `cmd_validate` and `cmd_extract` transcript capture**
+Today only `cmd_grade` persists transcripts (because only grade stages
+a workspace). Should validate/extract also?
+- **(A)** Keep grade-only. validate/extract stay free-form, no workspace.
+  Users needing transcripts run `grade`.
+- **(B)** Extend workspace staging to `cmd_validate` so it also writes
+  `run-0/output.jsonl` (under a different iteration-or-transient dir).
+  Larger lift — touches #22 workspace API.
+- **(C)** `cmd_validate` + `cmd_extract` write a lightweight transcript
+  to `.clauditor/transcripts/<skill>-<ts>.jsonl` (the ticket's original
+  path), bypassing iteration workspaces entirely. Two parallel layouts.
+- **(D)** (A) now, file a follow-up ticket for validate/extract if users
+  ask for it.
+
+**Q6 — Stream-json schema doc home**
+Where does the "clauditor depends on this stream-json shape" contract
+live?
+- **(A)** Leave it in `runner.py`'s module docstring (current state).
+  Close this scope item as already done.
+- **(B)** Promote to `docs/stream-json-schema.md` — a user-facing doc
+  that external contributors can read without opening source.
+- **(C)** Promote to `.claude/rules/stream-json-schema.md` — an
+  AI-agent-facing convention rule that future edits must respect.
+- **(D)** (B) + (C): user doc for humans, rule for agents, both
+  generated from a single source.
+
+---
+
+## Scoping Answers (2026-04-14)
+
+- **Q1 = B** — Opt-out `--no-transcript` flag; default stays on.
+- **Q2 = A** — New `AssertionResult.transcript_path: str | None` field.
+- **Q3 = B** — Hardcoded env-var names + known-prefix regexes. No user config.
+- **Q4 = A** — `-v` prints last 5 `assistant` text blocks from the failed run.
+- **Q5 = B** — Extend workspace staging to `cmd_validate`.
+- **Q6 = D** — Publish both `docs/stream-json-schema.md` and
+  `.claude/rules/stream-json-schema.md`.
+
+Note from user: library is unpublished, no back-compat constraints. Free to
+rename/add fields cleanly.
+
+---
+
+## Architecture Review
+
+| Area | Rating | Findings |
+|---|---|---|
+| Security | **concern** | Redaction correctness is load-bearing |
+| Performance | pass | Transcripts are <100 KB typical; validate workspace adds trivial overhead |
+| Data Model | **concern** | `cmd_validate` workspace sharing `iteration-N` with `cmd_grade` needs a clean design |
+| API Design | pass | `--no-transcript` on both `grade` and `validate` is mechanical |
+| Observability | **concern** | Redaction count should be visible under `-v` |
+| Testing Strategy | pass | Clear unit + integration test shape |
+| Rules Compliance | pass | No new JSON sidecars; `sidecar-during-staging` covers transcript writes |
+
+### Security — concern (not blocker)
+
+Redaction runs *before* disk write, in one place: a new
+`clauditor.transcripts.redact()` helper that walks the `stream_events`
+structure and scrubs string values matching:
+
+- Env-var name heuristic: any JSON key ending in `_KEY`, `_TOKEN`,
+  `_SECRET`, `_PASSWORD`, `_PASSPHRASE`, `_CREDENTIAL`, or exactly
+  `API_KEY` / `AUTH` (case-insensitive). Value replaced with `[REDACTED]`.
+- Regex heuristics on string values (any nesting depth):
+  - `sk-(ant|proj|live|test)?[-_]?[A-Za-z0-9]{20,}` (OpenAI / Anthropic)
+  - `ghp_[A-Za-z0-9]{36,}` and `github_pat_[A-Za-z0-9_]{80,}` (GitHub)
+  - `AKIA[0-9A-Z]{16}` and `ASIA[0-9A-Z]{16}` (AWS)
+  - `Bearer\s+[A-Za-z0-9._\-]{20,}` (generic auth headers)
+  - `xox[abprs]-[A-Za-z0-9-]{10,}` (Slack)
+
+Concerns to watch:
+- The `args` field on `SkillResult` — if a user passes a secret as a CLI
+  arg, it is embedded in the prompt string and lands in the transcript.
+  `redact()` must run on the textual prompt too, not just stream events.
+- `raw_messages` carries the same data as `stream_events` plus extras.
+  `_write_run_dir` only persists `stream_events`, so that is the only
+  stream that needs scrubbing on disk.
+- Redaction is a walk-and-replace on JSON, not on the serialized line.
+  This avoids double-escaping issues and keeps the NDJSON shape valid.
+
+### Data Model — concern (needs refinement decision)
+
+Today `cmd_validate` writes nothing to disk. Option Q5=B extends it to
+stage a workspace. Two possible layouts:
+
+- **(L1)** Share iteration-N with grade. A `validate` run bumps the
+  iteration counter, making `iteration-3/<skill>/` ambiguous: was it
+  written by grade or validate? `history.jsonl` would need a `command`
+  discriminator (already exists for grade).
+- **(L2)** Separate counter: `validate-iteration-N/`. Two parallel trees
+  under `.clauditor/`. Cleaner separation; slightly more machinery.
+- **(L3)** Transient: `validate` writes to a temp dir, prints the path,
+  does not publish. Root-cause analysis works; no longitudinal data. No
+  conflict with iteration layout.
+
+Refinement phase must pick one. **Default recommendation: L3** —
+validate is interactive/iterative by nature; users don't need a
+longitudinal history of validate runs, only the latest transcript for
+debugging. L3 is also the smallest lift.
+
+### Observability — concern (easy fix)
+
+Redaction should log a count under `-v` so users know scrubbing
+happened: `clauditor.transcripts: redacted 3 matches in run-0`. Silent
+redaction breeds distrust; users need to verify redaction is actually
+running.
+
+### Rules Compliance
+
+- `sidecar-during-staging.md` — all transcript writes already land in
+  `workspace.tmp_path` before `finalize()`; extending this to
+  `cmd_validate` (if L1/L2) must preserve the rule. L3 (temp dir) is
+  exempt because there is no publication event.
+- `json-schema-version.md` — `output.jsonl` is NDJSON owned by Anthropic
+  CLI; no version header. No new clauditor-owned JSON sidecar planned.
+- `path-validation.md` — not applicable (Q3=B, no user config).
+- `subprocess-cwd.md` — runner already compliant.
+
+## Refinement Log
+
+### Decisions
+
+- **DEC-001** — Opt-out `--no-transcript` flag; transcripts remain on by
+  default. (Q1=B)
+- **DEC-002** — Add new `AssertionResult.transcript_path: str | None`
+  field. Do not overload `evidence`. (Q2=A; library unpublished, free
+  to add.)
+- **DEC-003** — Redaction is a hardcoded env-var-name heuristic + known-
+  prefix regex set living in a new `clauditor/transcripts.py` module. No
+  user config file, no `EvalSpec` field. (Q3=B)
+- **DEC-004** — On `-v` with a failing grade, print the last 5
+  `assistant` text blocks from the failed run's `stream_events`.
+  Fewer-than-5 is fine. (Q4=A)
+- **DEC-005** — Extend workspace staging to `cmd_validate` so it writes
+  `run-0/output.jsonl` alongside assertion results. (Q5=B)
+- **DEC-006** — Stream-json schema contract is published to both
+  `docs/stream-json-schema.md` (human-facing) and
+  `.claude/rules/stream-json-schema.md` (agent-facing rule). The
+  existing `runner.py` module docstring stays as the in-code pointer.
+  (Q6=D)
+- **DEC-007** — Redaction is **mandatory**. No `--no-redact` escape
+  hatch. A user who needs raw capture must delete redaction regex
+  entries in source. (R1=A)
+- **DEC-008** — `cmd_validate` shares the `iteration-N/<skill>/`
+  counter with `cmd_grade`. Disambiguation happens via the existing
+  `history.append_record(command=...)` discriminator (already has
+  `"grade"` / `"validate"` slots in `history.py`). Both commands can
+  publish to the same iteration dir because the file layouts do not
+  collide: grade writes `grading.json` + `timing.json` +
+  `assertions.json`; validate writes only `assertions.json` + run dirs.
+  (R2=A)
+- **DEC-009** — Redaction count is always logged under `-v` as
+  `clauditor.transcripts: redacted N matches in run-K` — even when
+  `N == 0`, so silent-redaction trust concerns don't resurface. (R3=A)
+- **DEC-010** — `redact()` scrubs both `stream_events` (the disk
+  payload) and the prompt text / `args` field, since a user may pass a
+  secret on the CLI. Scrubbing happens once, in `_write_run_dir`,
+  immediately before `json.dumps`. The in-memory `SkillResult` is not
+  mutated — only the serialized form.
+- **DEC-011** — `cmd_validate`'s new history record uses
+  `command="validate"` so `clauditor trend` can filter/group correctly.
+  `pass_rate` maps to assertion pass rate; `mean_score` is omitted (no
+  Layer 3 grader in validate's path).
+- **DEC-012** — `cmd_extract` is **out of scope** for this ticket.
+  File a follow-up if users ask for transcript capture in extract
+  flows. Scope-line answer: Q5=B said "validate", not "extract".
+
+### Session Notes
+
+Discovery revealed #26 is 60% done incidentally via #21 + #22: transcripts
+are already captured in memory and persisted as `output.jsonl` inside
+iteration workspaces. The remaining work is redaction, assertion
+cross-references, the verbose slice printer, `cmd_validate` workspace
+extension, and the schema contract docs. The library being unpublished
+unblocks adding the `AssertionResult.transcript_path` field without
+ceremony.
+
+---
+
+## Detailed Breakdown
+
+Ordering: pure-logic primitive first (redaction module, TDD), then
+schema additions, then wire-up into the two commands, then the verbose
+slice, then docs, then quality gate + patterns.
+
+### US-001 — Redaction module (`clauditor/transcripts.py`)
+
+**Description:** New module `src/clauditor/transcripts.py` exposing
+`redact(obj: Any) -> tuple[Any, int]` — walks a JSON-compatible value
+recursively and returns `(scrubbed_copy, count)` where `count` is the
+number of replacements made. Pure logic; no I/O.
+
+**Traces to:** DEC-003, DEC-007, DEC-010.
+
+**Acceptance criteria:**
+- `redact()` replaces values of dict keys matching (case-insensitive)
+  `*_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, `*_PASSPHRASE`,
+  `*_CREDENTIAL`, exact `AUTH` / `API_KEY` → `"[REDACTED]"`.
+- Scans string values (any nesting depth) against this regex set and
+  replaces **the matched span only**, not the whole string:
+  `sk-(ant|proj|live|test)?[-_]?[A-Za-z0-9]{20,}`, `ghp_[A-Za-z0-9]{36,}`,
+  `github_pat_[A-Za-z0-9_]{80,}`, `AKIA[0-9A-Z]{16}`, `ASIA[0-9A-Z]{16}`,
+  `Bearer\s+[A-Za-z0-9._\-]{20,}`, `xox[abprs]-[A-Za-z0-9-]{10,}`.
+- Does not mutate input; returns a new structure.
+- `count` is the total number of replacements (both key-based and
+  regex-match-based) across the whole walk.
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest tests/test_transcripts.py -v` passes.
+- Module-level docstring names each regex and links to the rule file.
+
+**Done when:** module published, 100% unit test coverage on the
+redaction logic, all tests green.
+
+**Files:**
+- `src/clauditor/transcripts.py` (new)
+- `tests/test_transcripts.py` (new)
+
+**Depends on:** none
+
+**TDD cases (write first):**
+- env-var key scrub: `{"OPENAI_API_KEY": "abc"}` → `{"OPENAI_API_KEY": "[REDACTED]"}`, count=1
+- case-insensitive: `{"openai_api_key": "abc"}` scrubbed identically
+- nested dict: `{"env": {"GITHUB_TOKEN": "ghp_..."}}` scrubbed at depth
+- list traversal: `[{"API_KEY": "x"}]` scrubbed
+- OpenAI key regex: `"my key is sk-proj-abcdefghijklmnopqrstuv"` →
+  `"my key is [REDACTED]"`, count=1
+- GitHub PAT regex positive + negative (too short)
+- AWS AKIA regex positive
+- Bearer regex positive (with space)
+- Slack xoxb regex positive
+- Mixed: dict with key scrub AND nested string with regex scrub →
+  count=2
+- Non-match passthrough: plain text is untouched
+- Scrubs the matched span only: `"prefix sk-live-xxxxxxxxxxxxxxxxxxxx suffix"`
+  → `"prefix [REDACTED] suffix"`
+- Count=0 when no matches
+- None / int / bool values left alone
+- Returns new object, original unchanged (deep-equality check before
+  and after)
+
+---
+
+### US-002 — `AssertionResult.transcript_path` field
+
+**Description:** Add a new optional `transcript_path: str | None = None`
+field to `AssertionResult` and carry it through `to_json_dict` /
+`from_json_dict` and the `AssertionSet` container.
+
+**Traces to:** DEC-002.
+
+**Acceptance criteria:**
+- `AssertionResult` dataclass gets `transcript_path: str | None = None`
+  as a new keyword-default field.
+- `to_json_dict` emits `"transcript_path": ...` (even when `None`, for
+  schema stability).
+- `from_json_dict` accepts the key and threads it through (missing-key
+  tolerant for older fixtures).
+- `AssertionSet.summary()` / `__str__` representation unchanged.
+- Existing `assertions.json` writers set `transcript_path=None`
+  (wire-up happens in US-004).
+- Existing tests still pass unmodified.
+- New tests cover: round-trip with path set, round-trip with path
+  absent, default is None.
+
+**Done when:** `uv run pytest tests/test_assertions.py -v` green,
+existing assertions sidecars continue to round-trip.
+
+**Files:**
+- `src/clauditor/assertions.py` (edit `AssertionResult`, `run_assertions`
+  plumbing, `to_json_dict` / `from_json_dict`)
+- `tests/test_assertions.py` (new round-trip tests)
+
+**Depends on:** none
+
+**TDD cases:**
+- Round-trip: `AssertionResult(..., transcript_path="foo.jsonl")` →
+  `to_json_dict()` → `from_json_dict()` → equal path
+- Default: `AssertionResult(...).to_json_dict()["transcript_path"] is None`
+- Back-compat: old fixture without the key loads with
+  `transcript_path=None`
+
+---
+
+### US-003 — Wire redaction into `_write_run_dir`
+
+**Description:** In `cli.py::_write_run_dir`, call
+`transcripts.redact()` on the `stream_events` list before serializing,
+and on the output_text (in case a skill echoes a key in its final
+answer). Log the redaction count under `-v`.
+
+**Traces to:** DEC-003, DEC-007, DEC-009, DEC-010.
+
+**Acceptance criteria:**
+- `_write_run_dir` takes an additional `verbose: bool = False`
+  parameter (threaded from the CLI flag).
+- Calls `redact(stream_events)` and `redact({"output": output_text})`
+  (or similar) before writing; both returned counts are summed.
+- Under `verbose=True`, prints
+  `clauditor.transcripts: redacted N matches in <run_dir.name>` to
+  stderr, **always**, including when `N == 0`.
+- `output.jsonl` on disk contains the scrubbed form; in-memory
+  `stream_events` in `SkillResult` is untouched (DEC-010).
+- `output.txt` also contains the scrubbed form.
+- Does not write anything if `--no-transcript` was passed (US-004
+  wires the flag).
+- Integration test: grade a fake skill whose stream output contains a
+  `sk-proj-...` token; assert the token is absent from `output.jsonl`
+  and the redaction log line is printed.
+
+**Done when:** integration test passes, ruff clean, coverage ≥80% on
+touched lines.
+
+**Files:**
+- `src/clauditor/cli.py` (`_write_run_dir`, threading `verbose` from
+  callers)
+- `tests/test_cli_transcript_redaction.py` (new)
+
+**Depends on:** US-001
+
+---
+
+### US-004 — Thread `transcript_path` into grade's assertion results
+
+**Description:** In `_cmd_grade_with_workspace`, after staging each
+`run-K/output.jsonl`, populate the per-run `AssertionResult.transcript_path`
+with the repo-relative path to that `output.jsonl`. Applies to every
+assertion in the run, failing or passing (simpler, cheaper than
+computing per-assertion pointers).
+
+**Traces to:** DEC-002, DEC-011.
+
+**Acceptance criteria:**
+- `run_assertions(text, eval_spec.assertions)` is replaced with a
+  wrapper that post-processes the `AssertionSet` to set
+  `transcript_path` on every `AssertionResult`.
+- Path is computed via the existing `_relative_to_repo` helper
+  (`cli.py:709`) applied to `run_dir / "output.jsonl"`.
+- `--no-transcript` suppresses the path (set to `None`) since the file
+  won't exist.
+- `assertions.json` on disk carries the path per result.
+- When `_cmd_grade_with_workspace` is called with `args.output`
+  (captured text, no run), `transcript_path` is `None` for every
+  result (no stream to point at).
+- Existing grade tests continue to pass.
+
+**Done when:** running `clauditor grade <skill>` on a real fixture
+produces an `assertions.json` where failing rows carry a non-null
+`transcript_path` pointing at the actual on-disk file.
+
+**Files:**
+- `src/clauditor/cli.py` (`_cmd_grade_with_workspace` assertion block
+  around `:567–584`)
+- `tests/test_cli.py` (update fixture expectations)
+
+**Depends on:** US-002, US-003
+
+---
+
+### US-005 — `--no-transcript` opt-out flag
+
+**Description:** Add `--no-transcript` to both `clauditor grade` and
+`clauditor validate` argparse subparsers. When set, `_write_run_dir`
+is not called; `assertions.json` rows get `transcript_path=None`.
+
+**Traces to:** DEC-001.
+
+**Acceptance criteria:**
+- `cmd_grade` / `_cmd_grade_with_workspace` honor `args.no_transcript`.
+- `cmd_validate` honors it too (once US-006 lands the workspace).
+- Help text: `--no-transcript  Skip writing per-run stream-json transcripts`
+- `assertions.json` still lands, but its entries have `transcript_path=None`
+  and no `run-K/output.jsonl` / `output.txt` exist.
+- Grade still produces `grading.json` / `timing.json` unchanged.
+- Test: grade with `--no-transcript` → assert no `run-0/output.jsonl`
+  exists, `assertions.json` transcript_path is None, exit code matches
+  the run-with-transcripts case.
+
+**Done when:** flag works on both commands, test covers both.
+
+**Files:**
+- `src/clauditor/cli.py` (argparse additions + branch in
+  `_cmd_grade_with_workspace`)
+- `tests/test_cli.py`
+
+**Depends on:** US-004
+
+---
+
+### US-006 — Extend workspace staging to `cmd_validate`
+
+**Description:** `cmd_validate` currently runs the skill and prints
+output with no persistence. Wrap it in the same `allocate_iteration` /
+`workspace.tmp_path` / `workspace.finalize()` flow used by grade, so
+it writes `run-0/output.jsonl`, `run-0/output.txt`, and
+`assertions.json` (with `transcript_path` wired via US-004). Share the
+`iteration-N` counter with grade. Add history record with
+`command="validate"`.
+
+**Traces to:** DEC-005, DEC-008, DEC-011.
+
+**Acceptance criteria:**
+- `cmd_validate` uses `allocate_iteration(...)` and
+  `workspace.finalize()` / `workspace.abort()` on exception, per
+  `.claude/rules/sidecar-during-staging.md`.
+- Written artifacts: `iteration-N/<skill>/run-0/output.jsonl`,
+  `.../run-0/output.txt`, `.../assertions.json`. No `grading.json`,
+  no `timing.json` (validate has no Layer 3).
+- Respects `--no-transcript` from US-005.
+- Appends to `history.jsonl` with `command="validate"`, `pass_rate`
+  from the assertion set, `mean_score` omitted (or `None`).
+- Existing validate behavior (stdout print of skill output, exit code
+  on failure) unchanged.
+- Test: `clauditor validate <skill>` creates an iteration dir, writes
+  the expected files, appends the correct history row.
+
+**Done when:** `clauditor validate` fixture test publishes an iteration,
+`history.jsonl` grows by one `command="validate"` row, transcript is
+present under the iteration dir.
+
+**Files:**
+- `src/clauditor/cli.py` (`cmd_validate` rewrite)
+- `src/clauditor/history.py` (verify `command="validate"` acceptance;
+  likely already supported per DEC-008)
+- `tests/test_cli.py`
+
+**Depends on:** US-003, US-004, US-005
+
+---
+
+### US-007 — Verbose `-v` transcript slice printer
+
+**Description:** When `-v` / `--verbose` is set AND any assertion fails
+on a run, print the last 5 `assistant` text blocks from that run's
+`stream_events` to stderr, labeled with the run index. Fewer-than-5
+available is fine — print what exists.
+
+**Traces to:** DEC-004.
+
+**Acceptance criteria:**
+- New helper `clauditor.cli::_print_failing_transcript_slice(run_idx,
+  stream_events, out)` — pure function, testable.
+- Extracts `msg.get("message", {}).get("content", [])` from each
+  `assistant` event, filters to `block.get("type") == "text"`, keeps
+  the last 5 (across all assistant events in order).
+- Header line: `--- transcript slice (run-K, last 5 assistant blocks) ---`
+- Prints block texts separated by blank lines, capped at 2 KB per
+  block (truncation marker `... [truncated]` on overflow).
+- Invoked from `_cmd_grade_with_workspace` only when `args.verbose` is
+  true **and** `AssertionSet.failed()` is non-empty for that run.
+- Works for `cmd_validate` too (same call site pattern, once US-006
+  lands).
+- Redaction has already run on the in-memory `stream_events`? No —
+  in-memory is untouched per DEC-010. Run `redact()` on the slice
+  before printing. (One more small call; cheap.)
+- Test: synthetic `stream_events` with 8 assistant text blocks →
+  printer emits the last 5, in order, each under cap.
+- Test: fewer than 5 blocks → printer emits what's available.
+- Test: slice contains a fake token → token is redacted in the
+  printed output.
+
+**Done when:** tests pass; manual run on a failing skill shows the
+slice.
+
+**Files:**
+- `src/clauditor/cli.py` (new helper + call sites)
+- `tests/test_cli_transcript_slice.py` (new)
+
+**Depends on:** US-001 (for redaction), US-006 (to invoke from validate)
+
+---
+
+### US-008 — Stream-json schema contract docs
+
+**Description:** Promote the parser contract currently in
+`runner.py`'s module docstring to two published files:
+`docs/stream-json-schema.md` (human-readable, with examples) and
+`.claude/rules/stream-json-schema.md` (agent-facing rule in the
+established `.claude/rules/` format: pattern, why, canonical
+implementation).
+
+**Traces to:** DEC-006.
+
+**Acceptance criteria:**
+- `docs/stream-json-schema.md` documents every message shape
+  clauditor parses: `system`, `assistant{message.content[].text|tool_use}`,
+  `result{usage{input_tokens,output_tokens}}`. Notes which fields are
+  *required*, which are tolerated-if-missing, and how malformed lines
+  are handled (skip + stderr warning).
+- `.claude/rules/stream-json-schema.md` follows the rule-file shape
+  (Rule: …, The pattern, Why this shape, Canonical implementation:
+  `src/clauditor/runner.py::_invoke`).
+- `runner.py` module docstring is shortened to a pointer at both docs
+  (don't delete it; it's load-bearing for in-code navigation).
+- README or top-level docs index links to `docs/stream-json-schema.md`
+  if an index exists (grep for a docs index first).
+
+**Done when:** both files exist, `runner.py` points at them.
+
+**Files:**
+- `docs/stream-json-schema.md` (new)
+- `.claude/rules/stream-json-schema.md` (new)
+- `src/clauditor/runner.py` (docstring trim)
+
+**Depends on:** none
+
+---
+
+### US-009 — Quality Gate
+
+**Description:** Run the code reviewer 4 times across the full
+changeset, fix every real bug found each pass. Run CodeRabbit if
+available. Project validation (`uv run ruff check src/ tests/` +
+`uv run pytest --cov=clauditor --cov-report=term-missing` with 80%
+gate) must pass after all fixes.
+
+**Acceptance criteria:**
+- Code-reviewer pass 1–4 executed; each pass's real findings fixed
+  (false positives documented in the bead notes).
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` green,
+  coverage ≥ 80% global and ≥ 80% on touched files.
+- CodeRabbit findings (if PR is up) addressed or explicitly
+  documented as false positive per `pr-reviewer` conventions.
+
+**Done when:** all four review passes complete, validation green.
+
+**Depends on:** US-001 … US-008
+
+---
+
+### US-010 — Patterns & Memory
+
+**Description:** Capture any new patterns that emerged during
+implementation. Candidates:
+- Redaction walk pattern (if novel) → new `.claude/rules/` file
+- "Share iteration counter across multiple commands" pattern (if the
+  validate workspace sharing proved subtle) → rule
+- Auto-memory entries for any user preferences captured in this
+  session (none expected; not pre-published library → no major
+  preference shifts).
+
+**Acceptance criteria:**
+- Review all `.claude/rules/` additions the plan touched; verify none
+  were skipped.
+- If any implementation step surfaced a non-obvious convention, add it
+  as a new rule file or extend an existing one.
+- `bd remember` calls for persistent insights worth keeping across
+  sessions.
+
+**Depends on:** US-009
+
+---
+
+## Beads Manifest
+_pending devolve_

--- a/plans/super/26-execution-transcripts.md
+++ b/plans/super/26-execution-transcripts.md
@@ -4,9 +4,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/26
 - **Branch:** `feature/26-execution-transcripts`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/26-execution-transcripts`
-- **Phase:** `detailing`
-- **PR:** _pending_
-- **Sessions:** 1
+- **Phase:** `devolved`
+- **PR:** https://github.com/wjduenow/clauditor/pull/35
+- **Sessions:** 2
 - **Last session:** 2026-04-14
 
 ---
@@ -737,4 +737,21 @@ implementation. Candidates:
 ---
 
 ## Beads Manifest
-_pending devolve_
+
+Devolved 2026-04-14. Epic: `clauditor-061`.
+
+| Bead ID            | Story   | Title                                                 | Depends on                          |
+|--------------------|---------|-------------------------------------------------------|-------------------------------------|
+| `clauditor-061`    | Epic    | #26: Execution transcripts for root-cause analysis    | —                                   |
+| `clauditor-061.1`  | US-001  | Redaction module (`clauditor/transcripts.py`)         | —                                   |
+| `clauditor-061.2`  | US-002  | `AssertionResult.transcript_path` field               | —                                   |
+| `clauditor-061.3`  | US-003  | Wire redaction into `_write_run_dir`                  | `.1`                                |
+| `clauditor-061.4`  | US-004  | Thread `transcript_path` into grade assertion results | `.2`, `.3`                          |
+| `clauditor-061.5`  | US-005  | `--no-transcript` opt-out flag                        | `.4`                                |
+| `clauditor-061.6`  | US-006  | Extend workspace staging to `cmd_validate`            | `.3`, `.4`, `.5`                    |
+| `clauditor-061.7`  | US-007  | Verbose `-v` transcript slice printer                 | `.1`, `.6`                          |
+| `clauditor-061.8`  | US-008  | Stream-json schema contract docs                      | —                                   |
+| `clauditor-061.9`  | US-009  | Quality Gate                                          | `.1`–`.8`                           |
+| `clauditor-061.10` | US-010  | Patterns & Memory                                     | `.9`                                |
+
+**Ready to claim:** `clauditor-061.1`, `clauditor-061.2`, `clauditor-061.8` (zero deps).

--- a/plans/super/26-execution-transcripts.md
+++ b/plans/super/26-execution-transcripts.md
@@ -4,9 +4,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/26
 - **Branch:** `feature/26-execution-transcripts`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/26-execution-transcripts`
-- **Phase:** `devolved`
+- **Phase:** `implemented`
 - **PR:** https://github.com/wjduenow/clauditor/pull/35
-- **Sessions:** 2
+- **Sessions:** 3
 - **Last session:** 2026-04-14
 
 ---

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -36,6 +36,7 @@ class AssertionResult:
     evidence: str | None = None
     raw_data: dict | None = None
     id: str | None = None
+    transcript_path: str | None = None
 
     def __bool__(self) -> bool:
         return self.passed
@@ -55,7 +56,23 @@ class AssertionResult:
             "kind": self.kind,
             "evidence": self.evidence,
             "raw_data": self.raw_data,
+            "transcript_path": self.transcript_path,
         }
+
+    @classmethod
+    def from_json_dict(cls, data: dict) -> AssertionResult:
+        """Inverse of :meth:`to_json_dict` — tolerates missing keys for
+        older on-disk fixtures that predate newly added fields."""
+        return cls(
+            id=data.get("id"),
+            name=data.get("name", ""),
+            passed=bool(data["passed"]),
+            message=data.get("message", ""),
+            kind=data.get("kind", "custom"),
+            evidence=data.get("evidence"),
+            raw_data=data.get("raw_data"),
+            transcript_path=data.get("transcript_path"),
+        )
 
 
 @dataclass
@@ -106,16 +123,7 @@ class AssertionSet:
     def from_json(cls, data: dict) -> AssertionSet:
         """Inverse of :meth:`to_json` — used by tests and the auditor."""
         results = [
-            AssertionResult(
-                id=r.get("id"),
-                name=r.get("name", ""),
-                passed=bool(r["passed"]),
-                message=r.get("message", ""),
-                kind=r.get("kind", "custom"),
-                evidence=r.get("evidence"),
-                raw_data=r.get("raw_data"),
-            )
-            for r in data.get("results", [])
+            AssertionResult.from_json_dict(r) for r in data.get("results", [])
         ]
         return cls(
             results=results,

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -585,10 +585,12 @@ def _cmd_grade_with_workspace(
     if not only_criterion:
         skill_dir = workspace.tmp_path
         verbose = bool(getattr(args, "verbose", False))
-        for idx, (text, events) in enumerate(run_outputs):
-            _write_run_dir(
-                skill_dir / f"run-{idx}", text, events, verbose=verbose
-            )
+        no_transcript = bool(getattr(args, "no_transcript", False))
+        if not no_transcript:
+            for idx, (text, events) in enumerate(run_outputs):
+                _write_run_dir(
+                    skill_dir / f"run-{idx}", text, events, verbose=verbose
+                )
 
         (skill_dir / "grading.json").write_text(
             primary_report.to_json(), encoding="utf-8"
@@ -603,6 +605,10 @@ def _cmd_grade_with_workspace(
         ) -> AssertionSet:
             result = run_assertions(text, spec.eval_spec.assertions)
             if args.output:
+                return result
+            if no_transcript:
+                # US-005: --no-transcript suppresses the stream-json write,
+                # so there's no file to point at. Leave transcript_path=None.
                 return result
             # Path is computed against workspace.final_path (the post-
             # finalize iteration-N/<skill>/ dir), NOT the staging dir,
@@ -1763,6 +1769,11 @@ def main(argv: list[str] | None = None) -> int:
     p_validate.add_argument(
         "--json", action="store_true", help="Output results as JSON"
     )
+    p_validate.add_argument(
+        "--no-transcript",
+        action="store_true",
+        help="Skip writing per-run stream-json transcripts",
+    )
 
     # run
     p_run = subparsers.add_parser("run", help="Run a skill and print output")
@@ -1835,6 +1846,11 @@ def main(argv: list[str] | None = None) -> int:
             "Log per-run transcript redaction counts to stderr "
             "(clauditor.transcripts: redacted N matches in run-K)"
         ),
+    )
+    p_grade.add_argument(
+        "--no-transcript",
+        action="store_true",
+        help="Skip writing per-run stream-json transcripts",
     )
     p_grade.add_argument(
         "--only-criterion",

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -118,6 +118,11 @@ def cmd_validate(args: argparse.Namespace) -> int:
             verbose = bool(getattr(args, "verbose", False))
             no_transcript = bool(getattr(args, "no_transcript", False))
 
+            if verbose and results.failed:
+                _print_failing_transcript_slice(
+                    0, list(skill_result.stream_events), sys.stderr
+                )
+
             if not no_transcript:
                 _write_run_dir(
                     skill_dir / "run-0",
@@ -205,6 +210,76 @@ def cmd_validate(args: argparse.Namespace) -> int:
         print(results.summary())
 
     return 0 if results.passed else 1
+
+
+_TRANSCRIPT_SLICE_BLOCK_CAP_BYTES = 2048
+_TRANSCRIPT_SLICE_TRUNC_MARKER = "... [truncated]"
+
+
+def _print_failing_transcript_slice(
+    run_idx: int,
+    stream_events: list[dict],
+    out,
+) -> None:
+    """Print the last 5 ``assistant`` text blocks from ``stream_events``.
+
+    Pure helper — no filesystem or argparse access, so it is cheap to test
+    in isolation. The caller is responsible for gating invocation on
+    ``args.verbose`` and a non-empty ``AssertionSet.failed()`` for the run.
+
+    Each ``assistant`` event's ``message.content`` list is walked for
+    ``type == "text"`` blocks (in event order); the last 5 across all
+    events are kept. Each text is passed through
+    :func:`clauditor.transcripts.redact` before printing so that in-memory
+    ``stream_events`` stays untouched (DEC-010) while the printed output
+    is still scrubbed. Individual text blocks are capped at 2 KB by byte
+    count on the UTF-8 encoding (per-block, post-redaction); overflow is
+    truncated with a trailing ``... [truncated]`` marker.
+    """
+    from . import transcripts
+
+    text_blocks: list[str] = []
+    for event in stream_events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") != "assistant":
+            continue
+        message = event.get("message") or {}
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content") or []
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "text":
+                continue
+            text_val = block.get("text")
+            if isinstance(text_val, str):
+                text_blocks.append(text_val)
+
+    slice_blocks = text_blocks[-5:]
+    scrubbed_slice, _count = transcripts.redact(slice_blocks)
+
+    def _cap(text: str) -> str:
+        encoded = text.encode("utf-8")
+        if len(encoded) <= _TRANSCRIPT_SLICE_BLOCK_CAP_BYTES:
+            return text
+        # Decode the first N bytes tolerating split codepoints at the edge.
+        truncated = encoded[:_TRANSCRIPT_SLICE_BLOCK_CAP_BYTES].decode(
+            "utf-8", errors="ignore"
+        )
+        return truncated + _TRANSCRIPT_SLICE_TRUNC_MARKER
+
+    header = (
+        f"--- transcript slice (run-{run_idx}, last 5 assistant blocks) ---"
+    )
+    print(header, file=out)
+    for i, text in enumerate(scrubbed_slice):
+        if i > 0:
+            print("", file=out)
+        print(_cap(text), file=out)
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -694,16 +769,28 @@ def _cmd_grade_with_workspace(
                 r.transcript_path = transcript_rel
             return result
 
+        per_run_assertions: list[tuple[int, AssertionSet]] = [
+            (idx, _assertions_with_transcript(text, idx))
+            for idx, (text, _events) in enumerate(run_outputs)
+        ]
+
+        # US-007: verbose transcript slice for any run whose assertions
+        # failed. Runs against in-memory stream_events (no disk read)
+        # and routes to stderr so grading JSON stdout stays clean.
+        if verbose:
+            for idx, aset in per_run_assertions:
+                if aset.failed:
+                    _print_failing_transcript_slice(
+                        idx, run_outputs[idx][1], sys.stderr
+                    )
+
         assertions_payload = {
             "schema_version": 1,
             "skill": spec.skill_name,
             "iteration": workspace.iteration,
             "runs": [
-                {
-                    "run": idx,
-                    **_assertions_with_transcript(text, idx).to_json(),
-                }
-                for idx, (text, _events) in enumerate(run_outputs)
+                {"run": idx, **aset.to_json()}
+                for idx, aset in per_run_assertions
             ],
         }
         (skill_dir / "assertions.json").write_text(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -50,7 +50,17 @@ def _positive_int(value: str) -> int:
 
 
 def cmd_validate(args: argparse.Namespace) -> int:
-    """Validate a skill's output against its eval spec (Layer 1 only)."""
+    """Validate a skill's output against its eval spec (Layer 1 only).
+
+    Live runs (no ``--output``) publish a per-iteration workspace under
+    ``.clauditor/iteration-N/<skill>/`` containing ``run-0/output.jsonl``,
+    ``run-0/output.txt`` and ``assertions.json`` (with ``transcript_path``
+    wired onto every assertion result). No ``grading.json`` or
+    ``timing.json`` is written — validate has no Layer 3. Shares the
+    iteration counter with ``clauditor grade``. ``--no-transcript``
+    suppresses the ``run-0/`` stream-json write and leaves
+    ``transcript_path`` unset on assertion rows (US-006).
+    """
     spec = SkillSpec.from_file(args.skill, eval_path=args.eval)
 
     if not spec.eval_spec:
@@ -61,29 +71,89 @@ def cmd_validate(args: argparse.Namespace) -> int:
         )
         return 1
 
-    skill_result = None
-    if args.output:
-        # Validate against provided output file
-        output = Path(args.output).read_text()
-    else:
-        # Run the skill to get output
-        print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
-        skill_result = spec.run()
-        if not skill_result.succeeded:
-            print(
-                f"ERROR: Skill failed to run: {skill_result.error}",
-                file=sys.stderr,
-            )
-            return 1
-        output = skill_result.output
-        print(f"Skill completed in {skill_result.duration_seconds:.1f}s")
-
-    # Run Layer 1 assertions
-    results = run_assertions(output, spec.eval_spec.assertions)
-
-    # Record history (US-005). Layer 1 only — no grader/quality/triggers.
     from clauditor.metrics import TokenUsage, build_metrics
 
+    skill_result: SkillResult | None = None
+    workspace: IterationWorkspace | None = None
+    workspace_rel: str | None = None
+    iteration_index: int | None = None
+
+    if args.output:
+        # Validate against a pre-captured output file. This path is
+        # intentionally NOT wrapped in a workspace: there is no skill
+        # subprocess to capture a transcript from, so there's nothing
+        # to persist under ``run-0/``. Preserve pre-US-006 behavior.
+        output = Path(args.output).read_text()
+        results = run_assertions(output, spec.eval_spec.assertions)
+    else:
+        # Live-run path: allocate an iteration workspace, run the skill
+        # into ``workspace.tmp_path / run-0``, persist sidecars, and
+        # finalize atomically. On any exception, abort the staging dir.
+        clauditor_dir = resolve_clauditor_dir()
+        try:
+            workspace = allocate_iteration(clauditor_dir, spec.skill_name)
+        except InvalidSkillNameError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+        try:
+            print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
+            skill_result = spec.run(run_dir=workspace.tmp_path / "run-0")
+            if not skill_result.succeeded:
+                print(
+                    f"ERROR: Skill failed to run: {skill_result.error}",
+                    file=sys.stderr,
+                )
+                workspace.abort()
+                return 1
+            output = skill_result.output
+            print(f"Skill completed in {skill_result.duration_seconds:.1f}s")
+
+            results = run_assertions(output, spec.eval_spec.assertions)
+
+            skill_dir = workspace.tmp_path
+            verbose = bool(getattr(args, "verbose", False))
+            no_transcript = bool(getattr(args, "no_transcript", False))
+
+            if not no_transcript:
+                _write_run_dir(
+                    skill_dir / "run-0",
+                    output,
+                    list(skill_result.stream_events),
+                    verbose=verbose,
+                )
+                transcript_rel = _relative_to_repo(
+                    clauditor_dir,
+                    workspace.final_path / "run-0" / "output.jsonl",
+                )
+                for r in results.results:
+                    r.transcript_path = transcript_rel
+
+            assertions_payload = {
+                "schema_version": 1,
+                "skill": spec.skill_name,
+                "iteration": workspace.iteration,
+                "runs": [{"run": 0, **results.to_json()}],
+            }
+            (skill_dir / "assertions.json").write_text(
+                json.dumps(assertions_payload, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            workspace.finalize()
+            iteration_index = workspace.iteration
+            workspace_rel = _relative_to_repo(
+                clauditor_dir, workspace.final_path
+            )
+        except Exception:
+            if workspace is not None and not workspace.finalized:
+                workspace.abort()
+            raise
+
+    # Record history (US-005). Layer 1 only — no grader/quality/triggers.
     skill_tokens = TokenUsage(
         input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
         output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
@@ -100,6 +170,8 @@ def cmd_validate(args: argparse.Namespace) -> int:
             mean_score=None,
             metrics=metrics_dict,
             command="validate",
+            iteration=iteration_index,
+            workspace_path=workspace_rel,
         )
     except Exception as e:  # pragma: no cover - defensive
         print(f"WARNING: failed to append history: {e}", file=sys.stderr)

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -49,6 +49,46 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
+def _append_validate_history(
+    skill_name: str,
+    *,
+    pass_rate: float,
+    skill_result: SkillResult | None,
+    iteration: int | None,
+    workspace_path: str | None,
+) -> None:
+    """Append a ``command="validate"`` row to ``history.jsonl``.
+
+    Called on both the success and skill-failure paths of ``cmd_validate``
+    so failed live validates stay visible to trend/audit tooling. On the
+    failure path ``iteration`` / ``workspace_path`` are ``None`` (the
+    workspace was aborted) and ``pass_rate`` is ``0.0``.
+    """
+    from clauditor.metrics import TokenUsage, build_metrics
+
+    skill_tokens = TokenUsage(
+        input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
+        output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
+    )
+    skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
+    metrics_dict = build_metrics(
+        skill=skill_tokens,
+        duration_seconds=skill_duration,
+    )
+    try:
+        history.append_record(
+            skill=skill_name,
+            pass_rate=pass_rate,
+            mean_score=None,
+            metrics=metrics_dict,
+            command="validate",
+            iteration=iteration,
+            workspace_path=workspace_path,
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"WARNING: failed to append history: {e}", file=sys.stderr)
+
+
 def cmd_validate(args: argparse.Namespace) -> int:
     """Validate a skill's output against its eval spec (Layer 1 only).
 
@@ -70,8 +110,6 @@ def cmd_validate(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-
-    from clauditor.metrics import TokenUsage, build_metrics
 
     skill_result: SkillResult | None = None
     workspace: IterationWorkspace | None = None
@@ -108,6 +146,16 @@ def cmd_validate(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 workspace.abort()
+                # Still record history so failed live-validates remain
+                # visible in trend/audit tooling. No iteration is
+                # published, so iteration/workspace fields stay None.
+                _append_validate_history(
+                    spec.skill_name,
+                    pass_rate=0.0,
+                    skill_result=skill_result,
+                    iteration=None,
+                    workspace_path=None,
+                )
                 return 1
             output = skill_result.output
             print(f"Skill completed in {skill_result.duration_seconds:.1f}s")
@@ -136,6 +184,14 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 )
                 for r in results.results:
                     r.transcript_path = transcript_rel
+            else:
+                # Scrub any `run-0/` subtree the skill already wrote
+                # during staging (e.g. `inputs/` copies), so --no-transcript
+                # does not leak a half-populated run-0 dir into the
+                # published iteration.
+                import shutil
+
+                shutil.rmtree(skill_dir / "run-0", ignore_errors=True)
 
             assertions_payload = {
                 "schema_version": 1,
@@ -159,27 +215,13 @@ def cmd_validate(args: argparse.Namespace) -> int:
             raise
 
     # Record history (US-005). Layer 1 only — no grader/quality/triggers.
-    skill_tokens = TokenUsage(
-        input_tokens=getattr(skill_result, "input_tokens", 0) or 0,
-        output_tokens=getattr(skill_result, "output_tokens", 0) or 0,
+    _append_validate_history(
+        spec.skill_name,
+        pass_rate=results.pass_rate,
+        skill_result=skill_result,
+        iteration=iteration_index,
+        workspace_path=workspace_rel,
     )
-    skill_duration = getattr(skill_result, "duration_seconds", 0.0) or 0.0
-    metrics_dict = build_metrics(
-        skill=skill_tokens,
-        duration_seconds=skill_duration,
-    )
-    try:
-        history.append_record(
-            skill=spec.skill_name,
-            pass_rate=results.pass_rate,
-            mean_score=None,
-            metrics=metrics_dict,
-            command="validate",
-            iteration=iteration_index,
-            workspace_path=workspace_rel,
-        )
-    except Exception as e:  # pragma: no cover - defensive
-        print(f"WARNING: failed to append history: {e}", file=sys.stderr)
 
     if args.json:
         print(
@@ -260,7 +302,7 @@ def _print_failing_transcript_slice(
                 text_blocks.append(text_val)
 
     slice_blocks = text_blocks[-5:]
-    scrubbed_slice, _count = transcripts.redact(slice_blocks)
+    scrubbed_slice, redaction_count = transcripts.redact(slice_blocks)
 
     def _cap(text: str) -> str:
         encoded = text.encode("utf-8")
@@ -280,6 +322,10 @@ def _print_failing_transcript_slice(
         if i > 0:
             print("", file=out)
         print(_cap(text), file=out)
+    if redaction_count > 0:
+        # Match the audit-breadcrumb that `_write_run_dir` prints under
+        # verbose mode, so users can see the slice printer also scrubbed.
+        print(f"[{redaction_count} redactions applied]", file=out)
 
 
 def cmd_run(args: argparse.Namespace) -> int:

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -153,18 +153,45 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 
 def _write_run_dir(
-    run_dir: Path, output_text: str, stream_events: list[dict]
+    run_dir: Path,
+    output_text: str,
+    stream_events: list[dict],
+    *,
+    verbose: bool = False,
 ) -> None:
     """Write ``output.txt`` and ``output.jsonl`` to a ``run-K/`` subdir.
 
     ``stream_events`` is one JSON object per line. Empty list yields an
     empty ``output.jsonl`` (the file still exists for layout consistency).
+
+    Both the stream events and the output text are passed through
+    :func:`clauditor.transcripts.redact` before being serialized to disk
+    so that secrets captured in skill execution traces never land in the
+    iteration workspace (DEC-003, DEC-007, DEC-010). The in-memory
+    ``stream_events`` list is not mutated — ``redact()`` returns a fresh
+    copy. Under ``verbose=True``, the total redaction count for this run
+    is always logged to stderr (including when the count is zero) so
+    that users can audit what the scrubber matched.
     """
+    from . import transcripts
+
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "output.txt").write_text(output_text, encoding="utf-8")
-    lines = [json.dumps(ev) for ev in stream_events]
+
+    scrubbed_events, events_count = transcripts.redact(stream_events)
+    scrubbed_text_wrap, text_count = transcripts.redact({"output": output_text})
+    scrubbed_text = scrubbed_text_wrap["output"]
+    total = events_count + text_count
+
+    (run_dir / "output.txt").write_text(scrubbed_text, encoding="utf-8")
+    lines = [json.dumps(ev) for ev in scrubbed_events]
     body = ("\n".join(lines) + "\n") if lines else ""
     (run_dir / "output.jsonl").write_text(body, encoding="utf-8")
+
+    if verbose:
+        print(
+            f"clauditor.transcripts: redacted {total} matches in {run_dir.name}",
+            file=sys.stderr,
+        )
 
 
 def cmd_grade(args: argparse.Namespace) -> int:
@@ -557,8 +584,11 @@ def _cmd_grade_with_workspace(
 
     if not only_criterion:
         skill_dir = workspace.tmp_path
+        verbose = bool(getattr(args, "verbose", False))
         for idx, (text, events) in enumerate(run_outputs):
-            _write_run_dir(skill_dir / f"run-{idx}", text, events)
+            _write_run_dir(
+                skill_dir / f"run-{idx}", text, events, verbose=verbose
+            )
 
         (skill_dir / "grading.json").write_text(
             primary_report.to_json(), encoding="utf-8"
@@ -1775,6 +1805,15 @@ def main(argv: list[str] | None = None) -> int:
             "After grading, run the test args through Claude without the "
             "skill prefix (baseline) and capture L1/L2/L3 sidecars. "
             "Roughly doubles LLM cost; never the default."
+        ),
+    )
+    p_grade.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help=(
+            "Log per-run transcript redaction counts to stderr "
+            "(clauditor.transcripts: redacted N matches in run-K)"
         ),
     )
     p_grade.add_argument(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -594,6 +594,28 @@ def _cmd_grade_with_workspace(
             primary_report.to_json(), encoding="utf-8"
         )
 
+        # US-004: thread transcript_path onto every assertion result so
+        # the auditor can jump from a failing row to the stream-json that
+        # produced it. Captured-text mode (--output) has no run subprocess,
+        # so no transcript file exists — transcript_path stays None.
+        def _assertions_with_transcript(
+            text: str, run_idx: int
+        ) -> AssertionSet:
+            result = run_assertions(text, spec.eval_spec.assertions)
+            if args.output:
+                return result
+            # Path is computed against workspace.final_path (the post-
+            # finalize iteration-N/<skill>/ dir), NOT the staging dir,
+            # so readers of assertions.json see a stable repo-relative
+            # path after the atomic rename.
+            transcript_rel = _relative_to_repo(
+                clauditor_dir,
+                workspace.final_path / f"run-{run_idx}" / "output.jsonl",
+            )
+            for r in result.results:
+                r.transcript_path = transcript_rel
+            return result
+
         assertions_payload = {
             "schema_version": 1,
             "skill": spec.skill_name,
@@ -601,9 +623,7 @@ def _cmd_grade_with_workspace(
             "runs": [
                 {
                     "run": idx,
-                    **run_assertions(
-                        text, spec.eval_spec.assertions
-                    ).to_json(),
+                    **_assertions_with_transcript(text, idx).to_json(),
                 }
                 for idx, (text, _events) in enumerate(run_outputs)
             ],

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -2063,8 +2063,10 @@ def main(argv: list[str] | None = None) -> int:
         "--verbose",
         action="store_true",
         help=(
-            "Log per-run transcript redaction counts to stderr "
-            "(clauditor.transcripts: redacted N matches in run-K)"
+            "Log verbose grading details to stderr, including per-run "
+            "transcript redaction counts "
+            "(clauditor.transcripts: redacted N matches in run-K) and "
+            "failing transcript slices when assertions fail"
         ),
     )
     p_grade.add_argument(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1988,6 +1988,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip writing per-run stream-json transcripts",
     )
+    p_validate.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="On assertion failure, print the last 5 assistant text blocks to stderr",
+    )
 
     # run
     p_run = subparsers.add_parser("run", help="Run a skill and print output")

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -784,6 +784,15 @@ def _cmd_grade_with_workspace(
                 _write_run_dir(
                     skill_dir / f"run-{idx}", text, events, verbose=verbose
                 )
+        else:
+            # Scrub any `run-K/` subtrees the skill already staged
+            # (e.g. `inputs/` copies from input_files), so --no-transcript
+            # does not leak half-populated run dirs into the published
+            # iteration. Mirrors the same fix on the validate side.
+            import shutil as _shutil
+
+            for idx in range(len(run_outputs)):
+                _shutil.rmtree(skill_dir / f"run-{idx}", ignore_errors=True)
 
         (skill_dir / "grading.json").write_text(
             primary_report.to_json(), encoding="utf-8"

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -1,28 +1,13 @@
 """Skill runner — executes Claude Code skills and captures output.
 
-Stream-JSON parser notes
-------------------------
-This module invokes the Claude CLI with
-``--output-format stream-json --verbose`` and parses its NDJSON output
-line-by-line. Each line is a JSON object with a ``type`` field. The schema
-below reflects the Anthropic CLI streaming format (verified live against
-``claude`` 2.1.x):
+Invokes the Claude CLI with ``--output-format stream-json --verbose`` and
+parses the NDJSON stream in :meth:`SkillRunner._invoke`. The parser is
+intentionally permissive: malformed lines are skipped with a stderr
+warning and every field is tolerated-if-missing.
 
-- ``{"type": "system", ...}``                 — init / hook / misc events
-- ``{"type": "assistant", "message": {..., "content": [blocks]}}``
-    Each block in ``message.content`` has a ``type``. For ``type == "text"``
-    the block carries a ``text`` field. Tool-use blocks and other block
-    types are ignored for the purposes of ``SkillResult.output``.
-- ``{"type": "result", ..., "usage": {"input_tokens": N, "output_tokens": M}}``
-    The final line of a successful run. Carries aggregate token usage.
-
-Malformed lines (``json.JSONDecodeError``) are logged to stderr and
-skipped, never aborting the run. A missing ``result`` message leaves
-token counts at 0 and emits a warning but still yields a ``SkillResult``.
-
-Every exit path from ``_invoke`` is wrapped in ``try/finally`` so that
-``SkillResult.duration_seconds`` is set for success, timeout, missing
-binary, and any other error path (DEC-005).
+See ``docs/stream-json-schema.md`` (human-readable reference with
+concrete examples) and ``.claude/rules/stream-json-schema.md`` (agent
+rule: pattern, rationale, canonical implementation pointer).
 """
 
 from __future__ import annotations

--- a/src/clauditor/transcripts.py
+++ b/src/clauditor/transcripts.py
@@ -1,0 +1,110 @@
+"""Redaction helpers for execution transcripts.
+
+Pure logic; no I/O. The public entry point is :func:`redact`, which walks a
+JSON-compatible Python value and returns a new structure with secrets
+replaced by the literal string ``"[REDACTED]"``, along with a count of how
+many replacements were made.
+
+Two complementary scrub strategies run during the walk:
+
+1. **Key-based scrubbing.** When a dict key (case-insensitive) matches one
+   of the sensitive suffixes — ``*_KEY``, ``*_TOKEN``, ``*_SECRET``,
+   ``*_PASSWORD``, ``*_PASSPHRASE``, ``*_CREDENTIAL`` — or is exactly
+   ``AUTH`` / ``API_KEY``, the entire value is replaced.
+
+2. **Regex-based scrubbing inside string values.** String leaves are
+   scanned for known secret shapes and only the matched span is replaced.
+   The regex set:
+
+   - OpenAI-style keys: ``sk-(ant|proj|live|test)?[-_]?[A-Za-z0-9]{20,}``
+   - GitHub classic PAT: ``ghp_[A-Za-z0-9]{36,}``
+   - GitHub fine-grained PAT: ``github_pat_[A-Za-z0-9_]{80,}``
+   - AWS access key ids: ``AKIA[0-9A-Z]{16}``, ``ASIA[0-9A-Z]{16}``
+   - Bearer tokens: ``Bearer\\s+[A-Za-z0-9._\\-]{20,}``
+   - Slack tokens: ``xox[abprs]-[A-Za-z0-9-]{10,}``
+
+See ``plans/super/26-execution-transcripts.md`` §US-001 for the
+authoritative specification and decisions DEC-003, DEC-007, DEC-010.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEY_SUFFIXES = (
+    "_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_PASSWORD",
+    "_PASSPHRASE",
+    "_CREDENTIAL",
+)
+
+_SENSITIVE_EXACT_KEYS = frozenset({"AUTH", "API_KEY"})
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sk-(?:ant|proj|live|test)?[-_]?[A-Za-z0-9]{20,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{36,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{80,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"ASIA[0-9A-Z]{16}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-]{20,}"),
+    re.compile(r"xox[abprs]-[A-Za-z0-9-]{10,}"),
+)
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    upper = key.upper()
+    if upper in _SENSITIVE_EXACT_KEYS:
+        return True
+    return any(upper.endswith(suffix) for suffix in _SENSITIVE_KEY_SUFFIXES)
+
+
+def _scrub_string(value: str) -> tuple[str, int]:
+    count = 0
+    result = value
+    for pattern in _SECRET_PATTERNS:
+        result, n = pattern.subn(_REDACTED, result)
+        count += n
+    return result, count
+
+
+def redact(obj: Any) -> tuple[Any, int]:
+    """Return ``(scrubbed_copy, count)`` for a JSON-compatible value.
+
+    The input is never mutated; nested containers are rebuilt. ``count``
+    is the total number of key-based plus regex-based replacements made
+    anywhere in the walk.
+    """
+
+    if isinstance(obj, dict):
+        new_dict: dict[Any, Any] = {}
+        total = 0
+        for key, value in obj.items():
+            if _is_sensitive_key(key):
+                new_dict[key] = _REDACTED
+                total += 1
+                continue
+            scrubbed, n = redact(value)
+            new_dict[key] = scrubbed
+            total += n
+        return new_dict, total
+
+    if isinstance(obj, (list, tuple)):
+        new_list: list[Any] = []
+        total = 0
+        for item in obj:
+            scrubbed, n = redact(item)
+            new_list.append(scrubbed)
+            total += n
+        return new_list, total
+
+    if isinstance(obj, str):
+        return _scrub_string(obj)
+
+    return obj, 0

--- a/src/clauditor/transcripts.py
+++ b/src/clauditor/transcripts.py
@@ -16,7 +16,9 @@ Two complementary scrub strategies run during the walk:
    scanned for known secret shapes and only the matched span is replaced.
    The regex set:
 
-   - OpenAI-style keys: ``sk-(ant|proj|live|test)?[-_]?[A-Za-z0-9]{20,}``
+   - OpenAI / Anthropic-style keys: ``sk-[A-Za-z0-9_\\-]{20,}`` (matches
+     ``sk-proj-...``, ``sk-ant-api03-...``, etc. through trailing dashes
+     and underscores, so long keys are not truncated mid-secret)
    - GitHub classic PAT: ``ghp_[A-Za-z0-9]{36,}``
    - GitHub fine-grained PAT: ``github_pat_[A-Za-z0-9_]{80,}``
    - AWS access key ids: ``AKIA[0-9A-Z]{16}``, ``ASIA[0-9A-Z]{16}``
@@ -43,10 +45,22 @@ _SENSITIVE_KEY_SUFFIXES = (
     "_CREDENTIAL",
 )
 
-_SENSITIVE_EXACT_KEYS = frozenset({"AUTH", "API_KEY"})
+_SENSITIVE_EXACT_KEYS = frozenset(
+    {
+        "AUTH",
+        "API_KEY",
+        "KEY",
+        "TOKEN",
+        "SECRET",
+        "PASSWORD",
+        "PASSPHRASE",
+        "CREDENTIAL",
+        "CREDENTIALS",
+    }
+)
 
 _SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"sk-(?:ant|proj|live|test)?[-_]?[A-Za-z0-9]{20,}"),
+    re.compile(r"sk-[A-Za-z0-9_\-]{20,}"),
     re.compile(r"ghp_[A-Za-z0-9]{36,}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{80,}"),
     re.compile(r"AKIA[0-9A-Z]{16}"),

--- a/src/clauditor/transcripts.py
+++ b/src/clauditor/transcripts.py
@@ -9,8 +9,10 @@ Two complementary scrub strategies run during the walk:
 
 1. **Key-based scrubbing.** When a dict key (case-insensitive) matches one
    of the sensitive suffixes — ``*_KEY``, ``*_TOKEN``, ``*_SECRET``,
-   ``*_PASSWORD``, ``*_PASSPHRASE``, ``*_CREDENTIAL`` — or is exactly
-   ``AUTH`` / ``API_KEY``, the entire value is replaced.
+   ``*_PASSWORD``, ``*_PASSPHRASE``, ``*_CREDENTIAL`` — or is exactly one
+   of ``AUTH``, ``API_KEY``, ``KEY``, ``TOKEN``, ``SECRET``, ``PASSWORD``,
+   ``PASSPHRASE``, ``CREDENTIAL``, or ``CREDENTIALS``, the entire value
+   is replaced.
 
 2. **Regex-based scrubbing inside string values.** String leaves are
    scanned for known secret shapes and only the matched span is replaced.

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -936,3 +936,110 @@ class TestAssertionSetJson:
         assert ids == ["venues", "min-len"]
         # And every result_set entry carries the id directly too.
         assert [r.id for r in result_set.results] == ["venues", "min-len"]
+
+
+class TestTranscriptPathField:
+    """US-002: AssertionResult.transcript_path round-trip."""
+
+    def _sample(self, **overrides) -> AssertionResult:
+        defaults = dict(
+            name="contains:Venues",
+            passed=True,
+            message="Found 'Venues'",
+            kind="presence",
+            id="venues",
+        )
+        defaults.update(overrides)
+        return AssertionResult(**defaults)
+
+    def test_default_is_none(self):
+        r = self._sample()
+        assert r.transcript_path is None
+
+    def test_to_json_dict_always_emits_key(self):
+        r = self._sample()
+        payload = r.to_json_dict()
+        assert "transcript_path" in payload
+        assert payload["transcript_path"] is None
+
+    def test_round_trip_with_path_set(self):
+        r = self._sample(transcript_path="runs/run-0/output.jsonl")
+        payload = r.to_json_dict()
+        assert payload["transcript_path"] == "runs/run-0/output.jsonl"
+        restored = AssertionResult.from_json_dict(payload)
+        assert restored.transcript_path == "runs/run-0/output.jsonl"
+        assert restored.id == "venues"
+        assert restored.kind == "presence"
+
+    def test_round_trip_with_path_absent(self):
+        r = self._sample()
+        payload = r.to_json_dict()
+        restored = AssertionResult.from_json_dict(payload)
+        assert restored.transcript_path is None
+
+    def test_from_json_dict_missing_key_tolerant(self):
+        """Older fixtures lacking the key load with transcript_path=None."""
+        legacy = {
+            "id": "venues",
+            "name": "contains:Venues",
+            "passed": True,
+            "message": "Found 'Venues'",
+            "kind": "presence",
+            "evidence": None,
+            "raw_data": None,
+            # no transcript_path key at all
+        }
+        restored = AssertionResult.from_json_dict(legacy)
+        assert restored.transcript_path is None
+        assert restored.id == "venues"
+
+    def test_assertion_set_round_trip_threads_transcript_path(self):
+        results = [
+            AssertionResult(
+                id="a1",
+                name="contains:X",
+                passed=True,
+                message="ok",
+                kind="presence",
+                transcript_path="runs/run-0/output.jsonl",
+            ),
+            AssertionResult(
+                id="a2",
+                name="min_length>=5",
+                passed=True,
+                message="ok",
+                kind="count",
+                transcript_path=None,
+            ),
+        ]
+        payload = AssertionSet(results=results).to_json()
+        assert payload["results"][0]["transcript_path"] == (
+            "runs/run-0/output.jsonl"
+        )
+        assert payload["results"][1]["transcript_path"] is None
+        restored = AssertionSet.from_json(payload)
+        assert restored.results[0].transcript_path == (
+            "runs/run-0/output.jsonl"
+        )
+        assert restored.results[1].transcript_path is None
+
+    def test_assertion_set_from_json_back_compat(self):
+        """Legacy assertions.json without transcript_path loads cleanly."""
+        legacy_payload = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "results": [
+                {
+                    "id": "a1",
+                    "name": "contains:X",
+                    "passed": True,
+                    "message": "ok",
+                    "kind": "presence",
+                    "evidence": None,
+                    "raw_data": None,
+                },
+            ],
+        }
+        restored = AssertionSet.from_json(legacy_payload)
+        assert restored.results[0].transcript_path is None
+        assert restored.results[0].id == "a1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -900,6 +900,57 @@ class TestCmdGradeSaveDiff:
         # Every result carries an id (no position-keyed fallback).
         assert all(r["id"] is not None for r in run0["results"])
         assert all(r["passed"] for r in run0["results"])
+        # US-004: captured-text mode (--output) has no subprocess run,
+        # so transcript_path must be None for every result.
+        assert all(
+            r["transcript_path"] is None for r in run0["results"]
+        )
+
+    def test_cmd_grade_threads_transcript_path_on_assertions(
+        self, tmp_path, monkeypatch
+    ):
+        """US-004: in subprocess mode, every AssertionResult in
+        assertions.json carries a repo-relative transcript_path
+        pointing at run-K/output.jsonl."""
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec(
+            assertions=[
+                {"id": "has-primary", "type": "contains", "value": "primary"},
+                {"id": "min-len", "type": "min_length", "value": "3"},
+            ]
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run = MagicMock(
+            return_value=SkillResult(
+                output="primary output here",
+                exit_code=0,
+                skill_name="test-skill",
+                args="",
+                stream_events=[
+                    {"type": "assistant", "text": "primary output here"}
+                ],
+                input_tokens=10,
+                output_tokens=5,
+                duration_seconds=0.5,
+            )
+        )
+        report = self._make_grading_report()
+        s, g = self._patch_grade(spec, report)
+        with s, g:
+            rc = main(["grade", "skill.md"])
+        assert rc == 0
+
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        payload = json.loads(
+            (skill_dir / "assertions.json").read_text()
+        )
+        run0 = payload["runs"][0]
+        assert len(run0["results"]) == 2
+        expected = ".clauditor/iteration-1/test-skill/run-0/output.jsonl"
+        for r in run0["results"]:
+            assert r["transcript_path"] == expected
+        # And the file that path names actually exists on disk.
+        assert (skill_dir / "run-0" / "output.jsonl").is_file()
 
     def test_cmd_grade_variance_runs_each_have_assertions_json_entry(
         self, tmp_path, monkeypatch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -952,6 +952,56 @@ class TestCmdGradeSaveDiff:
         # And the file that path names actually exists on disk.
         assert (skill_dir / "run-0" / "output.jsonl").is_file()
 
+    def test_cmd_grade_no_transcript_suppresses_run_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """US-005: --no-transcript skips run-K/output.jsonl writes and
+        leaves every AssertionResult.transcript_path as None, while
+        assertions.json / grading.json still land."""
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec(
+            assertions=[
+                {"id": "has-primary", "type": "contains", "value": "primary"},
+                {"id": "min-len", "type": "min_length", "value": "3"},
+            ]
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run = MagicMock(
+            return_value=SkillResult(
+                output="primary output here",
+                exit_code=0,
+                skill_name="test-skill",
+                args="",
+                stream_events=[
+                    {"type": "assistant", "text": "primary output here"}
+                ],
+                input_tokens=10,
+                output_tokens=5,
+                duration_seconds=0.5,
+            )
+        )
+        report = self._make_grading_report()
+        s, g = self._patch_grade(spec, report)
+        with s, g:
+            rc = main(["grade", "skill.md", "--no-transcript"])
+        assert rc == 0
+
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        # No run-K dir written at all.
+        assert not (skill_dir / "run-0" / "output.jsonl").exists()
+        assert not (skill_dir / "run-0" / "output.txt").exists()
+        assert not (skill_dir / "run-0").exists()
+        # assertions.json still persisted, but transcript_path is None.
+        payload = json.loads(
+            (skill_dir / "assertions.json").read_text()
+        )
+        run0 = payload["runs"][0]
+        assert len(run0["results"]) == 2
+        for r in run0["results"]:
+            assert r["transcript_path"] is None
+        # grading.json still persisted.
+        assert (skill_dir / "grading.json").is_file()
+
     def test_cmd_grade_variance_runs_each_have_assertions_json_entry(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,8 +91,12 @@ class TestCmdValidate:
         # (contains assertion should pass since output has "hello")
         assert rc == 0
 
-    def test_validate_run_skill(self):
+    def test_validate_run_skill(self, tmp_path, monkeypatch):
         """Without --output, runs the skill to get output."""
+        # chdir into tmp_path so the new US-006 workspace staging does
+        # NOT pollute the repo's real .clauditor/ directory.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
         eval_spec = _make_eval_spec()
         spec = _make_spec(eval_spec=eval_spec)
         spec.run.return_value = SkillResult(
@@ -109,8 +113,10 @@ class TestCmdValidate:
         assert rc == 0
         spec.run.assert_called_once()
 
-    def test_validate_run_skill_fails(self, capsys):
+    def test_validate_run_skill_fails(self, capsys, tmp_path, monkeypatch):
         """Returns 1 when skill run fails."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
         eval_spec = _make_eval_spec()
         spec = _make_spec(eval_spec=eval_spec)
         spec.run.return_value = SkillResult(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3906,3 +3906,129 @@ class TestCmdValidateHistory:
         assert metrics["skill"]["output_tokens"] == 0
         assert metrics["duration_seconds"] == 0.0
         assert "grader" not in metrics
+
+
+class TestCmdValidateWorkspace:
+    """cmd_validate persists an iteration workspace on live runs (US-006)."""
+
+    def _live_spec(self, output_text: str = "hello world output"):
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output=output_text,
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=1.5,
+            input_tokens=100,
+            output_tokens=50,
+            stream_events=[
+                {"type": "system", "session_id": "abc"},
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [{"type": "text", "text": "hi"}]
+                    },
+                },
+            ],
+        )
+        return spec
+
+    def test_validate_live_run_publishes_iteration(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        spec = self._live_spec()
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        assert skill_dir.is_dir()
+        assert (skill_dir / "run-0" / "output.jsonl").is_file()
+        assert (skill_dir / "run-0" / "output.txt").is_file()
+        assertions_path = skill_dir / "assertions.json"
+        assert assertions_path.is_file()
+        # No Layer 3 artifacts for validate.
+        assert not (skill_dir / "grading.json").exists()
+        assert not (skill_dir / "timing.json").exists()
+
+        payload = json.loads(assertions_path.read_text())
+        assert payload["schema_version"] == 1
+        assert payload["skill"] == "test-skill"
+        assert payload["iteration"] == 1
+        assert len(payload["runs"]) == 1
+        run_row = payload["runs"][0]
+        assert run_row["run"] == 0
+        # transcript_path wired onto assertion rows.
+        for r in run_row["results"]:
+            assert r["transcript_path"].endswith("run-0/output.jsonl")
+
+        # History row.
+        hist = tmp_path / ".clauditor" / "history.jsonl"
+        lines = [ln for ln in hist.read_text().splitlines() if ln]
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["command"] == "validate"
+        assert rec["iteration"] == 1
+        assert rec["workspace_path"].endswith("iteration-1/test-skill")
+
+    def test_validate_no_transcript_skips_run_dir(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        spec = self._live_spec()
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--no-transcript"])
+
+        assert rc == 0
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        assert skill_dir.is_dir()
+        assert not (skill_dir / "run-0").exists()
+        payload = json.loads((skill_dir / "assertions.json").read_text())
+        for r in payload["runs"][0]["results"]:
+            assert r["transcript_path"] is None
+
+    def test_validate_shares_counter_with_grade(self, tmp_path, monkeypatch):
+        """A prior ``iteration-1`` dir forces validate onto ``iteration-2``."""
+        monkeypatch.chdir(tmp_path)
+        # Simulate a prior grade run.
+        prior = tmp_path / ".clauditor" / "iteration-1" / "other-skill"
+        prior.mkdir(parents=True)
+
+        spec = self._live_spec()
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        assert (
+            tmp_path / ".clauditor" / "iteration-2" / "test-skill"
+        ).is_dir()
+        assert not (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill"
+        ).exists()
+
+    def test_validate_skill_failure_aborts_workspace(
+        self, tmp_path, monkeypatch
+    ):
+        """Failed skill run cleans up the staging dir and returns 1."""
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output="",
+            exit_code=1,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=0.5,
+            error="boom",
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 1
+        clauditor_dir = tmp_path / ".clauditor"
+        # Neither a staging dir nor a finalized iteration should remain.
+        assert not (clauditor_dir / "iteration-1").exists()
+        assert not (clauditor_dir / "iteration-1-tmp").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4038,3 +4038,76 @@ class TestCmdValidateWorkspace:
         # Neither a staging dir nor a finalized iteration should remain.
         assert not (clauditor_dir / "iteration-1").exists()
         assert not (clauditor_dir / "iteration-1-tmp").exists()
+
+    def test_validate_invalid_skill_name_returns_2(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """allocate_iteration raising InvalidSkillNameError returns exit 2."""
+        from clauditor.workspace import InvalidSkillNameError
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        spec = _make_spec(eval_spec=_make_eval_spec())
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.cli.allocate_iteration",
+                side_effect=InvalidSkillNameError("bad/name"),
+            ),
+        ):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 2
+        assert "ERROR" in capsys.readouterr().err
+
+    def test_validate_allocate_value_error_returns_2(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """allocate_iteration raising ValueError returns exit 2."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        spec = _make_spec(eval_spec=_make_eval_spec())
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.cli.allocate_iteration",
+                side_effect=ValueError("boom"),
+            ),
+        ):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 2
+        assert "ERROR" in capsys.readouterr().err
+
+    def test_validate_staging_exception_aborts_and_reraises(
+        self, tmp_path, monkeypatch
+    ):
+        """A raise inside the staging block calls workspace.abort() and
+        re-raises, leaving no iteration published and no iteration-N-tmp
+        dir behind. Exercises the generic except branch."""
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = SkillResult(
+            output="hello world",
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=0.5,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.cli.run_assertions",
+                side_effect=RuntimeError("boom in staging"),
+            ),
+            pytest.raises(RuntimeError, match="boom in staging"),
+        ):
+            main(["validate", "skill.md"])
+
+        clauditor_dir = tmp_path / ".clauditor"
+        assert not (clauditor_dir / "iteration-1").exists()
+        assert not (clauditor_dir / "iteration-1-tmp").exists()

--- a/tests/test_cli_transcript_redaction.py
+++ b/tests/test_cli_transcript_redaction.py
@@ -1,0 +1,93 @@
+"""Integration tests for US-003 — ``_write_run_dir`` transcript redaction.
+
+These tests exercise the on-disk contract of
+``clauditor.cli._write_run_dir``: the staged ``output.jsonl`` and
+``output.txt`` must contain the scrubbed form of the stream events and
+final output text, while the in-memory ``stream_events`` list passed in
+by the caller must be left untouched (DEC-010). Under ``verbose=True``
+the per-run redaction count is always logged to stderr, even when no
+matches were found.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from clauditor.cli import _write_run_dir
+
+# A realistic OpenAI-style key shape that matches one of the regex
+# patterns in ``clauditor.transcripts._SECRET_PATTERNS``. Defined once so
+# all tests agree on the literal token being scrubbed.
+_FAKE_KEY = "sk-proj-" + "A" * 32
+
+
+class TestWriteRunDirRedaction:
+    def test_jsonl_contains_no_raw_secret(self, tmp_path: Path) -> None:
+        events = [
+            {"type": "assistant", "text": f"here is my key {_FAKE_KEY}"},
+            {"type": "result", "text": "done"},
+        ]
+        _write_run_dir(tmp_path / "run-0", "final answer", events)
+
+        jsonl = (tmp_path / "run-0" / "output.jsonl").read_text()
+        assert _FAKE_KEY not in jsonl
+        assert "[REDACTED]" in jsonl
+        # The shape is still valid JSONL: one event per line.
+        parsed = [json.loads(line) for line in jsonl.splitlines()]
+        assert len(parsed) == 2
+        assert parsed[1]["text"] == "done"
+
+    def test_output_txt_is_scrubbed(self, tmp_path: Path) -> None:
+        output_text = f"call me: {_FAKE_KEY}"
+        _write_run_dir(tmp_path / "run-1", output_text, [])
+
+        txt = (tmp_path / "run-1" / "output.txt").read_text()
+        assert _FAKE_KEY not in txt
+        assert "[REDACTED]" in txt
+
+    def test_in_memory_stream_events_not_mutated(
+        self, tmp_path: Path
+    ) -> None:
+        events = [{"type": "assistant", "text": f"leak: {_FAKE_KEY}"}]
+        snapshot = copy.deepcopy(events)
+        _write_run_dir(tmp_path / "run-0", "ok", events)
+        assert events == snapshot
+
+    def test_verbose_logs_count_when_matches_found(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        events = [{"type": "assistant", "text": f"x {_FAKE_KEY} y"}]
+        _write_run_dir(
+            tmp_path / "run-7", f"also {_FAKE_KEY}", events, verbose=True
+        )
+        err = capsys.readouterr().err
+        assert "clauditor.transcripts: redacted" in err
+        assert "run-7" in err
+        # One match in the event + one in the output text.
+        assert "redacted 2 matches" in err
+
+    def test_verbose_logs_zero_when_clean(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _write_run_dir(
+            tmp_path / "run-0",
+            "nothing secret here",
+            [{"type": "result", "text": "all clean"}],
+            verbose=True,
+        )
+        err = capsys.readouterr().err
+        assert "clauditor.transcripts: redacted 0 matches in run-0" in err
+
+    def test_quiet_mode_prints_nothing(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _write_run_dir(
+            tmp_path / "run-0",
+            f"secret {_FAKE_KEY}",
+            [],
+            verbose=False,
+        )
+        err = capsys.readouterr().err
+        assert err == ""

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -20,6 +20,7 @@ from clauditor.cli import (
     _TRANSCRIPT_SLICE_BLOCK_CAP_BYTES,
     _TRANSCRIPT_SLICE_TRUNC_MARKER,
     _print_failing_transcript_slice,
+    main,
 )
 
 # A fake secret that matches one of the ``clauditor.transcripts`` regexes.
@@ -147,65 +148,174 @@ class TestPrintFailingTranscriptSlice:
         assert x_count == _TRANSCRIPT_SLICE_BLOCK_CAP_BYTES
 
 
-class TestGradeVerboseGate:
-    """Gate-condition integration around ``_cmd_grade_with_workspace``.
-
-    We don't drive the full grade pipeline here — it depends on Haiku /
-    Sonnet calls. Instead we patch ``_print_failing_transcript_slice``
-    and exercise the small gating expression in situ by calling it
-    directly the way the call site does.
+class TestGradeVerboseInvocation:
+    """Drive ``main(['grade', ...])`` end-to-end with mocked runner +
+    grader, and assert the real call site inside
+    ``_cmd_grade_with_workspace`` (cli.py ~835-840) invokes
+    ``_print_failing_transcript_slice`` under the verbose + failing gate.
     """
 
-    def test_gate_printed_when_verbose_and_failed(self) -> None:
-        aset = AssertionSet(
-            results=[
-                AssertionResult(
-                    name="x", passed=False, message="no", kind="custom"
-                )
-            ]
+    def _make_spec(self, eval_spec):
+        from unittest.mock import MagicMock
+
+        from clauditor.spec import SkillSpec
+
+        spec = MagicMock(spec=SkillSpec)
+        spec.skill_name = "test-skill"
+        spec.eval_spec = eval_spec
+        return spec
+
+    def _make_eval_spec(self):
+        from clauditor.schemas import EvalSpec
+
+        return EvalSpec(
+            skill_name="test-skill",
+            description="T",
+            test_args="--depth quick",
+            # Assertion deliberately fails against the mocked output.
+            assertions=[{"type": "contains", "value": "WILL_NOT_MATCH"}],
+            sections=[],
+            grading_criteria=["Is it relevant?"],
+            grading_model="claude-sonnet-4-6",
+            trigger_tests=None,
+            variance=None,
         )
-        verbose = True
-        out = io.StringIO()
-        events = [_assistant_event("ctx")]
 
-        if verbose and aset.failed:
-            _print_failing_transcript_slice(0, events, out)
+    def _skill_result(self, *, text: str):
+        from clauditor.runner import SkillResult
 
-        assert "ctx" in out.getvalue()
-
-    def test_gate_suppressed_when_verbose_off(self) -> None:
-        aset = AssertionSet(
-            results=[
-                AssertionResult(
-                    name="x", passed=False, message="no", kind="custom"
-                )
-            ]
+        return SkillResult(
+            output=text,
+            exit_code=0,
+            skill_name="test-skill",
+            args="",
+            duration_seconds=0.5,
+            stream_events=[_assistant_event("assistant ctx line")],
         )
-        verbose = False
-        out = io.StringIO()
-        events = [_assistant_event("ctx")]
 
-        if verbose and aset.failed:  # pragma: no cover - gate false
-            _print_failing_transcript_slice(0, events, out)
+    def _grading_report(self):
+        from clauditor.quality_grader import GradingReport, GradingResult
 
-        assert out.getvalue() == ""
-
-    def test_gate_suppressed_when_no_failures(self) -> None:
-        aset = AssertionSet(
+        return GradingReport(
+            skill_name="test-skill",
+            model="claude-sonnet-4-6",
             results=[
-                AssertionResult(
-                    name="x", passed=True, message="ok", kind="custom"
+                GradingResult(
+                    criterion="Is it relevant?",
+                    passed=True,
+                    score=1.0,
+                    evidence="",
+                    reasoning="",
                 )
-            ]
+            ],
+            duration_seconds=1.0,
         )
-        verbose = True
-        out = io.StringIO()
-        events = [_assistant_event("ctx")]
 
-        if verbose and aset.failed:  # pragma: no cover - gate false
-            _print_failing_transcript_slice(0, events, out)
+    def test_grade_verbose_invokes_slice_on_failure(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """-v + at least one failing assertion triggers the slice printer
+        from inside _cmd_grade_with_workspace."""
+        from unittest.mock import AsyncMock
 
-        assert out.getvalue() == ""
+        monkeypatch.chdir(tmp_path)
+        spec = self._make_spec(self._make_eval_spec())
+        spec.run.return_value = self._skill_result(text="not the target word")
+        report = self._grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+            patch(
+                "clauditor.cli._print_failing_transcript_slice"
+            ) as mock_slice,
+        ):
+            # Grade's exit code is driven by Layer 3 (grading criteria),
+            # not Layer 1 assertions — so rc is 0 here even though the
+            # contains-assertion fails. The invariant under test is that
+            # the slice printer fires whenever -v is set AND any
+            # assertion in a run failed.
+            rc = main(["grade", "skill.md", "-v"])
+
+        assert rc == 0
+        assert mock_slice.call_count == 1
+        # The helper is called with (run_idx, stream_events, stderr).
+        args_, _ = mock_slice.call_args
+        assert args_[0] == 0  # primary run index
+
+    def test_grade_no_verbose_suppresses_slice(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Without -v, the slice printer is never invoked even on
+        assertion failure."""
+        from unittest.mock import AsyncMock
+
+        monkeypatch.chdir(tmp_path)
+        spec = self._make_spec(self._make_eval_spec())
+        spec.run.return_value = self._skill_result(text="not the target word")
+        report = self._grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+            patch(
+                "clauditor.cli._print_failing_transcript_slice"
+            ) as mock_slice,
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        assert mock_slice.call_count == 0
+
+    def test_grade_verbose_all_pass_suppresses_slice(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """-v with all-passing assertions does NOT invoke the slice
+        printer — the inner `if aset.failed` gate must fail closed."""
+        from unittest.mock import AsyncMock
+
+        from clauditor.schemas import EvalSpec
+
+        monkeypatch.chdir(tmp_path)
+        # Assertion now MATCHES the mocked output.
+        eval_spec = EvalSpec(
+            skill_name="test-skill",
+            description="T",
+            test_args="--depth quick",
+            assertions=[{"type": "contains", "value": "hello"}],
+            sections=[],
+            grading_criteria=["Is it relevant?"],
+            grading_model="claude-sonnet-4-6",
+            trigger_tests=None,
+            variance=None,
+        )
+        spec = self._make_spec(eval_spec)
+        spec.run.return_value = self._skill_result(text="hello world")
+        report = self._grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+            patch(
+                "clauditor.cli._print_failing_transcript_slice"
+            ) as mock_slice,
+        ):
+            rc = main(["grade", "skill.md", "-v"])
+
+        assert rc == 0
+        assert mock_slice.call_count == 0
 
 
 class TestValidateVerboseInvocation:

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -1,0 +1,369 @@
+"""Tests for US-007 — verbose `-v` transcript slice printer.
+
+Covers the pure helper ``clauditor.cli._print_failing_transcript_slice``
+in isolation (header, slice-of-5 window, fewer-than-5, redaction, 2 KB
+truncation) plus the gate conditions at its call site inside
+``_cmd_grade_with_workspace``: nothing printed without `-v`, nothing
+printed when every assertion passes, slice printed when both conditions
+hold.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.cli import (
+    _TRANSCRIPT_SLICE_BLOCK_CAP_BYTES,
+    _TRANSCRIPT_SLICE_TRUNC_MARKER,
+    _print_failing_transcript_slice,
+)
+
+# A fake secret that matches one of the ``clauditor.transcripts`` regexes.
+_FAKE_KEY = "sk-proj-" + "a" * 32
+
+
+def _assistant_event(*texts: str) -> dict:
+    """Build a synthetic ``assistant`` stream event with text blocks."""
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": t} for t in texts
+            ],
+        },
+    }
+
+
+class TestPrintFailingTranscriptSlice:
+    def test_print_last_5_of_8(self) -> None:
+        # Spread 8 text blocks across two assistant events so the helper
+        # has to collect across events in order before slicing.
+        events = [
+            _assistant_event("b0", "b1", "b2", "b3"),
+            _assistant_event("b4", "b5", "b6", "b7"),
+        ]
+        out = io.StringIO()
+        _print_failing_transcript_slice(2, events, out)
+
+        text = out.getvalue()
+        assert "--- transcript slice (run-2, last 5 assistant blocks) ---" in text
+        # First three should be dropped.
+        assert "b0" not in text
+        assert "b1" not in text
+        assert "b2" not in text
+        # Last five, in order.
+        for expected in ("b3", "b4", "b5", "b6", "b7"):
+            assert expected in text
+        # Order preservation check: b3 appears before b7.
+        assert text.index("b3") < text.index("b7")
+
+    def test_print_fewer_than_5(self) -> None:
+        events = [_assistant_event("only-a", "only-b")]
+        out = io.StringIO()
+        _print_failing_transcript_slice(0, events, out)
+
+        text = out.getvalue()
+        # Header still says "last 5" regardless of how many are present.
+        assert "last 5 assistant blocks" in text
+        assert "only-a" in text
+        assert "only-b" in text
+
+    def test_prints_nothing_but_header_when_no_text_blocks(self) -> None:
+        events = [{"type": "system", "foo": "bar"}]
+        out = io.StringIO()
+        _print_failing_transcript_slice(1, events, out)
+        text = out.getvalue()
+        assert "--- transcript slice (run-1" in text
+
+    def test_ignores_non_text_blocks(self) -> None:
+        events = [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "id": "tu_1"},
+                        {"type": "text", "text": "keep-me"},
+                    ],
+                },
+            },
+        ]
+        out = io.StringIO()
+        _print_failing_transcript_slice(0, events, out)
+        text = out.getvalue()
+        assert "keep-me" in text
+        assert "tu_1" not in text
+
+    def test_ignores_non_assistant_events(self) -> None:
+        events = [
+            {
+                "type": "system",
+                "message": {
+                    "content": [{"type": "text", "text": "sys"}]
+                },
+            },
+            _assistant_event("asst"),
+        ]
+        out = io.StringIO()
+        _print_failing_transcript_slice(0, events, out)
+        text = out.getvalue()
+        assert "asst" in text
+        assert "sys" not in text
+
+    def test_tolerates_malformed_events(self) -> None:
+        events = [
+            "not a dict",
+            {"type": "assistant", "message": "not a dict"},
+            {"type": "assistant", "message": {"content": "not a list"}},
+            {"type": "assistant", "message": {"content": [None, 42, "x"]}},
+            _assistant_event("good-one"),
+        ]
+        out = io.StringIO()
+        _print_failing_transcript_slice(0, events, out)
+        assert "good-one" in out.getvalue()
+
+    def test_redaction_applied(self) -> None:
+        events = [_assistant_event(f"here is my key {_FAKE_KEY} end")]
+        out = io.StringIO()
+        _print_failing_transcript_slice(0, events, out)
+        text = out.getvalue()
+        assert _FAKE_KEY not in text
+        assert "[REDACTED]" in text
+
+    def test_truncation_2kb(self) -> None:
+        big = "x" * 3072  # 3 KB of ASCII → 3 KB of bytes
+        events = [_assistant_event(big)]
+        out = io.StringIO()
+        _print_failing_transcript_slice(0, events, out)
+        text = out.getvalue()
+
+        assert _TRANSCRIPT_SLICE_TRUNC_MARKER in text
+        # The printed block itself (x-run) should be capped at the byte
+        # limit. Count consecutive x's to verify.
+        x_count = text.count("x")
+        assert x_count == _TRANSCRIPT_SLICE_BLOCK_CAP_BYTES
+
+
+class TestGradeVerboseGate:
+    """Gate-condition integration around ``_cmd_grade_with_workspace``.
+
+    We don't drive the full grade pipeline here — it depends on Haiku /
+    Sonnet calls. Instead we patch ``_print_failing_transcript_slice``
+    and exercise the small gating expression in situ by calling it
+    directly the way the call site does.
+    """
+
+    def test_gate_printed_when_verbose_and_failed(self) -> None:
+        aset = AssertionSet(
+            results=[
+                AssertionResult(
+                    name="x", passed=False, message="no", kind="custom"
+                )
+            ]
+        )
+        verbose = True
+        out = io.StringIO()
+        events = [_assistant_event("ctx")]
+
+        if verbose and aset.failed:
+            _print_failing_transcript_slice(0, events, out)
+
+        assert "ctx" in out.getvalue()
+
+    def test_gate_suppressed_when_verbose_off(self) -> None:
+        aset = AssertionSet(
+            results=[
+                AssertionResult(
+                    name="x", passed=False, message="no", kind="custom"
+                )
+            ]
+        )
+        verbose = False
+        out = io.StringIO()
+        events = [_assistant_event("ctx")]
+
+        if verbose and aset.failed:  # pragma: no cover - gate false
+            _print_failing_transcript_slice(0, events, out)
+
+        assert out.getvalue() == ""
+
+    def test_gate_suppressed_when_no_failures(self) -> None:
+        aset = AssertionSet(
+            results=[
+                AssertionResult(
+                    name="x", passed=True, message="ok", kind="custom"
+                )
+            ]
+        )
+        verbose = True
+        out = io.StringIO()
+        events = [_assistant_event("ctx")]
+
+        if verbose and aset.failed:  # pragma: no cover - gate false
+            _print_failing_transcript_slice(0, events, out)
+
+        assert out.getvalue() == ""
+
+
+class TestValidateVerboseInvocation:
+    """Smoke test that ``cmd_validate`` invokes the slice printer when
+    verbose and at least one assertion fails.
+    """
+
+    def test_cmd_validate_invokes_slice_on_failure(self, tmp_path, capsys) -> None:
+        from clauditor import cli
+
+        skill_path = tmp_path / "demo.md"
+        skill_path.write_text("# demo\nhello\n")
+        eval_path = tmp_path / "demo.eval.json"
+        eval_path.write_text(
+            '{"assertions": [{"id": "a1", "type": "contains", "value": "__nope__"}]}'
+        )
+
+        fake_skill_result = MagicMock()
+        fake_skill_result.succeeded = True
+        fake_skill_result.output = "produced output without the token"
+        fake_skill_result.stream_events = [
+            _assistant_event("A first chunk of reasoning"),
+            _assistant_event("Finally, the answer."),
+        ]
+        fake_skill_result.duration_seconds = 0.1
+        fake_skill_result.input_tokens = 0
+        fake_skill_result.output_tokens = 0
+
+        args = MagicMock()
+        args.skill = str(skill_path)
+        args.eval = str(eval_path)
+        args.output = None
+        args.json = False
+        args.verbose = True
+        args.no_transcript = False
+
+        with patch.object(cli.SkillSpec, "from_file") as from_file:
+            spec = MagicMock()
+            spec.skill_name = "demo"
+            spec.eval_spec = MagicMock()
+            spec.eval_spec.test_args = ""
+            spec.eval_spec.assertions = [
+                MagicMock(
+                    name="a1",
+                    type="contains",
+                    value="__nope__",
+                    description=None,
+                )
+            ]
+            spec.run.return_value = fake_skill_result
+            from_file.return_value = spec
+
+            with patch.object(cli, "run_assertions") as run_assertions:
+                run_assertions.return_value = AssertionSet(
+                    results=[
+                        AssertionResult(
+                            name="a1",
+                            passed=False,
+                            message="missing",
+                            kind="custom",
+                        )
+                    ]
+                )
+                with patch.object(cli, "history"):
+                    with patch.object(
+                        cli, "_print_failing_transcript_slice"
+                    ) as printer:
+                        with patch.object(cli, "allocate_iteration") as alloc:
+                            ws = MagicMock()
+                            ws.iteration = 1
+                            ws.tmp_path = tmp_path / "stage"
+                            ws.tmp_path.mkdir()
+                            ws.final_path = tmp_path / "final"
+                            ws.finalized = False
+
+                            def _finalize():
+                                ws.finalized = True
+
+                            ws.finalize.side_effect = _finalize
+                            alloc.return_value = ws
+
+                            rc = cli.cmd_validate(args)
+
+                        printer.assert_called_once()
+                        call_args = printer.call_args
+                        assert call_args.args[0] == 0
+                        assert call_args.args[1] == list(
+                            fake_skill_result.stream_events
+                        )
+
+        assert rc == 1
+
+    def test_cmd_validate_does_not_invoke_slice_when_verbose_off(
+        self, tmp_path
+    ) -> None:
+        from clauditor import cli
+
+        fake_skill_result = MagicMock()
+        fake_skill_result.succeeded = True
+        fake_skill_result.output = "out"
+        fake_skill_result.stream_events = [_assistant_event("x")]
+        fake_skill_result.duration_seconds = 0.0
+        fake_skill_result.input_tokens = 0
+        fake_skill_result.output_tokens = 0
+
+        args = MagicMock()
+        args.skill = "demo.md"
+        args.eval = None
+        args.output = None
+        args.json = False
+        args.verbose = False
+        args.no_transcript = False
+
+        with patch.object(cli.SkillSpec, "from_file") as from_file:
+            spec = MagicMock()
+            spec.skill_name = "demo"
+            spec.eval_spec = MagicMock()
+            spec.eval_spec.test_args = ""
+            spec.eval_spec.assertions = []
+            spec.run.return_value = fake_skill_result
+            from_file.return_value = spec
+
+            with patch.object(cli, "run_assertions") as run_assertions:
+                run_assertions.return_value = AssertionSet(
+                    results=[
+                        AssertionResult(
+                            name="a1",
+                            passed=False,
+                            message="missing",
+                            kind="custom",
+                        )
+                    ]
+                )
+                with patch.object(cli, "history"):
+                    with patch.object(
+                        cli, "_print_failing_transcript_slice"
+                    ) as printer:
+                        with patch.object(cli, "allocate_iteration") as alloc:
+                            ws = MagicMock()
+                            ws.iteration = 1
+                            ws.tmp_path = tmp_path / "stage2"
+                            ws.tmp_path.mkdir()
+                            ws.final_path = tmp_path / "final2"
+                            ws.finalized = False
+
+                            def _finalize():
+                                ws.finalized = True
+
+                            ws.finalize.side_effect = _finalize
+                            alloc.return_value = ws
+
+                            cli.cmd_validate(args)
+
+                        printer.assert_not_called()
+
+
+@pytest.mark.parametrize("run_idx", [0, 3, 12])
+def test_header_includes_run_index(run_idx: int) -> None:
+    out = io.StringIO()
+    _print_failing_transcript_slice(run_idx, [_assistant_event("hi")], out)
+    assert f"run-{run_idx}" in out.getvalue()

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -33,6 +33,14 @@ class TestKeyBasedScrub:
         assert scrubbed == {"AUTH": "[REDACTED]"}
         assert count == 1
 
+    def test_bare_sensitive_keys(self):
+        # Stream events and MCP tool args often use bare names like
+        # `token`, `password`, `secret` — must be scrubbed, case-insensitive.
+        for key in ("token", "password", "secret", "key", "credentials"):
+            scrubbed, count = redact({key: "hunter2"})
+            assert scrubbed == {key: "[REDACTED]"}, key
+            assert count == 1, key
+
     def test_suffix_matches(self):
         for key in (
             "MY_KEY",
@@ -62,6 +70,18 @@ class TestRegexScrub:
         scrubbed, count = redact("sk-abcdefghijklmnopqrstuvwx")
         assert scrubbed == "[REDACTED]"
         assert count == 1
+
+    def test_anthropic_long_key_fully_scrubbed(self):
+        # sk-ant-api03-<long-body-with-dashes-and-underscores> shape.
+        # The old regex stopped at the first dash after `api03`, leaking
+        # the tail. The widened char class must consume the whole token.
+        key = "sk-ant-api03-" + "A" * 20 + "-" + "B" * 20 + "_" + "C" * 20
+        scrubbed, count = redact(f"before {key} after")
+        assert scrubbed == "before [REDACTED] after"
+        assert count == 1
+        assert "A" * 20 not in scrubbed
+        assert "B" * 20 not in scrubbed
+        assert "C" * 20 not in scrubbed
 
     def test_github_pat_positive(self):
         token = "ghp_" + "A" * 40

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1,0 +1,168 @@
+"""Tests for clauditor.transcripts redaction logic."""
+
+from __future__ import annotations
+
+import copy
+
+from clauditor.transcripts import redact
+
+
+class TestKeyBasedScrub:
+    def test_env_var_api_key(self):
+        scrubbed, count = redact({"OPENAI_API_KEY": "abc"})
+        assert scrubbed == {"OPENAI_API_KEY": "[REDACTED]"}
+        assert count == 1
+
+    def test_case_insensitive(self):
+        scrubbed, count = redact({"openai_api_key": "abc"})
+        assert scrubbed == {"openai_api_key": "[REDACTED]"}
+        assert count == 1
+
+    def test_nested_dict(self):
+        scrubbed, count = redact({"env": {"GITHUB_TOKEN": "ghp_whatever"}})
+        assert scrubbed == {"env": {"GITHUB_TOKEN": "[REDACTED]"}}
+        assert count == 1
+
+    def test_list_traversal(self):
+        scrubbed, count = redact([{"API_KEY": "x"}])
+        assert scrubbed == [{"API_KEY": "[REDACTED]"}]
+        assert count == 1
+
+    def test_exact_auth_key(self):
+        scrubbed, count = redact({"AUTH": "xyz"})
+        assert scrubbed == {"AUTH": "[REDACTED]"}
+        assert count == 1
+
+    def test_suffix_matches(self):
+        for key in (
+            "MY_KEY",
+            "MY_TOKEN",
+            "MY_SECRET",
+            "MY_PASSWORD",
+            "MY_PASSPHRASE",
+            "MY_CREDENTIAL",
+        ):
+            scrubbed, count = redact({key: "v"})
+            assert scrubbed == {key: "[REDACTED]"}
+            assert count == 1
+
+    def test_unrelated_key_untouched(self):
+        scrubbed, count = redact({"name": "alice"})
+        assert scrubbed == {"name": "alice"}
+        assert count == 0
+
+
+class TestRegexScrub:
+    def test_openai_key(self):
+        scrubbed, count = redact("my key is sk-proj-abcdefghijklmnopqrstuv")
+        assert scrubbed == "my key is [REDACTED]"
+        assert count == 1
+
+    def test_openai_plain_sk(self):
+        scrubbed, count = redact("sk-abcdefghijklmnopqrstuvwx")
+        assert scrubbed == "[REDACTED]"
+        assert count == 1
+
+    def test_github_pat_positive(self):
+        token = "ghp_" + "A" * 40
+        scrubbed, count = redact(f"token={token}")
+        assert scrubbed == "token=[REDACTED]"
+        assert count == 1
+
+    def test_github_pat_too_short_negative(self):
+        scrubbed, count = redact("ghp_short")
+        assert scrubbed == "ghp_short"
+        assert count == 0
+
+    def test_github_pat_long_form(self):
+        token = "github_pat_" + "A" * 82
+        scrubbed, count = redact(token)
+        assert scrubbed == "[REDACTED]"
+        assert count == 1
+
+    def test_aws_akia(self):
+        scrubbed, count = redact("AKIAIOSFODNN7EXAMPLE")
+        assert scrubbed == "[REDACTED]"
+        assert count == 1
+
+    def test_aws_asia(self):
+        scrubbed, count = redact("ASIAIOSFODNN7EXAMPLE")
+        assert scrubbed == "[REDACTED]"
+        assert count == 1
+
+    def test_bearer(self):
+        scrubbed, count = redact("Authorization: Bearer abcdefghijklmnopqrstuvwxyz")
+        assert scrubbed == "Authorization: [REDACTED]"
+        assert count == 1
+
+    def test_slack_xoxb(self):
+        scrubbed, count = redact("xoxb-1234567890-abcdef")
+        assert scrubbed == "[REDACTED]"
+        assert count == 1
+
+    def test_matched_span_only(self):
+        scrubbed, count = redact("prefix sk-live-xxxxxxxxxxxxxxxxxxxx suffix")
+        assert scrubbed == "prefix [REDACTED] suffix"
+        assert count == 1
+
+    def test_plain_text_passthrough(self):
+        scrubbed, count = redact("hello world")
+        assert scrubbed == "hello world"
+        assert count == 0
+
+
+class TestCombined:
+    def test_mixed_key_and_regex(self):
+        obj = {
+            "API_KEY": "anything",
+            "log": "saw AKIAIOSFODNN7EXAMPLE in output",
+        }
+        scrubbed, count = redact(obj)
+        assert scrubbed == {
+            "API_KEY": "[REDACTED]",
+            "log": "saw [REDACTED] in output",
+        }
+        assert count == 2
+
+    def test_none_int_bool_untouched(self):
+        obj = {"a": None, "b": 42, "c": True, "d": 1.5}
+        scrubbed, count = redact(obj)
+        assert scrubbed == obj
+        assert count == 0
+
+    def test_input_not_mutated(self):
+        original = {
+            "API_KEY": "xyz",
+            "nested": [{"GITHUB_TOKEN": "ghp_" + "A" * 40}],
+            "msg": "Bearer abcdefghijklmnopqrstuvwxyz",
+        }
+        snapshot = copy.deepcopy(original)
+        scrubbed, count = redact(original)
+        assert original == snapshot
+        assert scrubbed != original
+        assert count == 3
+
+    def test_count_zero_when_no_matches(self):
+        scrubbed, count = redact({"name": "alice", "msg": "hello"})
+        assert count == 0
+        assert scrubbed == {"name": "alice", "msg": "hello"}
+
+    def test_deeply_nested(self):
+        obj = {"a": {"b": {"c": [{"DB_PASSWORD": "p"}]}}}
+        scrubbed, count = redact(obj)
+        assert scrubbed == {"a": {"b": {"c": [{"DB_PASSWORD": "[REDACTED]"}]}}}
+        assert count == 1
+
+    def test_non_string_dict_key(self):
+        # non-string keys (e.g. ints) must not crash the key check
+        scrubbed, count = redact({1: "plain", 2: "AKIAIOSFODNN7EXAMPLE"})
+        assert scrubbed == {1: "plain", 2: "[REDACTED]"}
+        assert count == 1
+
+    def test_tuple_treated_like_list(self):
+        # tuples are JSON-compatible via json module only as lists, but
+        # redact should still handle them by walking elements.
+        scrubbed, count = redact(("hello", {"API_KEY": "v"}))
+        assert count == 1
+        # returned structure need not preserve tuple type; list is fine
+        assert scrubbed[1] == {"API_KEY": "[REDACTED]"}


### PR DESCRIPTION
## Summary
Super plan for #26 — capture execution transcripts for root-cause analysis.

**Phase:** detailing (awaiting approval)
**Stories:** 8 implementation + Quality Gate + Patterns & Memory
**Decisions:** 12 decisions captured (DEC-001 … DEC-012)

## Key finding
Much of #26 is already done incidentally by #21 + #22. `runner.py` already invokes `claude -p --output-format stream-json --verbose` and `cli.py::_write_run_dir` already persists `iteration-N/<skill>/run-K/output.jsonl` on every grade run. The remaining work is: **redaction, assertion→transcript cross-refs, `-v` slice printer, `cmd_validate` workspace extension, schema contract docs.**

## Plan document
See `plans/super/26-execution-transcripts.md`.

## Next steps
- Review plan in this PR
- Approve → run Ralph against the devolved beads graph