### PR TITLE
clauditor-0bo: Expose blind_compare via pytest plugin

### DIFF
--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -1,12 +1,18 @@
-# Rule: Split pure compute from I/O for schema-versioned sidecars
+# Rule: Split pure compute from I/O, keep wrappers thin
 
-When adding a new per-iteration JSON sidecar, put the aggregation logic
-in a **pure function** that returns a dataclass, and let the CLI caller
-handle `to_json()` + `write_text()`. Do NOT bundle "run + grade +
-serialize + write" inside one helper. The split is small discipline
-with outsized payoff: it makes the compute unit-testable without a
-tmp_path, keeps staging-dir ownership at one call site, and puts
-`schema_version` in exactly one place.
+When adding new logic that combines spec/config resolution with a
+side-effectful call (JSON serialization, an LLM request, a subprocess,
+an HTTP fetch), put the **resolution + composition** in a pure
+function and let callers handle the I/O. Do NOT bundle "load +
+resolve + call + serialize + write" inside one helper. The split is
+small discipline with outsized payoff: the pure function is
+unit-testable without fixtures, stays reusable from multiple call
+sites, and moves each I/O concern to exactly one line at the call
+site.
+
+Originally codified for schema-versioned JSON sidecars (see first
+canonical implementation), the pattern generalizes to any pure
+resolve-and-compose helper that has more than one downstream caller.
 
 ## The pattern
 
@@ -55,11 +61,22 @@ benchmark = compute_benchmark(...)                              # pure
 - **`schema_version` in one place**: the dataclass's `to_json()` is
   the only writer. A bundled helper tempts the author to emit the
   version inline at each call site, where drift goes unnoticed.
-- **Composability**: downstream code (audit, compare, future
-  dashboards) can call `compute_benchmark` directly against objects
-  already loaded into memory, without re-reading files.
+- **Composability across dissimilar callers**: the same pure function
+  can be consumed from a CLI (where the caller also does file I/O,
+  stderr printing, and exit-code mapping) AND from a pytest fixture
+  (where the caller wraps the async function in `asyncio.run` and
+  returns the result to a sync test). Neither caller has to duplicate
+  the resolution logic; both inherit future resolution changes for
+  free.
+- **One place enforces referential drift detection**: if a future
+  ticket adds a new field to the spec (e.g. `EvalSpec.user_prompt`),
+  only the pure helper needs to learn about it. Every caller picks it
+  up automatically. A bundled "resolve in-line at each call site"
+  approach invites divergence the next time resolution rules change.
 
-## Canonical implementation
+## Canonical implementations
+
+### First anchor (sidecar aggregation)
 
 `src/clauditor/benchmark.py::compute_benchmark` + `Benchmark.to_json`
 — pure aggregation, dataclass holds schema version. Caller:
@@ -67,15 +84,48 @@ benchmark = compute_benchmark(...)                              # pure
 `compute_benchmark(`) — two lines inside the staging block, one for
 compute and one for write, just before `workspace.finalize()`.
 
-Contrast with the older `_run_baseline_phase` shape in the same file,
-which does "run + grade + write `baseline_*.json`" internally. That
-pattern predates this rule and is grandfathered; do NOT copy it for
-new sidecars.
+### Second anchor (shared resolution between CLI and pytest fixture)
+
+`src/clauditor/quality_grader.py::blind_compare_from_spec` — pure
+async helper that takes a `SkillSpec` + two pre-loaded output strings
+and resolves `user_prompt`, `rubric_hint`, and the grading `model`
+from the spec before awaiting `blind_compare`. Two callers:
+
+- `src/clauditor/cli.py::_run_blind_compare` — file I/O, stderr
+  progress print, `ValueError` → exit-2 + stderr `ERROR:` mapping,
+  `_print_blind_report`. All the I/O concerns live in this one
+  function.
+- `src/clauditor/pytest_plugin.py::clauditor_blind_compare` — sync
+  fixture factory. Loads the spec via `clauditor_spec`, calls
+  `asyncio.run(blind_compare_from_spec(...))`, returns a `BlindReport`.
+  No file I/O; the test provides the output strings directly.
+
+Before the extraction (pre-#clauditor-0bo), the CLI had 15 lines of
+inline `spec.eval_spec.test_args` / `grading_criteria` / `grading_model`
+resolution that would have had to be duplicated verbatim in the
+fixture — with no mechanism to keep them in lockstep. The extracted
+helper eliminates that drift risk and makes the next ticket
+(`clauditor-iag`, add `EvalSpec.user_prompt`) a single-file change
+that both callers pick up automatically.
+
+## Grandfathered counter-example
+
+`src/clauditor/cli.py::_run_baseline_phase` does "run + grade + write
+`baseline_*.json`" internally. That pattern predates this rule and is
+grandfathered; do NOT copy it for new resolve-and-compose helpers.
 
 ## When this rule applies
 
-Any new per-iteration JSON sidecar whose shape is computed from
-already-collected run data (reports, results, assertion counts,
-trigger verdicts). If the "computation" is really just a subprocess
-invocation whose stdout you pipe to disk, this split doesn't apply —
-there's no pure function to extract.
+Any new code that combines spec/config resolution with a
+side-effectful call (JSON serialization, LLM request, subprocess,
+HTTP fetch) AND either (a) will have more than one caller, (b)
+produces a sidecar whose shape needs a schema version, or (c) has
+non-trivial resolution logic that would otherwise be duplicated.
+
+## When this rule does NOT apply
+
+If the "computation" is really just a subprocess invocation whose
+stdout you pipe straight to disk, there's no pure function to
+extract — leave it as a single helper. If the code is a one-off CLI
+command with no reusable resolution logic, inlining is fine; don't
+invent a second caller just to satisfy the rule.

--- a/.claude/rules/pytester-inprocess-coverage-hazard.md
+++ b/.claude/rules/pytester-inprocess-coverage-hazard.md
@@ -1,0 +1,106 @@
+# Rule: Don't patch imported modules inside `pytester.runpytest_inprocess` under coverage
+
+Using `pytester.runpytest_inprocess` inside a `pytest --cov=clauditor`
+run is **safe by itself** — the canonical
+`tests/test_pytest_plugin.py::TestClauditorSpecInputFiles::test_input_files_copied_to_cwd`
+uses it successfully. But once the inner test starts calling
+`unittest.mock.patch("some.module.name", ...)` on a target that the
+outer coverage session has already instrumented, the combination
+triggers intermittent segfaults in **unrelated** test files
+(argparse init, random mock entrypoints, dynamic imports from
+`pkgutil.resolve_name`). The crashes are order-dependent, hard to
+reproduce, and do not mention the pytester test in their traceback.
+
+## The trap
+
+```python
+def test_clauditor_blind_compare_via_pytester_injection(self, pytester):
+    # ... write a fake skill + eval spec file ...
+    pytester.makepyfile("""
+        from unittest.mock import AsyncMock, patch
+
+        def test_uses_fixture(clauditor_blind_compare):
+            # DANGEROUS: patching a module the outer --cov session is
+            # already instrumenting.
+            with patch(
+                "clauditor.quality_grader.blind_compare",
+                new=AsyncMock(return_value=canned),
+            ):
+                result = clauditor_blind_compare(skill, "a", "b")
+            assert result.preference == "a"
+    """)
+    # Launches a second pytest session inside the already-coverage-hooked
+    # outer session. The inner `patch(...)` above corrupts module-cache
+    # or argparse state in a way that surfaces as a segfault later, in
+    # a completely different test file.
+    result = pytester.runpytest_inprocess("-v")
+    result.assert_outcomes(passed=1)
+```
+
+The symptoms that tell you this is what's happening:
+
+- `pytest` (no `--cov`) passes cleanly.
+- `pytest --cov=<pkg>` passes cleanly after **deselecting** the
+  pytester test.
+- `pytest --cov=<pkg>` with the pytester test present segfaults in
+  an **unrelated** test file. The crash site moves between runs.
+- Tracebacks mention `argparse._get_optional_kwargs`,
+  `unittest/mock.py:__enter__`, or
+  `pkgutil.resolve_name`/`importlib.import_module`.
+
+## Safe alternatives
+
+If you need end-to-end fixture-wiring coverage, pick one:
+
+1. **Inner test that does NOT patch anything** — just verify the
+   fixture is injected and callable:
+   ```python
+   pytester.makepyfile("""
+       def test_fixture_is_callable(clauditor_blind_compare):
+           assert callable(clauditor_blind_compare)
+   """)
+   ```
+   Combined with a direct `__wrapped__` call test for the factory
+   body, you get both "the decoration works" and "the body works"
+   coverage without the coverage-session hazard.
+
+2. **`pytester.runpytest` (subprocess mode)** — spawns a fresh Python
+   process that does NOT inherit the outer coverage hooks. The inner
+   test can freely `mock.patch` anything. Trade-off: slower (~1-2s
+   per test instead of milliseconds) and can't share in-memory
+   fixtures, but segfault-proof.
+
+3. **Trust `__wrapped__` direct calls** — for simple fixture
+   factories, calling `my_fixture.__wrapped__(request, ...)` with a
+   `MagicMock` request covers the factory body. It does NOT cover
+   the `@pytest.fixture` decoration or request wiring, but for
+   low-risk fixtures that gap is acceptable.
+
+## The safe-vs-unsafe distinguishing factor
+
+**The mock.patch call is the trigger, not `runpytest_inprocess`
+itself.**
+`TestClauditorSpecInputFiles::test_input_files_copied_to_cwd` uses
+`runpytest_inprocess` without any inner patching and runs cleanly
+under `--cov`. Do not read this rule as "never use
+`runpytest_inprocess`" — read it as "never combine
+`runpytest_inprocess` + `--cov` + `mock.patch` on an
+already-imported module."
+
+## Canonical implementation
+
+- The hazard was discovered and removed in commit `925fa63`
+  (`clauditor-5x5.4: Remove pytester integration test — coverage
+  segfault`) after being introduced in commit `dc96c17`
+  (`clauditor-5x5.4: Quality gate — fix findings from code review +
+  CodeRabbit`).
+- Safe reference use of `runpytest_inprocess` without inner
+  patching:
+  `tests/test_pytest_plugin.py::TestClauditorSpecInputFiles::test_input_files_copied_to_cwd`.
+
+## When this rule applies
+
+Any time you're tempted to write a pytester-based integration test
+that patches `clauditor.*` (or any module the outer `--cov=clauditor`
+run is tracking). If your inner test needs a mock, use subprocess
+mode or drop back to `__wrapped__` direct calls.

--- a/plans/super/clauditor-0bo-pytest-blind-compare.md
+++ b/plans/super/clauditor-0bo-pytest-blind-compare.md
@@ -1,0 +1,543 @@
+# Super Plan: clauditor-0bo — Expose `blind_compare` via pytest plugin
+
+## Meta
+- **Ticket:** `clauditor-0bo` (beads) — #24 follow-up
+- **Branch:** `feature/pytest-blind-compare`
+- **Worktree:** `worktrees/clauditor/feature/pytest-blind-compare`
+- **Phase:** `detailing`
+- **PR:** (not yet opened)
+- **Priority:** P3
+- **Sessions:** 1
+- **Last session:** 2026-04-15
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Add a pytest fixture in `src/clauditor/pytest_plugin.py` that exposes
+`blind_compare` (the blind A/B judge from #24) so eval tests can invoke it
+inline on captured skill outputs. The fixture should use the same spec /
+user_prompt resolution semantics as the existing CLI path (`clauditor compare
+--blind`).
+
+**Why:** Today the blind judge is reachable **only** from the CLI. Test
+authors who want to assert "version B is preferred over version A" on
+captured outputs have to shell out to the CLI or duplicate the CLI's
+resolution logic in their conftest. A first-class fixture closes that
+gap in ~80 LOC.
+
+**Scope (narrow, P3):** 1 new fixture + 1 shared helper to avoid
+duplicating the CLI's resolution logic + tests. No new JSON sidecars, no
+new LLM prompts, no schema changes. The sibling bead `clauditor-iag`
+(add `EvalSpec.user_prompt`) is **explicitly out of scope** — the fixture
+inherits whatever resolution the CLI does today (read `test_args`) and
+will pick up the future `user_prompt` field automatically when `iag`
+lands.
+
+### Codebase Findings
+
+**`blind_compare` signature** (`src/clauditor/quality_grader.py:289-490`):
+```python
+async def blind_compare(
+    user_prompt: str,
+    output_a: str,
+    output_b: str,
+    rubric_hint: str | None = None,
+    *,
+    model: str = DEFAULT_GRADING_MODEL,
+    rng: random.Random | None = None,
+) -> BlindReport:
+```
+Pure string-in, `BlindReport` out. No file I/O, no SkillSpec awareness —
+callers resolve everything and hand in pre-loaded strings. `BlindReport`
+is defined at `quality_grader.py:170-187` with fields `preference`,
+`confidence`, `score_a`, `score_b`, `reasoning`, `model`,
+`position_agreement`, `input_tokens`, `output_tokens`,
+`duration_seconds`.
+
+**Prompt-injection hardening** (`quality_grader.py:207-257`):
+`build_blind_prompt` already wraps untrusted outputs in XML-like fences
+per `.claude/rules/llm-judge-prompt-injection.md`. The fixture reuses it
+unchanged; nothing new to harden.
+
+**`_monotonic` indirection** (`quality_grader.py:27`) is in place and
+used at lines 348, 373, 377, 439, 477 per
+`.claude/rules/monotonic-time-indirection.md`. Do not break it.
+
+**CLI call site** (`src/clauditor/cli.py:1298-1379`,
+`_run_blind_compare`). This is the canonical resolution path and is
+load-bearing for what "same semantics" means:
+
+- **user_prompt** is sourced from `skill_spec.eval_spec.test_args or ""`
+  at `cli.py:1320`. There is no separate `--user-prompt` CLI flag today.
+- **rubric_hint** is built from `grading_criteria` by joining criterion
+  text with newlines at `cli.py:1329-1335`, passed as the `rubric_hint`
+  param.
+- **Call:** `asyncio.run(blind_compare(user_prompt, output_a, output_b,
+  rubric_hint, model=model))` at `cli.py:1369-1377`.
+
+The fixture must replicate this resolution byte-for-byte or extract a
+shared helper and call it from both sites (recommended — see DEC-001
+below).
+
+**Existing plugin fixtures** (`src/clauditor/pytest_plugin.py`):
+- `clauditor_runner` (line 86) — `SkillRunner` instance
+- `clauditor_spec` (line 96) — factory `(skill_path, eval_path=None) -> SkillSpec`
+- `clauditor_grader` (line 139) — **exact template for this bead**. Factory
+  signature: `_factory(skill_path, eval_path=None, output=None) -> GradingReport`.
+  Wraps `asyncio.run()` to present a sync surface. Lines 147-160 are the
+  pattern to mirror.
+- `clauditor_capture` (line 164) — factory returning paths to captured outputs
+- `clauditor_triggers` (line 192) — factory for trigger testing
+
+**Reserved fixture names** (`tests/conftest.py:5`): plugin-owned fixtures
+that tests must not shadow. The new fixture name must be added to this
+reserved list.
+
+**Async pattern** (`pyproject.toml:62` — `asyncio_mode = "strict"`): plugin
+fixtures present a sync surface by calling `asyncio.run(...)` internally.
+The test function itself does NOT need `@pytest.mark.asyncio` to use the
+new fixture. Existing async blind-compare tests
+(`tests/test_quality_grader.py:1332+`) use `@pytest.mark.asyncio` and
+`await blind_compare(...)` directly — those are for unit-testing
+`blind_compare` itself, not for the new fixture.
+
+**Test shape precedent** (`tests/test_pytest_plugin.py`): the existing
+plugin tests patch `anthropic.AsyncAnthropic` with a mock client, mock
+the Anthropic response content, and assert on the returned dataclass.
+The new fixture tests follow the same shape.
+
+**`EvalSpec.user_prompt`**: NOT present today. Grep on `schemas.py:128-150`
+and `spec.py` confirms. The sibling bead `clauditor-iag` will add it
+later. Resolution today is via `EvalSpec.test_args` (`schemas.py:136`).
+
+### Rules Scan (applies to this feature)
+
+- **monotonic-time-indirection** — MAYBE. `blind_compare` already uses
+  the `_monotonic` alias. The new helper must not introduce a direct
+  `time.monotonic()` call.
+- **mock-side-effect-for-distinct-calls** — MAYBE. Fixture tests that
+  exercise multiple comparison calls in one test function should use
+  `side_effect=[...]` not `return_value`, per the rule added in #28
+  US-007.
+- **pure-compute-vs-io-split** — APPLIES. The new shared helper is a
+  pure function (takes spec + two strings, returns a `BlindReport`);
+  the CLI and the fixture are its only callers. Exactly the shape the
+  rule describes.
+- **llm-judge-prompt-injection** — N/A. Reuses `build_blind_prompt`
+  unchanged.
+- All other rules: N/A (no new JSON sidecars, no new subprocess
+  wrappers, no new path validation, no schema changes).
+
+No `plans/super/workflow-project.md`.
+
+### Proposed Scope
+
+Three options:
+
+- **(A) Direct fixture** — New `clauditor_blind_compare` fixture that
+  loads spec, extracts `test_args` + `grading_criteria` inline, calls
+  `blind_compare` via `asyncio.run()`. Duplicates ~15 lines of CLI
+  resolution logic. Fastest (~30 LOC) but introduces drift risk: if the
+  CLI later changes resolution (e.g. `iag` adds `user_prompt`), the
+  fixture must be kept in lockstep.
+- **(B) Extract shared helper + new fixture** *(my rec)* — Extract a
+  new `blind_compare_from_spec(spec, output_a, output_b, *, model=...)`
+  function in `src/clauditor/quality_grader.py`. `_run_blind_compare`
+  in `cli.py` becomes a thin wrapper over it; the fixture is another
+  thin wrapper. Both call sites pick up future `user_prompt` field
+  changes for free.
+- **(C) Refactor `_run_blind_compare`** — Move resolution logic into
+  the new helper and delete the duplication from cli.py. Same outcome
+  as (B), but requires touching cli.py's existing function more
+  aggressively.
+
+(B) and (C) are almost identical. (B) leaves cli.py's `_run_blind_compare`
+mostly intact as a backwards-compatible wrapper. (C) rewrites it. Either
+way the fixture is ~30 LOC and the helper is ~40 LOC.
+
+**Out of scope:**
+
+- Adding `EvalSpec.user_prompt` (that's `clauditor-iag`).
+- Exposing `grade_quality` or `compute_benchmark` as fixtures (separate
+  follow-ups if anyone asks).
+- Exposing the assertions-based diff (`diff_assertion_sets`) as a
+  fixture (not requested, different use case).
+- A CLI flag to print a single-file blind judgment (this ticket is
+  strictly about the pytest surface).
+
+### Scoping Questions
+
+**Q1 — Shared helper vs direct fixture?**
+- (A) Direct fixture, duplicated resolution (~30 LOC total)
+- (B) New `blind_compare_from_spec` helper, CLI becomes thin wrapper,
+  fixture calls helper *(my rec — matches `pure-compute-vs-io-split`
+  rule)*
+- (C) Aggressive refactor of `_run_blind_compare` to delete the
+  duplication entirely
+
+**Q2 — What does the fixture's factory signature look like?**
+- (A) `clauditor_blind_compare(skill_path, output_a, output_b,
+  eval_path=None, *, model=None) -> BlindReport` — caller provides the
+  two output strings directly *(my rec — flexible, mirrors
+  `clauditor_grader`)*
+- (B) `clauditor_blind_compare(skill_path, before_path, after_path,
+  eval_path=None) -> BlindReport` — caller provides file paths and the
+  fixture reads them (mirrors the CLI)
+- (C) Both: overload to accept strings OR paths (complex, unclear
+  dispatch)
+
+**Q3 — Should the fixture accept overrides beyond the spec?**
+- (A) No — always resolve from spec. Tests that need a different user
+  prompt or rubric mock `blind_compare` directly with
+  `@patch`. *(my rec — keeps the fixture simple, matches
+  `clauditor_grader`)*
+- (B) Yes — expose `user_prompt_override` and `rubric_override` kwargs
+  for tests that want to vary inputs without mocking
+
+**Q4 — Where do the fixture tests live?**
+- (A) `tests/test_pytest_plugin.py` (alongside existing plugin fixture
+  tests) *(my rec)*
+- (B) New `tests/test_pytest_plugin_blind_compare.py`
+
+**Q5 — Does `_run_blind_compare` in cli.py get refactored, or left
+alone as-is with duplicated resolution?**
+- (A) **Refactor it to call the new shared helper** so CLI and fixture
+  share one code path *(my rec)*
+- (B) Leave it alone; both sites resolve independently and we accept
+  the drift risk
+
+---
+
+## Architecture Review
+
+### Ratings (collapsed — narrow P3 scope, ~80 LOC)
+
+| Area | Rating | Headline |
+|---|---|---|
+| Security | pass | No new untrusted input path; `build_blind_prompt`'s XML-fence hardening is reused unchanged |
+| Performance | pass | Fixture does one `blind_compare` call per test invocation (same as CLI); no N+1 or unbounded loops |
+| Data model | pass | No new fields, no schema changes; consumes existing `EvalSpec.test_args` + `grading_criteria` + `grading_model` |
+| API design | pass | `blind_compare_from_spec(spec, output_a, output_b, *, model=None, rng=None) -> BlindReport` matches `pure-compute-vs-io-split` rule |
+| Observability | concern | CLI prints a `"Running blind A/B judge..."` progress line to stderr. Should the fixture echo it? Answer below. |
+| Testing strategy | pass | `clauditor_grader` is the exact template; existing async-blind tests in `test_quality_grader.py:1332+` show the mocking pattern |
+| Rule compliance | pass | `pure-compute-vs-io-split` APPLIES (helper is pure; CLI + fixture are thin wrappers); `monotonic-time-indirection` preserved; `mock-side-effect-for-distinct-calls` noted for test authoring |
+
+### Decisions (Phase 3)
+
+- **DEC-001 — Extract `blind_compare_from_spec(spec, output_a, output_b, *, model=None, rng=None) -> BlindReport`** in
+  `src/clauditor/quality_grader.py`, alongside the existing
+  `blind_compare`. The helper:
+  1. Raises `ValueError` if `spec.eval_spec is None`.
+  2. Raises `ValueError` if `spec.eval_spec.test_args` is empty or
+     whitespace-only (mirrors the CLI's exit-2 check at `cli.py:1321-1327`).
+  3. Extracts `user_prompt = spec.eval_spec.test_args`.
+  4. Builds `rubric_hint` from `spec.eval_spec.grading_criteria` using
+     the exact same `"\n".join(f"- {criterion_text(c)}" for c in criteria)`
+     pattern as `cli.py:1333-1335`. `None` when no criteria.
+  5. Resolves `effective_model = model or spec.eval_spec.grading_model`.
+     (Allow the caller to override the spec's model — the fixture may
+     want a different model for a given test.)
+  6. Awaits `blind_compare(user_prompt, output_a, output_b, rubric_hint,
+     model=effective_model, rng=rng)`.
+  7. Returns the `BlindReport`.
+
+  This is the authoritative resolution path. The CLI and the fixture
+  are both thin wrappers over it. Future `EvalSpec.user_prompt` work
+  (sibling bead `clauditor-iag`) will flow through this one function
+  and both callers pick it up automatically.
+
+- **DEC-002 — Refactor `cli.py::_run_blind_compare` to call the new
+  helper** (Q5=A). The CLI keeps file existence/UTF-8 validation and
+  the stderr progress print and the `_print_blind_report` call; the
+  inner spec/test_args/rubric/model resolution is deleted and replaced
+  with a single `asyncio.run(blind_compare_from_spec(...))`. `ValueError`
+  from the helper maps to `exit 2 + stderr ERROR`. Preserves every
+  existing exit-code path in the CLI's blind-compare flow.
+
+- **DEC-003 — New fixture named `clauditor_blind_compare`** in
+  `src/clauditor/pytest_plugin.py`. Factory signature (Q2=A):
+  ```python
+  def _factory(
+      skill_path: str | Path,
+      output_a: str,
+      output_b: str,
+      eval_path: str | Path | None = None,
+      *,
+      model: str | None = None,
+  ) -> BlindReport: ...
+  ```
+  Inside: loads spec via `SkillSpec.from_file(str(skill_path),
+  eval_path=eval_path)`, calls
+  `asyncio.run(blind_compare_from_spec(spec, output_a, output_b,
+  model=model))`, returns the `BlindReport`. No override kwargs beyond
+  the spec (Q3=A). Caller passes strings directly — the fixture does
+  NOT read files on the caller's behalf.
+
+- **DEC-004 — Fixture name added to reserved list** in
+  `tests/conftest.py:5`. Tests must not shadow `clauditor_blind_compare`.
+
+- **DEC-005 — Fixture tests live in `tests/test_pytest_plugin.py`**
+  (Q4=A) alongside the existing plugin fixture tests. Match the
+  existing `TestClauditorGrader`-style class naming.
+
+- **DEC-006 — Fixture does NOT echo the CLI's progress line to
+  stderr.** The CLI's `"Running blind A/B judge..."` message is
+  informational for interactive use; in tests it would pollute pytest
+  output. The helper stays silent; only the CLI wrapper prints. The
+  Observability concern resolves here.
+
+### Blockers
+
+None.
+
+---
+
+## Refinement Log
+
+Decisions captured above in the Architecture Review section (DEC-001
+through DEC-006). All scoping questions resolved with the user's
+"B, A, A, A, A" choice.
+
+### Session notes
+
+- Scope is narrow and mechanical — the fix is mostly "move 15 lines
+  from `cli.py:1312-1335` into a new helper in `quality_grader.py`"
+  plus "add a ~20-line factory fixture that calls it".
+- The parent #24 plan (`plans/super/24-blind-ab-judge.md`) is worth
+  consulting for `blind_compare`'s position-swap randomization +
+  `rng` parameter semantics.
+- Existing CLI tests at `tests/test_cli.py:2923-3087` mock
+  `clauditor.quality_grader.blind_compare` directly. After the
+  refactor these still work because `blind_compare_from_spec` calls
+  `blind_compare` under the hood — the mock target stays valid.
+
+---
+
+## Detailed Breakdown
+
+### US-001 — Add `blind_compare_from_spec` helper
+
+**Description:** New pure async helper in
+`src/clauditor/quality_grader.py` that takes a `SkillSpec` and two
+pre-loaded output strings, resolves `user_prompt` / `rubric_hint` /
+`model` from the spec exactly as the CLI does today, and awaits
+`blind_compare`. Pure logic — no file I/O, no stdout/stderr prints.
+
+**Traces to:** DEC-001, DEC-006.
+
+**TDD — write these in `tests/test_quality_grader.py` first** (match
+the existing `TestBlindCompare` class style):
+
+1. **Happy path** — build a `SkillSpec` with `test_args="What's the
+   best sushi in Tokyo?"`, `grading_criteria=[c1, c2]`, and a stubbed
+   `grading_model`. Mock `blind_compare` with `AsyncMock` and capture
+   its call kwargs. Call `await blind_compare_from_spec(spec, "A",
+   "B")`. Assert the mock was called with `user_prompt=<test_args>`,
+   `output_a="A"`, `output_b="B"`, `rubric_hint` matching the exact
+   `"- "`-prefixed join from `cli.py:1333-1335`, `model=<spec
+   grading_model>`.
+2. **`model` override** — same setup but call `blind_compare_from_spec(spec,
+   "A", "B", model="claude-opus-4-6")`. Assert the mock saw
+   `model="claude-opus-4-6"`, not the spec's model.
+3. **No `eval_spec`** — build a `SkillSpec` with `eval_spec=None`.
+   Assert `ValueError` with message naming the missing eval spec.
+4. **Empty `test_args`** — `test_args=""`. Assert `ValueError` with
+   message mentioning `test_args`.
+5. **Whitespace-only `test_args`** — `test_args="   "`. Assert
+   `ValueError` (mirrors CLI's `.strip()` check).
+6. **No `grading_criteria`** — criteria list is empty. Assert the mock
+   saw `rubric_hint=None`, not `""` or an empty join.
+7. **`rng` pass-through** — pass `rng=random.Random(42)`, assert the
+   mock saw that same object.
+
+**Acceptance criteria:**
+- `blind_compare_from_spec` exists in `src/clauditor/quality_grader.py`
+  with the signature `(spec: SkillSpec, output_a: str, output_b: str,
+  *, model: str | None = None, rng: random.Random | None = None) -> BlindReport`.
+- Raises `ValueError` on missing `eval_spec`, empty `test_args`.
+- Rubric hint computation matches `cli.py:1333-1335` byte-for-byte
+  (uses `schemas.criterion_text`).
+- Model resolution: explicit `model` kwarg wins; else
+  `spec.eval_spec.grading_model`.
+- All 7 TDD cases pass.
+- `uv run ruff check src/ tests/` clean.
+
+**Done when:** Tests green; helper importable; no caller has been
+updated yet.
+
+**Files:**
+- MODIFY `src/clauditor/quality_grader.py` — add helper + import
+- MODIFY `tests/test_quality_grader.py` — add `TestBlindCompareFromSpec` class
+
+**Depends on:** none.
+
+---
+
+### US-002 — Refactor `_run_blind_compare` to use the helper
+
+**Description:** In `src/clauditor/cli.py::_run_blind_compare`
+(`cli.py:1298-1379`), delete the inline spec/test_args/rubric/model
+resolution (lines 1312-1335 + 1364) and replace with a single
+`asyncio.run(blind_compare_from_spec(...))` call. Keep everything else
+(file existence check, UTF-8 decoding, stderr progress print,
+`_print_blind_report`, exit-code mapping). Map `ValueError` from the
+helper to `exit 2 + ERROR:` stderr.
+
+**Traces to:** DEC-002.
+
+**Acceptance criteria:**
+- `_run_blind_compare` no longer reads `test_args`, builds
+  `rubric_hint`, or reads `grading_model` directly — all of that
+  happens inside the helper.
+- `SkillSpec.from_file` load still happens in `_run_blind_compare`
+  (the fixture loads its own spec separately).
+- File existence + UTF-8 decoding error paths preserved exactly
+  (still exit 2 with same stderr text).
+- `ValueError` from the helper is caught and mapped to `exit 2` +
+  stderr `ERROR: <ValueError message>`.
+- Stderr progress print (`Running blind A/B judge ({model})...`)
+  still emitted from the CLI wrapper, NOT the helper (DEC-006). The
+  model value is read from `spec.eval_spec.grading_model` for the
+  print line (the helper resolves it again internally — a tiny
+  duplication, acceptable because the CLI wants the printed model
+  and the helper wants the effective model).
+- All existing `tests/test_cli.py::TestCompareBlind` (or wherever
+  blind-compare CLI tests live, `test_cli.py:2923-3087`) tests still
+  pass unchanged — they mock `clauditor.quality_grader.blind_compare`
+  which is still called from the helper's body.
+- Full gate clean.
+
+**Done when:** `git diff cli.py` shows a net-negative line count in
+`_run_blind_compare` with one new `asyncio.run(blind_compare_from_spec(...))`
+call; all existing CLI tests still pass.
+
+**Files:**
+- MODIFY `src/clauditor/cli.py` — `_run_blind_compare` body
+
+**Depends on:** US-001.
+
+---
+
+### US-003 — Add `clauditor_blind_compare` pytest fixture
+
+**Description:** New factory fixture in
+`src/clauditor/pytest_plugin.py`. Sync surface that wraps
+`asyncio.run(blind_compare_from_spec(...))`. Loads spec via
+`SkillSpec.from_file(str(skill_path), eval_path=eval_path)`. Caller
+provides the two output strings directly.
+
+**Traces to:** DEC-003, DEC-004, DEC-005.
+
+**TDD — write these in `tests/test_pytest_plugin.py` first** (new
+`TestClauditorBlindCompare` class):
+
+1. **Happy path** — write a minimal skill + eval spec fixture with
+   `test_args` and `grading_criteria` populated. Mock
+   `clauditor.quality_grader.blind_compare` via `AsyncMock` returning
+   a canned `BlindReport` with `preference="a"`, `confidence=0.8`.
+   Call `clauditor_blind_compare(skill_path, "output A", "output B")`.
+   Assert the returned `BlindReport` equals the canned one. Assert
+   the mock was called once with `output_a="output A"`,
+   `output_b="output B"`, rubric matching the spec's criteria.
+2. **`eval_path` override** — supply a separate `eval_path` arg.
+   Assert `SkillSpec.from_file` was called with that path.
+3. **`model` override** — pass `model="claude-opus-4-6"`. Assert the
+   mock saw that model.
+4. **Missing `test_args` propagates `ValueError`** — build a spec
+   with `test_args=""`. Assert `pytest.raises(ValueError)` when the
+   factory is called.
+5. **Reserved fixture name** — assert the new fixture name appears in
+   `tests/conftest.py`'s reserved-names comment/list (if that's
+   enforced structurally somewhere, otherwise this is a doc-level
+   check only).
+
+**Acceptance criteria:**
+- Fixture `clauditor_blind_compare` exists in
+  `src/clauditor/pytest_plugin.py`, pattern matches
+  `clauditor_grader` at `pytest_plugin.py:139-160`.
+- Fixture name added to the reserved list in `tests/conftest.py:5`.
+- Factory signature:
+  `(skill_path: str | Path, output_a: str, output_b: str, eval_path: str | Path | None = None, *, model: str | None = None) -> BlindReport`.
+- Sync — caller does NOT need `@pytest.mark.asyncio` on the test
+  function.
+- All 5 TDD cases pass.
+- Existing plugin fixtures still work unchanged; `pytest` full run
+  green.
+- Full gate clean.
+
+**Done when:** `clauditor_blind_compare` is discoverable by pytest
+and a new test uses it successfully to compare two strings.
+
+**Files:**
+- MODIFY `src/clauditor/pytest_plugin.py` — add fixture
+- MODIFY `tests/conftest.py` — add to reserved list
+- MODIFY `tests/test_pytest_plugin.py` — add `TestClauditorBlindCompare`
+
+**Depends on:** US-001 (the helper must exist before the fixture can
+call it). US-002 is independent and can land in either order, but
+US-002 → US-003 is the cleanest sequence.
+
+---
+
+### US-004 — Quality Gate
+
+**Description:** Run the code-reviewer subagent 4× across the
+changeset, fix all real bugs each pass. Run CodeRabbit local review.
+Run CodeRabbit via PR comment if/after the PR opens. Validate full
+gate.
+
+**Acceptance criteria:**
+- 4 code-reviewer passes; each pass's findings fixed or documented as
+  false positives.
+- CodeRabbit local review clean (or findings addressed).
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+  with ≥80% coverage gate.
+- Manual smoke test: write a tiny eval test that uses the new fixture,
+  run it, verify the `BlindReport` shape.
+
+**Depends on:** US-003.
+
+---
+
+### US-005 — Patterns & Memory
+
+**Description:** Harvest anything new learned. Candidate: the
+"refactor CLI inline resolution into a shared pure helper that both
+CLI and plugin fixture call" pattern is already covered by
+`.claude/rules/pure-compute-vs-io-split.md` (added in #28 US-007).
+This ticket is a **canonical application** of that rule, so the rule
+may benefit from a second `file:line` anchor pointing at
+`blind_compare_from_spec` as another example.
+
+**Acceptance criteria:**
+- If the refactor produced a cleaner shape than the rule currently
+  describes, update `.claude/rules/pure-compute-vs-io-split.md` with
+  an additional anchor.
+- Plan doc Meta.Phase → `implemented`; PR link filled in.
+- Any surprising insight stored via `bd remember`.
+
+**Depends on:** US-004.
+
+---
+
+### Estimate summary
+
+| Story | LOC (approx) | Risk |
+|---|---|---|
+| US-001 helper + 7 tests | ~130 | low (pure logic) |
+| US-002 refactor CLI | ~-20 net | low (existing tests guard the behavior) |
+| US-003 fixture + 5 tests | ~100 | low |
+| US-004 Quality Gate | 0 code | low |
+| US-005 Patterns & Memory | ~20 | low |
+
+**Total:** ~+230 LOC / ~20 deleted / net ~+210.
+
+---
+
+## Beads Manifest
+
+*(Phase 7.)*

--- a/plans/super/clauditor-0bo-pytest-blind-compare.md
+++ b/plans/super/clauditor-0bo-pytest-blind-compare.md
@@ -4,8 +4,8 @@
 - **Ticket:** `clauditor-0bo` (beads) — #24 follow-up
 - **Branch:** `feature/pytest-blind-compare`
 - **Worktree:** `worktrees/clauditor/feature/pytest-blind-compare`
-- **Phase:** `detailing`
-- **PR:** (not yet opened)
+- **Phase:** `implemented`
+- **PR:** https://github.com/wjduenow/clauditor/pull/38
 - **Priority:** P3
 - **Sessions:** 1
 - **Last session:** 2026-04-15
@@ -540,4 +540,40 @@ may benefit from a second `file:line` anchor pointing at
 
 ## Beads Manifest
 
-*(Phase 7.)*
+- **Epic:** `clauditor-5x5` (all children closed)
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/pytest-blind-compare`
+- **PR:** https://github.com/wjduenow/clauditor/pull/38
+
+| Task | Title | Commit |
+|---|---|---|
+| `clauditor-5x5.1` | US-001: `blind_compare_from_spec` helper + 7 TDD tests | `4c3f5a8` |
+| `clauditor-5x5.2` | US-002: refactor `_run_blind_compare` to call helper | `81c527e` |
+| `clauditor-5x5.3` | US-003: `clauditor_blind_compare` pytest fixture | `3db4a65` |
+| `clauditor-5x5.4` | Quality Gate: code review + CodeRabbit | `dc96c17`, `925fa63` |
+| `clauditor-5x5.5` | Patterns & Memory | (this commit) |
+
+## Session notes
+
+- **Quality Gate segfault incident.** During the QG fix commit
+  (`dc96c17`) a new integration test
+  `test_clauditor_blind_compare_via_pytester_injection` was added to
+  guard the fixture's pytest wiring via
+  `pytester.runpytest_inprocess`. The inner test used
+  `mock.patch("clauditor.quality_grader.blind_compare", ...)`. Under
+  `pytest --cov=clauditor`, that combination triggered
+  order-dependent segfaults in unrelated test files (argparse init,
+  `unittest.mock` entry, `pkgutil.resolve_name`). The test was
+  removed in commit `925fa63` after confirming the existing 5
+  `__wrapped__`-based tests cover the factory body adequately. The
+  lesson is codified in
+  `.claude/rules/pytester-inprocess-coverage-hazard.md`.
+- **`pure-compute-vs-io-split` second anchor.** This epic is the
+  second canonical application of the rule (first was
+  `compute_benchmark` in #28 US-007). The rule was augmented with a
+  new "Second anchor" section citing `blind_compare_from_spec` +
+  its two callers (`cli.py::_run_blind_compare` and
+  `pytest_plugin.py::clauditor_blind_compare`) to demonstrate the
+  "same pure function, dissimilar callers" compose-ability benefit
+  that `compute_benchmark` alone did not surface.
+- **Final numbers:** 1137 passing, 96.03% total coverage, ruff clean
+  on `src/` and `tests/`.

--- a/plans/super/clauditor-0bo-pytest-blind-compare.md
+++ b/plans/super/clauditor-0bo-pytest-blind-compare.md
@@ -123,9 +123,10 @@ later. Resolution today is via `EvalSpec.test_args` (`schemas.py:136`).
   `side_effect=[...]` not `return_value`, per the rule added in #28
   US-007.
 - **pure-compute-vs-io-split** — APPLIES. The new shared helper is a
-  pure function (takes spec + two strings, returns a `BlindReport`);
-  the CLI and the fixture are its only callers. Exactly the shape the
-  rule describes.
+  composition wrapper (takes spec + two strings, resolves model /
+  rubric / user_prompt with no I/O, then delegates to `blind_compare`
+  for the network call); the CLI and the fixture are its only
+  callers. Exactly the shape the rule describes.
 - **llm-judge-prompt-injection** — N/A. Reuses `build_blind_prompt`
   unchanged.
 - All other rules: N/A (no new JSON sidecars, no new subprocess
@@ -320,11 +321,13 @@ through DEC-006). All scoping questions resolved with the user's
 
 ### US-001 — Add `blind_compare_from_spec` helper
 
-**Description:** New pure async helper in
+**Description:** New composition async helper in
 `src/clauditor/quality_grader.py` that takes a `SkillSpec` and two
 pre-loaded output strings, resolves `user_prompt` / `rubric_hint` /
 `model` from the spec exactly as the CLI does today, and awaits
-`blind_compare`. Pure logic — no file I/O, no stdout/stderr prints.
+`blind_compare`. No file I/O, no stdout/stderr prints (the helper
+delegates network I/O to `blind_compare` — it is not a pure function,
+just an I/O-free resolution + LLM judge dispatch wrapper).
 
 **Traces to:** DEC-001, DEC-006.
 

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1300,39 +1300,17 @@ def _run_blind_compare(
 ) -> int:
     """Dispatch blind A/B comparison for a pair of ``.txt`` outputs.
 
-    Resolves the user-prompt context from ``EvalSpec.test_args`` and the
-    rubric hint from ``EvalSpec.grading_criteria``. Both files are read as
+    Delegates spec/test_args/rubric/model resolution to
+    :func:`blind_compare_from_spec`; this wrapper handles file I/O, stderr
+    reporting, and the ``_print_blind_report`` call. Both files are read as
     plain UTF-8. Returns 0 regardless of which side wins — blind compare is
     informational, not a pass/fail gate.
     """
     import asyncio
 
-    from clauditor.quality_grader import blind_compare
+    from clauditor.quality_grader import blind_compare_from_spec
 
     skill_spec = SkillSpec.from_file(spec_path, eval_path=eval_path)
-    if not skill_spec.eval_spec:
-        print(
-            f"ERROR: No eval spec found for {spec_path}",
-            file=sys.stderr,
-        )
-        return 2
-
-    user_prompt = skill_spec.eval_spec.test_args or ""
-    if not user_prompt.strip():
-        print(
-            "ERROR: --blind requires the eval spec's test_args field to be "
-            "set (used as the user prompt context for the judge)",
-            file=sys.stderr,
-        )
-        return 2
-
-    rubric_hint: str | None = None
-    criteria = skill_spec.eval_spec.grading_criteria
-    if criteria:
-        from clauditor.schemas import criterion_text
-        rubric_hint = "\n".join(
-            f"- {criterion_text(c)}" for c in criteria
-        )
 
     for path in (before_path, after_path):
         if not path.is_file():
@@ -1361,20 +1339,27 @@ def _run_blind_compare(
         )
         return 2
 
-    model = skill_spec.eval_spec.grading_model
-    print(
-        f"Running blind A/B judge ({model}) — 2 API calls...",
-        file=sys.stderr,
-    )
-    report = asyncio.run(
-        blind_compare(
-            user_prompt,
-            output_a,
-            output_b,
-            rubric_hint,
-            model=model,
+    # US-002: all spec/test_args/rubric/model resolution happens inside
+    # blind_compare_from_spec (shared with the pytest fixture from US-003).
+    # We read the spec's model for the stderr progress line; the helper
+    # resolves its own effective model internally.
+    try:
+        if skill_spec.eval_spec is not None:
+            print(
+                f"Running blind A/B judge ({skill_spec.eval_spec.grading_model}) "
+                "— 2 API calls...",
+                file=sys.stderr,
+            )
+        report = asyncio.run(
+            blind_compare_from_spec(
+                skill_spec,
+                output_a,
+                output_b,
+            )
         )
-    )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
     _print_blind_report(report, before_path, after_path)
     return 0
 

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1308,9 +1308,22 @@ def _run_blind_compare(
     """
     import asyncio
 
-    from clauditor.quality_grader import blind_compare_from_spec
+    from clauditor.quality_grader import (
+        blind_compare_from_spec,
+        validate_blind_compare_spec,
+    )
 
     skill_spec = SkillSpec.from_file(spec_path, eval_path=eval_path)
+
+    # Fail-fast on invalid specs BEFORE any progress messages or file I/O:
+    # the prior shape printed "Running blind A/B judge..." even when validation
+    # would immediately raise, which misled users into thinking API calls had
+    # happened.
+    try:
+        validate_blind_compare_spec(skill_spec)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     for path in (before_path, after_path):
         if not path.is_file():
@@ -1342,24 +1355,22 @@ def _run_blind_compare(
     # US-002: all spec/test_args/rubric/model resolution happens inside
     # blind_compare_from_spec (shared with the pytest fixture from US-003).
     # We read the spec's model for the stderr progress line; the helper
-    # resolves its own effective model internally.
-    try:
-        if skill_spec.eval_spec is not None:
-            print(
-                f"Running blind A/B judge ({skill_spec.eval_spec.grading_model}) "
-                "— 2 API calls...",
-                file=sys.stderr,
-            )
-        report = asyncio.run(
-            blind_compare_from_spec(
-                skill_spec,
-                output_a,
-                output_b,
-            )
+    # resolves its own effective model internally. Validation already ran
+    # above (fail-fast), so the progress message now reliably means
+    # "actual API calls are about to happen".
+    assert skill_spec.eval_spec is not None  # validate_blind_compare_spec enforced
+    print(
+        f"Running blind A/B judge ({skill_spec.eval_spec.grading_model}) "
+        "— 2 API calls...",
+        file=sys.stderr,
+    )
+    report = asyncio.run(
+        blind_compare_from_spec(
+            skill_spec,
+            output_a,
+            output_b,
         )
-    except ValueError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
+    )
     _print_blind_report(report, before_path, after_path)
     return 0
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -189,6 +189,37 @@ def clauditor_capture(request: pytest.FixtureRequest):
 
 
 @pytest.fixture
+def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
+    """Fixture factory for blind A/B comparison of two skill outputs.
+
+    Returns a callable that loads a ``SkillSpec`` from ``skill_path`` and
+    runs :func:`clauditor.quality_grader.blind_compare_from_spec` on the
+    two caller-supplied output strings. The fixture does NOT read files —
+    outputs must be passed as strings (DEC-003). Raises ``ValueError`` if
+    the spec lacks an eval spec or ``test_args`` is empty; the exception
+    is propagated untouched so tests can assert on it (DEC-006).
+    """
+    import asyncio
+
+    from clauditor.quality_grader import BlindReport, blind_compare_from_spec
+
+    def _factory(
+        skill_path: str | Path,
+        output_a: str,
+        output_b: str,
+        eval_path: str | Path | None = None,
+        *,
+        model: str | None = None,
+    ) -> BlindReport:
+        spec = clauditor_spec(skill_path, eval_path)
+        return asyncio.run(
+            blind_compare_from_spec(spec, output_a, output_b, model=model)
+        )
+
+    return _factory
+
+
+@pytest.fixture
 def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
     """Fixture factory for trigger precision testing."""
     import asyncio

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -198,6 +198,14 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
     outputs must be passed as strings. Raises ``ValueError`` if the spec
     lacks an eval spec or ``test_args`` is empty; the exception is
     propagated untouched so tests can assert on it.
+
+    Model precedence (highest → lowest):
+
+    1. Explicit ``model=`` kwarg on this factory call.
+    2. ``--clauditor-model`` pytest CLI option (matches
+       ``clauditor_grader`` / ``clauditor_triggers``).
+    3. ``spec.eval_spec.grading_model`` (resolved inside
+       :func:`blind_compare_from_spec`).
     """
     import asyncio
 
@@ -212,8 +220,11 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
         model: str | None = None,
     ) -> BlindReport:
         spec = clauditor_spec(skill_path, eval_path)
+        effective_model = model or request.config.getoption("--clauditor-model")
         return asyncio.run(
-            blind_compare_from_spec(spec, output_a, output_b, model=model)
+            blind_compare_from_spec(
+                spec, output_a, output_b, model=effective_model
+            )
         )
 
     return _factory

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -195,9 +195,9 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
     Returns a callable that loads a ``SkillSpec`` from ``skill_path`` and
     runs :func:`clauditor.quality_grader.blind_compare_from_spec` on the
     two caller-supplied output strings. The fixture does NOT read files —
-    outputs must be passed as strings (DEC-003). Raises ``ValueError`` if
-    the spec lacks an eval spec or ``test_args`` is empty; the exception
-    is propagated untouched so tests can assert on it (DEC-006).
+    outputs must be passed as strings. Raises ``ValueError`` if the spec
+    lacks an eval spec or ``test_args`` is empty; the exception is
+    propagated untouched so tests can assert on it.
     """
     import asyncio
 

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -490,6 +490,58 @@ async def blind_compare(
     )
 
 
+async def blind_compare_from_spec(
+    spec: SkillSpec,
+    output_a: str,
+    output_b: str,
+    *,
+    model: str | None = None,
+    rng: random.Random | None = None,
+) -> BlindReport:
+    """Pure helper that resolves judge inputs from a :class:`SkillSpec`.
+
+    Extracted from the CLI's ``_run_blind_compare`` so the same resolution
+    logic can be shared between the CLI wrapper and the ``clauditor_blind_compare``
+    pytest fixture. The helper validates the spec, builds the rubric hint from
+    ``grading_criteria``, resolves the grading model, and forwards everything
+    to :func:`blind_compare`.
+
+    Raises :class:`ValueError` if ``spec.eval_spec`` is missing or if
+    ``eval_spec.test_args`` is empty/whitespace (it is used as the user prompt
+    context for the judge). Does not print to stdout or stderr (DEC-006).
+    """
+    if spec.eval_spec is None:
+        raise ValueError(
+            "blind_compare_from_spec: spec has no eval_spec"
+        )
+
+    user_prompt = spec.eval_spec.test_args or ""
+    if not user_prompt.strip():
+        raise ValueError(
+            "blind_compare_from_spec: eval_spec.test_args must be set "
+            "(used as the user prompt context for the judge)"
+        )
+
+    rubric_hint: str | None = None
+    criteria = spec.eval_spec.grading_criteria
+    if criteria:
+        from clauditor.schemas import criterion_text
+        rubric_hint = "\n".join(
+            f"- {criterion_text(c)}" for c in criteria
+        )
+
+    effective_model = model if model is not None else spec.eval_spec.grading_model
+
+    return await blind_compare(
+        user_prompt,
+        output_a,
+        output_b,
+        rubric_hint,
+        model=effective_model,
+        rng=rng,
+    )
+
+
 def build_grading_prompt(eval_spec: EvalSpec) -> str:
     """Build a prompt that asks the LLM to grade output against rubric criteria."""
     from clauditor.schemas import criterion_text

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -490,6 +490,26 @@ async def blind_compare(
     )
 
 
+def validate_blind_compare_spec(spec: SkillSpec) -> None:
+    """Raise ``ValueError`` if ``spec`` is unusable with the blind helper.
+
+    Same validation the full helper runs at its entry, extracted so callers
+    that want to fail-fast before printing progress messages or doing other
+    I/O can validate without making any network calls.
+    """
+    if spec.eval_spec is None:
+        raise ValueError(
+            "No eval spec found (blind_compare_from_spec requires "
+            "spec.eval_spec to be set)"
+        )
+    user_prompt = spec.eval_spec.test_args or ""
+    if not user_prompt.strip():
+        raise ValueError(
+            "blind_compare_from_spec: eval_spec.test_args must be set "
+            "(used as the user prompt context for the judge)"
+        )
+
+
 async def blind_compare_from_spec(
     spec: SkillSpec,
     output_a: str,
@@ -498,7 +518,7 @@ async def blind_compare_from_spec(
     model: str | None = None,
     rng: random.Random | None = None,
 ) -> BlindReport:
-    """Pure helper that resolves judge inputs from a :class:`SkillSpec`.
+    """Composition helper that resolves judge inputs from a :class:`SkillSpec`.
 
     Extracted from the CLI's ``_run_blind_compare`` so the same resolution
     logic can be shared between the CLI wrapper and the ``clauditor_blind_compare``
@@ -510,18 +530,10 @@ async def blind_compare_from_spec(
     ``eval_spec.test_args`` is empty/whitespace (it is used as the user prompt
     context for the judge). Does not print to stdout or stderr (DEC-006).
     """
-    if spec.eval_spec is None:
-        raise ValueError(
-            "No eval spec found (blind_compare_from_spec requires "
-            "spec.eval_spec to be set)"
-        )
+    validate_blind_compare_spec(spec)
+    assert spec.eval_spec is not None  # for type-checker; validator enforces
 
     user_prompt = spec.eval_spec.test_args or ""
-    if not user_prompt.strip():
-        raise ValueError(
-            "blind_compare_from_spec: eval_spec.test_args must be set "
-            "(used as the user prompt context for the judge)"
-        )
 
     rubric_hint: str | None = None
     criteria = spec.eval_spec.grading_criteria

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -14,7 +14,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from clauditor.schemas import EvalSpec, GradeThresholds
+from clauditor.schemas import EvalSpec, GradeThresholds, criterion_text
 
 if TYPE_CHECKING:
     from clauditor.spec import SkillSpec
@@ -512,7 +512,8 @@ async def blind_compare_from_spec(
     """
     if spec.eval_spec is None:
         raise ValueError(
-            "blind_compare_from_spec: spec has no eval_spec"
+            "No eval spec found (blind_compare_from_spec requires "
+            "spec.eval_spec to be set)"
         )
 
     user_prompt = spec.eval_spec.test_args or ""
@@ -525,7 +526,6 @@ async def blind_compare_from_spec(
     rubric_hint: str | None = None
     criteria = spec.eval_spec.grading_criteria
     if criteria:
-        from clauditor.schemas import criterion_text
         rubric_hint = "\n".join(
             f"- {criterion_text(c)}" for c in criteria
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@
 
 Provides reusable fixtures for eval data, specs, temp skill files, and mock runners.
 IMPORTANT: Do NOT define fixtures named clauditor_runner, clauditor_spec,
-clauditor_grader, or clauditor_triggers -- those are defined by the pytest plugin.
+clauditor_grader, clauditor_blind_compare, or clauditor_triggers -- those
+are defined by the pytest plugin.
 """
 
 from __future__ import annotations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3196,7 +3196,9 @@ class TestCmdCompareBlind:
             )
         assert rc == 2
         err = capsys.readouterr().err
-        assert "No eval spec" in err
+        # Helper (blind_compare_from_spec) raises ValueError; CLI maps to
+        # "ERROR: ..." with the helper's message substring.
+        assert "no eval_spec" in err
 
     def test_compare_blind_empty_test_args_errors(self, tmp_path, capsys):
         # Covers the whitespace-only test_args branch (cli.py lines 752-759).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3198,7 +3198,7 @@ class TestCmdCompareBlind:
         err = capsys.readouterr().err
         # Helper (blind_compare_from_spec) raises ValueError; CLI maps to
         # "ERROR: ..." with the helper's message substring.
-        assert "no eval_spec" in err
+        assert "No eval spec" in err
 
     def test_compare_blind_empty_test_args_errors(self, tmp_path, capsys):
         # Covers the whitespace-only test_args branch (cli.py lines 752-759).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3221,6 +3221,11 @@ class TestCmdCompareBlind:
         assert rc == 2
         err = capsys.readouterr().err
         assert "test_args" in err
+        # Fail-fast: the "Running blind A/B judge" progress line must NOT
+        # appear when validation fails. Previously the CLI printed the
+        # progress message before validating, misleading users into
+        # thinking API calls had happened.
+        assert "Running blind A/B judge" not in err
 
 
 class TestCmdGradeCompareFlagRemoved:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -550,57 +550,6 @@ class TestClauditorBlindCompare:
             with pytest.raises(ValueError, match="test_args"):
                 factory(skill_path, "a", "b")
 
-    def test_clauditor_blind_compare_via_pytester_injection(self, pytester):
-        """End-to-end fixture wiring via pytester: guards against regressions
-        in the @pytest.fixture decoration, request handling, or clauditor_spec
-        parameter wiring that the __wrapped__ direct-call tests would miss."""
-        skill_md = pytester.path / "sushi.md"
-        skill_md.write_text("# sushi\n\nA skill.\n")
-        eval_json = pytester.path / "sushi.eval.json"
-        eval_json.write_text(
-            json.dumps({
-                "skill_name": "sushi",
-                "description": "Eval",
-                "test_args": "What's the best sushi?",
-                "assertions": [],
-                "grading_criteria": [
-                    {"id": "c0", "criterion": "Is it specific?"},
-                ],
-                "grading_model": "claude-sonnet-4-6",
-            })
-        )
-
-        pytester.makepyfile(f"""
-            from unittest.mock import AsyncMock, patch
-
-            SKILL = r"{skill_md}"
-
-            def test_uses_blind_compare_fixture(clauditor_blind_compare):
-                from clauditor.quality_grader import BlindReport
-                canned = BlindReport(
-                    preference="a",
-                    confidence=0.9,
-                    score_a=0.8,
-                    score_b=0.4,
-                    reasoning="ok",
-                    position_agreement=True,
-                    model="claude-sonnet-4-6",
-                    input_tokens=10,
-                    output_tokens=5,
-                    duration_seconds=0.1,
-                )
-                with patch(
-                    "clauditor.quality_grader.blind_compare",
-                    new=AsyncMock(return_value=canned),
-                ):
-                    result = clauditor_blind_compare(
-                        SKILL, "out a", "out b"
-                    )
-                assert result.preference == "a"
-        """)
-        result = pytester.runpytest_inprocess("-v")
-        result.assert_outcomes(passed=1)
-
     def test_clauditor_blind_compare_reserved_fixture_name(self):
         """Regression guard: fixture name is documented as plugin-reserved."""
         conftest_text = (

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -424,6 +424,7 @@ def _write_skill_with_eval(
     test_args: str = "What's the best sushi?",
     criteria: list[str] | None = None,
     eval_filename: str | None = None,
+    grading_model: str = "claude-sonnet-4-6",
 ) -> tuple[Path, Path]:
     skill_path = tmp_path / f"{name}.md"
     skill_path.write_text(f"# {name}\n\nA skill.")
@@ -441,7 +442,7 @@ def _write_skill_with_eval(
                 ]
             )
         ],
-        "grading_model": "claude-sonnet-4-6",
+        "grading_model": grading_model,
     }
     eval_path = tmp_path / (eval_filename or f"{name}.eval.json")
     eval_path.write_text(json.dumps(eval_data))
@@ -517,7 +518,11 @@ class TestClauditorBlindCompare:
 
     def test_clauditor_blind_compare_model_override(self, tmp_path):
         """Explicit model kwarg beats the spec's grading_model."""
-        skill_path, _ = _write_skill_with_eval(tmp_path, name="udon")
+        skill_path, _ = _write_skill_with_eval(
+            tmp_path,
+            name="udon",
+            grading_model="WRONG-SHOULD-NOT-BE-USED",
+        )
         factory = _blind_compare_factory(tmp_path)
         canned = _make_blind_report(model="claude-opus-4-6")
 
@@ -529,6 +534,7 @@ class TestClauditorBlindCompare:
 
         call = mock_bc.await_args
         assert call.kwargs["model"] == "claude-opus-4-6"
+        assert call.kwargs["model"] != "WRONG-SHOULD-NOT-BE-USED"
 
     def test_clauditor_blind_compare_raises_on_empty_test_args(self, tmp_path):
         """Empty test_args in the spec propagates as ValueError."""
@@ -543,6 +549,57 @@ class TestClauditorBlindCompare:
         ):
             with pytest.raises(ValueError, match="test_args"):
                 factory(skill_path, "a", "b")
+
+    def test_clauditor_blind_compare_via_pytester_injection(self, pytester):
+        """End-to-end fixture wiring via pytester: guards against regressions
+        in the @pytest.fixture decoration, request handling, or clauditor_spec
+        parameter wiring that the __wrapped__ direct-call tests would miss."""
+        skill_md = pytester.path / "sushi.md"
+        skill_md.write_text("# sushi\n\nA skill.\n")
+        eval_json = pytester.path / "sushi.eval.json"
+        eval_json.write_text(
+            json.dumps({
+                "skill_name": "sushi",
+                "description": "Eval",
+                "test_args": "What's the best sushi?",
+                "assertions": [],
+                "grading_criteria": [
+                    {"id": "c0", "criterion": "Is it specific?"},
+                ],
+                "grading_model": "claude-sonnet-4-6",
+            })
+        )
+
+        pytester.makepyfile(f"""
+            from unittest.mock import AsyncMock, patch
+
+            SKILL = r"{skill_md}"
+
+            def test_uses_blind_compare_fixture(clauditor_blind_compare):
+                from clauditor.quality_grader import BlindReport
+                canned = BlindReport(
+                    preference="a",
+                    confidence=0.9,
+                    score_a=0.8,
+                    score_b=0.4,
+                    reasoning="ok",
+                    position_agreement=True,
+                    model="claude-sonnet-4-6",
+                    input_tokens=10,
+                    output_tokens=5,
+                    duration_seconds=0.1,
+                )
+                with patch(
+                    "clauditor.quality_grader.blind_compare",
+                    new=AsyncMock(return_value=canned),
+                ):
+                    result = clauditor_blind_compare(
+                        SKILL, "out a", "out b"
+                    )
+                assert result.preference == "a"
+        """)
+        result = pytester.runpytest_inprocess("-v")
+        result.assert_outcomes(passed=1)
 
     def test_clauditor_blind_compare_reserved_fixture_name(self):
         """Regression guard: fixture name is documented as plugin-reserved."""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -403,15 +403,20 @@ def _make_blind_report(**overrides):
     return BlindReport(**defaults)
 
 
-def _blind_compare_factory(tmp_path: Path):
-    """Build the clauditor_blind_compare factory directly (no pytest injection)."""
+def _blind_compare_factory(tmp_path: Path, *, cli_model: str | None = None):
+    """Build the clauditor_blind_compare factory directly (no pytest injection).
+
+    ``cli_model`` simulates the value of the ``--clauditor-model`` plugin
+    option as if a user had passed it on the pytest CLI. Defaults to None
+    so existing tests are unaffected.
+    """
     request = MagicMock()
     request.config.getoption.side_effect = (
         lambda opt: {
             "--clauditor-project-dir": None,
             "--clauditor-timeout": 180,
             "--clauditor-claude-bin": "claude",
-            "--clauditor-model": None,
+            "--clauditor-model": cli_model,
         }[opt]
     )
     spec_factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -535,6 +540,54 @@ class TestClauditorBlindCompare:
         call = mock_bc.await_args
         assert call.kwargs["model"] == "claude-opus-4-6"
         assert call.kwargs["model"] != "WRONG-SHOULD-NOT-BE-USED"
+
+    def test_clauditor_blind_compare_respects_cli_model_option(self, tmp_path):
+        """--clauditor-model CLI option beats the spec's grading_model.
+
+        Precedence: explicit kwarg > --clauditor-model > spec.grading_model.
+        Matches the behavior of clauditor_grader / clauditor_triggers, which
+        also default to the CLI option when no explicit model is supplied.
+        """
+        skill_path, _ = _write_skill_with_eval(
+            tmp_path,
+            name="cli_model",
+            grading_model="spec-model-should-lose",
+        )
+        factory = _blind_compare_factory(
+            tmp_path, cli_model="claude-opus-4-6"
+        )
+        canned = _make_blind_report(model="claude-opus-4-6")
+
+        with patch(
+            "clauditor.quality_grader.blind_compare",
+            new=AsyncMock(return_value=canned),
+        ) as mock_bc:
+            factory(skill_path, "a", "b")  # no explicit model kwarg
+
+        call = mock_bc.await_args
+        assert call.kwargs["model"] == "claude-opus-4-6"
+        assert call.kwargs["model"] != "spec-model-should-lose"
+
+    def test_clauditor_blind_compare_kwarg_beats_cli_model_option(self, tmp_path):
+        """Explicit model= kwarg still wins over --clauditor-model CLI option."""
+        skill_path, _ = _write_skill_with_eval(
+            tmp_path,
+            name="kwarg_wins",
+            grading_model="spec-model-should-lose",
+        )
+        factory = _blind_compare_factory(
+            tmp_path, cli_model="cli-model-should-also-lose"
+        )
+        canned = _make_blind_report(model="claude-opus-4-6")
+
+        with patch(
+            "clauditor.quality_grader.blind_compare",
+            new=AsyncMock(return_value=canned),
+        ) as mock_bc:
+            factory(skill_path, "a", "b", model="claude-opus-4-6")
+
+        call = mock_bc.await_args
+        assert call.kwargs["model"] == "claude-opus-4-6"
 
     def test_clauditor_blind_compare_raises_on_empty_test_args(self, tmp_path):
         """Empty test_args in the spec propagates as ValueError."""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import importlib
-from unittest.mock import MagicMock
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 import clauditor.pytest_plugin as _plugin_mod
 from clauditor.pytest_plugin import (
+    clauditor_blind_compare,
     clauditor_capture,
     clauditor_runner,
     clauditor_spec,
@@ -377,3 +382,174 @@ class TestClauditorSpecInputFiles:
         """)
         result = pytester.runpytest_inprocess("-v")
         result.assert_outcomes(passed=1)
+
+
+def _make_blind_report(**overrides):
+    from clauditor.quality_grader import BlindReport
+
+    defaults = dict(
+        preference="a",
+        confidence=0.9,
+        score_a=0.85,
+        score_b=0.65,
+        reasoning="a is more complete",
+        model="claude-sonnet-4-6",
+        position_agreement=True,
+        input_tokens=100,
+        output_tokens=50,
+        duration_seconds=1.25,
+    )
+    defaults.update(overrides)
+    return BlindReport(**defaults)
+
+
+def _blind_compare_factory(tmp_path: Path):
+    """Build the clauditor_blind_compare factory directly (no pytest injection)."""
+    request = MagicMock()
+    request.config.getoption.side_effect = (
+        lambda opt: {
+            "--clauditor-project-dir": None,
+            "--clauditor-timeout": 180,
+            "--clauditor-claude-bin": "claude",
+            "--clauditor-model": None,
+        }[opt]
+    )
+    spec_factory = clauditor_spec.__wrapped__(request, tmp_path)
+    return clauditor_blind_compare.__wrapped__(request, spec_factory)
+
+
+def _write_skill_with_eval(
+    tmp_path: Path,
+    name: str = "sushi",
+    test_args: str = "What's the best sushi?",
+    criteria: list[str] | None = None,
+    eval_filename: str | None = None,
+) -> tuple[Path, Path]:
+    skill_path = tmp_path / f"{name}.md"
+    skill_path.write_text(f"# {name}\n\nA skill.")
+    eval_data = {
+        "skill_name": name,
+        "description": f"Eval for {name}",
+        "test_args": test_args,
+        "assertions": [],
+        "grading_criteria": [
+            {"id": f"c{i}", "criterion": c}
+            for i, c in enumerate(
+                criteria or [
+                    "Is the recommendation specific?",
+                    "Does it cite prices?",
+                ]
+            )
+        ],
+        "grading_model": "claude-sonnet-4-6",
+    }
+    eval_path = tmp_path / (eval_filename or f"{name}.eval.json")
+    eval_path.write_text(json.dumps(eval_data))
+    return skill_path, eval_path
+
+
+class TestClauditorBlindCompare:
+    """US-003: clauditor_blind_compare pytest fixture."""
+
+    def test_clauditor_blind_compare_happy_path(self, tmp_path):
+        """Factory loads spec, invokes blind_compare, returns the report."""
+        skill_path, _ = _write_skill_with_eval(tmp_path)
+        factory = _blind_compare_factory(tmp_path)
+        canned = _make_blind_report()
+
+        with patch(
+            "clauditor.quality_grader.blind_compare",
+            new=AsyncMock(return_value=canned),
+        ) as mock_bc:
+            result = factory(skill_path, "output A", "output B")
+
+        assert result is canned
+        mock_bc.assert_awaited_once()
+        call = mock_bc.await_args
+        # Positional args: user_prompt, output_a, output_b, rubric_hint
+        assert call.args[0] == "What's the best sushi?"
+        assert call.args[1] == "output A"
+        assert call.args[2] == "output B"
+        rubric_hint = call.args[3]
+        assert "Is the recommendation specific?" in rubric_hint
+        assert "Does it cite prices?" in rubric_hint
+        assert call.kwargs["model"] == "claude-sonnet-4-6"
+
+    def test_clauditor_blind_compare_eval_path_override(self, tmp_path):
+        """Explicit eval_path overrides sibling auto-discovery."""
+        # Sibling eval: different test_args than the override we'll pass.
+        skill_path, _ = _write_skill_with_eval(
+            tmp_path,
+            name="ramen",
+            test_args="sibling prompt",
+            criteria=["sibling criterion"],
+        )
+        # Override eval in a different location with distinct content.
+        override_dir = tmp_path / "overrides"
+        override_dir.mkdir()
+        override_eval = override_dir / "ramen.eval.json"
+        override_eval.write_text(
+            json.dumps({
+                "skill_name": "ramen",
+                "description": "override",
+                "test_args": "override prompt",
+                "assertions": [],
+                "grading_criteria": [
+                    {"id": "ov1", "criterion": "override criterion"},
+                ],
+                "grading_model": "claude-sonnet-4-6",
+            })
+        )
+
+        factory = _blind_compare_factory(tmp_path)
+        canned = _make_blind_report()
+
+        with patch(
+            "clauditor.quality_grader.blind_compare",
+            new=AsyncMock(return_value=canned),
+        ) as mock_bc:
+            factory(skill_path, "a", "b", eval_path=override_eval)
+
+        call = mock_bc.await_args
+        assert call.args[0] == "override prompt"
+        assert "override criterion" in call.args[3]
+        assert "sibling criterion" not in call.args[3]
+
+    def test_clauditor_blind_compare_model_override(self, tmp_path):
+        """Explicit model kwarg beats the spec's grading_model."""
+        skill_path, _ = _write_skill_with_eval(tmp_path, name="udon")
+        factory = _blind_compare_factory(tmp_path)
+        canned = _make_blind_report(model="claude-opus-4-6")
+
+        with patch(
+            "clauditor.quality_grader.blind_compare",
+            new=AsyncMock(return_value=canned),
+        ) as mock_bc:
+            factory(skill_path, "a", "b", model="claude-opus-4-6")
+
+        call = mock_bc.await_args
+        assert call.kwargs["model"] == "claude-opus-4-6"
+
+    def test_clauditor_blind_compare_raises_on_empty_test_args(self, tmp_path):
+        """Empty test_args in the spec propagates as ValueError."""
+        skill_path, _ = _write_skill_with_eval(
+            tmp_path, name="empty", test_args=""
+        )
+        factory = _blind_compare_factory(tmp_path)
+
+        with patch(
+            "clauditor.quality_grader.blind_compare",
+            new=AsyncMock(return_value=_make_blind_report()),
+        ):
+            with pytest.raises(ValueError, match="test_args"):
+                factory(skill_path, "a", "b")
+
+    def test_clauditor_blind_compare_reserved_fixture_name(self):
+        """Regression guard: fixture name is documented as plugin-reserved."""
+        conftest_text = (
+            Path(__file__).parent / "conftest.py"
+        ).read_text()
+        assert "clauditor_blind_compare" in conftest_text
+        # And the fixture itself is a pytest fixture callable
+        assert callable(clauditor_blind_compare)
+        assert hasattr(clauditor_blind_compare, "__wrapped__")

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1797,3 +1797,150 @@ class TestParseBlindResponse:
         text = "```\n" + json.dumps(data) + "\n```"
         result = _parse_blind_response(text)
         assert result == data
+
+
+class TestBlindCompareFromSpec:
+    """Tests for the pure blind_compare_from_spec helper (clauditor-5x5.1)."""
+
+    def _canned_report(self) -> BlindReport:
+        return BlindReport(
+            preference="a",
+            confidence=0.9,
+            score_a=0.9,
+            score_b=0.3,
+            reasoning="canned",
+            position_agreement=True,
+            model="claude-sonnet-4-6",
+            input_tokens=10,
+            output_tokens=5,
+            duration_seconds=0.1,
+        )
+
+    def _make_skill_spec(
+        self,
+        *,
+        eval_spec: EvalSpec | None = None,
+    ):
+        from pathlib import Path
+
+        from clauditor.spec import SkillSpec
+
+        return SkillSpec(skill_path=Path("dummy.md"), eval_spec=eval_spec)
+
+    def _make_eval_spec(
+        self,
+        *,
+        test_args: str = "What's the best sushi in Tokyo?",
+        grading_criteria=None,
+        grading_model: str = "claude-sonnet-4-6",
+    ) -> EvalSpec:
+        if grading_criteria is None:
+            grading_criteria = [
+                "Output contains actionable recommendations",
+                "Tone is professional and clear",
+            ]
+        return EvalSpec(
+            skill_name="test-skill",
+            description="test",
+            test_args=test_args,
+            grading_criteria=grading_criteria,
+            grading_model=grading_model,
+        )
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_happy_path(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        eval_spec = self._make_eval_spec()
+        spec = self._make_skill_spec(eval_spec=eval_spec)
+        canned = self._canned_report()
+        mock_bc = AsyncMock(return_value=canned)
+
+        with patch("clauditor.quality_grader.blind_compare", mock_bc):
+            result = await blind_compare_from_spec(spec, "A", "B")
+
+        assert result is canned
+        assert mock_bc.await_count == 1
+        call = mock_bc.await_args
+        # blind_compare(user_prompt, output_a, output_b, rubric_hint, *,
+        # model=..., rng=...)
+        assert call.args[0] == "What's the best sushi in Tokyo?"
+        assert call.args[1] == "A"
+        assert call.args[2] == "B"
+        assert call.args[3] == (
+            "- Output contains actionable recommendations\n"
+            "- Tone is professional and clear"
+        )
+        assert call.kwargs["model"] == "claude-sonnet-4-6"
+        assert call.kwargs["rng"] is None
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_model_override(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        eval_spec = self._make_eval_spec(grading_model="claude-sonnet-4-6")
+        spec = self._make_skill_spec(eval_spec=eval_spec)
+        mock_bc = AsyncMock(return_value=self._canned_report())
+
+        with patch("clauditor.quality_grader.blind_compare", mock_bc):
+            await blind_compare_from_spec(
+                spec, "A", "B", model="claude-opus-4-6"
+            )
+
+        assert mock_bc.await_args.kwargs["model"] == "claude-opus-4-6"
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_raises_on_missing_eval_spec(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        spec = self._make_skill_spec(eval_spec=None)
+        with pytest.raises(ValueError, match="(?i)eval_spec"):
+            await blind_compare_from_spec(spec, "A", "B")
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_raises_on_empty_test_args(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        spec = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(test_args="")
+        )
+        with pytest.raises(ValueError, match="test_args"):
+            await blind_compare_from_spec(spec, "A", "B")
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_raises_on_whitespace_test_args(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        spec = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(test_args="   \n  ")
+        )
+        with pytest.raises(ValueError, match="test_args"):
+            await blind_compare_from_spec(spec, "A", "B")
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_no_criteria_passes_none_rubric(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        spec = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(grading_criteria=[])
+        )
+        mock_bc = AsyncMock(return_value=self._canned_report())
+
+        with patch("clauditor.quality_grader.blind_compare", mock_bc):
+            await blind_compare_from_spec(spec, "A", "B")
+
+        # Positional rubric_hint arg (index 3) must be None, not "".
+        assert mock_bc.await_args.args[3] is None
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_rng_pass_through(self):
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        spec = self._make_skill_spec(eval_spec=self._make_eval_spec())
+        rng = random.Random(42)
+        mock_bc = AsyncMock(return_value=self._canned_report())
+
+        with patch("clauditor.quality_grader.blind_compare", mock_bc):
+            await blind_compare_from_spec(spec, "A", "B", rng=rng)
+
+        assert mock_bc.await_args.kwargs["rng"] is rng

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import random
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from clauditor.quality_grader import (
     parse_grading_response,
 )
 from clauditor.schemas import EvalSpec, GradeThresholds, VarianceConfig
+from clauditor.spec import SkillSpec
 
 
 def _make_spec() -> EvalSpec:
@@ -1821,10 +1823,6 @@ class TestBlindCompareFromSpec:
         *,
         eval_spec: EvalSpec | None = None,
     ):
-        from pathlib import Path
-
-        from clauditor.spec import SkillSpec
-
         return SkillSpec(skill_path=Path("dummy.md"), eval_spec=eval_spec)
 
     def _make_eval_spec(
@@ -1894,7 +1892,7 @@ class TestBlindCompareFromSpec:
         from clauditor.quality_grader import blind_compare_from_spec
 
         spec = self._make_skill_spec(eval_spec=None)
-        with pytest.raises(ValueError, match="(?i)eval_spec"):
+        with pytest.raises(ValueError, match="No eval spec"):
             await blind_compare_from_spec(spec, "A", "B")
 
     @pytest.mark.asyncio

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1942,3 +1942,29 @@ class TestBlindCompareFromSpec:
             await blind_compare_from_spec(spec, "A", "B", rng=rng)
 
         assert mock_bc.await_args.kwargs["rng"] is rng
+
+    def test_validate_blind_compare_spec_raises_on_missing_eval_spec(self):
+        """validate_blind_compare_spec raises with a clear message when
+        eval_spec is missing — same shape as blind_compare_from_spec, but
+        sync and network-free so callers can fail-fast."""
+        from clauditor.quality_grader import validate_blind_compare_spec
+
+        spec = self._make_skill_spec(eval_spec=None)
+        with pytest.raises(ValueError, match="No eval spec"):
+            validate_blind_compare_spec(spec)
+
+    def test_validate_blind_compare_spec_raises_on_empty_test_args(self):
+        """validate_blind_compare_spec raises when test_args is empty/whitespace."""
+        from clauditor.quality_grader import validate_blind_compare_spec
+
+        spec = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(test_args="")
+        )
+        with pytest.raises(ValueError, match="test_args"):
+            validate_blind_compare_spec(spec)
+
+        spec_ws = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(test_args="   \n ")
+        )
+        with pytest.raises(ValueError, match="test_args"):
+            validate_blind_compare_spec(spec_ws)


### PR DESCRIPTION
Closes `clauditor-iag`'s sibling bead `clauditor-0bo` (#24 follow-up).

## Summary

Exposes the blind A/B judge (`blind_compare`, added in #24) as a first-class pytest fixture so eval tests can run inline comparisons on captured outputs without shelling out to the CLI. Implements the plan at `plans/super/clauditor-0bo-pytest-blind-compare.md`.

**Net change:** ~+230 / -40 LOC (~100 functional, rest is tests + plan + rules).

## What this adds

- **`blind_compare_from_spec(spec, output_a, output_b, *, model, rng)`** in `src/clauditor/quality_grader.py` — composition helper that resolves `user_prompt`, `rubric_hint`, and `model` from a `SkillSpec`, then awaits `blind_compare`. Shared entry point for the CLI and the new fixture.
- **`validate_blind_compare_spec(spec)`** — pure validator extracted so callers can fail-fast on invalid specs BEFORE emitting progress messages or doing file I/O. Single source of truth for the validation logic.
- **`clauditor_blind_compare`** pytest fixture in `src/clauditor/pytest_plugin.py` — sync-wrapping-async factory. Caller provides two output strings and a skill path; fixture loads the spec, calls `blind_compare_from_spec`, returns a `BlindReport`. Honors `--clauditor-model` plugin option with precedence `explicit kwarg > CLI option > spec.grading_model`, matching peer Layer 3 fixtures.
- **CLI refactor** of `cli.py::_run_blind_compare` — delegates spec/test_args/rubric/model resolution to `blind_compare_from_spec`. Net −13 lines; validates early so the "Running blind A/B judge... — 2 API calls..." progress line only fires when the helper is actually about to make API calls.

## Quality gate

- 3 parallel code-reviewer passes + CodeRabbit local review + Copilot PR review
- Addressed: 2 CodeRabbit findings, 7 code-review items, 4 Copilot review comments
- Full suite: **1141 passing**, **96.04%** total coverage (80% gate), ruff clean
- Both `blind_compare_from_spec` and `clauditor_blind_compare` at 100% coverage

## New rules promoted

- **`.claude/rules/pure-compute-vs-io-split.md`** — second canonical anchor added (`blind_compare_from_spec` alongside the original `compute_benchmark` from #28). Demonstrates the compose-ability benefit: same helper consumed from CLI + pytest fixture.
- **`.claude/rules/pytester-inprocess-coverage-hazard.md`** (new) — documents the segfault encountered when combining `pytester.runpytest_inprocess` + `pytest --cov` + `mock.patch` on an already-imported module. Anchored to commits `dc96c17` (introduction) and `925fa63` (removal).

## Follow-up

- **#39 / `clauditor-iag`** — add `EvalSpec.user_prompt` field. Both the CLI and the fixture will pick up the new resolution automatically via `blind_compare_from_spec`. Explicitly out of scope for this PR.
