### PR TITLE
#39: Add EvalSpec.user_prompt field

### DIFF
--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -104,11 +104,12 @@ Before the extraction (pre-#clauditor-0bo), the CLI had 15 lines of
 inline `spec.eval_spec.test_args` / `grading_criteria` / `grading_model`
 resolution that would have had to be duplicated verbatim in the
 fixture — with no mechanism to keep them in lockstep. The extracted
-helper eliminated that drift risk, and #39 / `clauditor-iag` (which
-added `EvalSpec.user_prompt` and swapped `blind_compare_from_spec` to
-read it instead of `test_args`) landed as a single-file change to
-`quality_grader.py`: both the CLI caller and the pytest fixture picked
-up the new resolution automatically, validating the rule's prediction.
+helper eliminated that drift risk, and when #39 / `clauditor-iag`
+added `EvalSpec.user_prompt`, the corresponding resolution-logic
+change in `blind_compare_from_spec` (switching from `test_args` to
+`user_prompt`) was isolated to `quality_grader.py`: both the CLI
+caller and the pytest fixture picked up the new resolution
+automatically, validating the rule's prediction.
 
 ## Grandfathered counter-example
 

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -104,9 +104,11 @@ Before the extraction (pre-#clauditor-0bo), the CLI had 15 lines of
 inline `spec.eval_spec.test_args` / `grading_criteria` / `grading_model`
 resolution that would have had to be duplicated verbatim in the
 fixture — with no mechanism to keep them in lockstep. The extracted
-helper eliminates that drift risk and makes the next ticket
-(`clauditor-iag`, add `EvalSpec.user_prompt`) a single-file change
-that both callers pick up automatically.
+helper eliminated that drift risk, and #39 / `clauditor-iag` (which
+added `EvalSpec.user_prompt` and swapped `blind_compare_from_spec` to
+read it instead of `test_args`) landed as a single-file change to
+`quality_grader.py`: both the CLI caller and the pytest fixture picked
+up the new resolution automatically, validating the rule's prediction.
 
 ## Grandfathered counter-example
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Rubric-based grading can miss holistic regressions where two outputs pass every 
 clauditor compare before.txt after.txt --spec <skill.md> --blind
 ```
 
-The judge runs twice with the A/B positions swapped so position bias shows up as disagreement. Output includes a preference (`BEFORE` / `AFTER` / `TIE`), confidence, per-output holistic score, whether the two runs agreed on the winner, and the judge's reasoning. Currently only the file-pair form is supported (iteration refs like `--from/--to` are rejected); `--blind` requires `--spec` for the user prompt context and uses `grading_criteria` from the spec as an optional rubric hint to the judge.
+The judge runs twice with the A/B positions swapped so position bias shows up as disagreement. Output includes a preference (`BEFORE` / `AFTER` / `TIE`), confidence, per-output holistic score, whether the two runs agreed on the winner, and the judge's reasoning. Currently only the file-pair form is supported (iteration refs like `--from/--to` are rejected); `--blind` requires `--spec` with `eval_spec.user_prompt` set (the natural-language query the judge will see) and uses `grading_criteria` from the spec as an optional rubric hint to the judge.
 
 #### Variance Measurement
 

--- a/examples/.claude/commands/example-skill.eval.json
+++ b/examples/.claude/commands/example-skill.eval.json
@@ -2,6 +2,7 @@
   "skill_name": "find-kid-activities",
   "description": "Validates /find-kid-activities produces venues and events with required fields",
   "test_args": "\"Cupertino, CA\" --dates today --distance 15mi --ages 4-6 --cost \"Free, $\" --type both --category any --count 5 --depth quick",
+  "user_prompt": "Find free or low-cost kid activities in Cupertino, CA today within 15 miles for ages 4-6.",
   "input_files": [
     "sample-input.txt"
   ],

--- a/plans/super/39-eval-spec-user-prompt.md
+++ b/plans/super/39-eval-spec-user-prompt.md
@@ -1,0 +1,258 @@
+---
+ticket: "#39 (clauditor-iag)"
+title: Add EvalSpec.user_prompt field
+phase: detailing
+branch: feature/39-user-prompt
+worktree: /home/wesd/dev/worktrees/clauditor/feature/39-user-prompt
+sessions: 1
+---
+
+# #39 — Add `EvalSpec.user_prompt` field
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/39
+- **Beads:** `clauditor-iag` (P3)
+- **Related PRs:** #24 (blind A/B judge), #38 (`blind_compare_from_spec`)
+- **Relevant rules:**
+  - `.claude/rules/pure-compute-vs-io-split.md` (second anchor explicitly
+    calls this feature out — both callers pick up the new field
+    automatically through `blind_compare_from_spec`)
+  - `.claude/rules/eval-spec-stable-ids.md` (does NOT apply — `user_prompt`
+    is a plain scalar, not a list of addressable entries)
+  - `.claude/rules/path-validation.md` (does NOT apply — string content,
+    not a filesystem path)
+
+## 1. Discovery
+
+### What and why
+
+`clauditor compare --blind` currently repurposes `EvalSpec.test_args` as
+the natural-language user query handed to the LLM judge in
+`build_blind_prompt`. `test_args` is semantically the skill runner's CLI
+argument string (e.g. `--depth quick --limit 10`), not a user query. When
+the test invocation happens to be plain English it works by accident;
+when it is structured flags the prompt-injection `<user_prompt>` block
+wraps meaningless CLI args as the supposed user intent.
+
+`blind_compare_from_spec` (added in #38) is the single resolution point
+for both callers:
+
+- `src/clauditor/cli.py::_run_blind_compare` — CLI wrapper for
+  `clauditor compare --blind`
+- `src/clauditor/pytest_plugin.py::clauditor_blind_compare` — pytest
+  fixture
+
+Adding `EvalSpec.user_prompt` and teaching the shared helper to prefer it
+over `test_args` is exactly the use case the
+`pure-compute-vs-io-split.md` rule anticipates: one resolution helper,
+two callers, zero drift.
+
+### Codebase surface
+
+Files to touch:
+
+| File | Change |
+| --- | --- |
+| `src/clauditor/schemas.py` | Add `user_prompt: str \| None = None` field on `EvalSpec`; load it in `from_file`; emit in `to_dict` when set |
+| `src/clauditor/quality_grader.py` | Update `validate_blind_compare_spec` + `blind_compare_from_spec` to prefer `spec.eval_spec.user_prompt`, fall back to `test_args` |
+| `tests/test_schemas.py` | Round-trip load/save tests for the new field |
+| `tests/test_quality_grader.py` | Resolution tests for `blind_compare_from_spec`: user_prompt wins, test_args fallback, both empty still raises |
+
+Files NOT touched (important negative scope):
+
+- `src/clauditor/spec.py::SkillSpec.run` — still uses `test_args` as
+  skill-runner CLI args. The two semantics stay distinct.
+- `src/clauditor/cli.py` — no CLI surface change; the Running-progress
+  print keeps using `test_args` since that is what the runner receives.
+- `_run_baseline_phase` — still passes `test_args` to `runner.run_raw`,
+  correct because it is a runner-arg context.
+- Any `.eval.json` schema-version bump — `EvalSpec` is input-only and has
+  no `schema_version` field today; adding an optional key is backwards
+  compatible.
+
+### Stable-id decision
+
+`user_prompt` is a single optional scalar, not a list of
+per-entry-addressable entries. The `.claude/rules/eval-spec-stable-ids.md`
+rule applies to **list-of-entries** fields (assertions, section fields,
+grading_criteria). A single nullable string is out of scope. **No id
+field.**
+
+## 2. Architecture Review
+
+Quick review — this is a one-field addition with no new I/O, no new
+subprocess call, no LLM prompt restructuring beyond a different source
+string for the same existing `<user_prompt>` block.
+
+| Area | Rating | Notes |
+| --- | --- | --- |
+| Security | **pass** | String flows through the existing prompt-injection-hardened `build_blind_prompt` XML fence. No new untrusted surface. |
+| Performance | **pass** | No queries, no loops, no extra API calls. |
+| Data model | **concern** | Optional field — existing on-disk `.eval.json` files must keep loading. `from_file` must default to `None` when absent, and `to_dict` must only emit the key when set (so round-tripping a legacy spec does not add noise). |
+| API design | **pass** | Dataclass-internal. No public CLI flag. |
+| Observability | **concern** | Should we emit a stderr warning when `test_args` is used as the fallback AND looks like CLI flags (starts with `-`)? Ticket proposes "ideally" — refine in Phase 3. |
+| Testing | **pass** | Unit tests cover both `from_file` round-trip and `blind_compare_from_spec` resolution. No integration test needed — the resolution logic is a pure helper. |
+
+No blockers.
+
+## 3. Refinement Log
+
+### DEC-001: No fallback — `user_prompt` is required for blind compare
+
+Library is pre-publication; backcompat is not a constraint. The cleanest
+shape is a hard split: `test_args` keeps its runner-CLI-args semantics
+*only*; `user_prompt` is the *only* source the blind judge consults. Any
+existing eval spec that was relying on `test_args`-as-user-query is
+updated in this same change.
+
+**Why:** a fallback shim is the worst-of-both-worlds — it keeps the
+ambiguity the ticket set out to remove, and bloats every new reader of
+`blind_compare_from_spec` with a two-source resolution. Users confirmed
+pre-publication status, so there is no migration burden to justify the
+shim.
+
+**Consequences:**
+- `blind_compare_from_spec` raises `ValueError` when
+  `spec.eval_spec.user_prompt` is missing/empty. The error message names
+  `user_prompt` specifically.
+- Any test fixture or eval.json in the repo that was using `test_args`
+  as the judge query migrates to `user_prompt` in this change.
+- No stderr warning heuristic. No deprecation docstring. No follow-up
+  bead.
+
+### DEC-002: `user_prompt` is a plain scalar, no stable id
+
+Single optional string, not a list-of-entries, so
+`.claude/rules/eval-spec-stable-ids.md` does not apply. No `id` field,
+no load-time uniqueness check.
+
+### DEC-003: `to_dict` emits `user_prompt` only when set
+
+Round-tripping a spec that does not set `user_prompt` should not inject
+a `"user_prompt": null` key. Match the existing pattern for
+`output_file` / `trigger_tests` / `variance` / `grade_thresholds`.
+
+## 4. Detailed Breakdown
+
+Single coherent change — one implementation story plus Quality Gate and
+Patterns & Memory. Too small to split further.
+
+### US-001 — Add `user_prompt` field and require it in blind compare
+
+**Description:** Add `EvalSpec.user_prompt: str | None = None`, wire it
+through `from_file` and `to_dict`, and flip `blind_compare_from_spec` +
+`validate_blind_compare_spec` to read `user_prompt` instead of
+`test_args`. Migrate any repo-internal eval.json / test fixtures that
+used `test_args` as the judge query.
+
+**Traces to:** DEC-001, DEC-002, DEC-003.
+
+**Files:**
+
+- `src/clauditor/schemas.py`
+  - Add `user_prompt: str | None = None` to `EvalSpec` (dataclass
+    field, after `test_args`).
+  - In `from_file`: `user_prompt=data.get("user_prompt")`. No validation
+    beyond "if present, must be a non-empty string" — empty string is
+    rejected so callers do not have to disambiguate `None` vs `""`.
+  - In `to_dict`: emit `"user_prompt": self.user_prompt` only when the
+    attribute is not `None`, after the `test_args` key.
+
+- `src/clauditor/quality_grader.py`
+  - `validate_blind_compare_spec`: replace the `test_args or ""` read
+    with `spec.eval_spec.user_prompt or ""`. Update error message to
+    `"blind_compare_from_spec: eval_spec.user_prompt must be set (used
+    as the user prompt context for the judge)"`.
+  - `blind_compare_from_spec`: same swap — `user_prompt = spec.eval_spec.user_prompt or ""`.
+  - Update the module docstring for `blind_compare_from_spec` — the
+    current copy still says "eval_spec.test_args must be set", which
+    becomes false after this change.
+
+- `tests/test_schemas.py`
+  - New test: `from_file` parses `user_prompt` from a JSON fixture.
+  - New test: `from_file` raises `ValueError` when `user_prompt` is
+    present but an empty string or non-string.
+  - New test: `to_dict` omits `user_prompt` when unset; includes it
+    when set. Round-trip via `json.dumps`/`EvalSpec.from_file`
+    equivalence.
+
+- `tests/test_quality_grader.py`
+  - `validate_blind_compare_spec`: test that missing `user_prompt`
+    raises, regardless of `test_args` content. (Explicitly assert that
+    a spec with `test_args="something"` and no `user_prompt` still
+    raises — this is the core behavior change.)
+  - `blind_compare_from_spec`: test that the judge prompt the downstream
+    `blind_compare` sees contains the `user_prompt` value, not the
+    `test_args` value. Patch `blind_compare` with `AsyncMock` to
+    capture the forwarded `user_prompt` arg.
+
+- **Repo-wide migration:** grep for `test_args` in `tests/*.py`,
+  `tests/conftest.py`, `examples/.claude/commands/example-skill.eval.json`,
+  and the `plans/super/*.md` cross-references. For each site whose
+  `test_args` value is a natural-language query (not CLI flags), add
+  `user_prompt=...` and either delete the `test_args=...` or leave it
+  as empty string if the runner still needs a CLI invocation. The
+  `_run_blind_compare` / `blind_compare_from_spec` path is the only one
+  whose semantics change; everything else that *actually* passes
+  `test_args` to the runner keeps working unchanged.
+
+**TDD:**
+
+1. Write `test_blind_compare_from_spec_requires_user_prompt` — asserts
+   `ValueError` mentioning `user_prompt` when `user_prompt` is unset.
+   Expected red.
+2. Write `test_blind_compare_from_spec_forwards_user_prompt` — patches
+   `clauditor.quality_grader.blind_compare` with `AsyncMock`, calls the
+   helper, asserts the captured `user_prompt` kwarg equals the spec's
+   `user_prompt` and NOT its `test_args`. Expected red.
+3. Write `test_evalspec_from_file_loads_user_prompt` and its omit/empty
+   variants. Expected red.
+4. Implement the field + resolution swap. Tests go green.
+5. Migrate in-repo fixtures; run full `uv run pytest --cov=clauditor`
+   and confirm coverage gate holds.
+
+**Done when:**
+- `uv run ruff check src/ tests/` clean
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with
+  the 80% gate
+- `blind_compare_from_spec` reads `user_prompt`, never `test_args`
+- No remaining repo grep hit where `test_args` is used as the judge
+  query
+
+**Depends on:** none.
+
+**Rules consulted:**
+- `pure-compute-vs-io-split.md` — this ticket is the canonical example
+  the rule cites. Shape already in place; no refactor needed.
+- `eval-spec-stable-ids.md` — checked and determined not applicable
+  (scalar, not list-of-entries). See DEC-002.
+- `mock-side-effect-for-distinct-calls.md` — not applicable here; the
+  blind_compare mock is a single call per test, `return_value` is
+  fine.
+
+### Quality Gate
+
+**Description:** Run the code-reviewer agent 4x over the full
+changeset, fixing every real bug each pass. Run CodeRabbit review if
+CI provides it. Final `uv run pytest --cov=clauditor` + `uv run ruff
+check` both clean.
+
+**Depends on:** US-001.
+
+### Patterns & Memory
+
+**Description:** Update `.claude/rules/` or docs if the implementation
+surfaced a new pattern. Expected outcome: **no new rule** — this
+ticket is a textbook application of the existing
+`pure-compute-vs-io-split.md` anchor, so the existing rule's second
+canonical anchor should be verified still accurate (the helper name
+and file path) and that's it. If verification finds drift, update the
+rule; otherwise close the story with a note that the pattern already
+covers this case.
+
+**Depends on:** Quality Gate.
+
+## 5. Beads Manifest
+
+_Pending devolve._

--- a/plans/super/39-eval-spec-user-prompt.md
+++ b/plans/super/39-eval-spec-user-prompt.md
@@ -3,7 +3,7 @@ ticket: "#39 (clauditor-iag)"
 title: Add EvalSpec.user_prompt field
 phase: devolved
 branch: feature/39-user-prompt
-worktree: /home/wesd/dev/worktrees/clauditor/feature/39-user-prompt
+worktree: feature/39-user-prompt
 sessions: 1
 ---
 
@@ -55,9 +55,9 @@ Files to touch:
 | File | Change |
 | --- | --- |
 | `src/clauditor/schemas.py` | Add `user_prompt: str \| None = None` field on `EvalSpec`; load it in `from_file`; emit in `to_dict` when set |
-| `src/clauditor/quality_grader.py` | Update `validate_blind_compare_spec` + `blind_compare_from_spec` to prefer `spec.eval_spec.user_prompt`, fall back to `test_args` |
+| `src/clauditor/quality_grader.py` | Update `validate_blind_compare_spec` + `blind_compare_from_spec` to read `spec.eval_spec.user_prompt` (no fallback — DEC-001) |
 | `tests/test_schemas.py` | Round-trip load/save tests for the new field |
-| `tests/test_quality_grader.py` | Resolution tests for `blind_compare_from_spec`: user_prompt wins, test_args fallback, both empty still raises |
+| `tests/test_quality_grader.py` | Resolution tests for `blind_compare_from_spec`: `user_prompt` required; missing `user_prompt` raises even when `test_args` is set |
 
 Files NOT touched (important negative scope):
 

--- a/plans/super/39-eval-spec-user-prompt.md
+++ b/plans/super/39-eval-spec-user-prompt.md
@@ -1,7 +1,7 @@
 ---
 ticket: "#39 (clauditor-iag)"
 title: Add EvalSpec.user_prompt field
-phase: detailing
+phase: devolved
 branch: feature/39-user-prompt
 worktree: /home/wesd/dev/worktrees/clauditor/feature/39-user-prompt
 sessions: 1
@@ -255,4 +255,11 @@ covers this case.
 
 ## 5. Beads Manifest
 
-_Pending devolve._
+- **Epic:** `clauditor-1qd` — #39: Add EvalSpec.user_prompt field
+- **US-001:** `clauditor-49m` — Add user_prompt field + require it in blind_compare_from_spec
+- **Quality Gate:** `clauditor-am6` — code review x4 + CodeRabbit (blocked by clauditor-49m)
+- **Patterns & Memory:** `clauditor-x8y` — verify pure-compute-vs-io-split anchor (blocked by clauditor-am6)
+
+Worktree: `/home/wesd/dev/worktrees/clauditor/feature/39-user-prompt`
+Branch: `feature/39-user-prompt`
+Plan PR: https://github.com/wjduenow/clauditor/pull/40

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1300,7 +1300,7 @@ def _run_blind_compare(
 ) -> int:
     """Dispatch blind A/B comparison for a pair of ``.txt`` outputs.
 
-    Delegates spec/test_args/rubric/model resolution to
+    Delegates spec/user_prompt/rubric/model resolution to
     :func:`blind_compare_from_spec`; this wrapper handles file I/O, stderr
     reporting, and the ``_print_blind_report`` call. Both files are read as
     plain UTF-8. Returns 0 regardless of which side wins — blind compare is
@@ -1352,7 +1352,7 @@ def _run_blind_compare(
         )
         return 2
 
-    # US-002: all spec/test_args/rubric/model resolution happens inside
+    # US-002: all spec/user_prompt/rubric/model resolution happens inside
     # blind_compare_from_spec (shared with the pytest fixture from US-003).
     # We read the spec's model for the stderr progress line; the helper
     # resolves its own effective model internally. Validation already ran

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -196,7 +196,7 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
     runs :func:`clauditor.quality_grader.blind_compare_from_spec` on the
     two caller-supplied output strings. The fixture does NOT read files —
     outputs must be passed as strings. Raises ``ValueError`` if the spec
-    lacks an eval spec or ``test_args`` is empty; the exception is
+    lacks an eval spec or ``user_prompt`` is empty; the exception is
     propagated untouched so tests can assert on it.
 
     Model precedence (highest → lowest):

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -502,10 +502,10 @@ def validate_blind_compare_spec(spec: SkillSpec) -> None:
             "No eval spec found (blind_compare_from_spec requires "
             "spec.eval_spec to be set)"
         )
-    user_prompt = spec.eval_spec.test_args or ""
+    user_prompt = spec.eval_spec.user_prompt or ""
     if not user_prompt.strip():
         raise ValueError(
-            "blind_compare_from_spec: eval_spec.test_args must be set "
+            "blind_compare_from_spec: eval_spec.user_prompt must be set "
             "(used as the user prompt context for the judge)"
         )
 
@@ -527,13 +527,14 @@ async def blind_compare_from_spec(
     to :func:`blind_compare`.
 
     Raises :class:`ValueError` if ``spec.eval_spec`` is missing or if
-    ``eval_spec.test_args`` is empty/whitespace (it is used as the user prompt
-    context for the judge). Does not print to stdout or stderr (DEC-006).
+    ``eval_spec.user_prompt`` is empty/whitespace (it is used as the user
+    prompt context for the judge). Does not print to stdout or stderr
+    (DEC-006).
     """
     validate_blind_compare_spec(spec)
     assert spec.eval_spec is not None  # for type-checker; validator enforces
 
-    user_prompt = spec.eval_spec.test_args or ""
+    user_prompt = spec.eval_spec.user_prompt or ""
 
     rubric_hint: str | None = None
     criteria = spec.eval_spec.grading_criteria

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -504,7 +504,13 @@ def validate_blind_compare_spec(spec: SkillSpec) -> None:
             "No eval spec found (blind_compare_from_spec requires "
             "spec.eval_spec to be set)"
         )
-    user_prompt = spec.eval_spec.user_prompt or ""
+    raw = spec.eval_spec.user_prompt
+    if raw is not None and not isinstance(raw, str):
+        raise ValueError(
+            "blind_compare_from_spec: eval_spec.user_prompt must be a "
+            f"string, got {type(raw).__name__}"
+        )
+    user_prompt = raw or ""
     if not user_prompt.strip():
         raise ValueError(
             "blind_compare_from_spec: eval_spec.user_prompt must be a "

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -305,6 +305,8 @@ async def blind_compare(
 
     Requires the 'grader' extra: pip install clauditor[grader]
     """
+    if not user_prompt or not user_prompt.strip():
+        raise ValueError("blind_compare: user_prompt must be non-empty")
     if not output_a or not output_a.strip():
         raise ValueError("blind_compare: output_a must be non-empty")
     if not output_b or not output_b.strip():
@@ -505,8 +507,9 @@ def validate_blind_compare_spec(spec: SkillSpec) -> None:
     user_prompt = spec.eval_spec.user_prompt or ""
     if not user_prompt.strip():
         raise ValueError(
-            "blind_compare_from_spec: eval_spec.user_prompt must be set "
-            "(used as the user prompt context for the judge)"
+            "blind_compare_from_spec: eval_spec.user_prompt must be a "
+            "non-empty, non-whitespace string (used as the user prompt "
+            "context for the judge)"
         )
 
 
@@ -532,9 +535,16 @@ async def blind_compare_from_spec(
     (DEC-006).
     """
     validate_blind_compare_spec(spec)
-    assert spec.eval_spec is not None  # for type-checker; validator enforces
+    # Validator above guarantees both are set, but use an explicit raise
+    # (not `assert`, which `python -O` strips) since ``user_prompt`` flows
+    # straight into an LLM prompt — defense in depth.
+    if spec.eval_spec is None or spec.eval_spec.user_prompt is None:  # pragma: no cover
+        raise RuntimeError(
+            "blind_compare_from_spec: validator failed to enforce "
+            "user_prompt invariant"
+        )
 
-    user_prompt = spec.eval_spec.user_prompt or ""
+    user_prompt = spec.eval_spec.user_prompt
 
     rubric_hint: str | None = None
     criteria = spec.eval_spec.grading_criteria

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -329,10 +329,11 @@ class EvalSpec:
 
         user_prompt = data.get("user_prompt")
         if user_prompt is not None:
-            if not isinstance(user_prompt, str) or user_prompt == "":
+            if not isinstance(user_prompt, str) or not user_prompt.strip():
                 raise ValueError(
                     f"EvalSpec(skill_name={skill_name!r}): user_prompt "
-                    f"must be a non-empty string, got {user_prompt!r}"
+                    f"must be a non-empty, non-whitespace string, "
+                    f"got {user_prompt!r}"
                 )
 
         trigger_tests = None
@@ -382,6 +383,11 @@ class EvalSpec:
             "skill_name": self.skill_name,
             "description": self.description,
             "test_args": self.test_args,
+            **(
+                {"user_prompt": self.user_prompt}
+                if self.user_prompt is not None
+                else {}
+            ),
             "input_files": self.input_files,
             "assertions": self.assertions,
             "sections": [
@@ -423,8 +429,6 @@ class EvalSpec:
             "grading_criteria": self.grading_criteria,
             "grading_model": self.grading_model,
         }
-        if self.user_prompt is not None:
-            result["user_prompt"] = self.user_prompt
         if self.output_file is not None:
             result["output_file"] = self.output_file
         if self.output_files:

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -134,6 +134,11 @@ class EvalSpec:
     skill_name: str
     description: str = ""
     test_args: str = ""  # Pre-filled args to skip interactive Q&A
+    # Natural-language user-query context handed to the blind A/B judge
+    # (see `blind_compare_from_spec`). Distinct from `test_args`, which is
+    # the skill-runner CLI arg string. Optional at load time, but required
+    # by the blind-compare helper when that code path is used.
+    user_prompt: str | None = None
     input_files: list[str] = field(default_factory=list)  # Resolved absolute paths
     assertions: list[dict] = field(default_factory=list)  # Layer 1 checks
     sections: list[SectionRequirement] = field(default_factory=list)  # Layer 2 schema
@@ -322,6 +327,14 @@ class EvalSpec:
                     f"grading_criteria[{i}]: 'criterion' must be a non-empty string"
                 )
 
+        user_prompt = data.get("user_prompt")
+        if user_prompt is not None:
+            if not isinstance(user_prompt, str) or user_prompt == "":
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): user_prompt "
+                    f"must be a non-empty string, got {user_prompt!r}"
+                )
+
         trigger_tests = None
         if "trigger_tests" in data:
             tt = data["trigger_tests"]
@@ -350,6 +363,7 @@ class EvalSpec:
             skill_name=skill_name,
             description=data.get("description", ""),
             test_args=data.get("test_args", ""),
+            user_prompt=user_prompt,
             input_files=resolved_input_files,
             assertions=data.get("assertions", []),
             sections=sections,
@@ -409,6 +423,8 @@ class EvalSpec:
             "grading_criteria": self.grading_criteria,
             "grading_model": self.grading_model,
         }
+        if self.user_prompt is not None:
+            result["user_prompt"] = self.user_prompt
         if self.output_file is not None:
             result["output_file"] = self.output_file
         if self.output_files:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2922,7 +2922,7 @@ class TestCmdCompareBlind:
 
     def test_compare_blind_happy_path(self, tmp_path, capsys):
         before, after = self._write_pair(tmp_path)
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         report = self._make_blind_report(
             preference="b",
@@ -2957,7 +2957,7 @@ class TestCmdCompareBlind:
 
     def test_compare_blind_tie_output(self, tmp_path, capsys):
         before, after = self._write_pair(tmp_path)
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         report = self._make_blind_report(preference="tie")
         with patch(
@@ -2982,7 +2982,7 @@ class TestCmdCompareBlind:
 
     def test_compare_blind_surfaces_position_bias(self, tmp_path, capsys):
         before, after = self._write_pair(tmp_path)
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         report = self._make_blind_report(position_agreement=False)
         with patch(
@@ -3049,7 +3049,7 @@ class TestCmdCompareBlind:
             before_text="UNIQUE_BEFORE_CONTENT_XYZ",
             after_text="UNIQUE_AFTER_CONTENT_XYZ",
         )
-        eval_spec = _make_eval_spec(test_args="Do a thing")
+        eval_spec = _make_eval_spec(user_prompt="Do a thing")
         spec = _make_spec(eval_spec=eval_spec)
         report = self._make_blind_report()
         mock_blind = AsyncMock(return_value=report)
@@ -3078,7 +3078,7 @@ class TestCmdCompareBlind:
 
     def test_compare_blind_before_branch(self, tmp_path, capsys):
         before, after = self._write_pair(tmp_path)
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         report = self._make_blind_report(preference="a")
         with patch(
@@ -3106,7 +3106,7 @@ class TestCmdCompareBlind:
         after = tmp_path / "after.txt"
         before.write_text("ok")
         # after intentionally not created
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         with patch(
             "clauditor.cli.SkillSpec.from_file", return_value=spec
@@ -3131,7 +3131,7 @@ class TestCmdCompareBlind:
         after = tmp_path / "after.txt"
         before.write_bytes(b"\xff\xfe\xfd")
         after.write_text("ok")
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         with patch(
             "clauditor.cli.SkillSpec.from_file", return_value=spec
@@ -3157,7 +3157,7 @@ class TestCmdCompareBlind:
         before, _ = self._write_pair(tmp_path)
         after = tmp_path / "after.txt"
         after.write_bytes(b"\xff\xfe\xfd")
-        eval_spec = _make_eval_spec(test_args="Write a hello world")
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
         spec = _make_spec(eval_spec=eval_spec)
         with patch(
             "clauditor.cli.SkillSpec.from_file", return_value=spec
@@ -3200,10 +3200,10 @@ class TestCmdCompareBlind:
         # "ERROR: ..." with the helper's message substring.
         assert "No eval spec" in err
 
-    def test_compare_blind_empty_test_args_errors(self, tmp_path, capsys):
-        # Covers the whitespace-only test_args branch (cli.py lines 752-759).
+    def test_compare_blind_empty_user_prompt_errors(self, tmp_path, capsys):
+        # Covers the whitespace-only user_prompt branch (cli.py lines 752-759).
         before, after = self._write_pair(tmp_path)
-        eval_spec = _make_eval_spec(test_args="   \n")
+        eval_spec = _make_eval_spec(user_prompt="   \n")
         spec = _make_spec(eval_spec=eval_spec)
         with patch(
             "clauditor.cli.SkillSpec.from_file", return_value=spec
@@ -3220,7 +3220,7 @@ class TestCmdCompareBlind:
             )
         assert rc == 2
         err = capsys.readouterr().err
-        assert "test_args" in err
+        assert "user_prompt" in err
         # Fail-fast: the "Running blind A/B judge" progress line must NOT
         # appear when validation fails. Previously the CLI printed the
         # progress message before validating, misleading users into

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3201,7 +3201,8 @@ class TestCmdCompareBlind:
         assert "No eval spec" in err
 
     def test_compare_blind_empty_user_prompt_errors(self, tmp_path, capsys):
-        # Covers the whitespace-only user_prompt branch (cli.py lines 752-759).
+        # Covers the whitespace-only user_prompt path through
+        # validate_blind_compare_spec for `clauditor compare --blind`.
         before, after = self._write_pair(tmp_path)
         eval_spec = _make_eval_spec(user_prompt="   \n")
         spec = _make_spec(eval_spec=eval_spec)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -426,17 +426,16 @@ def _blind_compare_factory(tmp_path: Path, *, cli_model: str | None = None):
 def _write_skill_with_eval(
     tmp_path: Path,
     name: str = "sushi",
-    test_args: str = "What's the best sushi?",
+    user_prompt: str | None = "What's the best sushi?",
     criteria: list[str] | None = None,
     eval_filename: str | None = None,
     grading_model: str = "claude-sonnet-4-6",
 ) -> tuple[Path, Path]:
     skill_path = tmp_path / f"{name}.md"
     skill_path.write_text(f"# {name}\n\nA skill.")
-    eval_data = {
+    eval_data: dict = {
         "skill_name": name,
         "description": f"Eval for {name}",
-        "test_args": test_args,
         "assertions": [],
         "grading_criteria": [
             {"id": f"c{i}", "criterion": c}
@@ -449,6 +448,8 @@ def _write_skill_with_eval(
         ],
         "grading_model": grading_model,
     }
+    if user_prompt is not None:
+        eval_data["user_prompt"] = user_prompt
     eval_path = tmp_path / (eval_filename or f"{name}.eval.json")
     eval_path.write_text(json.dumps(eval_data))
     return skill_path, eval_path
@@ -483,11 +484,11 @@ class TestClauditorBlindCompare:
 
     def test_clauditor_blind_compare_eval_path_override(self, tmp_path):
         """Explicit eval_path overrides sibling auto-discovery."""
-        # Sibling eval: different test_args than the override we'll pass.
+        # Sibling eval: different user_prompt than the override we'll pass.
         skill_path, _ = _write_skill_with_eval(
             tmp_path,
             name="ramen",
-            test_args="sibling prompt",
+            user_prompt="sibling prompt",
             criteria=["sibling criterion"],
         )
         # Override eval in a different location with distinct content.
@@ -498,7 +499,7 @@ class TestClauditorBlindCompare:
             json.dumps({
                 "skill_name": "ramen",
                 "description": "override",
-                "test_args": "override prompt",
+                "user_prompt": "override prompt",
                 "assertions": [],
                 "grading_criteria": [
                     {"id": "ov1", "criterion": "override criterion"},
@@ -589,10 +590,10 @@ class TestClauditorBlindCompare:
         call = mock_bc.await_args
         assert call.kwargs["model"] == "claude-opus-4-6"
 
-    def test_clauditor_blind_compare_raises_on_empty_test_args(self, tmp_path):
-        """Empty test_args in the spec propagates as ValueError."""
+    def test_clauditor_blind_compare_raises_on_missing_user_prompt(self, tmp_path):
+        """Missing user_prompt in the spec propagates as ValueError."""
         skill_path, _ = _write_skill_with_eval(
-            tmp_path, name="empty", test_args=""
+            tmp_path, name="empty", user_prompt=None
         )
         factory = _blind_compare_factory(tmp_path)
 
@@ -600,7 +601,7 @@ class TestClauditorBlindCompare:
             "clauditor.quality_grader.blind_compare",
             new=AsyncMock(return_value=_make_blind_report()),
         ):
-            with pytest.raises(ValueError, match="test_args"):
+            with pytest.raises(ValueError, match="user_prompt"):
                 factory(skill_path, "a", "b")
 
     def test_clauditor_blind_compare_reserved_fixture_name(self):

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1331,6 +1331,16 @@ class TestBlindCompare:
     # Seed 1: random.Random(1).random() < 0.5 is True → "ab->12".
 
     @pytest.mark.asyncio
+    async def test_blind_compare_rejects_empty_user_prompt(self):
+        with pytest.raises(ValueError, match="user_prompt must be non-empty"):
+            await blind_compare("", "a-out", "b-out")
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_rejects_whitespace_user_prompt(self):
+        with pytest.raises(ValueError, match="user_prompt must be non-empty"):
+            await blind_compare("   \n", "a-out", "b-out")
+
+    @pytest.mark.asyncio
     async def test_blind_compare_rejects_empty_output_a(self):
         with pytest.raises(ValueError, match="non-empty"):
             await blind_compare("q", "", "b-out")

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1828,7 +1828,8 @@ class TestBlindCompareFromSpec:
     def _make_eval_spec(
         self,
         *,
-        test_args: str = "What's the best sushi in Tokyo?",
+        user_prompt: str | None = "What's the best sushi in Tokyo?",
+        test_args: str = "",
         grading_criteria=None,
         grading_model: str = "claude-sonnet-4-6",
     ) -> EvalSpec:
@@ -1841,6 +1842,7 @@ class TestBlindCompareFromSpec:
             skill_name="test-skill",
             description="test",
             test_args=test_args,
+            user_prompt=user_prompt,
             grading_criteria=grading_criteria,
             grading_model=grading_model,
         )
@@ -1896,24 +1898,63 @@ class TestBlindCompareFromSpec:
             await blind_compare_from_spec(spec, "A", "B")
 
     @pytest.mark.asyncio
-    async def test_blind_compare_from_spec_raises_on_empty_test_args(self):
+    async def test_blind_compare_from_spec_raises_on_missing_user_prompt(self):
         from clauditor.quality_grader import blind_compare_from_spec
 
         spec = self._make_skill_spec(
-            eval_spec=self._make_eval_spec(test_args="")
+            eval_spec=self._make_eval_spec(user_prompt=None)
         )
-        with pytest.raises(ValueError, match="test_args"):
+        with pytest.raises(ValueError, match="user_prompt"):
             await blind_compare_from_spec(spec, "A", "B")
 
     @pytest.mark.asyncio
-    async def test_blind_compare_from_spec_raises_on_whitespace_test_args(self):
+    async def test_blind_compare_from_spec_raises_on_whitespace_user_prompt(self):
         from clauditor.quality_grader import blind_compare_from_spec
 
         spec = self._make_skill_spec(
-            eval_spec=self._make_eval_spec(test_args="   \n  ")
+            eval_spec=self._make_eval_spec(user_prompt="   \n  ")
         )
-        with pytest.raises(ValueError, match="test_args"):
+        with pytest.raises(ValueError, match="user_prompt"):
             await blind_compare_from_spec(spec, "A", "B")
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_requires_user_prompt_even_if_test_args_set(
+        self,
+    ):
+        """Core behavior change: test_args no longer substitutes for user_prompt.
+
+        A spec with runner CLI args set but no user_prompt must still
+        raise — the two fields now have distinct semantics.
+        """
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        spec = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(
+                user_prompt=None, test_args="--depth quick --limit 10"
+            )
+        )
+        with pytest.raises(ValueError, match="user_prompt"):
+            await blind_compare_from_spec(spec, "A", "B")
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_forwards_user_prompt_not_test_args(
+        self,
+    ):
+        """Forwards eval_spec.user_prompt (not test_args) to blind_compare."""
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        eval_spec = self._make_eval_spec(
+            user_prompt="Is sushi good?",
+            test_args="--depth quick",
+        )
+        spec = self._make_skill_spec(eval_spec=eval_spec)
+        mock_bc = AsyncMock(return_value=self._canned_report())
+
+        with patch("clauditor.quality_grader.blind_compare", mock_bc):
+            await blind_compare_from_spec(spec, "A", "B")
+
+        assert mock_bc.await_args.args[0] == "Is sushi good?"
+        assert mock_bc.await_args.args[0] != "--depth quick"
 
     @pytest.mark.asyncio
     async def test_blind_compare_from_spec_no_criteria_passes_none_rubric(self):
@@ -1953,18 +1994,33 @@ class TestBlindCompareFromSpec:
         with pytest.raises(ValueError, match="No eval spec"):
             validate_blind_compare_spec(spec)
 
-    def test_validate_blind_compare_spec_raises_on_empty_test_args(self):
-        """validate_blind_compare_spec raises when test_args is empty/whitespace."""
+    def test_validate_blind_compare_spec_raises_on_missing_user_prompt(self):
+        """validate_blind_compare_spec raises when user_prompt is missing/whitespace."""
         from clauditor.quality_grader import validate_blind_compare_spec
 
         spec = self._make_skill_spec(
-            eval_spec=self._make_eval_spec(test_args="")
+            eval_spec=self._make_eval_spec(user_prompt=None)
         )
-        with pytest.raises(ValueError, match="test_args"):
+        with pytest.raises(ValueError, match="user_prompt"):
             validate_blind_compare_spec(spec)
 
         spec_ws = self._make_skill_spec(
-            eval_spec=self._make_eval_spec(test_args="   \n ")
+            eval_spec=self._make_eval_spec(user_prompt="   \n ")
         )
-        with pytest.raises(ValueError, match="test_args"):
+        with pytest.raises(ValueError, match="user_prompt"):
             validate_blind_compare_spec(spec_ws)
+
+    def test_validate_blind_compare_spec_requires_user_prompt_even_if_test_args_set(
+        self,
+    ):
+        """Core behavior change: having test_args set no longer satisfies
+        the blind-compare validator. user_prompt is the only source."""
+        from clauditor.quality_grader import validate_blind_compare_spec
+
+        spec = self._make_skill_spec(
+            eval_spec=self._make_eval_spec(
+                user_prompt=None, test_args="--depth quick --limit 10"
+            )
+        )
+        with pytest.raises(ValueError, match="user_prompt"):
+            validate_blind_compare_spec(spec)

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1967,6 +1967,20 @@ class TestBlindCompareFromSpec:
         assert mock_bc.await_args.args[0] != "--depth quick"
 
     @pytest.mark.asyncio
+    async def test_blind_compare_from_spec_rejects_non_string_user_prompt(
+        self,
+    ):
+        """In-memory construction cannot smuggle a non-string user_prompt
+        past the validator — it raises ValueError, not AttributeError."""
+        from clauditor.quality_grader import blind_compare_from_spec
+
+        eval_spec = self._make_eval_spec(user_prompt=None)
+        eval_spec.user_prompt = 42  # type: ignore[assignment]
+        spec = self._make_skill_spec(eval_spec=eval_spec)
+        with pytest.raises(ValueError, match="must be a string, got int"):
+            await blind_compare_from_spec(spec, "A", "B")
+
+    @pytest.mark.asyncio
     async def test_blind_compare_from_spec_no_criteria_passes_none_rubric(self):
         from clauditor.quality_grader import blind_compare_from_spec
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1387,7 +1387,7 @@ class TestEvalSpecUserPrompt:
         assert spec.user_prompt == "What's the best sushi in Tokyo?"
 
     def test_from_file_user_prompt_absent_defaults_to_none(self, tmp_path):
-        """Backcompat: omitting user_prompt leaves the attribute None."""
+        """Omitting user_prompt leaves the attribute None."""
         data = {"skill_name": "s"}
         path = _write_json(tmp_path, data)
         spec = EvalSpec.from_file(path)
@@ -1399,7 +1399,18 @@ class TestEvalSpecUserPrompt:
         data = {"skill_name": "s", "user_prompt": ""}
         path = _write_json(tmp_path, data)
         with pytest.raises(
-            ValueError, match="user_prompt must be a non-empty string"
+            ValueError, match="user_prompt must be a non-empty"
+        ):
+            EvalSpec.from_file(path)
+
+    def test_from_file_user_prompt_whitespace_only_rejected(self, tmp_path):
+        """Whitespace-only user_prompt must be rejected at load time —
+        otherwise the failure only surfaces much later when the blind
+        judge is invoked."""
+        data = {"skill_name": "s", "user_prompt": "   \n\t"}
+        path = _write_json(tmp_path, data)
+        with pytest.raises(
+            ValueError, match="user_prompt must be a non-empty, non-whitespace"
         ):
             EvalSpec.from_file(path)
 
@@ -1408,7 +1419,7 @@ class TestEvalSpecUserPrompt:
         data = {"skill_name": "s", "user_prompt": 42}
         path = _write_json(tmp_path, data)
         with pytest.raises(
-            ValueError, match="user_prompt must be a non-empty string"
+            ValueError, match="user_prompt must be a non-empty"
         ):
             EvalSpec.from_file(path)
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1371,3 +1371,66 @@ class TestEvalSpecInputFiles:
         spec_path = self._write_spec(tmp_path, {"input_files": ["."]})
         with pytest.raises(ValueError, match="not a regular file"):
             EvalSpec.from_file(spec_path)
+
+
+class TestEvalSpecUserPrompt:
+    """Tests for the optional ``user_prompt`` field (#39)."""
+
+    def test_from_file_loads_user_prompt(self, tmp_path):
+        """A spec with user_prompt set parses into the dataclass."""
+        data = {
+            "skill_name": "s",
+            "user_prompt": "What's the best sushi in Tokyo?",
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.user_prompt == "What's the best sushi in Tokyo?"
+
+    def test_from_file_user_prompt_absent_defaults_to_none(self, tmp_path):
+        """Backcompat: omitting user_prompt leaves the attribute None."""
+        data = {"skill_name": "s"}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.user_prompt is None
+
+    def test_from_file_user_prompt_empty_string_rejected(self, tmp_path):
+        """An empty-string user_prompt must be rejected — callers should
+        not have to disambiguate ``None`` vs ``""``."""
+        data = {"skill_name": "s", "user_prompt": ""}
+        path = _write_json(tmp_path, data)
+        with pytest.raises(
+            ValueError, match="user_prompt must be a non-empty string"
+        ):
+            EvalSpec.from_file(path)
+
+    def test_from_file_user_prompt_non_string_rejected(self, tmp_path):
+        """A non-string user_prompt (e.g. a number) is rejected."""
+        data = {"skill_name": "s", "user_prompt": 42}
+        path = _write_json(tmp_path, data)
+        with pytest.raises(
+            ValueError, match="user_prompt must be a non-empty string"
+        ):
+            EvalSpec.from_file(path)
+
+    def test_to_dict_omits_user_prompt_when_unset(self):
+        """Round-tripping a spec without user_prompt does not inject the key."""
+        spec = EvalSpec(skill_name="s")
+        d = spec.to_dict()
+        assert "user_prompt" not in d
+
+    def test_to_dict_emits_user_prompt_when_set(self):
+        spec = EvalSpec(skill_name="s", user_prompt="hello there?")
+        d = spec.to_dict()
+        assert d["user_prompt"] == "hello there?"
+
+    def test_user_prompt_round_trip(self, tmp_path):
+        """to_dict -> JSON file -> from_file preserves user_prompt."""
+        original = EvalSpec(
+            skill_name="s",
+            description="d",
+            user_prompt="Is ramen good?",
+        )
+        path = tmp_path / "roundtrip.eval.json"
+        path.write_text(json.dumps(original.to_dict()))
+        loaded = EvalSpec.from_file(path)
+        assert loaded.user_prompt == "Is ramen good?"


### PR DESCRIPTION
## Summary

Adds `EvalSpec.user_prompt` and switches `blind_compare_from_spec` to read it instead of repurposing `test_args` as the judge query. `test_args` keeps its runner-CLI-args semantics; the two fields now have distinct meaning. Library is pre-publication, so no backcompat shim (DEC-001).

Both `clauditor compare --blind` and the `clauditor_blind_compare` pytest fixture pick up the new resolution automatically through the shared `blind_compare_from_spec` helper — the case `.claude/rules/pure-compute-vs-io-split.md`'s second anchor was written for.

## Changes

- **`src/clauditor/schemas.py`** — `EvalSpec.user_prompt: str | None = None`. `from_file` rejects empty/whitespace/non-string values at load time. `to_dict` emits it right after `test_args` only when set.
- **`src/clauditor/quality_grader.py`** — `validate_blind_compare_spec` + `blind_compare_from_spec` now read `user_prompt`; `blind_compare` validates `user_prompt` non-empty as defense-in-depth for direct callers.
- **`examples/.claude/commands/example-skill.eval.json`** — populated `user_prompt` so the example works with `--blind`.
- **`README.md`** — `--blind` docs name `eval_spec.user_prompt` explicitly.
- **Tests** — new `TestEvalSpecUserPrompt` class; `blind_compare` direct-call guards; migrated fixtures; non-string validator test.
- **Plan doc** `plans/super/39-eval-spec-user-prompt.md` + `.claude/rules/pure-compute-vs-io-split.md` rule anchor updated.

## Commits

- `6fc359f` — US-001: Add the field and swap the resolution
- `895b049` — Quality gate: fixes from 4 code review passes
- `7c0ec85` — Update the pure-compute-vs-io-split rule
- `33e689d` — Address Copilot PR review comments

## Validation

`uv run ruff check src/ tests/` clean. `uv run pytest --cov=clauditor` — 1155 passed, 96.05% coverage (80% gate).

Closes #39