### PR TITLE
#41: Audit and remove legacy/backcompat code

### DIFF
--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -63,9 +63,9 @@ def _records_from_sidecar(data: dict, source: Path) -> list[Record]:
 
 Writers: `src/clauditor/quality_grader.py::GradingReport.to_json`,
 `src/clauditor/grader.py::ExtractionReport.to_json`,
-`src/clauditor/audit.py::render_json`, and the sidecar envelopes in
-`src/clauditor/cli.py::_cmd_grade_with_workspace` /
-`_run_baseline_phase`.
+`src/clauditor/audit.py::render_json`,
+`src/clauditor/baseline.py::BaselineReports.to_json_map`, and the
+sidecar envelopes in `src/clauditor/cli.py::_cmd_grade_with_workspace`.
 
 Loaders: `src/clauditor/audit.py::_check_schema_version` and its call sites
 in `_records_from_assertions`, `_records_from_extraction`,

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -111,11 +111,26 @@ change in `blind_compare_from_spec` (switching from `test_args` to
 caller and the pytest fixture picked up the new resolution
 automatically, validating the rule's prediction.
 
-## Grandfathered counter-example
+### Third anchor (baseline phase split)
 
-`src/clauditor/cli.py::_run_baseline_phase` does "run + grade + write
-`baseline_*.json`" internally. That pattern predates this rule and is
-grandfathered; do NOT copy it for new resolve-and-compose helpers.
+`src/clauditor/baseline.py::compute_baseline` — pure function that
+takes an already-run `SkillResult` + `EvalSpec` and returns a
+`BaselineReports` dataclass containing L1 assertions, L2 extraction
+(when sections declared), and L3 grading. The dataclass provides
+`to_json_map()` returning `{filename: json_str}` for all baseline
+sidecars, with `schema_version` as the first key in each payload.
+
+Single caller: `src/clauditor/cli.py::_run_baseline_phase` — thin
+wrapper that handles subprocess invocation (`run_raw`), input-file
+staging, stderr progress, and `write_text()` for each sidecar.
+
+Before the extraction (pre-#41), `_run_baseline_phase` bundled
+subprocess invocation, grading, assertion evaluation, extraction,
+JSON serialization, and file writes in a single 98-line function —
+the grandfathered counter-example previously cited by this rule. The
+refactored split makes the grading logic unit-testable without
+`tmp_path` or subprocess mocks, and positions the pure helper for
+reuse from a future pytest fixture.
 
 ## When this rule applies
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ clauditor doctor                       # Report environment diagnostics
 
 ### Persistent metric history
 
-Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. All history records are schema v3 with a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`.
+Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Records use schema v3 with a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`. The reader requires `schema_version: 3` and skips older records with a warning.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ clauditor compare --skill my-skill --from 1 --to 2
 # 2. Iteration directory paths
 clauditor compare .clauditor/iteration-1/my-skill .clauditor/iteration-2/my-skill
 
-# 3. Legacy grade-report files
+# 3. Saved grade-report files
 clauditor compare before.grade.json after.grade.json
 
 # Or re-grade two raw captures against a spec:
@@ -602,9 +602,9 @@ bare hostnames too.
 Field-level checks still run over all extracted entries so you see both
 the count failure and any per-entry failures.
 
-## Migration notes
+## Notes
 
-- **`history.jsonl` is schema v3** with `iteration` and `workspace_path` fields on `grade` records. The reader hard-requires `schema_version: 3`; older records are skipped with a warning.
+- **`history.jsonl` uses schema v3** with `iteration` and `workspace_path` fields on `grade` records. The reader requires `schema_version: 3`; records with a different version are skipped with a warning.
 - **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
 
 ## Reference docs

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ clauditor grade .claude/commands/my-skill.md --iteration 5 --force  # Overwrite 
 clauditor grade .claude/commands/my-skill.md --diff         # Compare against prior iteration
 ```
 
-Every `grade` run is persisted to `.clauditor/iteration-N/<skill>/` — there is no opt-in `--save`. By default the iteration number auto-increments to the next free slot. Pass `--iteration N` to target a specific slot; if `iteration-N/` already exists the command errors unless you also pass `--force` to overwrite.
+Every `grade` run is persisted to `.clauditor/iteration-N/<skill>/` automatically. By default the iteration number auto-increments to the next free slot. Pass `--iteration N` to target a specific slot; if `iteration-N/` already exists the command errors unless you also pass `--force` to overwrite.
 
 Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--diff` to compare against a prior iteration (flags regressions where a criterion's score drops by more than 0.1).
 
@@ -392,7 +392,6 @@ clauditor grade <skill.md> --iteration 5 --force       # Overwrite an existing i
 clauditor grade <skill.md> --diff                      # Compare against prior iteration
 clauditor compare --skill <skill> --from 1 --to 2      # Diff two iterations by number
 clauditor compare .clauditor/iteration-1/<skill> .clauditor/iteration-2/<skill>  # Diff by directory
-clauditor compare before.grade.json after.grade.json   # Diff two legacy grade reports
 clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
 clauditor trend <skill> --metric total.total     # Tab-separated history + ASCII sparkline
 clauditor trend <skill> --list-metrics           # List available metric paths
@@ -603,15 +602,8 @@ bare hostnames too.
 Field-level checks still run over all extracted entries so you see both
 the count failure and any per-entry failures.
 
-> **Migration note (April 2026):** The legacy `"pattern"` key on
-> `FieldRequirement` has been removed. Migrate by renaming `pattern` to
-> `format` — inline regexes work as before; registered names are now the
-> preferred ergonomics.
-
 ## Migration notes
 
-- **`clauditor grade --save` has been removed.** Every `grade` run is now persisted to `.clauditor/iteration-N/<skill>/` automatically. Drop `--save` from scripts and CI; use `--iteration N` / `--force` if you need to target a specific slot.
-- **Legacy `.clauditor/<skill>.grade.json` files are ignored by auto-discovery.** The canonical grade report is `.clauditor/iteration-N/<skill>/grading.json`, and `grade --diff` / `cmd_trend` only look at the new layout. You can still pass a legacy `.grade.json` explicitly to `clauditor compare` (e.g. `compare old.grade.json new.grade.json`), but clauditor no longer writes that format.
 - **`history.jsonl` is now schema v3** with `iteration` and `workspace_path` fields on `grade` records. Mixed v2/v3 files continue to load.
 - **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ clauditor doctor                       # Report environment diagnostics
 
 ### Persistent metric history
 
-Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Records are schema v3 with a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`. Legacy v2 records still read cleanly.
+Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. All history records are schema v3 with a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`.
 
 ```json
 {
@@ -604,7 +604,7 @@ the count failure and any per-entry failures.
 
 ## Migration notes
 
-- **`history.jsonl` is now schema v3** with `iteration` and `workspace_path` fields on `grade` records. Mixed v2/v3 files continue to load.
+- **`history.jsonl` is schema v3** with `iteration` and `workspace_path` fields on `grade` records. The reader hard-requires `schema_version: 3`; older records are skipped with a warning.
 - **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
 
 ## Reference docs

--- a/plans/super/41-legacy-backcompat-audit.md
+++ b/plans/super/41-legacy-backcompat-audit.md
@@ -1,0 +1,334 @@
+# Super Plan: #41 — Audit and remove legacy / backcompat code
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/41
+- **Branch:** `feature/41-legacy-audit`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/41-legacy-audit`
+- **Phase:** detailing
+- **Sessions:** 1 (2026-04-15)
+
+## Ticket summary
+
+clauditor has never been published. Any backcompat artifact exists for a user who does not exist. Sweep the codebase, inventory every finding, get per-category approval, then plan removal. The audit IS the ticket — no code changes in Phase 1.
+
+## Discovery — Inventory
+
+Three parallel audit subagents (keyword sweep, structural sweep, docs sweep) produced the consolidated findings below. Each item has `file:line`, category, and confidence.
+
+### A. Active rejection code for already-removed features
+
+Code that hard-fails on old eval-spec shapes. In pre-publication context, the friendly error messages are unnecessary — nobody is migrating from them.
+
+| # | Location | What | Confidence |
+|---|---|---|---|
+| A1 | `src/clauditor/schemas.py:114-124` (`_resolve_field_format`) | `raise ValueError("the 'pattern' key is no longer supported…")` — rejects removed `pattern` field with friendly migration message | high |
+| A1t | `tests/test_schemas.py:675-690` | `test_from_file_legacy_pattern_key_rejected` | high |
+| A1d | `README.md:606-609` | "Migration note (April 2026): The legacy `pattern` key on FieldRequirement has been removed" | high |
+| A2 | `tests/test_cli.py:1334-1340` | `test_grade_save_flag_removed` — asserts argparse rejects `--save` | high |
+| A2d | `README.md:613` | "`clauditor grade --save` has been removed" migration note | high |
+
+### B. Legacy-format fallbacks in parsers/loaders
+
+Defensive branches in sidecar/history readers that exist only to tolerate shapes no longer written anywhere.
+
+| # | Location | What | Confidence |
+|---|---|---|---|
+| B1 | `src/clauditor/audit.py:162` | `rid = result.get("id") or result.get("name")` — fallback to pre-stable-id `name` key in L1 assertion sidecars | high |
+| B2 | `src/clauditor/audit.py:194-200` | Fallback to `presence_passed`+`format_passed` when top-level `passed` missing in old extraction.json | high |
+| B3 | `src/clauditor/assertions.py:64` + `tests/test_assertions.py:980-1044` | `AssertionResult.from_json_dict` "tolerates missing keys for older on-disk fixtures" (`transcript_path`) + two tests pinning the tolerance | high |
+| B4 | `src/clauditor/history.py:9-28,77` + README.md:407 | Reader explicitly tolerates v1 (no schema_version, no command) and v2 (no iteration, no workspace_path) history records. Writer only emits v3. | high |
+| B4t | `tests/test_cli.py:3809` + `tests/test_history.py:224` | Tests pinning mixed-version read behavior | high |
+| B5 | `src/clauditor/spec.py:263-312` + `tests/test_schemas.py:73,1122-1148` | "Legacy fields-style: normalize to single default tier" — `EvalSpec.from_file` has a parallel parser for pre-tiers flat `fields` shape | high |
+| B6 | `tests/test_cli.py:2867-2890` + README.md:395 | `test_compare_legacy_grade_json_files` + docs line describing `clauditor compare before.grade.json after.grade.json` — supports a sidecar format clauditor no longer writes | high |
+
+### C. Optional dataclass fields kept for test-fixture convenience
+
+Fields typed `| None = None` only because direct-construction fixtures skip them; production callers always set them.
+
+| # | Location | What | Confidence |
+|---|---|---|---|
+| C1 | `src/clauditor/quality_grader.py:59,62` | `GradingReport.thresholds: GradeThresholds \| None` and `metrics: dict \| None` — always populated by `grade_quality()`, optional only for ~10 test fixtures | med |
+
+### D. Grandfathered rule counter-examples
+
+| # | Location | What | Confidence |
+|---|---|---|---|
+| D1 | `src/clauditor/cli.py::_run_baseline_phase` (~lines 552-649) + `.claude/rules/pure-compute-vs-io-split.md:114-118` + `.claude/rules/json-schema-version.md:67` | Bundles spec-resolve + subprocess + LLM grading + sidecar writes. Explicitly grandfathered in two rule files. Either refactor (extract pure compute helper) or accept as permanent and scrub the "grandfathered" framing from the rules. | high (finding), decision-needed (action) |
+
+### E. Borderline / explicit non-findings
+
+Noted for completeness; recommended **leave alone** unless user disagrees.
+
+- `src/clauditor/quality_grader.py:128-151` — `GradingReport.from_json` defensive `.get(…, default)` defaults. Purpose is **crash/corruption tolerance**, not backcompat. Keep.
+- `src/clauditor/cli.py:82-85,178-179,447-448` — `getattr(args, …, default)` patterns. Standard argparse defensive shape; not legacy.
+- `src/clauditor/runner.py` stream-json permissive parsing. Governed by `.claude/rules/stream-json-schema.md` — intentional defensive-read of a third-party format. Keep.
+- `src/clauditor/schemas.py:101` — `grading_criteria` tolerates plain strings "for in-memory construction in tests". Test-ergonomics, not backcompat. Keep unless user disagrees.
+- `docs/stream-json-schema.md:10-11` — "verified live against `claude` 2.1.x" version pin note. Keep (it's a freshness marker, not legacy code).
+- `plans/super/*.md` historical plan docs referencing "legacy" — archive material, do not touch.
+- `pyproject.toml` Python lower bound — unremarkable.
+- `src/clauditor/spec.py:76` `test_args` — active CLI-args source, not legacy. The `test_args` vs `user_prompt` split is complete; both fields are load-bearing.
+
+## Categorization by removal risk
+
+| Category | Items | Risk | Notes |
+|---|---|---|---|
+| **Safe-delete** | A1, A1t, A1d, A2, A2d, B1, B2, B3, B6 | low | Pure deletion; existing tests protect non-legacy paths. README lines go with them. |
+| **Small refactor** | B4, B4t, B5, C1 | low-med | Drop parser branches + update affected tests/fixtures. B4 needs a `schema_version == 3` hard check per `.claude/rules/json-schema-version.md`. B5 needs eval-spec fixtures rewritten to tiered shape. C1 needs ~10 test fixtures updated to pass required fields. |
+| **Architectural decision** | D1 | med | `_run_baseline_phase` refactor is non-trivial (it coordinates subprocess + grading + sidecar atomicity). User decides: refactor now, or scrub "grandfathered" language and accept as permanent. |
+| **Leave alone** | E items | — | Not legacy. |
+
+## Scope question (Deliverable 4)
+
+The ticket asks whether this should be split across multiple issues. **Recommendation: one epic, ~4-5 stories, manageable in a single ticket.**
+
+- Safe-delete category is mechanical and can be one story
+- Small-refactor items each get one story (B4, B5, C1)
+- D1 gets its own story only if the user chooses "refactor now"
+
+Total: 4 stories if D1 is deferred, 5 if refactored. All fit within #41 without a split.
+
+## Approval checkpoint
+
+**Awaiting user go/no-go on each category.** No code changes until approval. Once approved, I'll run Phase 2 (architecture review — likely a light pass given mechanical nature) and Phase 3+ (decisions, story breakdown, PR, devolve to beads).
+
+### Specific questions for the user
+
+1. **Safe-delete (A + B1/B2/B3/B6):** approve bulk removal? (A/B: A=yes, B=hold any specific item)
+2. **B4 history v1/v2:** remove tolerance and enforce `schema_version == 3`? Any chance there are real `.clauditor/history.jsonl` files in your working dirs with v1/v2 records you want to preserve?
+3. **B5 flat-fields eval-spec parser:** remove? Any eval-spec files outside the repo (in your experiment dirs) that still use the flat `fields` shape instead of `tiers`?
+4. **C1 `GradingReport` optional fields:** make required? Tolerable to update ~10 test fixtures.
+5. **D1 `_run_baseline_phase`:**
+   - (a) refactor now into pure compute + thin I/O wrapper (one more story, medium effort), OR
+   - (b) accept as permanent architectural exception and scrub "grandfathered" framing from the two rule files
+6. **E items:** confirm leave-alone, or call out anything you want included?
+
+## Decisions
+
+- **DEC-001** — Bulk-delete Category A (pattern-key rejection code + `test_from_file_legacy_pattern_key_rejected` + README migration note; `test_grade_save_flag_removed` + `--save` README note). *Rationale:* No pre-existing users to migrate; the friendly error and grave-marker test are dead weight.
+- **DEC-002** — Drop Category B fallback branches: `audit.py:162` id-or-name, `audit.py:194-200` presence/format fallback, `assertions.py::from_json_dict` missing-key tolerance, `test_compare_legacy_grade_json_files` + README `.grade.json` reference. *Rationale:* No on-disk sidecars predate the current shape (user has no working dirs).
+- **DEC-003** — Drop history v1/v2 tolerance; `history.py` reader enforces `schema_version == 3` per `.claude/rules/json-schema-version.md`. *Rationale:* User confirmed no legacy history.jsonl files exist anywhere.
+- **DEC-004** — Drop flat-`fields` parser in `spec.py::EvalSpec.from_file`; tiered shape becomes the only accepted form. *Rationale:* User confirmed no external eval-specs use the flat shape.
+- **DEC-005** — Make `GradingReport.thresholds` and `metrics` required (non-Optional) fields. Update all direct-construction test fixtures to populate them. *Rationale:* Production callers always set them; optionality exists only for test ergonomics, which is a weak reason.
+- **DEC-006** — Refactor `_run_baseline_phase` into a pure `compute_baseline(...)` helper returning a dataclass + thin CLI I/O wrapper, following `.claude/rules/pure-compute-vs-io-split.md`. Scrub the "Grandfathered counter-example" section from that rule AND the `_run_baseline_phase` loader reference from `.claude/rules/json-schema-version.md:67`. *Rationale:* User chose refactor over permanent exception; eliminates the only documented rule-violator in the codebase.
+- **DEC-007** — Sweep README.md for any lingering legacy references after US-001/002 have touched it: the Migration Notes section header itself, `.grade.json` compare example, history v2 mention, pattern→format note. *Rationale:* Explicit user ask in approval checkpoint.
+
+## Detailed Breakdown
+
+Stories are sequenced linearly because several touch README.md and risk merge churn if parallelized. Each is sized for a single Ralph context window.
+
+### US-001 — Safe-delete bulk removal
+
+**Description:** Delete pattern-key rejection, `--save` grave-marker test, legacy sidecar fallbacks in `audit.py` and `assertions.py`, and the `.grade.json` compare test. Pure mechanical deletion; no behavior changes on current on-disk shapes.
+
+**Traces to:** DEC-001, DEC-002
+
+**Files:**
+- `src/clauditor/schemas.py:114-124` — delete `if "pattern" in field_dict: raise ValueError(...)` block in `_resolve_field_format`; simplify docstring
+- `src/clauditor/audit.py:162` — replace `result.get("id") or result.get("name")` with `result["id"]` (hard required)
+- `src/clauditor/audit.py:194-200` — replace fallback block with `passed = bool(entry["passed"])` (hard required)
+- `src/clauditor/assertions.py:64` + surrounding `from_json_dict` — remove "tolerates missing keys" behavior; require `transcript_path`
+- `tests/test_schemas.py:675-690` — delete `test_from_file_legacy_pattern_key_rejected`
+- `tests/test_cli.py:1334-1340` — delete `test_grade_save_flag_removed`
+- `tests/test_cli.py:2867-2890` — delete `test_compare_legacy_grade_json_files`
+- `tests/test_assertions.py:980-1044` — delete `test_from_json_dict_missing_key_tolerant` and `test_assertion_set_from_json_back_compat`
+- `README.md:606-609` — delete "Migration note (April 2026)" for pattern→format
+- `README.md:613` — delete `--save` removal bullet
+- `README.md:395` — remove the "Diff two legacy grade reports" example line
+
+**Acceptance criteria:**
+- `uv run ruff check src/ tests/` passes
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥80% coverage
+- No remaining references to "pattern" key rejection, `--save` flag, or `.grade.json` file inputs
+- `grep -rn "pattern.*no longer supported"` returns zero hits
+
+**Done when:** Tests green, files shrunk, README rendered preview has no lingering migration-note for pattern or `--save`.
+
+**Depends on:** none
+
+**Rules:** `json-schema-version.md` (tightening is allowed), `eval-spec-stable-ids.md` (removing `name` fallback enforces id-only)
+
+### US-002 — Enforce history.jsonl schema v3
+
+**Description:** Drop v1/v2 tolerance in `history.py`. Reader validates `schema_version == 3` and hard-skips (with stderr warning) anything else, matching the pattern in `.claude/rules/json-schema-version.md`.
+
+**Traces to:** DEC-003
+
+**TDD:**
+1. Write failing test: feeding a v2 record (no `iteration`/`workspace_path`) to `load_iterations` returns `[]` and emits stderr warning naming `schema_version=2`
+2. Write failing test: feeding a v1 record (no `schema_version`) returns `[]` with warning
+3. Write failing test: v3 record still loads successfully
+4. Implement `_check_schema_version` helper in `history.py`; wire into the reader
+5. Delete obsolete mixed-version tolerance docstring (history.py:9-28)
+
+**Files:**
+- `src/clauditor/history.py` — add `_SCHEMA_VERSION = 3`, add `_check_schema_version` helper, call from reader; delete mixed-version tolerance prose in module docstring
+- `tests/test_history.py:224` — replace `TestMixedVersions` with v2/v1-rejection tests per TDD list
+- `tests/test_cli.py:3809` — delete `test_trend_renders_mixed_v2_v3_history` (or rewrite to assert warning + skip)
+- `README.md:407` — rewrite "Legacy v2 records still read cleanly" to "All history records are schema v3"
+
+**Acceptance criteria:**
+- `uv run pytest tests/test_history.py tests/test_cli.py -q` passes
+- `grep -rn "v2.*history" README.md src/` returns zero hits
+- Full test suite still ≥80% coverage
+
+**Done when:** Reader hard-requires v3; README no longer promises v2 compat.
+
+**Depends on:** US-001
+
+**Rules:** `json-schema-version.md` (canonical loader pattern)
+
+### US-003 — Drop flat-fields eval-spec parser
+
+**Description:** Remove the "Legacy fields-style: normalize to single default tier" branch in `EvalSpec.from_file`. Tiered shape becomes the only accepted form; `fields` at section level is a `ValueError`.
+
+**Traces to:** DEC-004
+
+**TDD:**
+1. Failing test: `EvalSpec.from_file` on a spec with section-level `fields` raises `ValueError("sections[i]: expected 'tiers' key …")`
+2. Failing test: existing tiered-shape spec still loads (regression guard)
+3. Remove the `else` branch in `spec.py:263-312`; simplify the loader
+4. Rewrite `tests/test_schemas.py::test_legacy_fields_normalized_to_default_tier` → `test_from_file_rejects_flat_fields_shape`
+5. Audit `tests/fixtures/` and `examples/` for any flat-`fields` spec files; convert or delete
+
+**Files:**
+- `src/clauditor/spec.py:263-312` — delete legacy branch, keep only the `"tiers" in s` path
+- `src/clauditor/schemas.py:291` — delete "Legacy fields-style" comment
+- `tests/test_schemas.py:73` — remove legacy comment
+- `tests/test_schemas.py:1122-1148` — rewrite test per TDD step 4
+- Any fixture/example using flat `fields` — convert to tiered shape
+
+**Acceptance criteria:**
+- `uv run pytest tests/test_schemas.py tests/test_spec.py -q` passes
+- `grep -rn "legacy.*fields\|fields-style" src/ tests/` returns zero hits
+- Full suite ≥80% coverage
+
+**Done when:** Only tiered eval-specs load; rejection is explicit.
+
+**Depends on:** US-002
+
+**Rules:** `eval-spec-stable-ids.md`
+
+### US-004 — GradingReport required fields
+
+**Description:** Make `GradingReport.thresholds` and `metrics` non-Optional. Update every direct-construction fixture in tests to pass valid values.
+
+**Traces to:** DEC-005
+
+**TDD:**
+1. Failing test: `GradingReport(...)` without `thresholds` raises `TypeError` (dataclass missing arg)
+2. Update fixture factory (likely `tests/conftest.py` or a helper) to always pass `thresholds=GradeThresholds(...)` and `metrics={}`
+3. Remove `| None` from the dataclass fields; delete `None` defaults
+4. Fix any now-broken test construction sites
+
+**Files:**
+- `src/clauditor/quality_grader.py:59,62` — change type to non-Optional, remove `= None`
+- `tests/test_quality_grader.py` — update fixture factories and direct constructions (~10 sites per audit)
+- `tests/conftest.py` — if shared fixture exists, update there first
+- Check `tests/test_cli.py` and `tests/test_comparator.py` for any fallout
+
+**Acceptance criteria:**
+- `uv run pytest -q` passes (~10 fixture sites updated)
+- `grep -n "thresholds.*None\|metrics.*None" src/clauditor/quality_grader.py` returns zero hits
+- Coverage ≥80%
+
+**Done when:** `GradingReport` fields are structurally required; no `| None` dead branch in readers.
+
+**Depends on:** US-003
+
+**Rules:** none specific
+
+### US-005 — Refactor `_run_baseline_phase` into pure compute + thin I/O
+
+**Description:** Extract a `compute_baseline(...)` pure function from `cli.py::_run_baseline_phase` that returns a dataclass (e.g. `BaselineReports`), and keep only file I/O + stderr progress in the CLI wrapper. Scrub "grandfathered" framing from the two rule files. This is the plan's architectural story.
+
+**Traces to:** DEC-006
+
+**Design notes:**
+- Model after `compute_benchmark` (canonical impl in `.claude/rules/pure-compute-vs-io-split.md`)
+- Pure helper takes already-run `SkillResult`s + `SkillSpec` + `EvalSpec`, returns a dataclass of baseline reports
+- CLI wrapper handles: subprocess invocation (`runner.run(...)`), `.write_text(...)` for `baseline_grading.json` / `baseline_assertions.json` / `baseline_extraction.json`, and stderr progress lines
+- Must respect `.claude/rules/sidecar-during-staging.md`: writes happen inside `workspace.tmp_path` before `workspace.finalize()`
+- `schema_version` stays on the dataclass's `to_json()`, not inlined
+
+**TDD:**
+1. Failing unit test for `compute_baseline(...)` returning a dataclass with the right aggregated shape — no tmp_path, no subprocess, no file I/O
+2. Failing test for `BaselineReports.to_json()` emitting `schema_version: 1` as first key
+3. Implement the pure helper
+4. Rewrite `_run_baseline_phase` as thin I/O wrapper delegating to the helper
+5. Existing integration tests for the `--baseline` flag must still pass unchanged
+6. Delete "Grandfathered counter-example" section from `.claude/rules/pure-compute-vs-io-split.md:114-118`
+7. Delete `_run_baseline_phase` writer-mention from `.claude/rules/json-schema-version.md:67`
+
+**Files:**
+- `src/clauditor/cli.py:552-649` — split into pure helper + thin wrapper
+- new `src/clauditor/baseline.py` (or put helper in `cli.py` above wrapper if sibling module feels heavy — prefer sibling module for testability)
+- `tests/test_baseline.py` (new) — pure compute tests, no fixtures
+- `tests/test_cli.py` — keep existing `--baseline` integration coverage
+- `.claude/rules/pure-compute-vs-io-split.md` — remove grandfathered section; add `compute_baseline` as a second canonical implementation anchor
+- `.claude/rules/json-schema-version.md:67` — remove `_run_baseline_phase` from writer list; add new helper
+
+**Acceptance criteria:**
+- `uv run pytest tests/test_baseline.py tests/test_cli.py -q` passes
+- `grep -rn "grandfathered" .claude/rules/` returns zero hits
+- `_run_baseline_phase` (if kept as name) is ≤30 lines and only calls the pure helper + writes files
+- Pure helper has no `Path` I/O, no subprocess, no `print`
+- Coverage ≥80%
+
+**Done when:** Rule violator eliminated; `.claude/rules/pure-compute-vs-io-split.md` has no "grandfathered counter-example" section.
+
+**Depends on:** US-004
+
+**Rules:** `pure-compute-vs-io-split.md` (applied), `sidecar-during-staging.md`, `json-schema-version.md`
+
+### US-006 — README.md final sweep
+
+**Description:** After US-001/002 have touched README, do a consolidated pass for internal consistency: delete the "Migration Notes" section header if it's empty, scrub any other stray "legacy"/"deprecated"/"migration" references, and verify the doc reads cleanly end-to-end.
+
+**Traces to:** DEC-007
+
+**Files:**
+- `README.md` — grep-then-read pass for: "legacy", "deprecated", "migration", "pattern key", "`--save`", "`.grade.json`", "v2 records"
+
+**Acceptance criteria:**
+- `grep -nE "legacy|deprecat|migrat|pre-v1|backcompat" README.md` returns zero hits (or only clearly non-legacy hits like "migration" in a migration-file-handling context, if any)
+- Manual readthrough confirms no dangling references to removed features
+- `uv run pytest -q` still passes (no code changes expected, but safety check)
+
+**Done when:** README has no backcompat prose. Ready for eventual publication.
+
+**Depends on:** US-005
+
+**Rules:** none
+
+### QG-001 — Quality Gate
+
+**Description:** Run `code-reviewer` 4 times across the full changeset for US-001..006, fixing every real bug each pass. Run CodeRabbit if available. `uv run ruff check src/ tests/` and `uv run pytest --cov=clauditor --cov-report=term-missing` must both pass with ≥80% coverage after final fix pass.
+
+**Depends on:** US-006
+
+### PM-001 — Patterns & Memory
+
+**Description:** Update `.claude/rules/pure-compute-vs-io-split.md` to reflect `compute_baseline` as a new canonical anchor (done in US-005, but verify). If any new invariant emerged during the audit/removal work, capture it as a new rule. Save any surprising findings as `bd remember` entries. Priority 99.
+
+**Depends on:** QG-001
+
+## Rules compliance check
+
+- `pure-compute-vs-io-split.md` — US-005 applies this pattern; removes the counter-example. ✓
+- `json-schema-version.md` — US-002 adds `_check_schema_version` to history reader; US-005 ensures `BaselineReports` dataclass emits `schema_version` as first key. ✓
+- `eval-spec-stable-ids.md` — US-001 (audit.py id-only) and US-003 (tiered-only) enforce stable-id invariants harder. ✓
+- `sidecar-during-staging.md` — US-005 preserves the staging-before-finalize contract. ✓
+- `llm-judge-prompt-injection.md` — no LLM prompt changes. N/A
+- `pytester-inprocess-coverage-hazard.md` — no pytester tests added. N/A
+- All other rules — no impact.
+
+No story violates any rule.
+
+## Beads Manifest
+
+*(populated in Phase 7)*
+
+## Session Notes
+
+**2026-04-15 — Session 1:** Discovery phase. Fetched #41, created worktree, ran three parallel audit subagents (keyword, structural, docs). Consolidated 17 primary findings into 4 action categories + 7 explicit non-findings. Awaiting approval checkpoint before Phase 2.

--- a/plans/super/41-legacy-backcompat-audit.md
+++ b/plans/super/41-legacy-backcompat-audit.md
@@ -5,7 +5,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/41
 - **Branch:** `feature/41-legacy-audit`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/41-legacy-audit`
-- **Phase:** detailing
+- **Phase:** devolved
+- **PR:** https://github.com/wjduenow/clauditor/pull/42
 - **Sessions:** 1 (2026-04-15)
 
 ## Ticket summary
@@ -327,8 +328,22 @@ No story violates any rule.
 
 ## Beads Manifest
 
-*(populated in Phase 7)*
+- **Epic:** `clauditor-4ke` — #41: Legacy/backcompat audit and removal
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/41-legacy-audit`
+- **Branch:** `feature/41-legacy-audit`
+- **PR:** https://github.com/wjduenow/clauditor/pull/42
+
+| Bead ID | Story | Depends on |
+|---|---|---|
+| `clauditor-4ke.1` | US-001: Safe-delete bulk removal | — |
+| `clauditor-4ke.2` | US-002: Enforce history.jsonl schema v3 | .1 |
+| `clauditor-4ke.3` | US-003: Drop flat-fields eval-spec parser | .2 |
+| `clauditor-4ke.4` | US-004: GradingReport required fields | .3 |
+| `clauditor-4ke.5` | US-005: Refactor _run_baseline_phase | .4 |
+| `clauditor-4ke.6` | US-006: README.md final sweep | .5 |
+| `clauditor-4ke.7` | QG-001: Quality Gate | .6 |
+| `clauditor-4ke.8` | PM-001: Patterns & Memory | .7 |
 
 ## Session Notes
 
-**2026-04-15 — Session 1:** Discovery phase. Fetched #41, created worktree, ran three parallel audit subagents (keyword, structural, docs). Consolidated 17 primary findings into 4 action categories + 7 explicit non-findings. Awaiting approval checkpoint before Phase 2.
+**2026-04-15 — Session 1:** Discovery phase. Fetched #41, created worktree, ran three parallel audit subagents (keyword, structural, docs). Consolidated 17 primary findings into 4 action categories + 7 explicit non-findings. User approved all categories: bulk safe-delete, history v3 enforcement, flat-fields removal, GradingReport required fields, _run_baseline_phase refactor (option a), README sweep. Devolved to 8 beads (epic clauditor-4ke). Draft PR #42 published.

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -70,7 +70,7 @@ class AssertionResult:
             kind=data["kind"],
             evidence=data.get("evidence"),
             raw_data=data.get("raw_data"),
-            transcript_path=data["transcript_path"],
+            transcript_path=data.get("transcript_path"),
         )
 
 

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -61,17 +61,16 @@ class AssertionResult:
 
     @classmethod
     def from_json_dict(cls, data: dict) -> AssertionResult:
-        """Inverse of :meth:`to_json_dict` — tolerates missing keys for
-        older on-disk fixtures that predate newly added fields."""
+        """Inverse of :meth:`to_json_dict`."""
         return cls(
             id=data.get("id"),
-            name=data.get("name", ""),
+            name=data["name"],
             passed=bool(data["passed"]),
-            message=data.get("message", ""),
-            kind=data.get("kind", "custom"),
+            message=data["message"],
+            kind=data["kind"],
             evidence=data.get("evidence"),
             raw_data=data.get("raw_data"),
-            transcript_path=data.get("transcript_path"),
+            transcript_path=data["transcript_path"],
         )
 
 

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -159,7 +159,7 @@ def _records_from_assertions(
     records: list[IterationRecord] = []
     for run in data.get("runs", []) or []:
         for result in run.get("results", []) or []:
-            rid = result.get("id") or result.get("name")
+            rid = result["id"]
             if not rid:
                 continue
             records.append(
@@ -189,15 +189,7 @@ def _records_from_extraction(
     records: list[IterationRecord] = []
     for field_id, entries in (data.get("fields") or {}).items():
         for entry in entries or []:
-            # The on-disk shape stores pre-computed ``passed`` combining
-            # presence + format; prefer that, fall back to presence only.
-            if "passed" in entry:
-                passed = bool(entry["passed"])
-            else:
-                passed = bool(entry.get("presence_passed", False))
-                fmt_passed = entry.get("format_passed")
-                if fmt_passed is False:
-                    passed = False
+            passed = bool(entry["passed"])
             records.append(
                 IterationRecord(
                     iteration=iteration,

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -159,7 +159,7 @@ def _records_from_assertions(
     records: list[IterationRecord] = []
     for run in data.get("runs", []) or []:
         for result in run.get("results", []) or []:
-            rid = result["id"]
+            rid = result.get("id")
             if not rid:
                 continue
             records.append(
@@ -189,6 +189,8 @@ def _records_from_extraction(
     records: list[IterationRecord] = []
     for field_id, entries in (data.get("fields") or {}).items():
         for entry in entries or []:
+            if "passed" not in entry:
+                continue
             passed = bool(entry["passed"])
             records.append(
                 IterationRecord(

--- a/src/clauditor/baseline.py
+++ b/src/clauditor/baseline.py
@@ -1,4 +1,4 @@
-"""Pure compute for the ``--baseline`` phase of ``clauditor grade``.
+"""Compute helper for the ``--baseline`` phase of ``clauditor grade``.
 
 Aggregates Layer 1 assertions, Layer 2 extraction (when sections are
 declared), and Layer 3 grading for a baseline (no-skill-prefix) run.
@@ -101,10 +101,10 @@ def compute_baseline(
 ) -> BaselineReports:
     """Compute all baseline grading layers from an already-run result.
 
-    Pure function: takes the already-executed :class:`SkillResult` and the
-    evaluation spec, runs L1 assertions synchronously, and awaits L2/L3
-    grading via ``asyncio.run``. Returns a :class:`BaselineReports`
-    dataclass — no file I/O, no subprocess invocation, no stderr output.
+    Takes the already-executed :class:`SkillResult` and the evaluation
+    spec, runs L1 assertions synchronously, and awaits L2/L3 grading via
+    ``asyncio.run``. Returns a :class:`BaselineReports` dataclass — no
+    file I/O, no subprocess invocation, no stderr output.
 
     Parameters are keyword-only to match the codebase convention and keep
     call sites readable.

--- a/src/clauditor/baseline.py
+++ b/src/clauditor/baseline.py
@@ -1,0 +1,145 @@
+"""Pure compute for the ``--baseline`` phase of ``clauditor grade``.
+
+Aggregates Layer 1 assertions, Layer 2 extraction (when sections are
+declared), and Layer 3 grading for a baseline (no-skill-prefix) run.
+No file I/O, no subprocess calls, no ``print()`` — the CLI wrapper
+handles all side effects.
+
+Traces to DEC-006.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+# Import modules (not functions) so that tests patching the source
+# module (e.g. ``clauditor.quality_grader.grade_quality``) are
+# effective. Direct function imports would create a local binding
+# that the patch cannot reach.
+from clauditor import grader as _grader_mod
+from clauditor import quality_grader as _qg_mod
+from clauditor.assertions import AssertionSet, run_assertions
+from clauditor.grader import ExtractionReport
+from clauditor.runner import SkillResult
+from clauditor.schemas import EvalSpec
+
+__all__ = [
+    "BaselineReports",
+    "compute_baseline",
+]
+
+_SCHEMA_VERSION = 1
+
+
+@dataclass
+class BaselineReports:
+    """Collected baseline grading artifacts ready for persistence.
+
+    Returned by :func:`compute_baseline`. The CLI wrapper calls
+    :meth:`to_json_map` to get a ``{filename: json_str}`` mapping
+    and writes each entry into the staging directory.
+    """
+
+    skill_name: str
+    iteration: int
+    skill_result: SkillResult
+    grading_report: _qg_mod.GradingReport
+    assertion_set: AssertionSet
+    extraction_report: ExtractionReport | None
+
+    def to_json_map(self) -> dict[str, str]:
+        """Return ``{filename: json_string}`` for all baseline sidecars.
+
+        ``schema_version`` is the first key in every payload per
+        ``.claude/rules/json-schema-version.md``.
+        """
+        files: dict[str, str] = {}
+
+        # baseline.json — run metadata
+        meta = {
+            "schema_version": _SCHEMA_VERSION,
+            "skill": self.skill_name,
+            "iteration": self.iteration,
+            "output": self.skill_result.output,
+            "exit_code": self.skill_result.exit_code,
+            "input_tokens": self.skill_result.input_tokens,
+            "output_tokens": self.skill_result.output_tokens,
+            "duration_seconds": self.skill_result.duration_seconds,
+        }
+        files["baseline.json"] = json.dumps(meta, indent=2) + "\n"
+
+        # baseline_assertions.json — Layer 1
+        assertions_payload = {
+            "schema_version": _SCHEMA_VERSION,
+            "skill": self.skill_name,
+            "iteration": self.iteration,
+            **self.assertion_set.to_json(),
+        }
+        files["baseline_assertions.json"] = (
+            json.dumps(assertions_payload, indent=2) + "\n"
+        )
+
+        # baseline_extraction.json — Layer 2 (only when sections declared)
+        if self.extraction_report is not None:
+            files["baseline_extraction.json"] = self.extraction_report.to_json()
+
+        # baseline_grading.json — Layer 3
+        files["baseline_grading.json"] = self.grading_report.to_json()
+
+        return files
+
+
+def compute_baseline(
+    *,
+    skill_result: SkillResult,
+    eval_spec: EvalSpec,
+    skill_name: str,
+    iteration: int,
+    model: str,
+) -> BaselineReports:
+    """Compute all baseline grading layers from an already-run result.
+
+    Pure function: takes the already-executed :class:`SkillResult` and the
+    evaluation spec, runs L1 assertions synchronously, and awaits L2/L3
+    grading via ``asyncio.run``. Returns a :class:`BaselineReports`
+    dataclass — no file I/O, no subprocess invocation, no stderr output.
+
+    Parameters are keyword-only to match the codebase convention and keep
+    call sites readable.
+    """
+    baseline_text = skill_result.output
+
+    # Layer 1: deterministic assertions
+    assertion_set = run_assertions(baseline_text, eval_spec.assertions)
+
+    # Layer 2: LLM-graded extraction (only when sections declared)
+    extraction_report: ExtractionReport | None = None
+    if eval_spec.sections:
+        extraction_report = asyncio.run(
+            _grader_mod.extract_and_report(
+                baseline_text,
+                eval_spec,
+                skill_name=skill_name,
+            )
+        )
+
+    # Layer 3: LLM-graded quality
+    grading_report = asyncio.run(
+        _qg_mod.grade_quality(
+            baseline_text,
+            eval_spec,
+            model,
+            thresholds=eval_spec.grade_thresholds,
+        )
+    )
+
+    return BaselineReports(
+        skill_name=skill_name,
+        iteration=iteration,
+        skill_result=skill_result,
+        grading_report=grading_report,
+        assertion_set=assertion_set,
+        extraction_report=extraction_report,
+    )

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -556,33 +556,21 @@ def _run_baseline_phase(
     iteration: int,
     model: str,
 ) -> tuple[GradingReport, SkillResult]:
-    """US-004: run the test args without the skill prefix and persist L1/L2/L3
-    sidecars into ``skill_dir`` (the staging iteration dir).
+    """Run the baseline (no skill prefix) and persist sidecars.
 
-    Four files are written alongside the primary sidecars:
-    - ``baseline.json`` — run metadata (output, tokens, duration, exit_code)
-    - ``baseline_assertions.json`` — Layer 1 results against baseline output
-    - ``baseline_extraction.json`` — Layer 2 extraction (only when the spec
-      declares sections)
-    - ``baseline_grading.json`` — Layer 3 ``GradingReport``
+    Thin I/O wrapper around :func:`clauditor.baseline.compute_baseline`:
+    handles subprocess invocation, input-file staging, stderr progress,
+    and sidecar writes into ``skill_dir`` (the staging iteration dir).
 
-    Strictly opt-in via ``--baseline``; roughly doubles LLM cost per run.
-
-    Returns the ``(GradingReport, SkillResult)`` pair from the baseline run
-    (DEC-011) so the caller can feed them to
-    :func:`clauditor.benchmark.compute_benchmark` without reloading sidecars
-    from disk.
+    Returns ``(GradingReport, SkillResult)`` so the caller can feed
+    them to :func:`clauditor.benchmark.compute_benchmark`.
     """
-    import asyncio
-
-    from clauditor.grader import extract_and_report
-    from clauditor.quality_grader import grade_quality
+    from clauditor.baseline import compute_baseline
     from clauditor.workspace import stage_inputs
 
     test_args = spec.eval_spec.test_args or ""
     # FIX-15: mirror the primary run's staging so baseline finds input
-    # files in the same relative layout. Without this, a spec with
-    # ``input_files`` would run the baseline against an empty CWD.
+    # files in the same relative layout.
     effective_cwd: Path | None = None
     if spec.eval_spec.input_files:
         baseline_run_dir = skill_dir / "baseline-run"
@@ -592,61 +580,18 @@ def _run_baseline_phase(
     print(f"Running baseline (no skill prefix) {test_args}...")
     baseline_result = spec.runner.run_raw(test_args, cwd=effective_cwd)
 
-    baseline_text = baseline_result.output
-
-    baseline_meta = {
-        "schema_version": 1,
-        "skill": spec.skill_name,
-        "iteration": iteration,
-        "output": baseline_text,
-        "exit_code": baseline_result.exit_code,
-        "input_tokens": baseline_result.input_tokens,
-        "output_tokens": baseline_result.output_tokens,
-        "duration_seconds": baseline_result.duration_seconds,
-    }
-    (skill_dir / "baseline.json").write_text(
-        json.dumps(baseline_meta, indent=2) + "\n", encoding="utf-8"
+    reports = compute_baseline(
+        skill_result=baseline_result,
+        eval_spec=spec.eval_spec,
+        skill_name=spec.skill_name,
+        iteration=iteration,
+        model=model,
     )
 
-    baseline_assertion_set = run_assertions(
-        baseline_text, spec.eval_spec.assertions
-    )
-    baseline_assertions_payload = {
-        "schema_version": 1,
-        "skill": spec.skill_name,
-        "iteration": iteration,
-        **baseline_assertion_set.to_json(),
-    }
-    (skill_dir / "baseline_assertions.json").write_text(
-        json.dumps(baseline_assertions_payload, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    for filename, content in reports.to_json_map().items():
+        (skill_dir / filename).write_text(content, encoding="utf-8")
 
-    if spec.eval_spec.sections:
-        baseline_extraction = asyncio.run(
-            extract_and_report(
-                baseline_text,
-                spec.eval_spec,
-                skill_name=spec.skill_name,
-            )
-        )
-        (skill_dir / "baseline_extraction.json").write_text(
-            baseline_extraction.to_json(), encoding="utf-8"
-        )
-
-    baseline_grading = asyncio.run(
-        grade_quality(
-            baseline_text,
-            spec.eval_spec,
-            model,
-            thresholds=spec.eval_spec.grade_thresholds,
-        )
-    )
-    (skill_dir / "baseline_grading.json").write_text(
-        baseline_grading.to_json(), encoding="utf-8"
-    )
-
-    return baseline_grading, baseline_result
+    return reports.grading_report, reports.skill_result
 
 
 def _cmd_grade_with_workspace(

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -74,7 +74,6 @@ def _default_path() -> Path:
 
 SPARK_GLYPHS = "_.-=#"
 SCHEMA_VERSION = 3
-_SCHEMA_VERSION = 3
 
 _FLOCK_UNSUPPORTED_WARNED = False
 
@@ -180,10 +179,10 @@ def _check_schema_version(data: dict, source: Path, lineno: int) -> bool:
     ``.claude/rules/json-schema-version.md``.
     """
     version = data.get("schema_version")
-    if version != _SCHEMA_VERSION:
+    if version != SCHEMA_VERSION:
         print(
             f"warning: {source} line {lineno} has schema_version={version!r}, "
-            f"expected {_SCHEMA_VERSION} — skipping",
+            f"expected {SCHEMA_VERSION} — skipping",
             file=sys.stderr,
         )
         return False

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -22,10 +22,9 @@ top-level keys:
 The two new v3 fields (``iteration``, ``workspace_path``) are always
 written, even when ``None``, so the on-disk record shape is predictable.
 
-v2 records (``schema_version: 2``, no iteration/workspace_path) and v1
-records (no ``schema_version``, no ``command``) may still exist on disk
-and are returned as-is by :func:`read_records`. Callers must use
-``record.get("iteration")``-style access to tolerate missing keys.
+All history records are schema v3. :func:`read_records` hard-skips any
+record whose ``schema_version`` is not ``3``, emitting a stderr warning
+per ``.claude/rules/json-schema-version.md``.
 
 Concurrent appends from multiple processes are serialized via a
 ``fcntl.flock`` exclusive lock on ``<history_dir>/.lock``.
@@ -75,6 +74,7 @@ def _default_path() -> Path:
 
 SPARK_GLYPHS = "_.-=#"
 SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 3
 
 _FLOCK_UNSUPPORTED_WARNED = False
 
@@ -173,6 +173,23 @@ def append_record(
             f.write(line)
 
 
+def _check_schema_version(data: dict, source: Path, lineno: int) -> bool:
+    """Return ``True`` if ``data`` has the expected schema version.
+
+    Non-v3 records are skipped with a stderr warning per
+    ``.claude/rules/json-schema-version.md``.
+    """
+    version = data.get("schema_version")
+    if version != _SCHEMA_VERSION:
+        print(
+            f"warning: {source} line {lineno} has schema_version={version!r}, "
+            f"expected {_SCHEMA_VERSION} — skipping",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def read_records(
     skill: str | None = None,
     path: Path | None = None,
@@ -180,7 +197,8 @@ def read_records(
     """Read all history records, optionally filtered by skill.
 
     Missing file -> empty list. Corrupt lines are skipped with a warning to
-    stderr. ``path`` defaults to :data:`_DEFAULT_PATH` resolved at call
+    stderr. Records with ``schema_version`` other than 3 are skipped with a
+    warning. ``path`` defaults to :data:`_DEFAULT_PATH` resolved at call
     time so tests can monkeypatch the module attribute.
     """
     if path is None:
@@ -209,6 +227,8 @@ def read_records(
                     f"in {path}",
                     file=sys.stderr,
                 )
+                continue
+            if not _check_schema_version(record, path, lineno):
                 continue
             if skill is not None and record.get("skill") != skill:
                 continue

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -55,20 +55,16 @@ class GradingReport:
     skill_name: str
     results: list[GradingResult]
     model: str
+    thresholds: GradeThresholds
+    metrics: dict
     duration_seconds: float = 0.0
-    thresholds: GradeThresholds | None = None
     input_tokens: int = 0
     output_tokens: int = 0
-    metrics: dict | None = None
 
     @property
     def passed(self) -> bool:
-        """Whether grading meets threshold requirements.
-
-        Uses provided thresholds or defaults (min_pass_rate=0.7,
-        min_mean_score=0.5) when no thresholds are set.
-        """
-        t = self.thresholds if self.thresholds is not None else GradeThresholds()
+        """Whether grading meets threshold requirements."""
+        t = self.thresholds
         return (
             self.pass_rate >= t.min_pass_rate
             and self.mean_score >= t.min_mean_score
@@ -110,12 +106,11 @@ class GradingReport:
                 for r in self.results
             ],
         }
-        if self.thresholds is not None:
-            data["thresholds"] = {
-                "min_pass_rate": self.thresholds.min_pass_rate,
-                "min_mean_score": self.thresholds.min_mean_score,
-            }
-        if self.metrics is not None:
+        data["thresholds"] = {
+            "min_pass_rate": self.thresholds.min_pass_rate,
+            "min_mean_score": self.thresholds.min_mean_score,
+        }
+        if self.metrics:
             data["metrics"] = self.metrics
         return json.dumps(data, indent=2)
 
@@ -134,22 +129,20 @@ class GradingReport:
             )
             for item in parsed.get("results", [])
         ]
-        thresholds = None
-        if "thresholds" in parsed:
-            t = parsed["thresholds"]
-            thresholds = GradeThresholds(
-                min_pass_rate=float(t.get("min_pass_rate", 0.7)),
-                min_mean_score=float(t.get("min_mean_score", 0.5)),
-            )
+        t = parsed.get("thresholds") or {}
+        thresholds = GradeThresholds(
+            min_pass_rate=float(t.get("min_pass_rate", 0.7)),
+            min_mean_score=float(t.get("min_mean_score", 0.5)),
+        )
         return cls(
             skill_name=parsed.get("skill_name", ""),
             results=results,
             model=parsed.get("model", ""),
-            duration_seconds=float(parsed.get("duration_seconds", 0.0)),
             thresholds=thresholds,
+            metrics=parsed.get("metrics") or {},
+            duration_seconds=float(parsed.get("duration_seconds", 0.0)),
             input_tokens=int(parsed.get("input_tokens", 0)),
             output_tokens=int(parsed.get("output_tokens", 0)),
-            metrics=parsed.get("metrics"),
         )
 
     def summary(self) -> str:
@@ -714,6 +707,7 @@ async def grade_quality(
 
     Requires the 'grader' extra: pip install clauditor[grader]
     """
+    thresholds = thresholds if thresholds is not None else GradeThresholds()
     try:
         from anthropic import AsyncAnthropic
     except ImportError:
@@ -764,8 +758,9 @@ async def grade_quality(
                 )
             ],
             model=model,
-            duration_seconds=duration,
             thresholds=thresholds,
+            metrics={},
+            duration_seconds=duration,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
@@ -787,8 +782,9 @@ async def grade_quality(
                 )
             ],
             model=model,
-            duration_seconds=duration,
             thresholds=thresholds,
+            metrics={},
+            duration_seconds=duration,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
@@ -807,8 +803,9 @@ async def grade_quality(
                 )
             ],
             model=model,
-            duration_seconds=duration,
             thresholds=thresholds,
+            metrics={},
+            duration_seconds=duration,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
@@ -817,8 +814,9 @@ async def grade_quality(
         skill_name=eval_spec.skill_name,
         results=results,
         model=model,
-        duration_seconds=duration,
         thresholds=thresholds,
+        metrics={},
+        duration_seconds=duration,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
     )

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -110,6 +110,10 @@ def criterion_text(entry: object) -> str:
 
 def _resolve_field_format(field_dict: dict) -> str | None:
     """Resolve the ``format`` value for a field entry during spec load."""
+    if "pattern" in field_dict:
+        raise ValueError(
+            f"Field {field_dict.get('name')!r}: use 'format', not 'pattern'"
+        )
     return field_dict.get("format")
 
 
@@ -283,7 +287,10 @@ class EvalSpec:
                     "wrap fields inside a tiers[] entry"
                 )
             else:
-                tiers = []
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"sections[{si}] is missing 'tiers'"
+                )
             sections.append(
                 SectionRequirement(
                     name=s["name"],

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -276,29 +276,14 @@ class EvalSpec:
                             fields=tier_fields,
                         )
                     )
+            elif "fields" in s:
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"sections[{si}] has flat 'fields' without 'tiers' — "
+                    "wrap fields inside a tiers[] entry"
+                )
             else:
-                # Legacy fields-style: normalize to single default tier
-                legacy_fields = []
-                for fi, f in enumerate(s.get("fields", [])):
-                    fid = _require_id(
-                        f, f"sections[{si}].fields[{fi}]"
-                    )
-                    legacy_fields.append(
-                        FieldRequirement(
-                            name=f["name"],
-                            required=f.get("required", True),
-                            format=_resolve_field_format(f),
-                            id=fid,
-                        )
-                    )
-                tiers = [
-                    TierRequirement(
-                        label="default",
-                        min_entries=s.get("min_entries", 1),
-                        max_entries=s.get("max_entries"),
-                        fields=legacy_fields,
-                    )
-                ]
+                tiers = []
             sections.append(
                 SectionRequirement(
                     name=s["name"],

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -109,18 +109,7 @@ def criterion_text(entry: object) -> str:
 
 
 def _resolve_field_format(field_dict: dict) -> str | None:
-    """Resolve the ``format`` value for a field entry during spec load.
-
-    Rejects the legacy ``pattern`` key with a clear migration message
-    (DEC-006/DEC-007): eval specs should use ``format`` which now accepts
-    either a registered format name or an inline regex.
-    """
-    if "pattern" in field_dict:
-        raise ValueError(
-            f"Field {field_dict.get('name')!r}: the 'pattern' key is no "
-            f"longer supported. Use 'format' instead — it accepts either "
-            f"a registered format name (e.g. 'phone_us') or an inline regex."
-        )
+    """Resolve the ``format`` value for a field entry during spec load."""
     return field_dict.get("format")
 
 

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -977,22 +977,6 @@ class TestTranscriptPathField:
         restored = AssertionResult.from_json_dict(payload)
         assert restored.transcript_path is None
 
-    def test_from_json_dict_missing_key_tolerant(self):
-        """Older fixtures lacking the key load with transcript_path=None."""
-        legacy = {
-            "id": "venues",
-            "name": "contains:Venues",
-            "passed": True,
-            "message": "Found 'Venues'",
-            "kind": "presence",
-            "evidence": None,
-            "raw_data": None,
-            # no transcript_path key at all
-        }
-        restored = AssertionResult.from_json_dict(legacy)
-        assert restored.transcript_path is None
-        assert restored.id == "venues"
-
     def test_assertion_set_round_trip_threads_transcript_path(self):
         results = [
             AssertionResult(
@@ -1023,23 +1007,3 @@ class TestTranscriptPathField:
         )
         assert restored.results[1].transcript_path is None
 
-    def test_assertion_set_from_json_back_compat(self):
-        """Legacy assertions.json without transcript_path loads cleanly."""
-        legacy_payload = {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "results": [
-                {
-                    "id": "a1",
-                    "name": "contains:X",
-                    "passed": True,
-                    "message": "ok",
-                    "kind": "presence",
-                    "evidence": None,
-                    "raw_data": None,
-                },
-            ],
-        }
-        restored = AssertionSet.from_json(legacy_payload)
-        assert restored.results[0].transcript_path is None
-        assert restored.results[0].id == "a1"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -255,6 +255,40 @@ class TestLoadIterations:
         assert layers == {"L1", "L2", "L3"}
 
 
+    def test_extraction_entry_missing_passed_skipped(self, tmp_path: Path) -> None:
+        """Extraction entries without a 'passed' key are silently skipped."""
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        skill_dir.mkdir(parents=True)
+        extraction = {
+            "schema_version": 1,
+            "skill_name": "s",
+            "model": "test",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "parse_errors": [],
+            "fields": {
+                "f1": [
+                    {"field_name": "f1", "section": "s", "tier": "required",
+                     "entry_index": 0, "required": True, "passed": True,
+                     "presence_passed": True, "format_passed": None,
+                     "evidence": None},
+                    {"field_name": "f2", "section": "s", "tier": "required",
+                     "entry_index": 1, "required": True,
+                     "presence_passed": False, "format_passed": None,
+                     "evidence": None},
+                ],
+            },
+        }
+        (skill_dir / "extraction.json").write_text(
+            json.dumps(extraction, indent=2) + "\n"
+        )
+        records, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
+        l2 = [r for r in records if r.layer == "L2"]
+        assert len(l2) == 1
+        assert l2[0].passed is True
+
+
 # --------------------------------------------------------------------------- #
 # aggregate                                                                    #
 # --------------------------------------------------------------------------- #

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -66,7 +66,7 @@ def _make_grading_report(
     )
 
 
-def _make_eval_spec(*, with_sections: bool = False) -> EvalSpec:
+def _make_eval_spec() -> EvalSpec:
     spec = EvalSpec(
         skill_name="test-skill",
         test_args="test args",

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -85,7 +85,7 @@ def _make_eval_spec(*, with_sections: bool = False) -> EvalSpec:
 class TestBaselineReportsToJsonMap:
     """Verify the to_json_map serialization contract."""
 
-    def test_always_emits_four_files_without_sections(self) -> None:
+    def test_always_emits_three_files_without_sections(self) -> None:
         reports = BaselineReports(
             skill_name="test-skill",
             iteration=1,

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,325 @@
+"""Tests for ``clauditor.baseline`` — pure baseline compute.
+
+Covers the compute_baseline pure function and the BaselineReports
+serialization to JSON sidecars. No tmp_path, no subprocess — pure
+unit tests that construct fixtures and assert on return values.
+
+Traces: DEC-006.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.baseline import _SCHEMA_VERSION, BaselineReports, compute_baseline
+from clauditor.grader import ExtractionReport
+from clauditor.quality_grader import GradingReport, GradingResult
+from clauditor.runner import SkillResult
+from clauditor.schemas import EvalSpec, GradeThresholds
+
+
+def _make_skill_result(
+    *,
+    output: str = "baseline output",
+    duration: float = 5.0,
+    input_tokens: int = 200,
+    output_tokens: int = 100,
+) -> SkillResult:
+    return SkillResult(
+        output=output,
+        exit_code=0,
+        skill_name="test-skill",
+        args="test args",
+        duration_seconds=duration,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def _make_grading_report(
+    *,
+    skill_name: str = "test-skill",
+    pass_fractions: tuple[bool, ...] = (True, True, False),
+) -> GradingReport:
+    results = [
+        GradingResult(
+            criterion=f"c{i}",
+            passed=p,
+            score=1.0 if p else 0.0,
+            evidence="",
+            reasoning="",
+            id=f"c{i}",
+        )
+        for i, p in enumerate(pass_fractions)
+    ]
+    return GradingReport(
+        skill_name=skill_name,
+        results=results,
+        model="test-model",
+        duration_seconds=1.0,
+        input_tokens=100,
+        output_tokens=50,
+        thresholds=GradeThresholds(),
+        metrics={},
+    )
+
+
+def _make_eval_spec(*, with_sections: bool = False) -> EvalSpec:
+    spec = EvalSpec(
+        skill_name="test-skill",
+        test_args="test args",
+        assertions=[
+            {"id": "a1", "type": "contains", "value": "baseline"},
+        ],
+        grading_criteria=[
+            {"id": "c0", "criterion": "c0"},
+            {"id": "c1", "criterion": "c1"},
+            {"id": "c2", "criterion": "c2"},
+        ],
+    )
+    return spec
+
+
+class TestBaselineReportsToJsonMap:
+    """Verify the to_json_map serialization contract."""
+
+    def test_always_emits_four_files_without_sections(self) -> None:
+        reports = BaselineReports(
+            skill_name="test-skill",
+            iteration=1,
+            skill_result=_make_skill_result(),
+            grading_report=_make_grading_report(),
+            assertion_set=AssertionSet(results=[]),
+            extraction_report=None,
+        )
+        files = reports.to_json_map()
+        assert set(files.keys()) == {
+            "baseline.json",
+            "baseline_assertions.json",
+            "baseline_grading.json",
+        }
+
+    def test_includes_extraction_when_present(self) -> None:
+        extraction = ExtractionReport(
+            skill_name="test-skill",
+            results=[],
+            model="test-model",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        reports = BaselineReports(
+            skill_name="test-skill",
+            iteration=1,
+            skill_result=_make_skill_result(),
+            grading_report=_make_grading_report(),
+            assertion_set=AssertionSet(results=[]),
+            extraction_report=extraction,
+        )
+        files = reports.to_json_map()
+        assert "baseline_extraction.json" in files
+
+    def test_schema_version_is_first_key_in_meta(self) -> None:
+        reports = BaselineReports(
+            skill_name="test-skill",
+            iteration=1,
+            skill_result=_make_skill_result(),
+            grading_report=_make_grading_report(),
+            assertion_set=AssertionSet(results=[]),
+            extraction_report=None,
+        )
+        files = reports.to_json_map()
+        meta = json.loads(files["baseline.json"])
+        assert list(meta.keys())[0] == "schema_version"
+        assert meta["schema_version"] == _SCHEMA_VERSION
+
+    def test_schema_version_is_first_key_in_assertions(self) -> None:
+        reports = BaselineReports(
+            skill_name="test-skill",
+            iteration=1,
+            skill_result=_make_skill_result(),
+            grading_report=_make_grading_report(),
+            assertion_set=AssertionSet(results=[]),
+            extraction_report=None,
+        )
+        files = reports.to_json_map()
+        assertions = json.loads(files["baseline_assertions.json"])
+        assert list(assertions.keys())[0] == "schema_version"
+        assert assertions["schema_version"] == _SCHEMA_VERSION
+
+    def test_meta_contains_run_fields(self) -> None:
+        sr = _make_skill_result(
+            output="hello",
+            duration=3.5,
+            input_tokens=42,
+            output_tokens=17,
+        )
+        reports = BaselineReports(
+            skill_name="my-skill",
+            iteration=7,
+            skill_result=sr,
+            grading_report=_make_grading_report(skill_name="my-skill"),
+            assertion_set=AssertionSet(results=[]),
+            extraction_report=None,
+        )
+        meta = json.loads(reports.to_json_map()["baseline.json"])
+        assert meta["skill"] == "my-skill"
+        assert meta["iteration"] == 7
+        assert meta["output"] == "hello"
+        assert meta["exit_code"] == 0
+        assert meta["input_tokens"] == 42
+        assert meta["output_tokens"] == 17
+        assert meta["duration_seconds"] == 3.5
+
+    def test_assertions_payload_merges_set(self) -> None:
+        aset = AssertionSet(
+            results=[
+                AssertionResult(
+                    id="a1",
+                    name="check",
+                    passed=True,
+                    message="ok",
+                    kind="contains",
+                )
+            ],
+            input_tokens=5,
+            output_tokens=3,
+        )
+        reports = BaselineReports(
+            skill_name="test-skill",
+            iteration=1,
+            skill_result=_make_skill_result(),
+            grading_report=_make_grading_report(),
+            assertion_set=aset,
+            extraction_report=None,
+        )
+        payload = json.loads(reports.to_json_map()["baseline_assertions.json"])
+        assert payload["skill"] == "test-skill"
+        assert payload["iteration"] == 1
+        assert len(payload["results"]) == 1
+        assert payload["results"][0]["id"] == "a1"
+
+
+class TestComputeBaseline:
+    """Verify the pure compute_baseline function.
+
+    compute_baseline is sync (uses asyncio.run internally), so these
+    tests are plain sync methods. The async LLM calls are patched with
+    AsyncMock which asyncio.run handles correctly.
+    """
+
+    def test_computes_all_layers_without_sections(self) -> None:
+        sr = _make_skill_result(output="baseline output")
+        eval_spec = _make_eval_spec()
+        grading_report = _make_grading_report()
+
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=grading_report),
+        ):
+            reports = compute_baseline(
+                skill_result=sr,
+                eval_spec=eval_spec,
+                skill_name="test-skill",
+                iteration=1,
+                model="test-model",
+            )
+
+        assert reports.grading_report is grading_report
+        assert reports.skill_result is sr
+        assert reports.extraction_report is None
+        # L1 assertions ran — "baseline" is in "baseline output"
+        assert len(reports.assertion_set.results) == 1
+        assert reports.assertion_set.results[0].passed is True
+
+    def test_computes_extraction_when_sections_present(self) -> None:
+        sr = _make_skill_result(output="some output")
+        eval_spec = _make_eval_spec()
+        from clauditor.schemas import (
+            FieldRequirement,
+            SectionRequirement,
+            TierRequirement,
+        )
+
+        eval_spec.sections = [
+            SectionRequirement(
+                name="sec1",
+                tiers=[
+                    TierRequirement(
+                        label="tier1",
+                        fields=[FieldRequirement(id="f1", name="field1")],
+                    )
+                ],
+            )
+        ]
+        grading_report = _make_grading_report()
+        extraction_report = ExtractionReport(
+            skill_name="test-skill",
+            results=[],
+            model="test-model",
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+        with (
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new=AsyncMock(return_value=grading_report),
+            ),
+            patch(
+                "clauditor.grader.extract_and_report",
+                new=AsyncMock(return_value=extraction_report),
+            ),
+        ):
+            reports = compute_baseline(
+                skill_result=sr,
+                eval_spec=eval_spec,
+                skill_name="test-skill",
+                iteration=1,
+                model="test-model",
+            )
+
+        assert reports.extraction_report is extraction_report
+
+    def test_passes_model_and_thresholds_to_grade_quality(self) -> None:
+        sr = _make_skill_result(output="text")
+        eval_spec = _make_eval_spec()
+        grading_report = _make_grading_report()
+        mock_grade = AsyncMock(return_value=grading_report)
+
+        with patch("clauditor.quality_grader.grade_quality", new=mock_grade):
+            compute_baseline(
+                skill_result=sr,
+                eval_spec=eval_spec,
+                skill_name="test-skill",
+                iteration=2,
+                model="claude-sonnet-4-20250514",
+            )
+
+        mock_grade.assert_called_once_with(
+            "text",
+            eval_spec,
+            "claude-sonnet-4-20250514",
+            thresholds=eval_spec.grade_thresholds,
+        )
+
+    def test_skill_name_and_iteration_propagated(self) -> None:
+        sr = _make_skill_result()
+        eval_spec = _make_eval_spec()
+        grading_report = _make_grading_report()
+
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=grading_report),
+        ):
+            reports = compute_baseline(
+                skill_result=sr,
+                eval_spec=eval_spec,
+                skill_name="my-skill",
+                iteration=42,
+                model="test-model",
+            )
+
+        assert reports.skill_name == "my-skill"
+        assert reports.iteration == 42

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -15,6 +15,7 @@ import pytest
 from clauditor.benchmark import Benchmark, compute_benchmark
 from clauditor.quality_grader import GradingReport, GradingResult
 from clauditor.runner import SkillResult
+from clauditor.schemas import GradeThresholds
 
 
 def _make_grading_report(
@@ -43,6 +44,8 @@ def _make_grading_report(
         duration_seconds=duration,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        thresholds=GradeThresholds(),
+        metrics={},
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from clauditor.runner import SkillResult
 from clauditor.schemas import (
     EvalSpec,
     FieldRequirement,
+    GradeThresholds,
     SectionRequirement,
     TierRequirement,
     TriggerTests,
@@ -191,6 +192,8 @@ class TestCmdGrade:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def test_grade_with_output(self, tmp_path, monkeypatch):
@@ -290,6 +293,8 @@ class TestCmdGradeInputFilesStaging:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def _staging_spec(self, eval_spec, outputs):
@@ -464,6 +469,8 @@ class TestOnlyCriterion:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def _run(self, tmp_path, criteria, extra_args, monkeypatch=None):
@@ -643,6 +650,8 @@ class TestCmdGradeSaveDiff:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def _patch_grade(self, spec, report):
@@ -1437,6 +1446,8 @@ class TestCmdGradeLayer2Persistence:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def _make_sectioned_eval_spec(self):
@@ -1631,6 +1642,8 @@ class TestBaselineFlag:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def _make_baseline_skill_result(self, output="baseline output"):
@@ -1930,6 +1943,8 @@ class TestBaselineFlag:
                 ),
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         baseline_report = GradingReport(
             skill_name="test-skill",
@@ -1951,6 +1966,8 @@ class TestBaselineFlag:
                 ),
             ],
             duration_seconds=0.5,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         extraction_report = self._make_extraction_report()
 
@@ -2061,6 +2078,8 @@ class TestBaselineFlag:
                 ),
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         baseline_report = GradingReport(
             skill_name="test-skill",
@@ -2082,6 +2101,8 @@ class TestBaselineFlag:
                 ),
             ],
             duration_seconds=0.5,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         extraction_report = self._make_extraction_report()
 
@@ -2160,6 +2181,8 @@ class TestBaselineFlag:
                 ),
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         baseline_report = GradingReport(
             skill_name="test-skill",
@@ -2181,6 +2204,8 @@ class TestBaselineFlag:
                 ),
             ],
             duration_seconds=0.5,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         extraction_report = self._make_extraction_report()
 
@@ -2328,6 +2353,8 @@ class TestBaselineFlag:
             model="claude-sonnet-4-6",
             results=results,
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def _prepare_gate_spec(self):
@@ -2611,6 +2638,8 @@ class TestCmdCompare:
             model="test-model",
             results=results,
             duration_seconds=0.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         path = tmp_path / f"{name}.grade.json"
         path.write_text(report.to_json())
@@ -2728,6 +2757,8 @@ class TestCmdCompareIterationDirs:
             model="test-model",
             results=results,
             duration_seconds=0.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         (dir_path / "grading.json").write_text(report.to_json())
         return dir_path
@@ -2778,6 +2809,8 @@ class TestCmdCompareNumericRefs:
             model="test-model",
             results=results,
             duration_seconds=0.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         (dir_path / "grading.json").write_text(report.to_json())
 
@@ -2809,6 +2842,8 @@ class TestCmdCompareNumericRefs:
             model="m",
             results=[],
             duration_seconds=0.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         before.write_text(report.to_json())
         after.write_text(report.to_json())
@@ -4055,6 +4090,8 @@ class TestCmdGradeHistory:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         with (
@@ -4103,6 +4140,8 @@ class TestCmdGradeHistory:
             duration_seconds=1.0,
             input_tokens=500,
             output_tokens=200,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         with (
@@ -4173,6 +4212,8 @@ class TestCmdGradeHistory:
             duration_seconds=1.0,
             input_tokens=200,
             output_tokens=100,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         with (
@@ -4239,6 +4280,8 @@ class TestCmdGradeHistory:
             duration_seconds=1.0,
             input_tokens=300,
             output_tokens=100,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         with (
@@ -4288,6 +4331,8 @@ class TestCmdGradeHistory:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         with (
@@ -4336,6 +4381,8 @@ class TestCmdGradeHistory:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         with (
@@ -4766,6 +4813,8 @@ class TestCmdSuggest:
             model="claude-sonnet-4-6",
             results=results,
             duration_seconds=0.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         (skill_dir / "grading.json").write_text(report.to_json())
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1331,14 +1331,6 @@ class TestCmdGradeSaveDiff:
         assert "score_mean" in payload["variance"]
         assert "stability" in payload["variance"]
 
-    def test_grade_save_flag_removed(self, tmp_path, monkeypatch, capsys):
-        """argparse rejects --save with an unrecognized argument error."""
-        monkeypatch.chdir(tmp_path)
-        with pytest.raises(SystemExit):
-            main(["grade", "skill.md", "--save"])
-        err = capsys.readouterr().err
-        assert "--save" in err or "unrecognized" in err
-
     def test_grade_crash_leaves_no_iteration_dir(self, tmp_path, monkeypatch):
         """An exception mid-write must not leave a finalized iteration-N/."""
         monkeypatch.chdir(tmp_path)
@@ -2864,34 +2856,6 @@ class TestCmdCompareNumericRefs:
         err = capsys.readouterr().err
         assert "invalid skill name" in err
 
-    def test_compare_legacy_grade_json_files(self, tmp_path, capsys):
-        """Regression: legacy two .grade.json file form still works."""
-        before = tmp_path / "before.grade.json"
-        after = tmp_path / "after.grade.json"
-        for p, passes in [
-            (before, {"c1": True}),
-            (after, {"c1": True}),
-        ]:
-            report = GradingReport(
-                skill_name=p.stem,
-                model="test-model",
-                results=[
-                    GradingResult(
-                        criterion=c,
-                        passed=v,
-                        score=0.9 if v else 0.3,
-                        evidence="",
-                        reasoning="",
-                    )
-                    for c, v in passes.items()
-                ],
-                duration_seconds=0.0,
-            )
-            p.write_text(report.to_json())
-        rc = main(["compare", str(before), str(after)])
-        assert rc == 0
-        out = capsys.readouterr().out
-        assert "no flips" in out
 
 
 class TestCmdCompareBlind:
@@ -4824,6 +4788,7 @@ class TestCmdSuggest:
                             "passed": True,
                             "kind": "contains",
                             "message": "ok",
+                            "transcript_path": None,
                         }
                     ],
                 }
@@ -4848,6 +4813,7 @@ class TestCmdSuggest:
                             "passed": False,
                             "kind": "contains",
                             "message": "no match",
+                            "transcript_path": None,
                         }
                     ],
                 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3769,8 +3769,8 @@ class TestCmdTrend:
         data_lines = [ln for ln in out.splitlines() if "\t" in ln]
         assert len(data_lines) == 5
 
-    def test_trend_over_mixed_schema(self, tmp_path, monkeypatch, capsys):
-        """cmd_trend renders cleanly over mixed v2 and v3 history (US-005)."""
+    def test_trend_skips_v2_records(self, tmp_path, monkeypatch, capsys):
+        """cmd_trend skips v2 records; only v3 records appear (DEC-003)."""
         import json as _json
 
         from clauditor import history
@@ -3779,7 +3779,7 @@ class TestCmdTrend:
         path = tmp_path / ".clauditor" / "history.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        # One v2 record (no iteration/workspace_path).
+        # One v2 record — should be skipped by the reader.
         v2_rec = {
             "schema_version": 2,
             "command": "grade",
@@ -3807,8 +3807,8 @@ class TestCmdTrend:
         rc = main(["trend", "test-skill", "--metric", "pass_rate"])
         assert rc == 0
         out = capsys.readouterr().out
-        # Both records should appear in the trend output.
-        assert "0.4" in out
+        # v2 record skipped, only v3 record appears.
+        assert "0.4" not in out
         assert "0.9" in out
 
 

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -195,6 +195,7 @@ class TestGradeVerboseInvocation:
 
     def _grading_report(self):
         from clauditor.quality_grader import GradingReport, GradingResult
+        from clauditor.schemas import GradeThresholds
 
         return GradingReport(
             skill_name="test-skill",
@@ -209,6 +210,8 @@ class TestGradeVerboseInvocation:
                 )
             ],
             duration_seconds=1.0,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
     def test_grade_verbose_invokes_slice_on_failure(

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -218,14 +218,13 @@ class TestAppendV3:
         assert rec["workspace_path"] is None
 
 
-class TestReadMixedSchema:
-    """Reading mixed v2 and v3 history files (US-005)."""
+class TestSchemaVersionEnforcement:
+    """read_records hard-requires schema_version=3 (DEC-003)."""
 
-    def test_read_mixed_v2_v3_records(self, tmp_path):
+    def test_v2_record_skipped_with_warning(self, tmp_path, capsys):
         import json as _json
 
         path = tmp_path / "history.jsonl"
-        path.parent.mkdir(parents=True, exist_ok=True)
         v2_record = {
             "schema_version": 2,
             "command": "grade",
@@ -235,29 +234,84 @@ class TestReadMixedSchema:
             "mean_score": 0.6,
             "metrics": {},
         }
-        with path.open("w", encoding="utf-8") as f:
-            f.write(_json.dumps(v2_record) + "\n")
+        path.write_text(_json.dumps(v2_record) + "\n")
 
-        # Append a v3 record via the API.
+        records = read_records(path=path)
+        assert len(records) == 0
+        err = capsys.readouterr().err
+        assert "schema_version=2" in err
+        assert "expected 3" in err
+
+    def test_v1_record_skipped_with_warning(self, tmp_path, capsys):
+        import json as _json
+
+        path = tmp_path / "history.jsonl"
+        # v1 records have no schema_version key at all
+        v1_record = {
+            "ts": "2025-01-01T00:00:00+00:00",
+            "skill": "skill-a",
+            "pass_rate": 0.5,
+            "mean_score": 0.6,
+            "metrics": {},
+        }
+        path.write_text(_json.dumps(v1_record) + "\n")
+
+        records = read_records(path=path)
+        assert len(records) == 0
+        err = capsys.readouterr().err
+        assert "schema_version=None" in err
+        assert "expected 3" in err
+
+    def test_v3_record_passes(self, tmp_path, capsys):
+        path = tmp_path / "history.jsonl"
         append_record(
-            "skill-a",
-            0.9,
-            0.85,
-            {},
-            command="grade",
-            path=path,
-            iteration=2,
-            workspace_path="ws/2",
+            "skill-a", 0.9, 0.85, {}, command="grade", path=path,
+            iteration=2, workspace_path="ws/2",
         )
 
         records = read_records(path=path)
-        assert len(records) == 2
-        assert records[0]["schema_version"] == 2
-        assert records[0].get("iteration") is None
-        assert records[0].get("workspace_path") is None
-        assert records[1]["schema_version"] == 3
-        assert records[1]["iteration"] == 2
-        assert records[1]["workspace_path"] == "ws/2"
+        assert len(records) == 1
+        assert records[0]["schema_version"] == 3
+        assert records[0]["iteration"] == 2
+        # No warnings emitted
+        err = capsys.readouterr().err
+        assert "schema_version" not in err
+
+    def test_mixed_file_only_v3_returned(self, tmp_path, capsys):
+        import json as _json
+
+        path = tmp_path / "history.jsonl"
+        v1 = {"schema_version": 1, "skill": "a", "pass_rate": 0.1}
+        v2 = {
+            "schema_version": 2,
+            "skill": "a",
+            "pass_rate": 0.5,
+            "metrics": {},
+        }
+        v3 = {
+            "schema_version": 3,
+            "command": "grade",
+            "ts": "t",
+            "skill": "a",
+            "pass_rate": 0.9,
+            "mean_score": None,
+            "metrics": {},
+            "iteration": None,
+            "workspace_path": None,
+        }
+        lines = [
+            _json.dumps(v1),
+            _json.dumps(v2),
+            _json.dumps(v3),
+        ]
+        path.write_text("\n".join(lines) + "\n")
+
+        records = read_records(path=path)
+        assert len(records) == 1
+        assert records[0]["schema_version"] == 3
+        err = capsys.readouterr().err
+        assert "schema_version=1" in err
+        assert "schema_version=2" in err
 
 
 def _concurrent_writer(args):

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -58,11 +58,22 @@ def _make_results(
 
 
 class TestGradingReport:
+    def test_thresholds_and_metrics_required(self):
+        """GradingReport() without thresholds/metrics raises TypeError (DEC-005)."""
+        with pytest.raises(TypeError):
+            GradingReport(
+                skill_name="test",
+                results=[],
+                model="claude-sonnet-4-6",
+            )
+
     def test_passed_all_true(self):
         report = GradingReport(
             skill_name="test",
             results=_make_results([True, True, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         assert report.passed is True
 
@@ -71,6 +82,8 @@ class TestGradingReport:
             skill_name="test",
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         assert report.passed is False
 
@@ -79,6 +92,8 @@ class TestGradingReport:
             skill_name="test",
             results=_make_results([True, True, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         assert report.pass_rate == pytest.approx(1.0)
 
@@ -87,12 +102,16 @@ class TestGradingReport:
             skill_name="test",
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         assert report.pass_rate == pytest.approx(2 / 3)
 
     def test_pass_rate_empty(self):
         report = GradingReport(
-            skill_name="test", results=[], model="claude-sonnet-4-6"
+            skill_name="test", results=[], model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         assert report.pass_rate == 0.0
 
@@ -101,13 +120,17 @@ class TestGradingReport:
             skill_name="test",
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         # Two at 0.9, one at 0.2 => (0.9 + 0.2 + 0.9) / 3
         assert report.mean_score == pytest.approx(2.0 / 3)
 
     def test_mean_score_empty(self):
         report = GradingReport(
-            skill_name="test", results=[], model="claude-sonnet-4-6"
+            skill_name="test", results=[], model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         assert report.mean_score == 0.0
 
@@ -116,6 +139,8 @@ class TestGradingReport:
             skill_name="test",
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         s = report.summary()
         assert "2/3 criteria passed" in s
@@ -126,6 +151,8 @@ class TestGradingReport:
             skill_name="test",
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         s = report.summary()
         assert "PASS: Output contains actionable" in s
@@ -139,6 +166,8 @@ class TestGradingReportSerialization:
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
             duration_seconds=1.5,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         raw = report.to_json()
         data = json.loads(raw)
@@ -159,6 +188,8 @@ class TestGradingReportSerialization:
             results=_make_results([True, False, True]),
             model="claude-sonnet-4-6",
             duration_seconds=2.3,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         raw = original.to_json()
         restored = GradingReport.from_json(raw)
@@ -187,6 +218,8 @@ class TestGradingReportSerialization:
             ],
             model="claude-sonnet-4-6",
             duration_seconds=3.14159,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         restored = GradingReport.from_json(report.to_json())
         assert restored.results[0].score == pytest.approx(0.8765)
@@ -214,6 +247,8 @@ class TestGradingReportSerialization:
             skill_name="ts-test",
             results=[],
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         raw = report.to_json()
         data = json.loads(raw)
@@ -228,6 +263,7 @@ class TestGradingReportSerialization:
             results=_make_results([True, False]),
             model="claude-sonnet-4-6",
             thresholds=thresholds,
+            metrics={},
         )
         raw = original.to_json()
         data = json.loads(raw)
@@ -248,6 +284,8 @@ class TestGradingReportSerialization:
             model="claude-sonnet-4-6",
             input_tokens=500,
             output_tokens=200,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         raw = original.to_json()
         data = json.loads(raw)
@@ -269,19 +307,23 @@ class TestGradingReportSerialization:
         assert restored.input_tokens == 0
         assert restored.output_tokens == 0
 
-    def test_no_thresholds_roundtrip(self):
-        """Report without thresholds omits them from JSON."""
+    def test_default_thresholds_roundtrip(self):
+        """Default thresholds survive JSON round-trip."""
         original = GradingReport(
-            skill_name="no-thresh",
+            skill_name="default-thresh",
             results=_make_results([True]),
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
         raw = original.to_json()
         data = json.loads(raw)
-        assert "thresholds" not in data
+        assert data["thresholds"]["min_pass_rate"] == 0.7
+        assert data["thresholds"]["min_mean_score"] == 0.5
 
         restored = GradingReport.from_json(raw)
-        assert restored.thresholds is None
+        assert restored.thresholds.min_pass_rate == pytest.approx(0.7)
+        assert restored.thresholds.min_mean_score == pytest.approx(0.5)
 
 
 class TestParseGradingResponse:
@@ -827,7 +869,9 @@ def _make_grading_report(
             ),
         ]
     return GradingReport(
-        skill_name="test-skill", results=results, model="claude-sonnet-4-6"
+        skill_name="test-skill", results=results, model="claude-sonnet-4-6",
+        thresholds=GradeThresholds(),
+        metrics={},
     )
 
 
@@ -900,6 +944,8 @@ class TestVarianceReport:
                         )
                     ],
                     model="claude-sonnet-4-6",
+                    thresholds=GradeThresholds(),
+                    metrics={},
                 )
             )
 
@@ -983,6 +1029,8 @@ class TestMeasureVariance:
                 )
             ],
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         mock_result = MagicMock()
@@ -1030,6 +1078,8 @@ class TestMeasureVariance:
                 )
             ],
             model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         mock_result = MagicMock()
@@ -1070,6 +1120,8 @@ class TestMeasureVariance:
             model="claude-sonnet-4-6",
             input_tokens=100,
             output_tokens=50,
+            thresholds=GradeThresholds(),
+            metrics={},
         )
 
         # Use real attrs (not MagicMock defaults) so skill-side token
@@ -1127,6 +1179,7 @@ class TestGradeThresholdsOnReport:
         scores: list[float],
         thresholds: GradeThresholds | None = None,
     ) -> GradingReport:
+        thresholds = thresholds if thresholds is not None else GradeThresholds()
         results = [
             GradingResult(
                 criterion=f"c{i}",
@@ -1142,6 +1195,7 @@ class TestGradeThresholdsOnReport:
             results=results,
             model="claude-sonnet-4-6",
             thresholds=thresholds,
+            metrics={},
         )
 
     def test_all_above_threshold_passes(self):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -672,22 +672,6 @@ class TestFromFile:
         with pytest.raises(ValueError, match=r"duplicate id 'shared'"):
             EvalSpec.from_file(path)
 
-    def test_from_file_legacy_pattern_key_rejected(self, tmp_path):
-        """DEC-006: legacy 'pattern' key is rejected with a migration message."""
-        data = {
-            "skill_name": "test",
-            "sections": [
-                {
-                    "name": "S",
-                    "fields": [
-                        {"id": "f1", "name": "f1", "required": True, "pattern": r"\d+"},
-                    ],
-                }
-            ],
-        }
-        path = _write_json(tmp_path, data)
-        with pytest.raises(ValueError, match="no longer supported"):
-            EvalSpec.from_file(path)
 
 
 class TestToDict:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1195,6 +1195,39 @@ class TestTieredSections:
         with pytest.raises(ValueError, match="flat .fields. without .tiers"):
             EvalSpec.from_file(path)
 
+    def test_pattern_key_rejected(self, tmp_path):
+        """Field entries using 'pattern' instead of 'format' are rejected."""
+        data = {
+            "skill_name": "test",
+            "sections": [
+                {
+                    "name": "S",
+                    "tiers": [
+                        {
+                            "label": "required",
+                            "fields": [
+                                {"id": "f1", "name": "f1", "required": True,
+                                 "pattern": r"\d+"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        path = _write_json(tmp_path, data)
+        with pytest.raises(ValueError, match="use 'format', not 'pattern'"):
+            EvalSpec.from_file(path)
+
+    def test_section_missing_tiers_rejected(self, tmp_path):
+        """Section with neither 'tiers' nor 'fields' raises ValueError."""
+        data = {
+            "skill_name": "test",
+            "sections": [{"name": "S"}],
+        }
+        path = _write_json(tmp_path, data)
+        with pytest.raises(ValueError, match="missing 'tiers'"):
+            EvalSpec.from_file(path)
+
     def test_tier_description_preserved_through_roundtrip(self, tmp_path):
         """Tier description field survives from_file -> to_dict -> from_file."""
         path1 = _write_json(tmp_path, TIERED_SECTION_DATA, name="first.json")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -31,22 +31,32 @@ SAMPLE_EVAL = {
     "sections": [
         {
             "name": "Venues",
-            "min_entries": 3,
-            "fields": [
-                {"id": "v_name", "name": "name", "required": True},
-                {"id": "v_address", "name": "address", "required": True},
-                {"id": "v_hours", "name": "hours", "required": True},
-                {"id": "v_website", "name": "website", "required": True},
-                {"id": "v_phone", "name": "phone", "required": False},
+            "tiers": [
+                {
+                    "label": "default",
+                    "min_entries": 3,
+                    "fields": [
+                        {"id": "v_name", "name": "name", "required": True},
+                        {"id": "v_address", "name": "address", "required": True},
+                        {"id": "v_hours", "name": "hours", "required": True},
+                        {"id": "v_website", "name": "website", "required": True},
+                        {"id": "v_phone", "name": "phone", "required": False},
+                    ],
+                }
             ],
         },
         {
             "name": "Events",
-            "min_entries": 0,
-            "fields": [
-                {"id": "e_name", "name": "name", "required": True},
-                {"id": "e_date", "name": "date", "required": True},
-                {"id": "e_url", "name": "event_url", "required": True},
+            "tiers": [
+                {
+                    "label": "default",
+                    "min_entries": 0,
+                    "fields": [
+                        {"id": "e_name", "name": "name", "required": True},
+                        {"id": "e_date", "name": "date", "required": True},
+                        {"id": "e_url", "name": "event_url", "required": True},
+                    ],
+                }
             ],
         },
     ],
@@ -70,7 +80,6 @@ class TestEvalSpecFromFile:
         assert len(spec.assertions) == 2
         assert len(spec.sections) == 2
         assert spec.sections[0].name == "Venues"
-        # Legacy fields normalized to single default tier
         assert len(spec.sections[0].tiers) == 1
         tier = spec.sections[0].tiers[0]
         assert tier.label == "default"
@@ -142,20 +151,25 @@ class TestFormatFieldRoundTrip:
             "sections": [
                 {
                     "name": "Items",
-                    "min_entries": 1,
-                    "fields": [
+                    "tiers": [
                         {
-                            "id": "f_phone",
-                            "name": "phone",
-                            "required": True,
-                            "format": "phone_us",
-                        },
-                        {
-                            "id": "f_email",
-                            "name": "email",
-                            "required": False,
-                            "format": "email",
-                        },
+                            "label": "default",
+                            "min_entries": 1,
+                            "fields": [
+                                {
+                                    "id": "f_phone",
+                                    "name": "phone",
+                                    "required": True,
+                                    "format": "phone_us",
+                                },
+                                {
+                                    "id": "f_email",
+                                    "name": "email",
+                                    "required": False,
+                                    "format": "email",
+                                },
+                            ],
+                        }
                     ],
                 }
             ],
@@ -182,9 +196,14 @@ class TestFormatFieldRoundTrip:
             "sections": [
                 {
                     "name": "Items",
-                    "min_entries": 1,
-                    "fields": [
-                        {"id": "f_name", "name": "name", "required": True},
+                    "tiers": [
+                        {
+                            "label": "default",
+                            "min_entries": 1,
+                            "fields": [
+                                {"id": "f_name", "name": "name", "required": True},
+                            ],
+                        }
                     ],
                 }
             ],
@@ -352,11 +371,21 @@ FULL_EVAL_DATA = {
     "sections": [
         {
             "name": "Places",
-            "min_entries": 2,
-            "fields": [
-                {"id": "p_name", "name": "name", "required": True},
-                {"id": "p_address", "name": "address", "required": True},
-                {"id": "p_zip", "name": "zip", "required": False, "format": r"^\d{5}$"},
+            "tiers": [
+                {
+                    "label": "default",
+                    "min_entries": 2,
+                    "fields": [
+                        {"id": "p_name", "name": "name", "required": True},
+                        {"id": "p_address", "name": "address", "required": True},
+                        {
+                            "id": "p_zip",
+                            "name": "zip",
+                            "required": False,
+                            "format": r"^\d{5}$",
+                        },
+                    ],
+                }
             ],
         },
     ],
@@ -448,7 +477,17 @@ class TestFromFile:
         data = {
             "skill_name": "test",
             "sections": [
-                {"name": "S", "fields": [{"id": "f1", "name": "f1", "required": True}]}
+                {
+                    "name": "S",
+                    "tiers": [
+                        {
+                            "label": "default",
+                            "fields": [
+                                {"id": "f1", "name": "f1", "required": True}
+                            ],
+                        }
+                    ],
+                }
             ],
         }
         path = _write_json(tmp_path, data)
@@ -509,8 +548,8 @@ class TestFromFile:
         ):
             EvalSpec.from_file(path)
 
-    def test_field_requirement_legacy_missing_id_rejected(self, tmp_path):
-        """Legacy (no-tiers) field shape also requires explicit ids."""
+    def test_flat_fields_without_tiers_rejected(self, tmp_path):
+        """Section with flat fields (no tiers) raises ValueError."""
         data = {
             "skill_name": "s",
             "sections": [
@@ -522,7 +561,7 @@ class TestFromFile:
         }
         path = _write_json(tmp_path, data)
         with pytest.raises(
-            ValueError, match=r"sections\[0\]\.fields\[0\]: missing 'id'"
+            ValueError, match="flat .fields. without .tiers"
         ):
             EvalSpec.from_file(path)
 
@@ -689,7 +728,7 @@ class TestToDict:
         assert d["assertions"] == FULL_EVAL_DATA["assertions"]
         assert d["grading_criteria"] == FULL_EVAL_DATA["grading_criteria"]
         assert d["grading_model"] == FULL_EVAL_DATA["grading_model"]
-        # Sections structure matches (legacy normalized to tiers)
+        # Sections structure matches
         assert len(d["sections"]) == 1
         assert d["sections"][0]["name"] == "Places"
         tier = d["sections"][0]["tiers"][0]
@@ -985,9 +1024,8 @@ class TestTierRequirement:
         tier_out = out["sections"][0]["tiers"][0]
         assert tier_out["max_entries"] == 3
 
-    def test_max_entries_propagates_through_legacy_section_shape(self, tmp_path):
-        """Legacy (no-tiers) section shape must propagate max_entries into
-        the synthesized default tier — otherwise the cap is silently ignored."""
+    def test_flat_fields_with_max_entries_rejected(self, tmp_path):
+        """Flat fields at section level are rejected even with max_entries."""
         data = {
             "skill_name": "legacy-skill",
             "sections": [
@@ -1001,11 +1039,8 @@ class TestTierRequirement:
         }
         path = tmp_path / "spec.eval.json"
         path.write_text(json.dumps(data))
-        spec = EvalSpec.from_file(path)
-        default_tier = spec.sections[0].tiers[0]
-        assert default_tier.label == "default"
-        assert default_tier.min_entries == 1
-        assert default_tier.max_entries == 3
+        with pytest.raises(ValueError, match="flat .fields. without .tiers"):
+            EvalSpec.from_file(path)
 
     def test_max_entries_none_omitted_from_dict(self, tmp_path):
         """When max_entries is None, it is omitted from serialized output."""
@@ -1103,8 +1138,8 @@ class TestTieredSections:
         assert section.tiers[1].min_entries == 1
         assert len(section.tiers[1].fields) == 4
 
-    def test_legacy_fields_normalized_to_default_tier(self, tmp_path):
-        """Legacy fields-style JSON is normalized to a single default tier."""
+    def test_from_file_rejects_flat_fields_shape(self, tmp_path):
+        """Flat fields (without tiers) raises ValueError."""
         legacy_data = {
             "skill_name": "legacy",
             "sections": [
@@ -1119,17 +1154,8 @@ class TestTieredSections:
             ],
         }
         path = _write_json(tmp_path, legacy_data)
-        spec = EvalSpec.from_file(path)
-
-        section = spec.sections[0]
-        assert len(section.tiers) == 1
-        tier = section.tiers[0]
-        assert tier.label == "default"
-        assert tier.description == ""
-        assert tier.min_entries == 5
-        assert len(tier.fields) == 2
-        assert tier.fields[0].name == "title"
-        assert tier.fields[1].required is False
+        with pytest.raises(ValueError, match="flat .fields. without .tiers"):
+            EvalSpec.from_file(path)
 
     def test_tiered_roundtrip(self, tmp_path):
         """from_file -> to_dict -> from_file preserves tiered structure."""
@@ -1153,8 +1179,8 @@ class TestTieredSections:
         assert spec2.sections[0].tiers[1].label == "detailed"
         assert len(spec2.sections[0].tiers[1].fields) == 4
 
-    def test_legacy_roundtrip(self, tmp_path):
-        """Legacy format -> load -> to_dict -> reload produces consistent tiers."""
+    def test_flat_fields_rejected_even_with_min_entries(self, tmp_path):
+        """Flat fields at section level are rejected regardless of other keys."""
         legacy_data = {
             "skill_name": "legacy-rt",
             "sections": [
@@ -1165,20 +1191,9 @@ class TestTieredSections:
                 }
             ],
         }
-        path1 = _write_json(tmp_path, legacy_data, name="first.json")
-        spec1 = EvalSpec.from_file(path1)
-        d = spec1.to_dict()
-
-        # Output always uses tiers form
-        assert "tiers" in d["sections"][0]
-        assert d["sections"][0]["tiers"][0]["label"] == "default"
-
-        # Reload produces same structure
-        path2 = _write_json(tmp_path, d, name="second.json")
-        spec2 = EvalSpec.from_file(path2)
-        assert spec2.sections[0].tiers[0].label == "default"
-        assert spec2.sections[0].tiers[0].min_entries == 2
-        assert len(spec2.sections[0].tiers[0].fields) == 1
+        path = _write_json(tmp_path, legacy_data, name="first.json")
+        with pytest.raises(ValueError, match="flat .fields. without .tiers"):
+            EvalSpec.from_file(path)
 
     def test_tier_description_preserved_through_roundtrip(self, tmp_path):
         """Tier description field survives from_file -> to_dict -> from_file."""

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -587,6 +587,7 @@ class TestLoadSuggestInputMalformedJson:
                                 "passed": False,
                                 "message": "missing",
                                 "kind": "presence",
+                                "transcript_path": None,
                             },
                         ],
                     }
@@ -664,6 +665,7 @@ class TestLoadSuggestInputMalformedJson:
                                     "passed": False,
                                     "message": "msg",
                                     "kind": "presence",
+                                    "transcript_path": None,
                                 },
                             ],
                         }
@@ -732,6 +734,7 @@ class TestLoadSuggestInputMalformedJson:
                                     "passed": False,
                                     "message": "m",
                                     "kind": "presence",
+                                    "transcript_path": None,
                                 }
                             ],
                         }
@@ -771,6 +774,7 @@ class TestLoadSuggestInputMalformedJson:
                                 "passed": False,
                                 "message": "m",
                                 "kind": "presence",
+                                "transcript_path": None,
                             }
                         ],
                     },
@@ -804,6 +808,7 @@ class TestLoadSuggestInputMalformedJson:
                                 "passed": False,
                                 "message": "fails in run 0",
                                 "kind": "presence",
+                                "transcript_path": None,
                             },
                             {
                                 "id": "a2",
@@ -811,6 +816,7 @@ class TestLoadSuggestInputMalformedJson:
                                 "passed": True,
                                 "message": "",
                                 "kind": "presence",
+                                "transcript_path": None,
                             },
                         ],
                     },
@@ -823,6 +829,7 @@ class TestLoadSuggestInputMalformedJson:
                                 "passed": False,
                                 "message": "fails in run 1 too",
                                 "kind": "presence",
+                                "transcript_path": None,
                             },
                             {
                                 "id": "a3",
@@ -830,6 +837,7 @@ class TestLoadSuggestInputMalformedJson:
                                 "passed": False,
                                 "message": "only fails in variance",
                                 "kind": "presence",
+                                "transcript_path": None,
                             },
                         ],
                     },
@@ -995,6 +1003,7 @@ class TestLoadSuggestInputCRLF:
                                     "passed": False,
                                     "message": "missing",
                                     "kind": "presence",
+                                    "transcript_path": None,
                                 }
                             ],
                         }


### PR DESCRIPTION
## Summary
Audit and remove legacy/backcompat artifacts from the pre-publication codebase (#41).

- **US-001**: Safe-delete bulk removal (pattern-key rejection, --save test, sidecar fallbacks)
- **US-002**: Enforce history.jsonl schema v3 — drop v1/v2 tolerance
- **US-003**: Drop flat-fields eval-spec parser — tiered shape only
- **US-004**: GradingReport required fields — thresholds/metrics non-Optional
- **US-005**: Refactor _run_baseline_phase into compute_baseline + thin I/O wrapper
- **US-006**: README.md final sweep — remove all legacy/backcompat prose

**20 files changed, ~1250 insertions, ~380 deletions.** 1167 tests pass, 96% coverage.

## Test plan
- [x] uv run ruff check src/ tests/ — lint clean
- [x] uv run pytest --cov=clauditor --cov-report=term-missing — 1167 passed, 96.19% coverage
- [x] 4-pass code review (architecture, security, testing, code quality, project rules)
- [x] CodeRabbit review — all findings addressed
- [x] Copilot review — all findings addressed
- [x] Codecov patch coverage gaps closed

Generated with [Claude Code](https://claude.com/claude-code)