### PR TITLE
#43: clauditor setup slash-command installer (plan)

### DIFF
--- a/.claude/rules/project-root-home-exclusion.md
+++ b/.claude/rules/project-root-home-exclusion.md
@@ -1,0 +1,140 @@
+# Rule: Home-directory exclusion for `.claude` marker walks
+
+Any helper that walks up the filesystem looking for a project root by
+checking for a `.claude/` marker directory MUST explicitly exclude
+the user's home directory (`Path.home()`) from matching on that
+specific marker. Claude Code itself ships a `~/.claude/` user config
+dir on every developer workstation, so without the exclusion any
+walk that starts under `$HOME` with no intermediate project marker
+silently ascends to `$HOME` — and the caller then treats the user's
+global Claude Code config as "the project root," contaminating
+unrelated work.
+
+This is a class of bug, not a one-off. Any new helper that accepts
+`.claude/` as a marker inherits the hazard.
+
+## The trap
+
+```python
+# WRONG — ascends into ~/.claude for any cwd under $HOME lacking an
+# intermediate project marker.
+def find_project_root(cwd: Path) -> Path | None:
+    current = cwd
+    for _ in range(50):
+        if (current / ".git").exists():
+            return current
+        if (current / ".claude").is_dir():  # matches ~/.claude!
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return None
+```
+
+The failure is silent:
+
+- `clauditor setup` run from `~/Downloads` (no intermediate
+  `.git`/`.claude`) walks up to `$HOME`, finds `~/.claude/`, and
+  installs the skill symlink at `~/.claude/skills/clauditor/` — in
+  the user's Claude Code config tree, not their intended project.
+- A later `clauditor setup --unlink` from inside any actual project
+  appears to do nothing (cwd walks up to `$HOME` again, removes the
+  symlink from `~/.claude/` but leaves the user confused about why
+  their project-local install is still present).
+- No exit-2 "no project root found" ever fires — the walk *did*
+  find a marker, just the wrong one.
+
+## The pattern
+
+Resolve `Path.home()` once outside the loop (with a `try/except` for
+systems where `HOME` is undefined or unreadable), compare the
+resolved candidate dir to it, and skip the `.claude` marker — but
+NOT `.git` — when at home:
+
+```python
+def find_project_root(cwd: Path) -> Path | None:
+    try:
+        home = Path.home().resolve()
+    except (RuntimeError, OSError):
+        home = None
+
+    current = cwd
+    for _ in range(50):
+        try:
+            resolved = current.resolve()
+        except OSError:
+            resolved = current
+        at_home = home is not None and resolved == home
+
+        if (current / ".git").exists():
+            return current
+        if not at_home and (current / ".claude").is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return None
+```
+
+Three invariants to preserve:
+
+- **`home` resolution happens once**, outside the loop. Calling
+  `Path.home().resolve()` per iteration is wasteful and can surface
+  different values if `HOME` changes mid-walk.
+- **`try/except` both the home lookup and the candidate `resolve()`**.
+  Broken perms along the walk path, containerized envs with no
+  `HOME`, and `os.fspath` edge cases all manifest as `OSError` or
+  `RuntimeError` from `Path.home()`. Fall through to "no exclusion"
+  rather than crashing — a failure to detect home is not a reason
+  to abort the walk.
+- **Exclude `.claude` only, not `.git`**. A user who treats `$HOME`
+  as a git repo is making an explicit, uncommon choice; that
+  decision should still be honored. The hazard is specifically that
+  `.claude` at `$HOME` is the *default* Claude Code state, not an
+  intentional project marker.
+
+## Why `.git` is different
+
+- `~/.git/` is rare and signals "I have explicitly chosen to treat
+  my home dir as a checkout." Honoring it matches user intent.
+- `~/.claude/` is shipped by Claude Code on install and exists on
+  essentially every developer machine that has Claude Code set up.
+  Matching it contaminates user config with unrelated workspace
+  data.
+- The asymmetry is documented in the Claude Code install docs: the
+  user config dir lives at `$HOME/.claude/` and is not meant to
+  stand in for a project marker.
+
+## Canonical implementations
+
+- `src/clauditor/paths.py::resolve_clauditor_dir` — first anchor;
+  originally solved this class of bug when clauditor's `.clauditor/`
+  output dir was otherwise landing in `~/.clauditor/` for users
+  running from scratch dirs under `$HOME`.
+- `src/clauditor/setup.py::find_project_root` — second anchor;
+  regressed by losing the home-exclusion when the module was first
+  written for issue #43, then re-fixed in Quality Gate Pass 4.
+  `tests/test_setup.py::TestFindProjectRoot::test_find_project_root_skips_claude_at_home`
+  is the regression guard;
+  `test_find_project_root_accepts_git_at_home` proves the exclusion
+  is `.claude`-specific, not a blanket home-dir block.
+
+## When this rule applies
+
+Any new marker-walk helper whose marker set includes `.claude` (as a
+directory or a file). The exclusion is load-bearing for `.claude`
+specifically because it has an established meaning in `$HOME`.
+
+## When this rule does NOT apply
+
+- Marker walks that use only `.git` (or other project-specific
+  markers like `Cargo.toml`, `pyproject.toml`, `package.json`).
+  Those markers have no `$HOME`-default collision.
+- Walks that are explicitly scoped to a user-provided directory
+  (e.g. `--project-dir /foo`) and do not ascend beyond it. No walk
+  means no hazard.
+- Contexts where landing at `$HOME` is the intended behavior (e.g.
+  resolving the user's config dir on purpose). Those should call
+  `Path.home()` directly rather than walking a marker set.

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -132,6 +132,40 @@ refactored split makes the grading logic unit-testable without
 `tmp_path` or subprocess mocks, and positions the pure helper for
 reuse from a future pytest fixture.
 
+### Fourth anchor (decision function for setup)
+
+`src/clauditor/setup.py::plan_setup` — pure function that takes a
+`cwd`, a resolved `pkg_skill_root`, and the `force` / `unlink` flags
+and returns a `SetupAction` enum member describing what the I/O
+layer should do next. First anchor for a *decision function*
+(returns an enum discriminator) rather than a data-aggregation or
+resolve-and-compose helper: the pure compute is "inspect the
+filesystem, classify the situation, pick the branch"; the I/O layer
+then dispatches on the enum to run `os.symlink`, `os.unlink`,
+`shutil.rmtree`, or print a refusal. Traces to DEC-014 in
+`plans/super/43-setup-slash-command.md`.
+
+Two callers:
+
+- `src/clauditor/cli.py::cmd_setup` — side-effect layer. Translates
+  each `SetupAction` into filesystem operations, stdout/stderr
+  messages, and exit codes (DEC-008 / DEC-009 / DEC-016). Also runs
+  the "plan + dispatch, retry once on `FileExistsError`" loop for
+  the atomic create-or-fail path.
+- `tests/test_setup.py` — pure consumer. 23 tests, one per enum
+  branch plus home-exclusion guards for `find_project_root`. Each
+  test constructs a `cwd` + `pkg_skill_root` under `tmp_path`, calls
+  `plan_setup`, and asserts on the returned enum member — no
+  subprocess mocks, no stdout capture, no exit-code assertions.
+
+The split makes the home-directory exclusion in `find_project_root`
+directly unit-testable (see also
+`.claude/rules/project-root-home-exclusion.md`): a bundled "classify
+and execute" helper would have hidden that guard behind a subprocess
+mock and an assertion on the absence of a symlink, instead of a
+direct `plan_setup(cwd=home_like_dir, ...)` returning the refusal
+enum.
+
 ## When this rule applies
 
 Any new code that combines spec/config resolution with a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ jobs:
       - uses: astral-sh/setup-uv@v4
       - run: uv run ruff check src/ tests/
 
+  validate-skill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Validate bundled skill frontmatter (agentskills.io core)
+        # Uses an inline fallback instead of `skills-ref validate`: the
+        # upstream validator rejects Claude Code extension fields
+        # (argument-hint, disable-model-invocation) that DEC-004 of
+        # plans/super/43-setup-slash-command.md mandates on the bundled
+        # SKILL.md. The fallback enforces only the core agentskills.io
+        # invariants the spec actually requires.
+        run: python scripts/validate_skill_frontmatter.py src/clauditor/skills/clauditor
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to clauditor
+
+## Pre-release dogfood
+
+Before tagging a new release, clauditor must pass two gates against its
+own bundled slash-command skill. These are not run in CI (see rationale
+below); they are maintainer-run immediately before any release tag.
+
+### The two gates
+
+1. **L1 — deterministic assertions (free, seconds):**
+
+   ```bash
+   uv run clauditor validate src/clauditor/skills/clauditor/SKILL.md
+   ```
+
+2. **L3 — LLM-graded quality (costs Sonnet tokens, ~1 minute):**
+
+   ```bash
+   uv run clauditor grade src/clauditor/skills/clauditor/SKILL.md \
+     --eval src/clauditor/skills/clauditor/assets/clauditor.eval.json
+   ```
+
+Both commands must exit 0. If either gate fails, do NOT tag the
+release — a failing bundled skill is the user-visible failure mode
+that this checklist exists to catch.
+
+### Why manual, not CI
+
+The `clauditor_spec` pytest fixture (the natural candidate for a
+per-PR CI check) shells out to the live `claude -p` subprocess on
+every invocation — it is not a mock. Running dogfood on every pull
+request would:
+
+- Burn Anthropic API tokens on unrelated changes.
+- Couple CI uptime to Claude's infrastructure uptime (unrelated
+  Claude outages would turn every PR red).
+- Add 30–60 seconds of latency to every CI run.
+
+Pre-release is where the bundled-skill regression actually matters:
+we ship a wheel with a broken `/clauditor` at most once per release,
+not once per merge.
+
+### Debugging a failed gate
+
+If either gate fails, do not tag. Investigate via the sidecar
+artifacts clauditor persists under `.clauditor/iteration-N/clauditor/`:
+
+- `assertions.json` — per-assertion pass/fail with the matching text
+  excerpt.
+- `grading.json` — per-criterion verdict, score, evidence, and
+  reasoning.
+- `run-0/output.txt` / `run-0/output.jsonl` — the raw skill output
+  and stream-json transcript.
+
+File a beads issue describing the regression (what changed, which
+gate failed, which criterion or assertion) and hold the release
+until the issue is closed.
+
+### Lineage
+
+This protocol is recorded in DEC-007 of
+[`plans/super/43-setup-slash-command.md`](plans/super/43-setup-slash-command.md)
+and is delivered by the `clauditor-3xy` bead epic (see `bd show
+clauditor-3xy` for the full story list).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ uv run clauditor setup
 Expected output:
 
 ```
-Installed /clauditor: .claude/skills/clauditor -> <site-packages path>/clauditor/skills/clauditor
+Installed /clauditor: <project root>/.claude/skills/clauditor -> <site-packages path>/clauditor/skills/clauditor
 ```
 
 `setup` creates a single symlink at `.claude/skills/clauditor` pointing

--- a/README.md
+++ b/README.md
@@ -62,6 +62,53 @@ cd clauditor
 uv sync --dev
 ```
 
+## Installing the /clauditor slash command
+
+clauditor ships a bundled Claude Code skill that exposes its
+capture/validate/grade workflow as a `/clauditor` slash command. After
+installing the CLI (pip/uv), run one command from your project root:
+
+```bash
+uv run clauditor setup
+```
+
+Expected output:
+
+```
+Installed /clauditor: .claude/skills/clauditor -> <site-packages path>/clauditor/skills/clauditor
+```
+
+`setup` creates a single symlink at `.claude/skills/clauditor` pointing
+at the bundled skill directory inside the installed clauditor package,
+so `pip install --upgrade clauditor` picks up skill updates automatically
+without re-running `setup`.
+
+**Flags:**
+
+- `--unlink` — remove the `/clauditor` symlink. Refuses to delete regular
+  files or symlinks that don't point at the installed clauditor package,
+  so it won't touch user-authored skills.
+- `--force` — overwrite an existing file or symlink at
+  `.claude/skills/clauditor`. Without `--force`, `setup` refuses to
+  clobber any pre-existing entry. Use `--force` only when you know the
+  entry is ours.
+- `--project-dir PATH` — override project-root detection. By default,
+  `setup` walks up from the current directory looking for a `.git/` or
+  `.claude/` marker; pass `--project-dir` to target a different root.
+
+**Restart note:** if `.claude/skills/` did not exist before
+`clauditor setup` ran, restart Claude Code once so it picks up the new
+directory. Subsequent edits under `.claude/skills/clauditor/` are
+hot-reloaded — see the Claude Code
+[live change detection](https://code.claude.com/docs/en/skills#live-change-detection)
+reference.
+
+**Diagnostic:** `uv run clauditor doctor` reports the skill symlink's
+health (absent / installed / stale / wrong-target / unmanaged).
+
+**Maintainers:** the bundled skill has a pre-release dogfood gate — see
+[`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood).
+
 ## Quick Start
 
 ### 1. Create an eval spec for your skill

--- a/build_hooks/stamp_skill_version.py
+++ b/build_hooks/stamp_skill_version.py
@@ -1,0 +1,102 @@
+"""Hatchling custom build hook: stamp ``metadata.clauditor-version`` in SKILL.md.
+
+At wheel build time, substitute the real ``[project].version`` from
+``pyproject.toml`` into the bundled
+``src/clauditor/skills/clauditor/SKILL.md`` YAML frontmatter. The
+source-tree file is never mutated; the stamped content is emitted to a
+temporary file and routed into the wheel via ``build_data["force_include"]``,
+which also reserves the target path so the original source-tree file is
+not double-packaged.
+
+Traces to: DEC-005 of ``plans/super/43-setup-slash-command.md``.
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.plugin import hookimpl
+
+SKILL_MD_RELATIVE = Path("src/clauditor/skills/clauditor/SKILL.md")
+WHEEL_TARGET_PATH = "src/clauditor/skills/clauditor/SKILL.md"
+VERSION_LINE_PATTERN = re.compile(r'clauditor-version:\s*"[^"]*"')
+
+
+def _read_project_version(pyproject_path: Path) -> str:
+    with pyproject_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    try:
+        version = data["project"]["version"]
+    except KeyError as exc:
+        raise RuntimeError(
+            f"stamp_skill_version: could not find [project].version in "
+            f"{pyproject_path}"
+        ) from exc
+    if not isinstance(version, str) or not version:
+        raise RuntimeError(
+            f"stamp_skill_version: [project].version in {pyproject_path} "
+            f"must be a non-empty string (got {version!r})"
+        )
+    return version
+
+
+def _stamp_version(skill_md_text: str, version: str) -> str:
+    new_text, n = VERSION_LINE_PATTERN.subn(
+        f'clauditor-version: "{version}"', skill_md_text, count=1
+    )
+    if n == 0:
+        raise RuntimeError(
+            "stamp_skill_version: did not find `clauditor-version: \"...\"` "
+            "line to substitute in bundled SKILL.md"
+        )
+    return new_text
+
+
+class StampSkillVersionHook(BuildHookInterface):
+    """Substitute the real project version into the bundled SKILL.md."""
+
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        root = Path(self.root)
+        pyproject_path = root / "pyproject.toml"
+        skill_md_path = root / SKILL_MD_RELATIVE
+
+        if not skill_md_path.is_file():
+            raise RuntimeError(
+                f"stamp_skill_version: bundled SKILL.md not found at "
+                f"{skill_md_path}"
+            )
+
+        project_version = _read_project_version(pyproject_path)
+        original_text = skill_md_path.read_text(encoding="utf-8")
+        stamped_text = _stamp_version(original_text, project_version)
+
+        # Write the stamped copy to a temporary file and force-include it at
+        # the intended wheel path. Hatchling reserves that target path so the
+        # unstamped source-tree file is NOT also packaged. The source tree is
+        # never mutated.
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            suffix="-SKILL.md",
+            prefix="clauditor-stamped-",
+            delete=False,
+        )
+        try:
+            tmp.write(stamped_text)
+        finally:
+            tmp.close()
+
+        force_include = build_data.setdefault("force_include", {})
+        force_include[tmp.name] = WHEEL_TARGET_PATH
+
+
+@hookimpl
+def hatch_register_build_hook() -> type[BuildHookInterface]:
+    return StampSkillVersionHook

--- a/build_hooks/stamp_skill_version.py
+++ b/build_hooks/stamp_skill_version.py
@@ -46,8 +46,13 @@ def _read_project_version(pyproject_path: Path) -> str:
 
 
 def _stamp_version(skill_md_text: str, version: str) -> str:
+    # Use a callable replacement to bypass re's backref interpretation of
+    # ``\1``/``\g``/etc. in the version string. Semver is safe today, but
+    # release-candidate tags with unusual characters would otherwise mangle.
     new_text, n = VERSION_LINE_PATTERN.subn(
-        f'clauditor-version: "{version}"', skill_md_text, count=1
+        lambda _match: f'clauditor-version: "{version}"',
+        skill_md_text,
+        count=1,
     )
     if n == 0:
         raise RuntimeError(
@@ -80,7 +85,8 @@ class StampSkillVersionHook(BuildHookInterface):
         # Write the stamped copy to a temporary file and force-include it at
         # the intended wheel path. Hatchling reserves that target path so the
         # unstamped source-tree file is NOT also packaged. The source tree is
-        # never mutated.
+        # never mutated. We stash the tmp path so ``finalize`` can clean it
+        # up; otherwise every wheel build leaks one file in the system temp.
         tmp = tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
@@ -93,8 +99,19 @@ class StampSkillVersionHook(BuildHookInterface):
         finally:
             tmp.close()
 
+        self._stamped_tmp_path = tmp.name
         force_include = build_data.setdefault("force_include", {})
         force_include[tmp.name] = WHEEL_TARGET_PATH
+
+    def finalize(
+        self,
+        version: str,
+        build_data: dict[str, Any],
+        artifact_path: str,
+    ) -> None:
+        tmp_name = getattr(self, "_stamped_tmp_path", None)
+        if tmp_name:
+            Path(tmp_name).unlink(missing_ok=True)
 
 
 @hookimpl

--- a/plans/super/43-setup-slash-command.md
+++ b/plans/super/43-setup-slash-command.md
@@ -1,0 +1,1021 @@
+# Super Plan: #43 — `clauditor setup` slash command installer
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/43
+- **Branch:** `feature/43-setup-slash-command` *(to be created)*
+- **Worktree:** `worktrees/clauditor/feature/43-setup-slash-command` *(to be created)*
+- **Phase:** `detailing`
+- **PR:** _pending_
+- **Sessions:** 1
+- **Last session:** 2026-04-16
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Add a `clauditor setup` CLI subcommand that installs a bundled
+skill file from the installed package into the project's
+`.claude/commands/clauditor.md` via a symlink. `clauditor setup --unlink`
+removes the symlink. The shipped skill file exposes clauditor's
+capture → validate → grade workflow as a Claude Code slash command.
+
+**Why:** After `pip install clauditor`, the CLI works but there is no
+Claude Code integration — users must remember CLI commands. A `/clauditor`
+slash command makes the workflow discoverable from inside Claude Code.
+
+**User addendum (this session):** Shipping this feature requires using
+clauditor itself to test the bundled skill — dogfood the grader against
+the artifact we're about to ship. The new skill must have an eval spec
+and a passing gate before the feature is considered done.
+
+**Done when:**
+- `clauditor setup` creates `.claude/commands/clauditor.md` symlink to the
+  bundled `skill/clauditor.md` inside the installed package
+- `clauditor setup --unlink` removes the symlink cleanly
+- The bundled skill file is correctly packaged into the wheel
+- A clauditor eval run (L1 and/or L3) passes against the bundled skill and
+  is wired into the shipping gate
+- `pip install clauditor && clauditor setup` works from a clean venv
+
+### Codebase Findings
+
+**CLI subcommand pattern** (`src/clauditor/cli.py`):
+- Subparsers defined at `cli.py:2225-2230` (`add_subparsers(dest="command", required=True)`)
+- Existing subparser templates:
+  - `validate` — `cli.py:2233-2257` (positional args + flags)
+  - `run` — `cli.py:2259-2264` (simpler shape)
+  - `doctor` — `cli.py:2620-2626` (no args)
+- Dispatch is an elif chain at `cli.py:2644-2668`
+- Each `cmd_*(args: argparse.Namespace) -> int` convention; `cmd_doctor`
+  (`cli.py:1680-1760`) is the closest shape reference — read-only, returns 0
+
+**Bundled non-Python resources — NONE TODAY.**
+- `src/clauditor/` is Python-only (grep confirmed)
+- `pyproject.toml:50-51` wheel target: `packages = ["src/clauditor"]` only;
+  no `include-package-data`, no `[tool.hatch.build.targets.wheel.shared-data]`
+- No `MANIFEST.in`
+- We must add packaging config **and** runtime lookup via
+  `importlib.resources.files("clauditor") / "skill" / "clauditor.md"`
+
+**Existing `.claude/commands/`** — 9 synced `*.md` skills already present
+(`chunk.md`, `code-review.md`, `closeout.md`, etc.). Each has:
+- A `<!-- Synced from glaude. Do not edit in project repos. -->` comment
+- `# /<name> — Title` H1
+- `## Usage`, `## What This Does`, `## Steps` with numbered subsections
+- The bundled `clauditor.md` we ship must follow the same structural
+  convention so it renders correctly as a slash command
+
+**Symlink prior art — almost none.** Single reference at `cli.py:1759`
+(`origin.is_symlink()`) in `cmd_doctor`. No `symlink_to()`/`os.symlink()`
+calls anywhere. Build from scratch.
+
+**CLI test patterns** (`tests/test_cli.py`):
+- `TestCmdValidate::test_validate_with_output_file` (line 52-116): invoke via
+  `main([...])`, mock `SkillSpec.from_file`, assert return code
+- `TestCmdRun::test_run_happy_path` (line 142-157): mock `SkillRunner`,
+  `capsys.readouterr().out`
+- `TestCmdGrade::test_grade_with_output` (line 199-219): `tmp_path` +
+  `monkeypatch.chdir()` for filesystem-rooted tests
+
+**Eval spec shape** (`src/clauditor/schemas.py:121-359`, fixture at
+`examples/.claude/commands/example-skill.eval.json`):
+- JSON, sibling `{skill_name}.eval.json` next to the skill `.md`
+- Keys: `skill_name`, `description`, `test_args`, `user_prompt`,
+  `input_files`, `assertions` (L1), `sections` (L2), `grading_criteria`
+  (L3), `grading_model`, `trigger_tests`, `variance`
+- Skills are referenced **by name**, not path — `SkillRunner.run()` takes
+  `skill_name` and prompts Claude with `/<name>` (`runner.py:136-139`),
+  which Claude resolves against `.claude/commands/<name>.md` at runtime.
+  This means: once `clauditor setup` has installed the symlink, an eval
+  spec can reference the skill by the plain name `clauditor` with no
+  special handling.
+
+**pytest plugin** (`src/clauditor/pytest_plugin.py`):
+- `clauditor_grader` fixture at `pytest_plugin.py:139-160` — takes a skill
+  path + optional eval path, returns a `GradingReport`. L3 grading is
+  gated behind the `--clauditor-grade` pytest flag (line 76-82) to avoid
+  accidental API charges.
+- `clauditor_runner` (line 86) — direct skill invocation, no grading
+- `clauditor_spec` (line 96) — run the skill without L3 grading
+
+**Cost of a full L3 grading run:** ~1000 input + ~500 output tokens on
+Sonnet per grading pass. `clauditor validate` (L1 only) is free and
+sub-second — that's the right shape for a PR-gate, with L3 reserved for
+pre-release or manual runs.
+
+### Applicable `.claude/rules/` (Convention Checker)
+
+- **`path-validation.md`** — RELEVANT. `.claude/commands/clauditor.md`
+  destination path and the bundled source path both need validation: no
+  absolute escape, resolved target must land inside the expected dir,
+  correct file type.
+- **`pure-compute-vs-io-split.md`** — RELEVANT. Split "resolve source
+  path, resolve destination path, decide action (create/skip/error)"
+  (pure) from "actually create the symlink" (I/O). One caller today, but
+  the pure `plan_setup()` return becomes trivially unit-testable.
+- **`subprocess-cwd.md`** — N/A (no subprocess in `setup`).
+- **`eval-spec-stable-ids.md`** — RELEVANT for the dogfood eval spec;
+  every assertion/criterion must carry a stable `id`.
+- **`llm-judge-prompt-injection.md`** — N/A unless we add a new judge.
+- **`json-schema-version.md`** — N/A (no new JSON artifact written by
+  `setup`; the eval spec we author follows existing shape).
+- **`sidecar-during-staging.md`** — N/A (not a grading command).
+- **`stream-json-schema.md`**, **`non-mutating-scrub.md`**,
+  **`monotonic-time-indirection.md`** — N/A.
+
+### Proposed Scope
+
+1. Add `src/clauditor/skill/clauditor.md` — bundled slash-command skill
+   that describes the capture → validate → grade workflow.
+2. Wire packaging so `clauditor.md` is included in the wheel.
+3. Add `clauditor setup` and `clauditor setup --unlink` subcommands.
+4. Add `src/clauditor/skill/clauditor.eval.json` — eval spec for the
+   bundled skill (shipped next to it).
+5. Add a dogfood test (mechanism TBD in scoping Q3).
+6. Unit tests for the new CLI subcommand and the pure resolver.
+7. Documentation updates (README install section).
+
+### Scoping Questions
+
+**Q1 — Bundled file layout.** Where does the shipped skill live inside
+the package?
+- **A.** `src/clauditor/skill/clauditor.md` (singular dir, exactly as the
+  ticket describes) ← default
+- **B.** `src/clauditor/skills/clauditor.md` (plural, anticipating growth
+  if we ship more skills later)
+- **C.** `src/clauditor/_bundled/clauditor.md` (underscore prefix signals
+  "resource dir, not a Python subpackage")
+
+**Q2 — Installation mechanism.**
+- **A.** Symlink only (matches ticket) ← simplest
+- **B.** Hard copy only — immune to pip cache clears; risks drifting from
+  the installed package's version
+- **C.** Symlink by default, `--copy` flag for environments where
+  symlinks are problematic (Windows, certain CI containers)
+
+**Q3 — Dogfood test approach** (user's shipping requirement).
+- **A.** **L1 only via pytest** — add a test using `clauditor_runner` +
+  `clauditor_spec` fixtures that invokes `/clauditor` and asserts L1
+  criteria. Free, fast, runs on every PR.
+- **B.** **L3 via pytest behind `--clauditor-grade`** — full rubric
+  grading; manual / pre-release only, not on every PR.
+- **C.** **Both** — L1 on every PR (free), L3 gated behind the existing
+  `--clauditor-grade` flag for pre-release runs.
+- **D.** **CLI shell-out in a release script** — `make ship` or
+  documented pre-release checklist invokes
+  `uv run clauditor grade <path>`, not in pytest.
+
+**Q4 — Eval spec location.** The bundled skill needs an eval spec. Where
+does it live?
+- **A.** `src/clauditor/skill/clauditor.eval.json` — shipped with the
+  package alongside `clauditor.md`; users who install clauditor get it
+  for free and can point their own `clauditor grade` runs at it
+- **B.** `tests/fixtures/clauditor.eval.json` — dev-only, not shipped in
+  the wheel
+- **C.** Both — ship a lean user-facing spec, keep a heavier dev spec
+  for CI
+
+**Q5 — `setup` collision semantics.** When `.claude/commands/clauditor.md`
+already exists:
+- **A.** No-op if it's our correct symlink; **error** if it's anything
+  else (requires `--force` to overwrite) ← safest
+- **B.** No-op if it's our correct symlink; **silently overwrite** if
+  it's an old symlink to a different target; error only if it's a
+  regular file
+- **C.** Always overwrite without prompt (simplest, riskiest)
+
+**Q6 — Shipping gate wiring.** Where does the "dogfood must pass before
+shipping" requirement actually get enforced?
+- **A.** A GitHub Actions workflow step that runs `uv run pytest
+  tests/test_bundled_skill.py` on every PR (free if L1-only)
+- **B.** A `Makefile` target (`make dogfood`) documented in
+  `CONTRIBUTING.md` / release checklist — developer discipline, not
+  CI-enforced
+- **C.** Both — CI for fast L1, human-run Makefile target for L3 before
+  tagging a release
+- **D.** Defer — ship the feature, file a follow-up ticket for the CI
+  wiring; just require the dogfood test exists and passes locally at
+  merge time
+
+---
+
+## Architecture Review
+
+### Resolved Scoping Choices (from Discovery)
+
+- **Q1 → B:** Bundled file lives at `src/clauditor/skills/clauditor.md`
+  (plural, anticipates growth).
+- **Q2 → A:** Symlink only.
+- **Q3 → C:** Dogfood L1 on every PR + L3 gated behind
+  `--clauditor-grade` for pre-release.
+- **Q4 → A:** Eval spec shipped alongside at
+  `src/clauditor/skills/clauditor.eval.json`.
+- **Q5 → A:** No-op if correct symlink; hard error otherwise (`--force`
+  overrides).
+- **Q6 → C:** Both — CI L1 + human-run L3 pre-release documented.
+
+### Review Summary
+
+| Area | Verdict | Notes |
+|---|---|---|
+| Security — symlink TOCTOU | concern | Atomic create-or-fail + `--unlink` verifies target is ours |
+| Security — `--unlink` on non-symlink | concern | Must error, not delete |
+| Security — CWD detection | concern | Require project-root marker before creating `.claude/commands/` |
+| Security — `--force` destructiveness | pass | Matches project convention (`cmd_init`) |
+| Security — symlink target escape | pass | `importlib.resources` is namespace-bound |
+| Packaging — hatchling `.md` inclusion | concern | Needs explicit `include = ["src/clauditor/skills/*"]` |
+| Packaging — editable install | pass | Resolves to source tree correctly |
+| Packaging — `importlib.resources` API | pass | Py3.11+, modern `files()` API |
+| **Packaging — wheel contents test** | **BLOCKER** | No test validates wheel actually contains `skills/clauditor.md` |
+| Packaging — stale symlink after uninstall | concern | Extend `cmd_doctor` with a stale-symlink check |
+| Packaging — upgrade workflow | pass | Symlink rebinding is stateless |
+| CLI — subcommand naming (`setup` / `--unlink` / `--force`) | pass | Aligns with `cmd_init` precedent |
+| CLI — output format | concern | Adopt `cmd_init` single-line confirmation style |
+| CLI — exit codes | pass | 1 = business error, 2 = validation/package broken |
+| CLI — help text richness | concern | `--unlink` / `--force` need multi-line help explaining collision |
+| Testing — pure resolver shape | pass | `plan_setup(cwd, pkg_root, *, force, unlink) -> SetupAction` enumerated 8 edge cases |
+| Testing — dogfood mechanics feasible | pass | `clauditor_spec("clauditor")` works against installed symlink |
+| Testing — pytester-coverage hazard | pass | Not applicable (no `mock.patch` inside pytester) |
+| **Testing — "L1 is free" assumption** | **BLOCKER** | `clauditor_spec` invokes real `claude -p` subprocess — not a mock. L1 per-PR is NOT free |
+| Observability — `cmd_doctor` extension | pass | Easy add to existing checks list |
+| Observability — stale-symlink user message | concern | Wording spec'd during refinement |
+
+### Blocker Details
+
+**BLOCKER-1 — Wheel contents validation missing.**
+No CI test or grep match validates that the built wheel actually contains
+`clauditor/skills/clauditor.md` + `clauditor.eval.json`. Without this,
+a packaging config mistake (forgotten `include` directive, typo in path)
+only surfaces on user reports after release. Fix: add a pytest test that
+builds a wheel and inspects its contents via `zipfile`.
+
+**BLOCKER-2 — L1 per-PR dogfood is NOT free.**
+The original scoping assumed L1 assertion-only pytest runs were free,
+but `clauditor_spec` (`pytest_plugin.py:96-135`, specifically line
+invoking `spec.run()`) shells out to the real `claude -p` subprocess on
+every test. That's a live Claude API call per PR — not free, not fast,
+and noisy in token budget. Three options to resolve:
+- **B2-A.** Accept the cost (~50-100 tokens/run, a few seconds). Simple,
+  honest, but makes CI flaky if Claude is down.
+- **B2-B.** Add a "canned-output" fixture mode — run the skill once
+  locally, snapshot stdout to a fixture file, test assertions against
+  the snapshot in CI. Removes the live API dependency but tests
+  assertion logic not the skill-under-load.
+- **B2-C.** Defer dogfood L1 from CI to pre-release checklist only.
+  CI runs pure unit tests (pure resolver, symlink I/O with
+  `tmp_path`, packaging wheel-contents test). L1 + L3 dogfood both
+  become pre-release human-run steps.
+
+---
+
+## Refinement Log
+
+### Key Finding — Agent Skills spec reshapes the ticket
+
+Both Claude Code docs and agentskills.io confirm: **custom commands have
+been merged into skills.** A file at `.claude/commands/<name>.md` and a
+skill at `.claude/skills/<name>/SKILL.md` both create `/<name>`. Skills
+are now a *directory* containing a required `SKILL.md` entrypoint plus
+optional `scripts/` / `references/` / `assets/` subdirs. This
+supersedes the ticket's premise (install `.claude/commands/clauditor.md`
+as a single file). The ticket body needs an amendment — see DEC-017.
+
+Core agentskills.io required frontmatter: `name` (lowercase a-z + digits
++ hyphens, ≤64 chars, must match parent dir name), `description` (≤1024
+chars). Optional: `license`, `compatibility`, `metadata`,
+`allowed-tools` (experimental). Claude Code layers on extensions:
+`when_to_use`, `argument-hint`, `disable-model-invocation`,
+`user-invocable`, `model`, `effort`, `context`, `agent`, `hooks`,
+`paths`, `shell`, `$ARGUMENTS`, `${CLAUDE_SESSION_ID}`,
+`${CLAUDE_SKILL_DIR}`, inline `` !`cmd` `` execution.
+
+### Resolved Scoping (full ledger)
+
+| Q | Choice | Intent |
+|---|---|---|
+| Q1 | B | Plural `src/clauditor/skills/` top-level |
+| Q2 | A | Symlink only |
+| Q3 | C → revised by B2-C | Original "L1 per PR + L3 pre-release" → all dogfood deferred to pre-release (see DEC-007) |
+| Q4 | A → revised | Eval spec bundled inside the skill dir under `assets/` (see DEC-002) |
+| Q5 | A | Strict collision; `--force` overrides |
+| Q6 | C → revised by B2-C | CI runs unit + wheel + skills-ref only; dogfood moves to pre-release |
+| Q7 | A | Install target `.claude/skills/clauditor/` |
+| Q8 | A | Single whole-directory symlink |
+| Q9 | C | Don't print restart-required warning; document in README |
+| Q10 | C | Hybrid frontmatter: core + Claude Code extensions |
+| Q11 | A | `metadata.clauditor-version` stamped at wheel-build time |
+| Q12 | A | `skills-ref validate` in CI |
+| B1 | Accept | Add wheel-contents pytest |
+| B2 | C | Dogfood not in CI — pre-release checklist only |
+
+### Decisions
+
+**DEC-001 — Install location: `.claude/skills/<name>/SKILL.md`.**
+Bundled skill installs to `<cwd>/.claude/skills/clauditor/` (directory
+symlink), not the legacy `.claude/commands/clauditor.md`.
+*Rationale:* Claude Code docs mark skills as the recommended path;
+directory layout unlocks supporting files. agentskills.io spec mandates
+`SKILL.md` at the skill-dir root with frontmatter `name` matching the
+parent directory name.
+
+**DEC-002 — Bundled source layout.**
+```
+src/clauditor/skills/clauditor/
+├── SKILL.md
+└── assets/
+    └── clauditor.eval.json
+```
+*Rationale:* Spec recommends `assets/` for static data files.
+`clauditor.eval.json` is neither code (`scripts/`) nor docs
+(`references/`); `assets/` is the correct slot.
+
+**DEC-003 — Installation mechanism: single directory symlink.**
+`clauditor setup` creates one symlink: `<cwd>/.claude/skills/clauditor`
+→ `<importlib.resources path>/clauditor/skills/clauditor/`.
+*Rationale:* Covers `SKILL.md` + `assets/` + future supporting files in
+one operation. pip upgrade updates the target contents automatically;
+the symlink itself never needs re-creation.
+
+**DEC-004 — Frontmatter: hybrid core + Claude Code extensions.**
+Bundled `SKILL.md` frontmatter:
+```yaml
+---
+name: clauditor
+description: Run the clauditor capture/validate/grade workflow against a skill. Use when evaluating a Claude Code skill's output against an eval spec, or when the user asks to validate / grade / audit a skill.
+compatibility: Requires clauditor installed via pip/uv
+metadata:
+  clauditor-version: "0.0.0-dev"   # substituted at wheel build (DEC-005)
+argument-hint: "[skill-path]"       # Claude Code extension
+disable-model-invocation: true      # Claude Code extension
+allowed-tools: Bash(uv run clauditor *)  # both core + Claude Code
+---
+```
+*Rationale:* Unknown YAML fields are ignored by non-Claude-Code agents,
+so portability is preserved. `disable-model-invocation: true` is
+load-bearing — clauditor writes sidecars and spawns subprocesses; we
+don't want Claude speculatively invoking it mid-conversation.
+
+**DEC-005 — Self-versioning via hatch build hook.**
+A hatch build hook reads `pyproject.toml`'s `[project] version` and
+substitutes `metadata.clauditor-version` in the bundled `SKILL.md` at
+wheel build. Source-tree `SKILL.md` ships with `"0.0.0-dev"` as a
+placeholder so dev workflow stays simple.
+*Rationale:* Enables `cmd_doctor` drift detection (DEC-013). The YAML
+`metadata` slot is the spec's official extension point for client-
+specific fields.
+
+**DEC-006 — CI validation: wheel-contents test + `skills-ref validate`.**
+Two new CI steps:
+- `tests/test_packaging.py` — builds wheel via `hatchling build`,
+  opens with `zipfile`, asserts `clauditor/skills/clauditor/SKILL.md`
+  and `clauditor/skills/clauditor/assets/clauditor.eval.json` are both
+  present.
+- `skills-ref validate src/clauditor/skills/clauditor` — optional
+  belt-and-suspenders frontmatter/naming check via the
+  agentskills.io reference validator. If the validator is unavailable
+  at CI install time, fall back to an inline YAML parse of the
+  required fields.
+
+*Rationale:* Catches forgotten hatchling `include` directive and
+frontmatter drift before release.
+
+**DEC-007 — Dogfood testing deferred to pre-release checklist.**
+CI runs only: unit tests + `test_packaging.py` + skills-ref validate.
+The `clauditor_spec` fixture shells out to live `claude -p`
+(`pytest_plugin.py:96-135`), so per-PR dogfood would burn tokens and
+break on unrelated Claude-infra flakes. Instead, a new `CONTRIBUTING.md`
+(or `docs/release.md`) section adds two explicit pre-tag gates:
+- L1: `uv run clauditor validate src/clauditor/skills/clauditor/SKILL.md`
+- L3: `uv run clauditor grade src/clauditor/skills/clauditor/SKILL.md`
+  (with `--eval` pointing at `assets/clauditor.eval.json`)
+
+*Rationale:* Shipping a broken bundled skill is the user-visible
+failure mode; the pre-release gate catches it where the cost is
+amortized over one release, not every PR. CI stays hermetic/free/fast.
+
+**DEC-008 — Collision handling: strict mode + `--force`.**
+`.claude/skills/clauditor` exists:
+- our correct symlink → no-op + success line, exit 0
+- anything else → exit 1, stderr hint `use --force to overwrite`
+
+With `--force`: remove existing entry (file, dir, or wrong-target
+symlink), create fresh symlink.
+*Rationale:* Mirrors `cmd_init` convention; protects user-authored
+skills from silent overwrite.
+
+**DEC-009 — `--unlink` safety: verify-ours-before-remove.**
+`clauditor setup --unlink`:
+- nothing at path → no-op info line, exit 0
+- our symlink (resolves into installed clauditor package root) →
+  remove, exit 0
+- regular file/dir → refuse, exit 1, `"not a symlink; refusing to
+  unlink"`
+- symlink to somewhere else → refuse, exit 1, `"symlink target
+  doesn't match installed clauditor; refusing"`
+
+*Rationale:* destructive operations default safe. Matches the security-
+review concern about `--unlink` deleting user files.
+
+**DEC-010 — Symlink creation: atomic create-or-fail (no check-then-create).**
+`os.symlink(src, dst)` is called directly. On `FileExistsError`,
+*then* inspect what's there; no prior existence check.
+*Rationale:* Closes TOCTOU surfaced in security review. POSIX-atomic
+at the syscall layer.
+
+**DEC-011 — CWD detection: require project-root marker.**
+`clauditor setup` walks up from `cwd` looking for `.git/` or an
+existing `.claude/`. If neither found within the search bound, refuse
+with exit 2 and `"no project root found; run from a project
+directory or pass --project-dir"` (flag added for explicit override).
+*Rationale:* Prevents accidental `~/.claude/skills/` creation when the
+user runs `clauditor setup` from `$HOME`. Mirrors the `paths.py`
+`resolve_clauditor_dir` pattern.
+
+**DEC-012 — Directory creation mode: explicit `0o755`.**
+`Path.mkdir(mode=0o755, parents=True, exist_ok=True)` for both
+`.claude/` and `.claude/skills/` creation.
+*Rationale:* Umask-independent — a user with `umask 0o000` doesn't end
+up with world-writable config dirs.
+
+**DEC-013 — `cmd_doctor` stale-symlink check.**
+New entry in the `cmd_doctor` (cli.py:1680) checks list inspects
+`.claude/skills/clauditor`:
+- absent → info `"clauditor skill not installed; run 'clauditor setup'"`
+- correct symlink → ok `"symlink → <target>"`
+- stale (broken) symlink → warn `"stale symlink; 'clauditor setup --force' to fix"`
+- wrong-target symlink → warn `"symlink target doesn't match installed package"`
+- regular file/dir → warn `"not a symlink; unmanaged by clauditor"`
+
+*Rationale:* pip uninstall/upgrade surfaces dangling symlinks;
+doctor is the right diagnostic channel.
+
+**DEC-014 — Pure resolver `plan_setup(...)`.**
+```python
+def plan_setup(
+    cwd: Path,
+    pkg_skill_root: Path,
+    *,
+    force: bool,
+    unlink: bool,
+) -> SetupAction: ...
+
+class SetupAction(Enum):
+    CREATE_SYMLINK = ...
+    NOOP_ALREADY_INSTALLED = ...
+    REPLACE_WITH_FORCE = ...
+    REFUSE_EXISTING_FILE = ...
+    REFUSE_EXISTING_DIR = ...
+    REFUSE_WRONG_SYMLINK = ...
+    REMOVE_SYMLINK = ...
+    NOOP_NOTHING_TO_UNLINK = ...
+    REFUSE_UNLINK_NON_SYMLINK = ...
+    REFUSE_UNLINK_WRONG_TARGET = ...
+```
+Each enum member maps to a message + exit code at the `cmd_setup`
+call site. Unit tests cover each branch without `tmp_path`.
+*Rationale:* `.claude/rules/pure-compute-vs-io-split.md` compliance.
+
+**DEC-015 — Help text.**
+Subparser `help=` / `description=` on `setup` explains collision
+semantics for `--unlink` and `--force` inline. Matches `cmd_grade`
+help-text richness, not `cmd_init`'s sparseness.
+
+**DEC-016 — Output format.**
+Single-line stdout confirmation, `cmd_init` style:
+- Create: `"Installed /clauditor: .claude/skills/clauditor -> <target>"`
+- No-op: `"/clauditor already installed (no changes)"`
+- Unlink: `"Removed .claude/skills/clauditor"`
+- Errors: `ERROR:` prefix on stderr per `cli.py:1788` convention.
+
+**DEC-017 — Amend issue #43 body.**
+Post a comment on GH issue #43 amending the install target from
+`.claude/commands/clauditor.md` to `.claude/skills/clauditor/SKILL.md`
+and appending the user's dogfood-pre-release requirement. Draft after
+plan approval, before devolve-to-beads.
+
+---
+
+## Detailed Breakdown
+
+Natural ordering: packaging foundation → bundled content → build hook →
+pure resolver → CLI glue → doctor integration → CI validator → docs →
+ticket amendment → quality gate → patterns & memory.
+
+**Validation command** for every story's acceptance: `uv run ruff check
+src/ tests/ && uv run pytest --cov=clauditor --cov-report=term-missing`
+(80% coverage gate enforced).
+
+---
+
+### US-001 — Packaging foundation: hatch include + wheel-contents test
+
+**Description:** Add an empty `src/clauditor/skills/` subpackage and
+wire hatchling to include non-`.py` files under it in the built wheel.
+Add a pytest that builds the wheel and asserts expected files are
+present. This unblocks every subsequent story that ships a bundled
+resource.
+
+**Traces to:** DEC-002, DEC-006 (wheel-contents portion)
+
+**Acceptance criteria:**
+- `pyproject.toml` declares an explicit hatchling include for
+  `src/clauditor/skills/**/*` (markdown, JSON, any extension).
+- `src/clauditor/skills/__init__.py` exists (empty — ensures the
+  subpackage is importable, makes `importlib.resources.files("clauditor.skills")` work).
+- `tests/test_packaging.py` builds a wheel via `hatchling build` or
+  `python -m build --wheel`, opens it with `zipfile.ZipFile`, and
+  asserts `clauditor/skills/__init__.py` is present plus any
+  sentinel `.md` file (use a fixture `.md` file if no real skill
+  file exists yet — it can be deleted/replaced in US-002).
+- Test runs in CI under `uv run pytest` without any extra deps
+  beyond `[project.optional-dependencies].dev`.
+- Validation command passes.
+
+**Done when:** CI runs `test_packaging.py` green and the wheel
+contains the expected files.
+
+**Files:**
+- `pyproject.toml` — add `[tool.hatch.build.targets.wheel]` include
+  directive
+- `src/clauditor/skills/__init__.py` — new, empty
+- `tests/test_packaging.py` — new
+- `src/clauditor/skills/.sentinel.md` — temporary fixture file so the
+  test has something to assert on; US-002 replaces it
+
+**Depends on:** none
+
+**TDD:**
+- `test_wheel_contains_skills_subpackage` — build wheel, assert
+  `clauditor/skills/__init__.py` in members
+- `test_wheel_contains_bundled_markdown` — build wheel, assert the
+  sentinel `.md` is included
+- `test_wheel_excludes_pycache` — regression guard that the include
+  pattern doesn't accidentally ship `__pycache__/`
+
+---
+
+### US-002 — Bundled skill content: `SKILL.md` + `clauditor.eval.json`
+
+**Description:** Author the bundled slash-command skill file and its
+eval spec. Frontmatter follows the agentskills.io core spec with
+Claude Code extensions layered in per DEC-004. Body is a concise
+playbook for the capture/validate/grade workflow. Remove the
+sentinel from US-001.
+
+**Traces to:** DEC-002, DEC-004
+
+**Acceptance criteria:**
+- `src/clauditor/skills/clauditor/SKILL.md` exists with the
+  frontmatter shown in DEC-004 (placeholder version `"0.0.0-dev"`
+  — US-003 replaces at build time).
+- `src/clauditor/skills/clauditor/assets/clauditor.eval.json` exists
+  following `examples/.claude/commands/example-skill.eval.json`
+  shape with `assertions` (L1), at least one `grading_criteria`
+  entry (L3). All `id` fields present and unique per
+  `.claude/rules/eval-spec-stable-ids.md`.
+- Frontmatter `name` value equals the parent directory name
+  (`clauditor`) per agentskills.io spec.
+- Body is ≤500 lines, ≤5000 tokens (tracked via word count heuristic
+  in the test).
+- `tests/test_bundled_skill.py` parses the frontmatter, asserts
+  required fields, naming constraints (regex
+  `^[a-z0-9]+(-[a-z0-9]+)*$`), and length bounds.
+- Sentinel file from US-001 is deleted; `test_packaging.py` updated
+  to assert real paths.
+- Validation command passes.
+
+**Done when:** Frontmatter validates, eval spec loads via
+`EvalSpec.from_file()` without error, wheel test still green.
+
+**Files:**
+- `src/clauditor/skills/clauditor/SKILL.md` — new
+- `src/clauditor/skills/clauditor/assets/clauditor.eval.json` — new
+- `tests/test_bundled_skill.py` — new
+- `tests/test_packaging.py` — update assertions
+- `src/clauditor/skills/.sentinel.md` — delete
+
+**Depends on:** US-001
+
+**TDD:**
+- `test_skill_md_has_required_frontmatter`
+- `test_skill_md_name_matches_directory`
+- `test_skill_md_name_conforms_to_spec_regex`
+- `test_skill_md_description_under_1024_chars`
+- `test_eval_spec_loads_via_from_file`
+- `test_eval_spec_all_ids_unique`
+
+---
+
+### US-003 — Hatch build hook: stamp `metadata.clauditor-version`
+
+**Description:** Add a hatchling custom build hook that reads the
+`[project] version` from `pyproject.toml` and substitutes it into the
+bundled `SKILL.md` frontmatter's `metadata.clauditor-version` field
+at wheel build time. Source-tree file keeps `"0.0.0-dev"` for dev
+workflow.
+
+**Traces to:** DEC-005
+
+**Acceptance criteria:**
+- Hatchling build-hook plugin configured in `pyproject.toml` under
+  `[tool.hatch.build.targets.wheel.hooks.custom]`.
+- Hook script at `build_hooks/stamp_skill_version.py` reads
+  `pyproject.toml` version, rewrites the `metadata.clauditor-version`
+  line in the bundled `SKILL.md` using a minimal-risk regex (no
+  full YAML re-serialization to avoid accidental formatting churn).
+- Source `SKILL.md` still has `"0.0.0-dev"` after build (hook only
+  mutates the staged wheel copy).
+- `tests/test_packaging.py` extracts `SKILL.md` from the built wheel
+  and asserts `metadata.clauditor-version` equals the project's
+  declared version.
+- Validation command passes.
+
+**Done when:** Build-hook test passes; source-tree `SKILL.md` is
+unmodified after `python -m build`.
+
+**Files:**
+- `pyproject.toml` — add `[tool.hatch.build.targets.wheel.hooks.custom]`
+- `build_hooks/__init__.py` — new, empty
+- `build_hooks/stamp_skill_version.py` — new
+- `tests/test_packaging.py` — add the version-stamp assertion
+
+**Depends on:** US-002
+
+**TDD:**
+- `test_wheel_skill_md_has_stamped_version` — extract SKILL.md from
+  built wheel, regex the `clauditor-version` line, assert it matches
+  `pyproject.toml`'s `[project] version`
+- `test_source_skill_md_remains_dev_placeholder` — after build, the
+  source-tree file still says `"0.0.0-dev"`
+
+---
+
+### US-004 — Pure resolver: `plan_setup(...)` + `SetupAction` enum
+
+**Description:** Implement the pure decision function that, given a
+cwd, an installed-package skill root, and `force`/`unlink` flags,
+returns a `SetupAction` enum member describing what the I/O layer
+should do. Per `.claude/rules/pure-compute-vs-io-split.md`, no file
+I/O here — caller handles the side effect. Ten enum branches cover
+every edge case from architecture review.
+
+**Traces to:** DEC-008, DEC-009, DEC-010, DEC-011, DEC-014
+
+**Acceptance criteria:**
+- New module `src/clauditor/setup.py` exports:
+  - `class SetupAction(Enum)` with members per DEC-014
+  - `def plan_setup(cwd: Path, pkg_skill_root: Path, *, force: bool, unlink: bool) -> SetupAction`
+  - `def find_project_root(cwd: Path) -> Path | None` (walks up for
+    `.git` or `.claude`)
+- Function is pure: no side effects, no writes, no network. Accepts
+  `pathlib.Path` instances for both args, returns the enum.
+- **Project-root resolution**: if `find_project_root(cwd)` returns
+  `None`, raise `ValueError("no project root found; run from a
+  project directory")`. Caller maps to exit 2.
+- **Symlink semantics**: correct-target detection uses
+  `Path.resolve()` on the symlink and compares with
+  `Path.is_relative_to(pkg_skill_root)`.
+- `tests/test_setup.py` covers all 10 enum branches with `tmp_path`
+  fixtures (scratch files/dirs/symlinks), plus:
+  - `cwd` with `.git` marker → resolves root correctly
+  - `cwd` with `.claude` marker → resolves root correctly
+  - neither → raises `ValueError`
+  - walks up multiple levels correctly
+- Validation command passes. Coverage on `setup.py` ≥ 95%.
+
+**Done when:** All 10 enum branches have dedicated tests and
+`plan_setup` is the only decision maker for US-005's `cmd_setup`.
+
+**Files:**
+- `src/clauditor/setup.py` — new
+- `tests/test_setup.py` — new
+
+**Depends on:** none (can run in parallel with US-001/002/003)
+
+**TDD:** One test per `SetupAction` enum member — named
+`test_plan_setup_returns_<member_name_lower>` — plus 3 project-root
+tests. 13 tests total.
+
+---
+
+### US-005 — CLI glue: `clauditor setup` subcommand
+
+**Description:** Wire the `setup` subparser and `cmd_setup(args) ->
+int` handler in `cli.py`. Dispatches on the `SetupAction` enum from
+US-004, performs the actual symlink creation/removal atomically per
+DEC-010, handles directory creation with explicit mode 0o755,
+prints per DEC-016, exits per DEC-008/DEC-009 semantics.
+
+**Traces to:** DEC-001, DEC-003, DEC-012, DEC-015, DEC-016
+
+**Acceptance criteria:**
+- New `cmd_setup(args)` in `src/clauditor/cli.py` returning `int`.
+- New subparser registered in the subparsers block, with rich
+  multi-line help per DEC-015 and `argparse` flags:
+  - `--unlink` (store_true)
+  - `--force` (store_true)
+  - `--project-dir PATH` (override project-root detection from DEC-011)
+- I/O side: `os.symlink(target, dst)` is attempted directly; on
+  `FileExistsError`, re-inspect and map to correct `SetupAction`.
+  Directory creation uses `Path.mkdir(mode=0o755, parents=True,
+  exist_ok=True)`.
+- Installed-package skill root resolved via
+  `importlib.resources.files("clauditor") / "skills" / "clauditor"`,
+  converted to a `Path` via `with as_file(...)` guard for
+  zipped-wheel safety (fallback path for the unlikely pyc-zipped
+  install case — just `Path(str(traversable))`).
+- Stdout/stderr/exit code per DEC-008/DEC-009/DEC-016.
+- `tests/test_cli.py` adds a `TestCmdSetup` class mirroring other
+  subcommand tests — `tmp_path` + `monkeypatch.chdir()`, invoke via
+  `main(["setup", ...])`, assert `capsys.readouterr()`. Covers:
+  - create when absent
+  - no-op when correct
+  - refuse when existing file (exit 1)
+  - refuse when wrong-target symlink (exit 1)
+  - `--force` replace
+  - `--unlink` removes our symlink
+  - `--unlink` refuses non-symlink (exit 1)
+  - `--unlink` on absent (exit 0, info)
+  - project-root detection failure (exit 2)
+  - `--project-dir` override
+- Validation command passes.
+
+**Done when:** `uv run clauditor setup` end-to-end works in a test
+project; all CLI tests green.
+
+**Files:**
+- `src/clauditor/cli.py` — add `cmd_setup` + subparser + dispatch elif
+- `tests/test_cli.py` — add `TestCmdSetup` class
+
+**Depends on:** US-002 (bundled content exists to symlink at),
+US-004 (pure resolver)
+
+**TDD:** 10 CLI tests mirroring the `SetupAction` branches + 1
+override test.
+
+---
+
+### US-006 — `cmd_doctor` extension: stale-symlink check
+
+**Description:** Add a single check entry to `cmd_doctor` (cli.py:1680)
+that inspects `.claude/skills/clauditor` and reports 5 distinct states
+per DEC-013.
+
+**Traces to:** DEC-013
+
+**Acceptance criteria:**
+- New helper `_check_clauditor_skill_symlink(project_root: Path,
+  pkg_skill_root: Path) -> tuple[str, str, str]` returning
+  `(check_name, status, detail)` tuple matching the existing
+  `checks` list shape in `cmd_doctor`.
+- Status values: `ok`, `warn`, `info` (existing codebase convention;
+  grep for `"warn"` in `cmd_doctor` to confirm).
+- 5 branches per DEC-013: absent, correct, stale, wrong-target,
+  non-symlink.
+- `tests/test_cli.py::TestCmdDoctor` adds 5 tests (one per branch)
+  with `tmp_path` fixtures.
+- Validation command passes.
+
+**Done when:** `uv run clauditor doctor` surfaces the new check in
+every matching state.
+
+**Files:**
+- `src/clauditor/cli.py` — extend `cmd_doctor`
+- `tests/test_cli.py` — add doctor-check tests
+
+**Depends on:** US-005
+
+**TDD:** 5 tests (one per DEC-013 branch).
+
+---
+
+### US-007 — CI: `skills-ref validate` step
+
+**Description:** Add a CI step that runs `skills-ref validate
+src/clauditor/skills/clauditor` to catch frontmatter drift. Fallback
+to an inline YAML parse if the validator isn't available in CI.
+
+**Traces to:** DEC-006 (validator portion)
+
+**Acceptance criteria:**
+- `.github/workflows/<ci>.yml` (or equivalent existing workflow
+  file — check repo layout) adds a step invoking `skills-ref
+  validate src/clauditor/skills/clauditor`. If `skills-ref` is
+  unavailable via pip, the step uses a minimal Python fallback that
+  parses the frontmatter and asserts the agentskills.io core
+  constraints (`name` pattern, length; `description` length).
+- Step exits non-zero on frontmatter issues.
+- Validation command passes.
+
+**Done when:** CI workflow passes on a valid skill, fails if
+frontmatter is corrupted deliberately.
+
+**Files:**
+- `.github/workflows/*.yml` — new step (check existing workflow
+  names; do NOT add a new workflow file if an existing `ci.yml`
+  fits)
+- `scripts/validate_skill_frontmatter.py` — new (fallback
+  implementation)
+
+**Depends on:** US-002
+
+**TDD:** N/A — configuration task. Verify by temporarily breaking
+frontmatter on a feature branch and confirming CI red.
+
+---
+
+### US-008 — Docs: pre-release checklist + README install section
+
+**Description:** Document the pre-release dogfood gate (DEC-007) in
+`CONTRIBUTING.md` (or create `docs/release.md`). Add a README
+section describing `clauditor setup` for end users, including the
+Q9=C note that creating `.claude/skills/` for the first time
+requires a Claude Code restart.
+
+**Traces to:** DEC-007, Q9 (C — document in README)
+
+**Acceptance criteria:**
+- `README.md` gains a `## Installing the /clauditor slash command`
+  section with:
+  - `uv run clauditor setup` example
+  - Expected output line
+  - `--unlink` / `--force` descriptions
+  - One-line note: "If `.claude/skills/` didn't exist before, restart
+    Claude Code once so it picks up the new directory."
+- `CONTRIBUTING.md` (or `docs/release.md`) gains a `## Pre-release
+  dogfood` section enumerating the two required gates:
+  - `uv run clauditor validate src/clauditor/skills/clauditor/SKILL.md`
+  - `uv run clauditor grade src/clauditor/skills/clauditor/SKILL.md --eval src/clauditor/skills/clauditor/assets/clauditor.eval.json`
+- Both must pass before tagging a release.
+- Validation command passes.
+
+**Done when:** Docs landed; a fresh reader can install the slash
+command and find the dogfood gate.
+
+**Files:**
+- `README.md` — new section
+- `CONTRIBUTING.md` — new section (create if missing)
+
+**Depends on:** US-005
+
+**TDD:** N/A — docs.
+
+---
+
+### US-009 — Amend issue #43 on GitHub
+
+**Description:** Post a comment on GH #43 amending the ticket's
+install-target language (commands/.md → skills/SKILL.md) and
+appending the dogfood pre-release gate requirement. Close out the
+original ticket body's "Proposed Design" section by cross-linking
+to the plan doc at `plans/super/43-setup-slash-command.md`.
+
+**Traces to:** DEC-017, original user request
+
+**Acceptance criteria:**
+- Comment posted on #43 via `gh issue comment 43 --body "..."`
+  containing:
+  - Amendment note: install path is `.claude/skills/clauditor/SKILL.md`
+    per agentskills.io + Claude Code skills docs
+  - New requirement: clauditor must be used to dogfood the bundled
+    skill in the pre-release checklist (L1 + L3)
+  - Link to the plan doc on the `dev` branch
+- Optionally update the issue body via `gh issue edit` if the team
+  prefers in-place amendments over appended comments — confirm with
+  the user at execution time.
+
+**Done when:** Comment visible on issue #43.
+
+**Files:** none (GitHub-only)
+
+**Depends on:** none (can run any time after approval; recommended
+just before or during devolve)
+
+**TDD:** N/A.
+
+---
+
+### US-010 — Quality Gate
+
+**Description:** Run code-reviewer agent 4 times across the full
+changeset, fixing every real bug surfaced each pass. Run CodeRabbit
+if available. Rerun the full validation gate and confirm all tests +
+coverage pass.
+
+**Traces to:** all implementation DECs (coverage of the entire
+changeset)
+
+**Acceptance criteria:**
+- Code reviewer agent invoked 4 times; each pass's findings either
+  fixed or documented as false positives with rationale.
+- CodeRabbit review (if available on the PR) addressed via
+  `pr-reviewer` agent.
+- `uv run ruff check src/ tests/` — clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` — all
+  tests pass, coverage ≥80% on the new modules.
+- Wheel-contents test green.
+- `skills-ref validate` green.
+- Manual spot-check of `uv run clauditor setup` end-to-end in a
+  fresh temp project.
+
+**Done when:** All 4 reviewer passes are clean + validation gate
+green.
+
+**Files:** whatever reviewer/CodeRabbit findings touch
+
+**Depends on:** US-001 through US-008
+
+---
+
+### US-011 — Patterns & Memory
+
+**Description:** Distill reusable patterns from this feature into
+`.claude/rules/` and update `docs/` / beads memory as appropriate.
+
+**Traces to:** this ticket's novel patterns
+
+**Acceptance criteria:**
+- Evaluate whether any of these are new-rule-worthy:
+  - Hatchling custom-build-hook pattern for substituting version
+    fields into bundled non-Python resources (candidate new rule
+    if we expect future resources to need similar stamping)
+  - `importlib.resources.files()` + `as_file` guard pattern for
+    resolving bundled artifacts to symlink targets (candidate if
+    we ship more bundled files)
+  - `find_project_root` helper + marker search (probably belongs
+    in `paths.py`, not a rule — mention in that module's docstring)
+  - Pure-compute-vs-io-split applied to a Pathlib-only function
+    that raises on precondition failure (already covered by the
+    existing rule; augment with a second-anchor reference)
+- Update `.claude/rules/pure-compute-vs-io-split.md` with a new
+  anchor pointing to `src/clauditor/setup.py::plan_setup` as the
+  fourth canonical example.
+- Run `bd remember` for any ephemeral insight not worth a rule file.
+- Validation command passes.
+
+**Done when:** Rule updates merged; any transient insights
+captured in beads memory.
+
+**Files:**
+- `.claude/rules/pure-compute-vs-io-split.md` — add fourth anchor
+- Potentially a new rule file for the build-hook pattern if the
+  reviewer decides it's load-bearing
+- `bd remember` calls as needed
+
+**Depends on:** US-010
+
+---
+
+### Dependency graph
+
+```
+US-001 ─┬─► US-002 ──► US-003 ──┐
+        │                        │
+        └──────► US-007 ◄────────┤
+                                 │
+US-004 ───────────────► US-005 ──┼─► US-006 ──┐
+                                 │            │
+                         US-008 ─┤            │
+                                 ├─► US-010 ─► US-011
+                         US-009 ─┘
+```
+
+US-004 and US-009 are fully independent of the others and can start
+immediately. US-001 unlocks US-002/US-003/US-007 in sequence.
+US-005 needs both US-002 (target exists) and US-004 (resolver).
+US-006 and US-008 need US-005.
+
+---
+
+## Beads Manifest
+
+_(Pending — populated in Phase 7.)_
+
+---
+
+## Session Notes
+
+### Session 1 — 2026-04-16
+
+**Discovery complete.** Ticket fetched, codebase scouted across CLI
+subcommand patterns, packaging conventions, existing eval-spec shape,
+and pytest-plugin fixtures. Zero bundled non-Python resources exist
+today — this feature introduces both the packaging pattern AND its
+first consumer. Added user's dogfood-testing requirement as explicit
+scope.
+
+**Architecture review complete.** Three parallel reviews (security,
+packaging, CLI/testing/observability) surfaced two blockers and
+several concerns. User answered Q1–Q6.
+
+**Spec fetch complete.** User requested fetching the Claude Code slash
+commands docs and agentskills.io specification. Discovery **reshaped**
+the ticket: custom commands have merged into skills; correct install
+path is `.claude/skills/<name>/SKILL.md` (directory), not
+`.claude/commands/<name>.md` (file). Core agentskills.io spec
+enumerated, Claude Code extensions identified. Added Q7–Q12.
+
+**Refinement complete.** User resolved Q7–Q12 + both blockers. 17
+decisions recorded. Next: move to Detailing (generate stories).

--- a/plans/super/43-setup-slash-command.md
+++ b/plans/super/43-setup-slash-command.md
@@ -2,10 +2,10 @@
 
 ## Meta
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/43
-- **Branch:** `feature/43-setup-slash-command` *(to be created)*
-- **Worktree:** `worktrees/clauditor/feature/43-setup-slash-command` *(to be created)*
-- **Phase:** `detailing`
-- **PR:** _pending_
+- **Branch:** `feature/43-setup-slash-command`
+- **Worktree:** _n/a (working on branch directly)_
+- **Phase:** `devolved`
+- **PR:** https://github.com/wjduenow/clauditor/pull/44
 - **Sessions:** 1
 - **Last session:** 2026-04-16
 
@@ -991,7 +991,27 @@ US-006 and US-008 need US-005.
 
 ## Beads Manifest
 
-_(Pending — populated in Phase 7.)_
+- **Epic:** `clauditor-3xy`
+- **Branch:** `feature/43-setup-slash-command`
+- **PR:** https://github.com/wjduenow/clauditor/pull/44
+
+| Story | Bead ID | Depends on | Ready to start |
+|---|---|---|---|
+| US-001 Packaging foundation | `clauditor-3xy.1` | — | ✅ |
+| US-002 Bundled skill content | `clauditor-3xy.2` | US-001 | |
+| US-003 Hatch build hook | `clauditor-3xy.3` | US-002 | |
+| US-004 Pure resolver | `clauditor-3xy.4` | — | ✅ |
+| US-005 CLI glue | `clauditor-3xy.5` | US-002, US-004 | |
+| US-006 `cmd_doctor` check | `clauditor-3xy.6` | US-005 | |
+| US-007 `skills-ref` CI | `clauditor-3xy.7` | US-002 | |
+| US-008 Docs | `clauditor-3xy.8` | US-005 | |
+| US-009 Amend GH #43 | `clauditor-3xy.9` | — | ✅ |
+| US-010 Quality Gate | `clauditor-3xy.10` | US-001..US-008 | |
+| US-011 Patterns & Memory | `clauditor-3xy.11` (P4) | US-010 | |
+
+17 dependency edges wired. `bd ready` at devolve time shows
+`{clauditor-3xy.1, clauditor-3xy.4, clauditor-3xy.9}` as the kickoff
+set.
 
 ---
 
@@ -1018,4 +1038,14 @@ path is `.claude/skills/<name>/SKILL.md` (directory), not
 enumerated, Claude Code extensions identified. Added Q7–Q12.
 
 **Refinement complete.** User resolved Q7–Q12 + both blockers. 17
-decisions recorded. Next: move to Detailing (generate stories).
+decisions recorded.
+
+**Detailing complete.** 11 stories drafted (9 implementation + Quality
+Gate + Patterns & Memory), each traceable to specific DEC-### entries.
+
+**Published.** Feature branch `feature/43-setup-slash-command` pushed;
+draft PR #44 opened against `dev`.
+
+**Approved and devolved.** Epic `clauditor-3xy` + 11 beads tasks
+created with 17 dependency edges. Three kickoff tasks ready:
+`clauditor-3xy.{1,4,9}`.

--- a/plans/super/43-setup-slash-command.md
+++ b/plans/super/43-setup-slash-command.md
@@ -971,11 +971,13 @@ captured in beads memory.
 ### Dependency graph
 
 ```
-US-001 ─┬─► US-002 ──► US-003 ──┐
-        │                        │
-        └──────► US-007 ◄────────┤
-                                 │
-US-004 ───────────────► US-005 ──┼─► US-006 ──┐
+US-001 ──► US-002 ─┬─► US-003 ──┐
+                   │             │
+                   ├─► US-007 ───┤
+                   │             │
+                   └─► US-005 ───┼─► US-006 ──┐
+                                 │            │
+US-004 ───────────► US-005       │            │
                                  │            │
                          US-008 ─┤            │
                                  ├─► US-010 ─► US-011
@@ -983,9 +985,10 @@ US-004 ───────────────► US-005 ──┼─► U
 ```
 
 US-004 and US-009 are fully independent of the others and can start
-immediately. US-001 unlocks US-002/US-003/US-007 in sequence.
-US-005 needs both US-002 (target exists) and US-004 (resolver).
-US-006 and US-008 need US-005.
+immediately. US-001 unlocks US-002; US-002 then unlocks US-003,
+US-005, and US-007 (each consumes the bundled skill content). US-005
+additionally needs US-004 (the resolver). US-006 and US-008 need
+US-005.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ Issues = "https://github.com/wjduenow/clauditor/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/clauditor"]
+include = ["src/clauditor/skills/**/*"]
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ Issues = "https://github.com/wjduenow/clauditor/issues"
 packages = ["src/clauditor"]
 include = ["src/clauditor/skills/**/*"]
 
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "build_hooks/stamp_skill_version.py"
+
 [tool.ruff]
 target-version = "py311"
 line-length = 88

--- a/scripts/validate_skill_frontmatter.py
+++ b/scripts/validate_skill_frontmatter.py
@@ -56,8 +56,8 @@ def _extract_frontmatter(text: str) -> tuple[str | None, str | None]:
 def _parse_top_level_string(block: str, key: str) -> str | None:
     """Extract a top-level ``key: value`` string from a YAML-ish block.
 
-    Handles optional single/double quoting and strips trailing comments.
-    Returns ``None`` if the key is absent. This is intentionally a tiny
+    Handles optional single/double quoting. Returns ``None`` if the key
+    is absent. This is intentionally a tiny
     parser, not a full YAML engine — the bundled skill's frontmatter is a
     fixed shape (a handful of scalar strings, one nested mapping, one
     list).

--- a/scripts/validate_skill_frontmatter.py
+++ b/scripts/validate_skill_frontmatter.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Validate a bundled skill's SKILL.md frontmatter against agentskills.io core.
+
+Fallback for the optional ``skills-ref validate`` CI step (DEC-006 of
+``plans/super/43-setup-slash-command.md``). The upstream ``skills-ref``
+validator rejects Claude Code extension fields (``argument-hint``,
+``disable-model-invocation``) that DEC-004 explicitly mandates for our
+hybrid frontmatter, so CI uses this script to enforce only the
+spec-mandated core invariants:
+
+- ``name``: present, non-empty string, matches ``^[a-z0-9]+(-[a-z0-9]+)*$``,
+  length 1-64 chars, equal to the parent directory name.
+- ``description``: present, non-empty string, length <=1024 chars.
+- Frontmatter delimiters (``---``) present at top of file.
+
+Usage::
+
+    python scripts/validate_skill_frontmatter.py <skill-dir>
+
+Exits 0 on success, 1 on any violation. All violations found are reported
+before exiting (the script does not bail on the first one) so CI logs show
+every problem in a single pass.
+
+Zero third-party dependencies — uses only the Python standard library so
+it runs without ``uv sync`` / ``pip install`` in CI.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+NAME_REGEX = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+NAME_MAX_LEN = 64
+DESCRIPTION_MAX_LEN = 1024
+
+
+def _extract_frontmatter(text: str) -> tuple[str | None, str | None]:
+    """Split a SKILL.md body into (frontmatter_block, error).
+
+    Returns ``(block, None)`` on success, ``(None, reason)`` on failure.
+    The frontmatter is the YAML region bounded by ``---`` delimiters at
+    the very start of the file. A missing opening delimiter or a missing
+    closing delimiter is an error.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, "missing opening frontmatter delimiter '---' on line 1"
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return "\n".join(lines[1:idx]), None
+    return None, "missing closing frontmatter delimiter '---'"
+
+
+def _parse_top_level_string(block: str, key: str) -> str | None:
+    """Extract a top-level ``key: value`` string from a YAML-ish block.
+
+    Handles optional single/double quoting and strips trailing comments.
+    Returns ``None`` if the key is absent. This is intentionally a tiny
+    parser, not a full YAML engine — the bundled skill's frontmatter is a
+    fixed shape (a handful of scalar strings, one nested mapping, one
+    list).
+    """
+    pattern = re.compile(rf"^{re.escape(key)}:\s*(.*?)\s*$")
+    for raw in block.splitlines():
+        # Skip nested entries (indented lines belong to a parent mapping).
+        if raw.startswith((" ", "\t")):
+            continue
+        m = pattern.match(raw)
+        if not m:
+            continue
+        value = m.group(1)
+        # Strip surrounding quotes.
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        return value
+    return None
+
+
+def validate_skill(skill_dir: Path) -> list[str]:
+    """Validate a skill directory and return a list of human-readable errors.
+
+    An empty list means the skill passes. The function reports every
+    violation it can detect — it does not stop at the first one — so
+    callers can surface all problems in a single CI run.
+    """
+    errors: list[str] = []
+
+    if not skill_dir.is_dir():
+        return [f"{skill_dir}: not a directory"]
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return [f"{skill_md}: SKILL.md not found"]
+
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{skill_md}: unreadable ({exc})"]
+
+    block, fm_error = _extract_frontmatter(text)
+    if fm_error is not None or block is None:
+        return [f"{skill_md}: {fm_error}"]
+
+    # name: present, non-empty, regex, length, matches parent dir.
+    name = _parse_top_level_string(block, "name")
+    if name is None:
+        errors.append(f"{skill_md}: 'name' field missing from frontmatter")
+    elif name == "":
+        errors.append(f"{skill_md}: 'name' must be a non-empty string")
+    else:
+        if not NAME_REGEX.match(name):
+            errors.append(
+                f"{skill_md}: 'name'={name!r} does not match "
+                f"^[a-z0-9]+(-[a-z0-9]+)*$ (lowercase a-z/0-9 + hyphens)"
+            )
+        if len(name) > NAME_MAX_LEN:
+            errors.append(
+                f"{skill_md}: 'name' length {len(name)} > {NAME_MAX_LEN} chars"
+            )
+        parent_name = skill_dir.name
+        if name != parent_name:
+            errors.append(
+                f"{skill_md}: 'name'={name!r} does not match "
+                f"parent directory name {parent_name!r}"
+            )
+
+    # description: present, non-empty, length <=1024.
+    description = _parse_top_level_string(block, "description")
+    if description is None:
+        errors.append(f"{skill_md}: 'description' field missing from frontmatter")
+    elif description == "":
+        errors.append(f"{skill_md}: 'description' must be a non-empty string")
+    elif len(description) > DESCRIPTION_MAX_LEN:
+        errors.append(
+            f"{skill_md}: 'description' length {len(description)} > "
+            f"{DESCRIPTION_MAX_LEN} chars"
+        )
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {Path(argv[0]).name if argv else 'validate_skill_frontmatter.py'} "
+            "<skill-dir>",
+            file=sys.stderr,
+        )
+        return 2
+    skill_dir = Path(argv[1])
+    errors = validate_skill(skill_dir)
+    if errors:
+        for err in errors:
+            print(f"error: {err}", file=sys.stderr)
+        return 1
+    print(f"{skill_dir}: frontmatter OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1714,13 +1714,15 @@ def _check_clauditor_skill_symlink(
         # symlinks but ``is_symlink()`` is True — this is how we detect
         # dangling symlinks after a pip uninstall/upgrade.
         if not dest.exists():
-            target = os.readlink(dest)
+            # repr() protects the single-line doctor output from symlink
+            # targets containing newlines or control characters.
+            target_display = repr(os.readlink(dest))
             return (
                 check_name,
                 "warn",
                 (
                     f"stale symlink; 'clauditor setup --force' to fix "
-                    f"(target: {target})"
+                    f"(target: {target_display})"
                 ),
             )
         if dest.resolve() == pkg_skill_root.resolve():
@@ -1937,7 +1939,10 @@ def _install_symlink(dest: Path, pkg_skill_root: Path) -> None:
     """Create the symlink at ``dest`` pointing to ``pkg_skill_root``.
 
     Ensures the parent ``.claude/skills/`` dir exists with explicit mode
-    ``0o755`` per DEC-012, then calls :func:`os.symlink` per DEC-010.
+    ``0o755`` per DEC-012, then calls :func:`os.symlink`. Raises
+    :exc:`FileExistsError` if ``dest`` appeared between the caller's
+    :func:`plan_setup` inspection and this call — the caller re-plans
+    once per DEC-010.
     """
     dest.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
     os.symlink(pkg_skill_root, dest)
@@ -1956,6 +1961,76 @@ def _remove_existing(dest: Path) -> None:
         shutil.rmtree(dest)
 
 
+def _dispatch_setup_action(
+    action: setup_module.SetupAction,
+    dest: Path,
+    pkg_skill_root: Path,
+) -> int:
+    """Translate a :class:`SetupAction` into I/O + exit code.
+
+    May raise :exc:`FileExistsError` from :func:`_install_symlink` when
+    ``dest`` appeared since ``plan_setup`` inspected it. The caller
+    (:func:`cmd_setup`) re-plans once on that exception per DEC-010.
+    """
+    if action is setup_module.SetupAction.CREATE_SYMLINK:
+        _install_symlink(dest, pkg_skill_root)
+        print(f"Installed /clauditor: {dest} -> {pkg_skill_root}")
+        return 0
+    if action is setup_module.SetupAction.NOOP_ALREADY_INSTALLED:
+        print("/clauditor already installed (no changes)")
+        return 0
+    if action is setup_module.SetupAction.REPLACE_WITH_FORCE:
+        _remove_existing(dest)
+        _install_symlink(dest, pkg_skill_root)
+        print(f"Installed /clauditor: {dest} -> {pkg_skill_root}")
+        return 0
+    if action is setup_module.SetupAction.REFUSE_EXISTING_FILE:
+        print(
+            "ERROR: .claude/skills/clauditor exists (regular file); "
+            "use --force to overwrite",
+            file=sys.stderr,
+        )
+        return 1
+    if action is setup_module.SetupAction.REFUSE_EXISTING_DIR:
+        print(
+            "ERROR: .claude/skills/clauditor exists (directory); "
+            "use --force to overwrite",
+            file=sys.stderr,
+        )
+        return 1
+    if action is setup_module.SetupAction.REFUSE_WRONG_SYMLINK:
+        print(
+            "ERROR: .claude/skills/clauditor is a symlink pointing "
+            "elsewhere; use --force to overwrite",
+            file=sys.stderr,
+        )
+        return 1
+    if action is setup_module.SetupAction.REMOVE_SYMLINK:
+        dest.unlink()
+        print("Removed .claude/skills/clauditor")
+        return 0
+    if action is setup_module.SetupAction.NOOP_NOTHING_TO_UNLINK:
+        print("/clauditor not installed (nothing to unlink)")
+        return 0
+    if action is setup_module.SetupAction.REFUSE_UNLINK_NON_SYMLINK:
+        print(
+            "ERROR: .claude/skills/clauditor is not a symlink; "
+            "refusing to unlink",
+            file=sys.stderr,
+        )
+        return 1
+    if action is setup_module.SetupAction.REFUSE_UNLINK_WRONG_TARGET:
+        print(
+            "ERROR: .claude/skills/clauditor symlink target does "
+            "not match installed clauditor; refusing",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Unreachable: every SetupAction member is handled above.
+    return 1  # pragma: no cover
+
+
 def cmd_setup(args: argparse.Namespace) -> int:
     """Install the bundled ``/clauditor`` skill symlink (or remove it).
 
@@ -1963,6 +2038,11 @@ def cmd_setup(args: argparse.Namespace) -> int:
     :func:`clauditor.setup.plan_setup`; this function translates the
     returned :class:`SetupAction` into filesystem operations, stdout/
     stderr messages, and exit codes per DEC-008, DEC-009, DEC-016.
+
+    Retries the plan+dispatch once on :exc:`FileExistsError` so a
+    concurrent process that created ``dest`` between our inspection
+    and our :func:`os.symlink` call is handled cleanly per DEC-010
+    (atomic create-or-fail, no check-then-create).
     """
     traversable = files("clauditor") / "skills" / "clauditor"
     with as_file(traversable) as pkg_skill_root_path:
@@ -1974,80 +2054,38 @@ def cmd_setup(args: argparse.Namespace) -> int:
             else Path.cwd().resolve()
         )
 
-        try:
-            action = setup_module.plan_setup(
-                cwd,
-                pkg_skill_root,
-                force=args.force,
-                unlink=args.unlink,
-            )
-        except ValueError as e:
-            print(f"ERROR: {e}", file=sys.stderr)
-            return 2
+        for attempt in range(2):
+            try:
+                action = setup_module.plan_setup(
+                    cwd,
+                    pkg_skill_root,
+                    force=args.force,
+                    unlink=args.unlink,
+                )
+            except ValueError as e:
+                print(f"ERROR: {e}", file=sys.stderr)
+                return 2
 
-        project_root = setup_module.find_project_root(cwd)
-        # find_project_root cannot return None here: plan_setup already
-        # raised ValueError in that case and we returned above.
-        assert project_root is not None
-        dest = project_root / ".claude" / "skills" / "clauditor"
+            project_root = setup_module.find_project_root(cwd)
+            # find_project_root cannot return None here: plan_setup already
+            # raised ValueError in that case and we returned above.
+            assert project_root is not None
+            dest = project_root / ".claude" / "skills" / "clauditor"
 
-        if action is setup_module.SetupAction.CREATE_SYMLINK:
-            _install_symlink(dest, pkg_skill_root)
-            print(f"Installed /clauditor: {dest} -> {pkg_skill_root}")
-            return 0
-        if action is setup_module.SetupAction.NOOP_ALREADY_INSTALLED:
-            print("/clauditor already installed (no changes)")
-            return 0
-        if action is setup_module.SetupAction.REPLACE_WITH_FORCE:
-            _remove_existing(dest)
-            _install_symlink(dest, pkg_skill_root)
-            print(f"Installed /clauditor: {dest} -> {pkg_skill_root}")
-            return 0
-        if action is setup_module.SetupAction.REFUSE_EXISTING_FILE:
-            print(
-                "ERROR: .claude/skills/clauditor exists (regular file); "
-                "use --force to overwrite",
-                file=sys.stderr,
-            )
-            return 1
-        if action is setup_module.SetupAction.REFUSE_EXISTING_DIR:
-            print(
-                "ERROR: .claude/skills/clauditor exists (directory); "
-                "use --force to overwrite",
-                file=sys.stderr,
-            )
-            return 1
-        if action is setup_module.SetupAction.REFUSE_WRONG_SYMLINK:
-            print(
-                "ERROR: .claude/skills/clauditor is a symlink pointing "
-                "elsewhere; use --force to overwrite",
-                file=sys.stderr,
-            )
-            return 1
-        if action is setup_module.SetupAction.REMOVE_SYMLINK:
-            dest.unlink()
-            print("Removed .claude/skills/clauditor")
-            return 0
-        if action is setup_module.SetupAction.NOOP_NOTHING_TO_UNLINK:
-            print("/clauditor not installed (nothing to unlink)")
-            return 0
-        if action is setup_module.SetupAction.REFUSE_UNLINK_NON_SYMLINK:
-            print(
-                "ERROR: .claude/skills/clauditor is not a symlink; "
-                "refusing to unlink",
-                file=sys.stderr,
-            )
-            return 1
-        if action is setup_module.SetupAction.REFUSE_UNLINK_WRONG_TARGET:
-            print(
-                "ERROR: .claude/skills/clauditor symlink target does "
-                "not match installed clauditor; refusing",
-                file=sys.stderr,
-            )
-            return 1
+            try:
+                return _dispatch_setup_action(action, dest, pkg_skill_root)
+            except FileExistsError:
+                if attempt == 1:
+                    print(
+                        "ERROR: .claude/skills/clauditor changed during "
+                        "setup (concurrent modification); retry",
+                        file=sys.stderr,
+                    )
+                    return 1
+                # Re-plan once: dest appeared after our inspection.
+                continue
 
-        # Unreachable: every SetupAction member is handled above.
-        return 1  # pragma: no cover
+        return 1  # pragma: no cover (loop always returns)
 
 
 def cmd_trend(args: argparse.Namespace) -> int:

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import sys
+from importlib.resources import as_file, files
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clauditor import history
+from clauditor import setup as setup_module
 
 if TYPE_CHECKING:
     from clauditor.quality_grader import GradingReport
@@ -1850,6 +1854,123 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def _install_symlink(dest: Path, pkg_skill_root: Path) -> None:
+    """Create the symlink at ``dest`` pointing to ``pkg_skill_root``.
+
+    Ensures the parent ``.claude/skills/`` dir exists with explicit mode
+    ``0o755`` per DEC-012, then calls :func:`os.symlink` per DEC-010.
+    """
+    dest.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+    os.symlink(pkg_skill_root, dest)
+
+
+def _remove_existing(dest: Path) -> None:
+    """Remove whatever is at ``dest`` — symlink, file, or directory.
+
+    Used only in the ``--force`` replace path. ``Path.unlink`` handles
+    symlinks (even broken ones) and regular files; ``shutil.rmtree``
+    handles a real directory.
+    """
+    if dest.is_symlink() or dest.is_file():
+        dest.unlink(missing_ok=True)
+    elif dest.is_dir():
+        shutil.rmtree(dest)
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    """Install the bundled ``/clauditor`` skill symlink (or remove it).
+
+    Side-effect layer for US-005. Pure decision logic lives in
+    :func:`clauditor.setup.plan_setup`; this function translates the
+    returned :class:`SetupAction` into filesystem operations, stdout/
+    stderr messages, and exit codes per DEC-008, DEC-009, DEC-016.
+    """
+    traversable = files("clauditor") / "skills" / "clauditor"
+    with as_file(traversable) as pkg_skill_root_path:
+        pkg_skill_root = Path(pkg_skill_root_path).resolve()
+
+        cwd = (
+            Path(args.project_dir).resolve()
+            if args.project_dir
+            else Path.cwd().resolve()
+        )
+
+        try:
+            action = setup_module.plan_setup(
+                cwd,
+                pkg_skill_root,
+                force=args.force,
+                unlink=args.unlink,
+            )
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+
+        project_root = setup_module.find_project_root(cwd)
+        # find_project_root cannot return None here: plan_setup already
+        # raised ValueError in that case and we returned above.
+        assert project_root is not None
+        dest = project_root / ".claude" / "skills" / "clauditor"
+
+        if action is setup_module.SetupAction.CREATE_SYMLINK:
+            _install_symlink(dest, pkg_skill_root)
+            print(f"Installed /clauditor: {dest} -> {pkg_skill_root}")
+            return 0
+        if action is setup_module.SetupAction.NOOP_ALREADY_INSTALLED:
+            print("/clauditor already installed (no changes)")
+            return 0
+        if action is setup_module.SetupAction.REPLACE_WITH_FORCE:
+            _remove_existing(dest)
+            _install_symlink(dest, pkg_skill_root)
+            print(f"Installed /clauditor: {dest} -> {pkg_skill_root}")
+            return 0
+        if action is setup_module.SetupAction.REFUSE_EXISTING_FILE:
+            print(
+                "ERROR: .claude/skills/clauditor exists (regular file); "
+                "use --force to overwrite",
+                file=sys.stderr,
+            )
+            return 1
+        if action is setup_module.SetupAction.REFUSE_EXISTING_DIR:
+            print(
+                "ERROR: .claude/skills/clauditor exists (directory); "
+                "use --force to overwrite",
+                file=sys.stderr,
+            )
+            return 1
+        if action is setup_module.SetupAction.REFUSE_WRONG_SYMLINK:
+            print(
+                "ERROR: .claude/skills/clauditor is a symlink pointing "
+                "elsewhere; use --force to overwrite",
+                file=sys.stderr,
+            )
+            return 1
+        if action is setup_module.SetupAction.REMOVE_SYMLINK:
+            dest.unlink()
+            print("Removed .claude/skills/clauditor")
+            return 0
+        if action is setup_module.SetupAction.NOOP_NOTHING_TO_UNLINK:
+            print("/clauditor not installed (nothing to unlink)")
+            return 0
+        if action is setup_module.SetupAction.REFUSE_UNLINK_NON_SYMLINK:
+            print(
+                "ERROR: .claude/skills/clauditor is not a symlink; "
+                "refusing to unlink",
+                file=sys.stderr,
+            )
+            return 1
+        if action is setup_module.SetupAction.REFUSE_UNLINK_WRONG_TARGET:
+            print(
+                "ERROR: .claude/skills/clauditor symlink target does "
+                "not match installed clauditor; refusing",
+                file=sys.stderr,
+            )
+            return 1
+
+        # Unreachable: every SetupAction member is handled above.
+        return 1  # pragma: no cover
+
+
 def cmd_trend(args: argparse.Namespace) -> int:
     """Render a trend line (TSV + ASCII sparkline) for a skill metric."""
     records = history.read_records(skill=args.skill_name)
@@ -2468,6 +2589,45 @@ def main(argv: list[str] | None = None) -> int:
         "--force", action="store_true", help="Overwrite existing eval.json"
     )
 
+    # setup
+    p_setup = subparsers.add_parser(
+        "setup",
+        help="Install the /clauditor slash command into .claude/skills/",
+        description=(
+            "Create a symlink at .claude/skills/clauditor pointing at the "
+            "bundled skill shipped with the clauditor package. By default, "
+            "refuses to overwrite existing files or symlinks at that path. "
+            "Use --unlink to remove a previously-installed symlink."
+        ),
+    )
+    p_setup.add_argument(
+        "--unlink",
+        action="store_true",
+        help=(
+            "Remove the /clauditor symlink instead of creating it. "
+            "Only removes our own symlinks; refuses to remove files or "
+            "symlinks pointing elsewhere (use --force with care)."
+        ),
+    )
+    p_setup.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Overwrite an existing file or symlink at "
+            ".claude/skills/clauditor. Has no effect in --unlink mode "
+            "(which always refuses to remove non-matching entries)."
+        ),
+    )
+    p_setup.add_argument(
+        "--project-dir",
+        type=str,
+        default=None,
+        help=(
+            "Override project-root detection; use this directory as the "
+            "cwd for .claude/ resolution (default: current working dir)."
+        ),
+    )
+
     # capture
     p_capture = subparsers.add_parser(
         "capture",
@@ -2655,6 +2815,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_extract(parsed)
     elif parsed.command == "init":
         return cmd_init(parsed)
+    elif parsed.command == "setup":
+        return cmd_setup(parsed)
     elif parsed.command == "capture":
         return cmd_capture(parsed)
     elif parsed.command == "doctor":

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1688,7 +1688,7 @@ def _check_clauditor_skill_symlink(
     """Return a ``(check_name, status, detail)`` tuple describing the health
     of ``<project_root>/.claude/skills/clauditor`` per DEC-013.
 
-    Five states:
+    Six states:
 
     - project root missing → ``info`` (doctor keeps running outside projects)
     - dest does not exist → ``info`` ("run ``clauditor setup``")
@@ -2055,6 +2055,19 @@ def cmd_setup(args: argparse.Namespace) -> int:
     (atomic create-or-fail, no check-then-create).
     """
     traversable = files("clauditor") / "skills" / "clauditor"
+    # Reject zip/PEX-style installs up front: as_file() would extract to a
+    # tmp dir that gets cleaned up when the context exits, leaving a
+    # dangling symlink and making doctor comparisons always mismatch.
+    if not isinstance(traversable, Path):
+        print(
+            "ERROR: bundled clauditor skill is not available as a stable "
+            "filesystem path; `clauditor setup` requires an unpacked "
+            "installation and does not support zip/PEX-style package "
+            "resources",
+            file=sys.stderr,
+        )
+        return 2
+
     with as_file(traversable) as pkg_skill_root_path:
         pkg_skill_root = Path(pkg_skill_root_path).resolve()
 
@@ -2088,7 +2101,8 @@ def cmd_setup(args: argparse.Namespace) -> int:
                 if attempt == 1:
                     print(
                         "ERROR: .claude/skills/clauditor changed during "
-                        "setup (concurrent modification); retry",
+                        "setup (concurrent modification); aborting, "
+                        "please retry manually",
                         file=sys.stderr,
                     )
                     return 1
@@ -2733,7 +2747,8 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Remove the /clauditor symlink instead of creating it. "
             "Only removes our own symlinks; refuses to remove files or "
-            "symlinks pointing elsewhere (use --force with care)."
+            "symlinks pointing elsewhere. --force does not override this "
+            "refusal in --unlink mode."
         ),
     )
     p_setup.add_argument(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1701,13 +1701,12 @@ def _check_clauditor_skill_symlink(
     check_name = "clauditor-skill-symlink"
 
     if project_root is None:
+        # Doctor has no --project-dir flag, so do not suggest one here.
+        # The matching cmd_setup message retains the flag hint per DEC-011.
         return (
             check_name,
             "info",
-            (
-                "no project root found; run from a project directory "
-                "or pass --project-dir"
-            ),
+            "no project root found; run from a project directory",
         )
 
     dest = project_root / ".claude" / "skills" / "clauditor"
@@ -2014,7 +2013,10 @@ def _dispatch_setup_action(
         )
         return 1
     if action is setup_module.SetupAction.REMOVE_SYMLINK:
-        dest.unlink()
+        # missing_ok handles the race where a concurrent peer removed the
+        # symlink between plan_setup and here: treat "already gone" as a
+        # success (the user wanted it gone; it's gone).
+        dest.unlink(missing_ok=True)
         print("Removed .claude/skills/clauditor")
         return 0
     if action is setup_module.SetupAction.NOOP_NOTHING_TO_UNLINK:

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1949,16 +1949,21 @@ def _install_symlink(dest: Path, pkg_skill_root: Path) -> None:
 
 
 def _remove_existing(dest: Path) -> None:
-    """Remove whatever is at ``dest`` — symlink, file, or directory.
+    """Remove whatever is at ``dest`` — symlink, file, directory, or exotic.
 
     Used only in the ``--force`` replace path. ``Path.unlink`` handles
     symlinks (even broken ones) and regular files; ``shutil.rmtree``
-    handles a real directory.
+    handles a real directory. The ``unlink(missing_ok=True)`` fallback
+    catches exotic types (FIFO, socket, device) and benign races where a
+    concurrent peer removed ``dest`` between our inspection and this call;
+    ``rmtree`` passes ``ignore_errors=True`` for the same race.
     """
     if dest.is_symlink() or dest.is_file():
         dest.unlink(missing_ok=True)
     elif dest.is_dir():
-        shutil.rmtree(dest)
+        shutil.rmtree(dest, ignore_errors=True)
+    else:
+        dest.unlink(missing_ok=True)
 
 
 def _dispatch_setup_action(

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1681,8 +1681,73 @@ def cmd_capture(args: argparse.Namespace) -> int:
     return 0
 
 
+def _check_clauditor_skill_symlink(
+    project_root: Path | None,
+    pkg_skill_root: Path,
+) -> tuple[str, str, str]:
+    """Return a ``(check_name, status, detail)`` tuple describing the health
+    of ``<project_root>/.claude/skills/clauditor`` per DEC-013.
+
+    Five states:
+
+    - project root missing → ``info`` (doctor keeps running outside projects)
+    - dest does not exist → ``info`` ("run ``clauditor setup``")
+    - dest is our symlink → ``ok`` (resolves to ``pkg_skill_root``)
+    - dest is a broken symlink → ``warn`` (stale — target removed by pip
+      uninstall/upgrade)
+    - dest is a symlink to the wrong target → ``warn``
+    - dest is a regular file or directory → ``warn`` ("unmanaged")
+    """
+    check_name = "clauditor-skill-symlink"
+
+    if project_root is None:
+        return (
+            check_name,
+            "info",
+            "no project root found; run from a project directory",
+        )
+
+    dest = project_root / ".claude" / "skills" / "clauditor"
+
+    if dest.is_symlink():
+        # Handle symlinks first: ``dest.exists()`` is False for broken
+        # symlinks but ``is_symlink()`` is True — this is how we detect
+        # dangling symlinks after a pip uninstall/upgrade.
+        if not dest.exists():
+            target = os.readlink(dest)
+            return (
+                check_name,
+                "warn",
+                (
+                    f"stale symlink; 'clauditor setup --force' to fix "
+                    f"(target: {target})"
+                ),
+            )
+        if dest.resolve() == pkg_skill_root.resolve():
+            return (check_name, "ok", f"symlink -> {dest.resolve()}")
+        return (
+            check_name,
+            "warn",
+            (
+                f"symlink target doesn't match installed package "
+                f"(points to {dest.resolve()})"
+            ),
+        )
+
+    if not dest.exists():
+        return (
+            check_name,
+            "info",
+            "clauditor skill not installed; run 'clauditor setup'",
+        )
+
+    # Regular file or real directory (not a symlink).
+    kind = "file" if dest.is_file() else "directory"
+    return (check_name, "warn", f"{kind}; unmanaged by clauditor")
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
-    """Read-only environment diagnostics (DEC-005/008/014).
+    """Read-only environment diagnostics (DEC-005/008/013/014).
 
     Always exits 0 — this is a reporting tool, not a CI gate.
     """
@@ -1773,6 +1838,20 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             checks.append(("editable-install", "ok", str(origin.parent)))
     else:
         checks.append(("editable-install", "fail", "clauditor package not importable"))
+
+    # DEC-013: inspect the /clauditor skill symlink and report its health.
+    try:
+        traversable = files("clauditor") / "skills" / "clauditor"
+        with as_file(traversable) as pkg_skill_root_path:
+            pkg_skill_root = Path(pkg_skill_root_path).resolve()
+            project_root = setup_module.find_project_root(Path.cwd())
+            checks.append(
+                _check_clauditor_skill_symlink(project_root, pkg_skill_root)
+            )
+    except Exception as e:  # pragma: no cover - defensive
+        checks.append(
+            ("clauditor-skill-symlink", "warn", f"check failed: {e}")
+        )
 
     width = max(len(name) for name, _, _ in checks)
     for name, status, detail in checks:

--- a/src/clauditor/cli.py
+++ b/src/clauditor/cli.py
@@ -1704,7 +1704,10 @@ def _check_clauditor_skill_symlink(
         return (
             check_name,
             "info",
-            "no project root found; run from a project directory",
+            (
+                "no project root found; run from a project directory "
+                "or pass --project-dir"
+            ),
         )
 
     dest = project_root / ".claude" / "skills" / "clauditor"

--- a/src/clauditor/setup.py
+++ b/src/clauditor/setup.py
@@ -121,7 +121,10 @@ def plan_setup(
     """
     project_root = find_project_root(cwd)
     if project_root is None:
-        raise ValueError("no project root found; run from a project directory")
+        raise ValueError(
+            "no project root found; run from a project directory "
+            "or pass --project-dir"
+        )
 
     dest = project_root / ".claude" / "skills" / "clauditor"
 

--- a/src/clauditor/setup.py
+++ b/src/clauditor/setup.py
@@ -1,0 +1,186 @@
+"""Pure decision layer for ``clauditor setup`` install/unlink planning.
+
+This module is intentionally PURE per
+``.claude/rules/pure-compute-vs-io-split.md``: it only reads metadata from
+``pathlib.Path`` objects (``.exists``, ``.is_symlink``, ``.is_file``,
+``.is_dir``, ``.resolve``, ``.parent``) and returns a ``SetupAction`` enum
+member. No ``os.symlink``, ``open``, ``write``, or ``shutil`` calls live
+here — all side effects are the caller's responsibility.
+
+The CLI (US-005) dispatches on the enum to perform the actual symlink
+create/remove using atomic ``os.symlink`` + ``FileExistsError`` handling
+per DEC-010.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+# Bound the project-root search so a mis-rooted cwd does not walk to the
+# filesystem root and beyond. 50 levels is several orders of magnitude
+# deeper than any realistic checkout.
+_PROJECT_ROOT_SEARCH_LIMIT = 50
+
+
+class SetupAction(Enum):
+    """Discrete outcomes ``plan_setup`` can return.
+
+    Each member names what the I/O layer should do next. The CLI maps
+    each value to a message + exit code per DEC-008/DEC-009/DEC-016.
+    """
+
+    CREATE_SYMLINK = "create_symlink"
+    NOOP_ALREADY_INSTALLED = "noop_already_installed"
+    REPLACE_WITH_FORCE = "replace_with_force"
+    REFUSE_EXISTING_FILE = "refuse_existing_file"
+    REFUSE_EXISTING_DIR = "refuse_existing_dir"
+    REFUSE_WRONG_SYMLINK = "refuse_wrong_symlink"
+    REMOVE_SYMLINK = "remove_symlink"
+    NOOP_NOTHING_TO_UNLINK = "noop_nothing_to_unlink"
+    REFUSE_UNLINK_NON_SYMLINK = "refuse_unlink_non_symlink"
+    REFUSE_UNLINK_WRONG_TARGET = "refuse_unlink_wrong_target"
+
+
+def find_project_root(cwd: Path) -> Path | None:
+    """Walk up from ``cwd`` looking for a ``.git`` or ``.claude`` marker.
+
+    Returns the first ancestor (or ``cwd`` itself) that contains either
+    marker. Returns ``None`` if no marker is found before hitting the
+    filesystem root or the search bound.
+
+    ``.git`` may be a file (inside a git worktree) or a directory (normal
+    checkout); either counts. ``.claude`` must be a directory — a stray
+    file named ``.claude`` next to some unrelated project would not
+    indicate a project root.
+    """
+    current = cwd
+    for _ in range(_PROJECT_ROOT_SEARCH_LIMIT):
+        git_marker = current / ".git"
+        claude_marker = current / ".claude"
+        if git_marker.exists():
+            return current
+        if claude_marker.is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            # Reached filesystem root.
+            return None
+        current = parent
+    # Exhausted the search bound — treat as "no project root" rather
+    # than walking the whole filesystem tree.
+    return None  # pragma: no cover
+
+
+def _is_our_symlink(dest: Path, pkg_skill_root: Path) -> bool:
+    """Return True if ``dest`` is a symlink whose resolved target equals the
+    installed bundled skill directory.
+
+    The comparison uses ``Path.resolve()`` on both sides so relative
+    symlinks and differently-spelled-but-equivalent absolute paths compare
+    equal. Callers must verify ``dest.is_symlink()`` themselves — this
+    helper assumes a symlink and is only correct under that precondition.
+    """
+    try:
+        resolved = dest.resolve()
+    except OSError:  # pragma: no cover — broken symlink or perms
+        return False
+    return resolved == pkg_skill_root.resolve()
+
+
+def plan_setup(
+    cwd: Path,
+    pkg_skill_root: Path,
+    *,
+    force: bool,
+    unlink: bool,
+) -> SetupAction:
+    """Decide what the I/O layer should do. PURE — no file I/O, no writes.
+
+    Args:
+        cwd: user's current working directory (search origin for project
+            root detection via :func:`find_project_root`).
+        pkg_skill_root: absolute path to the installed bundled skill dir,
+            e.g. ``<site-packages>/clauditor/skills/clauditor/``. The
+            caller is responsible for resolving this via
+            ``importlib.resources``.
+        force: if ``True``, a conflicting destination triggers
+            :attr:`SetupAction.REPLACE_WITH_FORCE` instead of a
+            ``REFUSE_*`` variant. Ignored when ``unlink=True`` — refusal
+            branches in unlink mode apply regardless of ``force``.
+        unlink: if ``True``, interpret the operation as a removal rather
+            than an install.
+
+    Returns:
+        One of the :class:`SetupAction` members describing what the
+        caller should do next.
+
+    Raises:
+        ValueError: if :func:`find_project_root` returns ``None`` — the
+            CLI maps this to exit code 2 with a user-visible error.
+    """
+    project_root = find_project_root(cwd)
+    if project_root is None:
+        raise ValueError("no project root found; run from a project directory")
+
+    dest = project_root / ".claude" / "skills" / "clauditor"
+
+    if unlink:
+        return _plan_unlink(dest, pkg_skill_root)
+    return _plan_install(dest, pkg_skill_root, force=force)
+
+
+def _plan_install(
+    dest: Path,
+    pkg_skill_root: Path,
+    *,
+    force: bool,
+) -> SetupAction:
+    """Install-mode branch of :func:`plan_setup`."""
+    # Symlink check must come before ``exists()`` — a symlink with a
+    # broken target reports ``exists() is False`` but ``is_symlink() is
+    # True``, and we still want to classify it as a wrong-target symlink
+    # so ``--force`` can clear it.
+    if dest.is_symlink():
+        if _is_our_symlink(dest, pkg_skill_root):
+            return SetupAction.NOOP_ALREADY_INSTALLED
+        return (
+            SetupAction.REPLACE_WITH_FORCE
+            if force
+            else SetupAction.REFUSE_WRONG_SYMLINK
+        )
+    if not dest.exists():
+        return SetupAction.CREATE_SYMLINK
+    if dest.is_file():
+        return (
+            SetupAction.REPLACE_WITH_FORCE
+            if force
+            else SetupAction.REFUSE_EXISTING_FILE
+        )
+    # Remaining case: regular directory. ``is_dir()`` is true here; an
+    # exotic entry (FIFO/socket/device) is rare enough that we do not
+    # enumerate it separately — the install-mode branches above cover
+    # every documented case.
+    return (
+        SetupAction.REPLACE_WITH_FORCE
+        if force
+        else SetupAction.REFUSE_EXISTING_DIR
+    )
+
+
+def _plan_unlink(dest: Path, pkg_skill_root: Path) -> SetupAction:
+    """Unlink-mode branch of :func:`plan_setup`.
+
+    ``force`` is intentionally absent from this signature: the design
+    decision (DEC-009) is that ``--force`` has no effect in unlink mode.
+    Destructive operations stay safe by default.
+    """
+    if dest.is_symlink():
+        if _is_our_symlink(dest, pkg_skill_root):
+            return SetupAction.REMOVE_SYMLINK
+        return SetupAction.REFUSE_UNLINK_WRONG_TARGET
+    if not dest.exists():
+        return SetupAction.NOOP_NOTHING_TO_UNLINK
+    # Regular file, real directory, or exotic type — refuse regardless
+    # of force.
+    return SetupAction.REFUSE_UNLINK_NON_SYMLINK

--- a/src/clauditor/setup.py
+++ b/src/clauditor/setup.py
@@ -53,14 +53,31 @@ def find_project_root(cwd: Path) -> Path | None:
     checkout); either counts. ``.claude`` must be a directory — a stray
     file named ``.claude`` next to some unrelated project would not
     indicate a project root.
+
+    The user's home directory is accepted only via the ``.git`` marker,
+    never via ``.claude``. Claude Code itself ships a ``~/.claude/`` user
+    config dir, so without this exclusion every ``clauditor setup`` run
+    from a cwd under ``$HOME`` lacking an intermediate project marker
+    would install the skill symlink into ``~/.claude/skills/clauditor``
+    — contaminating the user's global Claude Code config. Mirrors the
+    home-exclusion pattern in :func:`clauditor.paths.resolve_clauditor_dir`.
     """
+    try:
+        home = Path.home().resolve()
+    except (RuntimeError, OSError):
+        home = None
+
     current = cwd
     for _ in range(_PROJECT_ROOT_SEARCH_LIMIT):
-        git_marker = current / ".git"
-        claude_marker = current / ".claude"
-        if git_marker.exists():
+        try:
+            resolved = current.resolve()
+        except OSError:  # pragma: no cover — broken perms along the path
+            resolved = current
+        at_home = home is not None and resolved == home
+
+        if (current / ".git").exists():
             return current
-        if claude_marker.is_dir():
+        if not at_home and (current / ".claude").is_dir():
             return current
         parent = current.parent
         if parent == current:

--- a/src/clauditor/skills/.sentinel.md
+++ b/src/clauditor/skills/.sentinel.md
@@ -1,0 +1,1 @@
+# sentinel — replaced by US-002 with real bundled skill content

--- a/src/clauditor/skills/.sentinel.md
+++ b/src/clauditor/skills/.sentinel.md
@@ -1,1 +1,0 @@
-# sentinel — replaced by US-002 with real bundled skill content

--- a/src/clauditor/skills/clauditor/SKILL.md
+++ b/src/clauditor/skills/clauditor/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: clauditor
+description: Run the clauditor capture/validate/grade workflow against a Claude Code skill. Use when evaluating a skill's output against an eval spec, when the user asks to validate or grade a skill, or when auditing a skill's stability across runs.
+compatibility: Requires clauditor installed via pip/uv (provides the 'clauditor' CLI and the pytest plugin).
+metadata:
+  clauditor-version: "0.0.0-dev"
+argument-hint: "[skill-path]"
+disable-model-invocation: true
+allowed-tools: Bash(uv run clauditor *)
+---
+
+# /clauditor — Validate and grade a Claude Code skill
+
+You help the user evaluate a Claude Code skill using clauditor's three-layer
+framework. Keep responses terse and concrete; prefer running the CLI over
+explaining what it would do.
+
+## Three-layer model
+
+- **Layer 1 — assertions:** deterministic regex/string/count checks against
+  the skill's output. Fast and free; runs in milliseconds and costs zero
+  API tokens.
+- **Layer 2 — extraction:** LLM-graded schema extraction (Haiku) that
+  pulls structured fields from free-form output. Optional — only runs when
+  the eval spec declares `sections`.
+- **Layer 3 — grading:** LLM-graded rubric scoring (Sonnet) against
+  user-authored `grading_criteria`. Costs tokens; run after L1 passes.
+
+## Workflow
+
+1. **Identify the skill file.** If `$ARGUMENTS` is non-empty, treat it as
+   the path to a `SKILL.md` (or a legacy `.claude/commands/<name>.md`).
+   Otherwise ask the user which skill to evaluate.
+
+2. **Locate the eval spec.** Look for a sibling file named
+   `<skill-name>.eval.json` next to the skill. For skill-directory layouts,
+   check `<skill-dir>/assets/<skill-name>.eval.json` as well. If neither
+   exists, ask the user whether to point at an explicit `--eval` path or
+   stop.
+
+3. **Run L1 validation first.** It is fast and free:
+
+   ```bash
+   uv run clauditor validate <skill-path>
+   ```
+
+   This runs the skill once, checks every `assertions[]` entry, and writes
+   `assertions.json` into `.clauditor/iteration-N/<skill-name>/`. If any
+   assertion fails, report the failing ids and stop — grading a broken
+   skill wastes tokens.
+
+4. **If L1 passes, offer L3 grading.** Ask the user to confirm (this
+   costs Sonnet tokens):
+
+   ```bash
+   uv run clauditor grade <skill-path>
+   ```
+
+   This runs the skill, evaluates every `grading_criteria[]` entry against
+   the rubric, and writes `grading.json` alongside the assertions sidecar.
+   Report the overall `pass_rate`, any failing criterion ids, and the
+   path to the sidecar for follow-up.
+
+5. **Report concisely.** Surface:
+   - Which layers ran (L1 / L2 / L3)
+   - Pass/fail counts per layer
+   - Sidecar paths the user can open to inspect full results
+   - One-line next step (re-run, inspect transcript, tighten rubric)
+
+## Common errors
+
+- **`no eval spec found`** — the skill has no sibling `.eval.json`. Ask
+  the user to author one or point `--eval` at an existing spec.
+- **`duplicate id` / `missing id`** — every assertion, field, and
+  criterion needs a unique string `id`. Edit the spec and re-run.
+- **`no project root found`** — `clauditor` expects to run inside a
+  project with `.git/` or `.claude/`. Use `--project-dir` or `cd` first.

--- a/src/clauditor/skills/clauditor/SKILL.md
+++ b/src/clauditor/skills/clauditor/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   clauditor-version: "0.0.0-dev"
 argument-hint: "[skill-path]"
 disable-model-invocation: true
-allowed-tools: Bash(uv run clauditor *)
+allowed-tools: Bash(clauditor *), Bash(uv run clauditor *)
 ---
 
 # /clauditor — Validate and grade a Claude Code skill

--- a/src/clauditor/skills/clauditor/assets/clauditor.eval.json
+++ b/src/clauditor/skills/clauditor/assets/clauditor.eval.json
@@ -1,8 +1,8 @@
 {
   "skill_name": "clauditor",
   "description": "Eval spec for the bundled /clauditor skill — validates that the slash command explains the capture/validate/grade workflow correctly.",
-  "test_args": "examples/.claude/commands/example-skill.eval.json",
-  "user_prompt": "Validate the skill at examples/.claude/commands/example-skill.eval.json — report which clauditor layers you would run and the commands involved.",
+  "test_args": ".claude/commands/chunk.md",
+  "user_prompt": "Validate the skill at .claude/commands/chunk.md — report which clauditor layers you would run (L1 assertions, L3 grading) and the concrete commands involved.",
   "assertions": [
     {
       "id": "mentions-assertions",

--- a/src/clauditor/skills/clauditor/assets/clauditor.eval.json
+++ b/src/clauditor/skills/clauditor/assets/clauditor.eval.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "clauditor",
-  "description": "Eval spec for the bundled /clauditor skill — validates that the slash command explains the capture/validate/grade workflow correctly.",
+  "description": "Eval spec for the bundled /clauditor skill — maintainer-only pre-release dogfood gate (DEC-007). Requires the clauditor source repo as cwd because test_args references .claude/commands/chunk.md. Not runnable from a user's project.",
   "test_args": ".claude/commands/chunk.md",
   "user_prompt": "Validate the skill at .claude/commands/chunk.md — report which clauditor layers you would run (L1 assertions, L3 grading) and the concrete commands involved.",
   "assertions": [

--- a/src/clauditor/skills/clauditor/assets/clauditor.eval.json
+++ b/src/clauditor/skills/clauditor/assets/clauditor.eval.json
@@ -1,0 +1,34 @@
+{
+  "skill_name": "clauditor",
+  "description": "Eval spec for the bundled /clauditor skill — validates that the slash command explains the capture/validate/grade workflow correctly.",
+  "test_args": "examples/.claude/commands/example-skill.eval.json",
+  "user_prompt": "Validate the skill at examples/.claude/commands/example-skill.eval.json — report which clauditor layers you would run and the commands involved.",
+  "assertions": [
+    {
+      "id": "mentions-assertions",
+      "type": "contains",
+      "value": "assertion"
+    },
+    {
+      "id": "no-error-trace",
+      "type": "not_contains",
+      "value": "Traceback"
+    },
+    {
+      "id": "produces-output",
+      "type": "min_length",
+      "value": "50"
+    }
+  ],
+  "grading_criteria": [
+    {
+      "id": "identifies-layer-correctly",
+      "criterion": "The response correctly distinguishes between L1 deterministic assertions and L3 LLM-graded rubric criteria, naming at least one layer accurately."
+    },
+    {
+      "id": "provides-concrete-guidance",
+      "criterion": "The response provides actionable next steps (specific clauditor commands such as 'clauditor validate' or 'clauditor grade', or specific file paths) rather than generic advice."
+    }
+  ],
+  "grading_model": "claude-sonnet-4-6"
+}

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -1,0 +1,238 @@
+"""Tests for the bundled /clauditor skill shipped under ``src/clauditor/skills/``.
+
+Validates frontmatter shape, naming constraints, and that the sibling eval
+spec loads via :func:`clauditor.schemas.EvalSpec.from_file`. The bundled skill
+itself is the canonical example of a clauditor slash-command; these tests
+guard against silent drift in the frontmatter contract (agentskills.io core
+spec + Claude Code extensions, per DEC-004 of
+``plans/super/43-setup-slash-command.md``).
+
+Frontmatter parsing uses a small hand-rolled YAML reader to avoid adding
+``PyYAML`` as a runtime dependency — the contract is intentionally small
+(strings, booleans, one nested mapping, one list of tool patterns).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from clauditor.schemas import EvalSpec, criterion_text
+
+SKILL_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "clauditor"
+    / "skills"
+    / "clauditor"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+EVAL_JSON = SKILL_DIR / "assets" / "clauditor.eval.json"
+
+# agentskills.io naming constraints: lowercase a-z + digits + hyphens, with
+# hyphens between segments, 1-64 chars total.
+NAME_REGEX = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+NAME_MAX_LEN = 64
+DESCRIPTION_MAX_LEN = 1024
+BODY_MAX_LINES = 500
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Return ``(frontmatter_text, body_text)`` for a SKILL.md.
+
+    Expects the canonical ``---\\n<yaml>\\n---\\n<body>`` shape. Raises
+    ``AssertionError`` if the delimiters are missing or malformed.
+    """
+    lines = text.splitlines(keepends=True)
+    assert lines and lines[0].rstrip("\r\n") == "---", (
+        "frontmatter must start with '---' delimiter on the first line"
+    )
+    # Find the closing '---' on its own line, starting after line 0.
+    close_idx = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\r\n") == "---":
+            close_idx = i
+            break
+    assert close_idx is not None, "frontmatter missing closing '---' delimiter"
+    frontmatter = "".join(lines[1:close_idx])
+    body = "".join(lines[close_idx + 1 :])
+    return frontmatter, body
+
+
+def _parse_frontmatter(frontmatter_text: str) -> dict:
+    """Parse a minimal YAML-ish frontmatter block into a dict.
+
+    Supports:
+      - top-level ``key: value`` pairs (scalar string / bool / quoted string)
+      - one level of nested mapping via leading-space indentation
+
+    NOT a general YAML parser — intentionally tight to keep the bundled-skill
+    frontmatter shape from drifting into anything we cannot validate inline.
+    """
+    result: dict[str, object] = {}
+    current_dict: dict[str, object] | None = None
+
+    for raw in frontmatter_text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        # Indented line: belongs to current_dict (nested mapping).
+        if raw.startswith(" ") or raw.startswith("\t"):
+            assert current_dict is not None, (
+                f"unexpected indented line with no parent mapping: {raw!r}"
+            )
+            k, _, v = raw.strip().partition(":")
+            current_dict[k.strip()] = _coerce_scalar(v.strip())
+            continue
+        # Top-level line.
+        key, _, value = raw.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value == "":
+            # Begins a nested mapping.
+            nested: dict[str, object] = {}
+            result[key] = nested
+            current_dict = nested
+        else:
+            result[key] = _coerce_scalar(value)
+            current_dict = None
+
+    return result
+
+
+def _coerce_scalar(raw: str) -> object:
+    """Coerce a YAML-ish scalar: quoted string, bool, or bare string."""
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ('"', "'"):
+        return raw[1:-1]
+    return raw
+
+
+@pytest.fixture(scope="module")
+def skill_md_text() -> str:
+    return SKILL_MD.read_text()
+
+
+@pytest.fixture(scope="module")
+def frontmatter_and_body(skill_md_text: str) -> tuple[dict, str]:
+    fm_text, body = _split_frontmatter(skill_md_text)
+    return _parse_frontmatter(fm_text), body
+
+
+class TestSkillMdFrontmatter:
+    def test_skill_md_exists_and_has_frontmatter_delimiters(
+        self, skill_md_text: str
+    ) -> None:
+        assert SKILL_MD.is_file(), f"bundled SKILL.md missing at {SKILL_MD}"
+        lines = skill_md_text.splitlines()
+        assert lines[0] == "---", "first line must be '---'"
+        assert "---" in lines[1:], "closing '---' delimiter missing"
+
+    def test_skill_md_has_required_frontmatter_fields(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        fm, _ = frontmatter_and_body
+        # Core agentskills.io required fields.
+        assert isinstance(fm.get("name"), str) and fm["name"], (
+            "frontmatter 'name' must be a non-empty string"
+        )
+        assert isinstance(fm.get("description"), str) and fm["description"], (
+            "frontmatter 'description' must be a non-empty string"
+        )
+
+    def test_skill_md_name_equals_directory_name(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        fm, _ = frontmatter_and_body
+        # Per agentskills.io spec, `name` must match the parent directory
+        # name of the skill dir.
+        assert fm["name"] == SKILL_DIR.name, (
+            f"frontmatter name={fm['name']!r} must equal parent dir "
+            f"name={SKILL_DIR.name!r}"
+        )
+
+    def test_skill_md_name_matches_spec_regex(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        fm, _ = frontmatter_and_body
+        name = fm["name"]
+        assert 1 <= len(name) <= NAME_MAX_LEN, (
+            f"name length {len(name)} outside [1, {NAME_MAX_LEN}]"
+        )
+        assert NAME_REGEX.match(name), (
+            f"name={name!r} does not match agentskills.io regex "
+            f"{NAME_REGEX.pattern}"
+        )
+
+    def test_skill_md_description_length_under_1024(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        fm, _ = frontmatter_and_body
+        description = fm["description"]
+        assert len(description) <= DESCRIPTION_MAX_LEN, (
+            f"description length {len(description)} exceeds "
+            f"{DESCRIPTION_MAX_LEN} chars"
+        )
+
+    def test_skill_md_uses_disable_model_invocation(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        # DEC-004: clauditor writes sidecars and spawns subprocesses, so
+        # the skill must not be speculatively invoked by the model.
+        fm, _ = frontmatter_and_body
+        assert fm.get("disable-model-invocation") is True, (
+            "disable-model-invocation must be true per DEC-004"
+        )
+
+    def test_skill_md_body_under_500_lines(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        _, body = frontmatter_and_body
+        line_count = len(body.splitlines())
+        assert line_count <= BODY_MAX_LINES, (
+            f"body has {line_count} lines; must be ≤ {BODY_MAX_LINES}"
+        )
+
+
+class TestBundledEvalSpec:
+    def test_eval_spec_loads_via_eval_spec_from_file(self) -> None:
+        # This must not raise — a raise here means the bundled eval spec
+        # is structurally invalid or fails stable-id uniqueness.
+        spec = EvalSpec.from_file(EVAL_JSON)
+        assert spec.skill_name == "clauditor"
+        assert spec.grading_model == "claude-sonnet-4-6"
+        assert len(spec.assertions) >= 3, (
+            f"bundled eval spec must declare at least 3 assertions, "
+            f"got {len(spec.assertions)}"
+        )
+        assert len(spec.grading_criteria) >= 2, (
+            f"bundled eval spec must declare at least 2 grading_criteria, "
+            f"got {len(spec.grading_criteria)}"
+        )
+
+    def test_eval_spec_all_ids_unique(self) -> None:
+        # Per .claude/rules/eval-spec-stable-ids.md: every assertion, field,
+        # and criterion carries a unique id, spanning all three layers.
+        data = json.loads(EVAL_JSON.read_text())
+        ids: list[str] = []
+        for a in data.get("assertions", []):
+            ids.append(a["id"])
+        for s in data.get("sections", []):
+            for tier in s.get("tiers", []):
+                for fld in tier.get("fields", []):
+                    ids.append(fld["id"])
+        for c in data.get("grading_criteria", []):
+            ids.append(c["id"])
+        assert len(ids) == len(set(ids)), (
+            f"duplicate ids in bundled eval spec: {ids}"
+        )
+        # Belt-and-suspenders: every criterion text should be non-empty.
+        for c in data.get("grading_criteria", []):
+            assert criterion_text(c).strip(), (
+                f"criterion id={c['id']!r} has empty text"
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3951,6 +3951,135 @@ class TestCmdDoctor:
         lines = [line for line in out.splitlines() if "claude-cli" in line]
         assert any("[fail]" in line for line in lines)
 
+    # --- DEC-013 clauditor-skill-symlink check (5 states) ---------------
+
+    def test_doctor_reports_info_when_skill_not_installed(
+        self, setup_env, capsys
+    ):
+        """Dest doesn't exist → info with 'run clauditor setup'."""
+        dest = setup_env["dest"]
+        assert not dest.exists()
+
+        rc = main(["doctor"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "clauditor-skill-symlink" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[info]")
+        assert "not installed" in lines[0]
+        assert "clauditor setup" in lines[0]
+
+    def test_doctor_reports_ok_when_our_symlink_installed(
+        self, setup_env, capsys
+    ):
+        """Dest is our symlink → ok with resolved target."""
+        import os as _os
+
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _os.symlink(pkg_skill, dest)
+
+        rc = main(["doctor"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "clauditor-skill-symlink" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[ok]")
+        assert str(pkg_skill.resolve()) in lines[0]
+
+    def test_doctor_reports_warn_for_stale_symlink(
+        self, setup_env, capsys, tmp_path
+    ):
+        """Dangling symlink (target removed) → warn with '--force to fix'."""
+        import os as _os
+
+        dest = setup_env["dest"]
+        # Create a symlink pointing at a target that we then delete.
+        vanished = tmp_path / "vanished-target"
+        vanished.mkdir()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _os.symlink(vanished, dest)
+        # Now remove the target, leaving a dangling symlink.
+        vanished.rmdir()
+
+        assert dest.is_symlink()
+        assert not dest.exists()
+
+        rc = main(["doctor"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "clauditor-skill-symlink" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[warn]")
+        assert "stale symlink" in lines[0]
+        assert "--force" in lines[0]
+
+    def test_doctor_reports_warn_for_wrong_target_symlink(
+        self, setup_env, capsys, tmp_path
+    ):
+        """Symlink → somewhere else → warn 'doesn't match'."""
+        import os as _os
+
+        dest = setup_env["dest"]
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _os.symlink(elsewhere, dest)
+
+        rc = main(["doctor"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "clauditor-skill-symlink" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[warn]")
+        assert "doesn't match" in lines[0]
+        assert str(elsewhere.resolve()) in lines[0]
+
+    @pytest.mark.parametrize("kind", ["file", "dir"])
+    def test_doctor_reports_warn_for_non_symlink_file_or_dir(
+        self, setup_env, capsys, kind
+    ):
+        """Regular file or real directory (not a symlink) → warn 'unmanaged'."""
+        dest = setup_env["dest"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if kind == "file":
+            dest.write_text("not a symlink\n")
+            expected_kind = "file"
+        else:
+            dest.mkdir()
+            (dest / "junk.txt").write_text("stuff\n")
+            expected_kind = "directory"
+
+        rc = main(["doctor"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "clauditor-skill-symlink" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[warn]")
+        assert expected_kind in lines[0]
+        assert "unmanaged" in lines[0]
+
 
 class TestCmdTrend:
     """Tests for the trend subcommand (US-006)."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3539,6 +3539,47 @@ class TestCmdSetup:
         err = capsys.readouterr().err
         assert "target does not match" in err or "does not match" in err
 
+    def test_setup_retries_on_race_then_succeeds(
+        self, setup_env, monkeypatch, capsys
+    ):
+        """FileExistsError on first os.symlink → re-plan → success (DEC-010)."""
+        from clauditor import cli as cli_module
+
+        call_count = {"n": 0}
+        original_install = cli_module._install_symlink
+
+        def racy_install(dest, pkg_skill_root):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise FileExistsError("simulated TOCTOU race")
+            return original_install(dest, pkg_skill_root)
+
+        monkeypatch.setattr("clauditor.cli._install_symlink", racy_install)
+
+        rc = main(["setup"])
+
+        assert rc == 0
+        assert call_count["n"] == 2  # first raced, second succeeded
+        dest = setup_env["dest"]
+        assert dest.is_symlink()
+        assert "Installed /clauditor" in capsys.readouterr().out
+
+    def test_setup_exits_1_after_two_race_attempts(
+        self, setup_env, monkeypatch, capsys
+    ):
+        """Persistent FileExistsError → exit 1 with concurrent-mod error."""
+
+        def always_race(dest, pkg_skill_root):
+            raise FileExistsError("persistent race")
+
+        monkeypatch.setattr("clauditor.cli._install_symlink", always_race)
+
+        rc = main(["setup"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "concurrent modification" in err
+
     def test_setup_errors_when_no_project_root(self, tmp_path, monkeypatch, capsys):
         """No .git, no .claude → exit 2, stderr 'no project root'."""
         # Fake package skill tree outside any git checkout.
@@ -4099,6 +4140,37 @@ class TestCmdDoctor:
         assert lines[0].startswith("[warn]")
         assert expected_kind in lines[0]
         assert "unmanaged" in lines[0]
+
+    def test_doctor_reports_info_when_no_project_root(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """No .git or .claude in ancestry → info line (DEC-013, 6th state)."""
+        pkg_skill = tmp_path / "fake-pkg" / "clauditor" / "skills" / "clauditor"
+        pkg_skill.mkdir(parents=True)
+        (pkg_skill / "SKILL.md").write_text("# sentinel\n")
+
+        # cwd is a markerless subdir under tmp_path.
+        subdir = tmp_path / "nowhere"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+
+        def fake_files(pkg_name):
+            assert pkg_name == "clauditor"
+            return tmp_path / "fake-pkg" / "clauditor"
+
+        monkeypatch.setattr("clauditor.cli.files", fake_files)
+
+        rc = main(["doctor"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "clauditor-skill-symlink" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[info]")
+        assert "no project root" in lines[0]
 
 
 class TestCmdTrend:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3519,6 +3519,26 @@ class TestCmdSetup:
         out = capsys.readouterr().out
         assert "not installed" in out
 
+    def test_setup_unlink_refuses_wrong_target_symlink(self, setup_env, capsys):
+        """--unlink on a symlink pointing elsewhere → exit 1, preserved."""
+        dest = setup_env["dest"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        elsewhere = setup_env["project_root"] / "other-dir"
+        elsewhere.mkdir()
+        import os as _os
+
+        _os.symlink(elsewhere, dest)
+
+        rc = main(["setup", "--unlink"])
+
+        assert rc == 1
+        # Symlink preserved — we do NOT silently delete user-authored
+        # symlinks just because `--unlink` was passed (DEC-009).
+        assert dest.is_symlink()
+        assert dest.resolve() == elsewhere.resolve()
+        err = capsys.readouterr().err
+        assert "target does not match" in err or "does not match" in err
+
     def test_setup_errors_when_no_project_root(self, tmp_path, monkeypatch, capsys):
         """No .git, no .claude → exit 2, stderr 'no project root'."""
         # Fake package skill tree outside any git checkout.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3357,6 +3357,223 @@ class TestCmdInit:
         assert data["skill_name"] == "my-skill"
 
 
+@pytest.fixture
+def setup_env(tmp_path, monkeypatch):
+    """Scratch project root + fake installed-package skill dir.
+
+    Creates a ``.git`` marker at ``tmp_path`` so
+    :func:`clauditor.setup.find_project_root` resolves, and plants a
+    sentinel SKILL.md inside a fake ``site-packages/clauditor/skills/
+    clauditor/`` tree whose location is returned by the monkeypatched
+    ``clauditor.cli.files`` callable.
+    """
+    # Project root with a .git marker.
+    (tmp_path / ".git").mkdir()
+    # Fake installed-package skill tree.
+    pkg_skill = tmp_path / "fake-pkg" / "clauditor" / "skills" / "clauditor"
+    pkg_skill.mkdir(parents=True)
+    (pkg_skill / "SKILL.md").write_text("# sentinel\n")
+    monkeypatch.chdir(tmp_path)
+
+    # Replace cli.files so `files("clauditor") / "skills" / "clauditor"`
+    # lands in the fake tree.
+    def fake_files(pkg_name):
+        assert pkg_name == "clauditor"
+        return tmp_path / "fake-pkg" / "clauditor"
+
+    monkeypatch.setattr("clauditor.cli.files", fake_files)
+    return {
+        "project_root": tmp_path,
+        "pkg_skill_root": pkg_skill,
+        "dest": tmp_path / ".claude" / "skills" / "clauditor",
+    }
+
+
+class TestCmdSetup:
+    """Tests for the ``clauditor setup`` subcommand."""
+
+    def test_setup_creates_symlink_when_absent(self, setup_env, capsys):
+        """Dest doesn't exist → creates symlink, exit 0, stdout ok."""
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        assert not dest.exists()
+
+        rc = main(["setup"])
+
+        assert rc == 0
+        assert dest.is_symlink()
+        # Resolved target should match the bundled pkg skill root.
+        assert dest.resolve() == pkg_skill.resolve()
+        out = capsys.readouterr().out
+        assert "Installed /clauditor" in out
+        assert str(dest) in out
+
+    def test_setup_noop_when_already_our_symlink(self, setup_env, capsys):
+        """Dest is symlink → pkg_skill → 'already installed', exit 0."""
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        import os as _os
+        _os.symlink(pkg_skill, dest)
+
+        rc = main(["setup"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "already installed" in out
+
+    def test_setup_refuses_existing_regular_file(self, setup_env, capsys):
+        """Dest is regular file → exit 1, stderr contains 'use --force'."""
+        dest = setup_env["dest"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("not a symlink\n")
+
+        rc = main(["setup"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "use --force" in err
+        assert "regular file" in err
+
+    def test_setup_refuses_wrong_symlink(self, setup_env, capsys, tmp_path):
+        """Dest is symlink → elsewhere → exit 1."""
+        dest = setup_env["dest"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        import os as _os
+        _os.symlink(elsewhere, dest)
+
+        rc = main(["setup"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "pointing elsewhere" in err
+
+    def test_setup_force_replaces_regular_file(self, setup_env, capsys):
+        """Regular file + --force → replaced with symlink, exit 0."""
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("not a symlink\n")
+
+        rc = main(["setup", "--force"])
+
+        assert rc == 0
+        assert dest.is_symlink()
+        assert dest.resolve() == pkg_skill.resolve()
+        assert "Installed /clauditor" in capsys.readouterr().out
+
+    def test_setup_force_replaces_real_dir(self, setup_env, capsys):
+        """Regular directory + --force → replaced with symlink, exit 0."""
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        dest.mkdir(parents=True)
+        (dest / "some-file.txt").write_text("junk\n")
+
+        rc = main(["setup", "--force"])
+
+        assert rc == 0
+        assert dest.is_symlink()
+        assert dest.resolve() == pkg_skill.resolve()
+        assert "Installed /clauditor" in capsys.readouterr().out
+
+    def test_setup_unlink_removes_our_symlink(self, setup_env, capsys):
+        """--unlink on our symlink → removed, exit 0."""
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        import os as _os
+        _os.symlink(pkg_skill, dest)
+
+        rc = main(["setup", "--unlink"])
+
+        assert rc == 0
+        assert not dest.exists()
+        assert not dest.is_symlink()
+        out = capsys.readouterr().out
+        assert "Removed .claude/skills/clauditor" in out
+
+    def test_setup_unlink_refuses_non_symlink(self, setup_env, capsys):
+        """--unlink on regular file → exit 1, stderr 'not a symlink'."""
+        dest = setup_env["dest"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("not a symlink\n")
+
+        rc = main(["setup", "--unlink"])
+
+        assert rc == 1
+        # File still there, not removed.
+        assert dest.exists()
+        err = capsys.readouterr().err
+        assert "not a symlink" in err
+
+    def test_setup_unlink_noop_when_absent(self, setup_env, capsys):
+        """--unlink with nothing present → exit 0, 'not installed' info."""
+        dest = setup_env["dest"]
+        assert not dest.exists()
+
+        rc = main(["setup", "--unlink"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "not installed" in out
+
+    def test_setup_errors_when_no_project_root(self, tmp_path, monkeypatch, capsys):
+        """No .git, no .claude → exit 2, stderr 'no project root'."""
+        # Fake package skill tree outside any git checkout.
+        pkg_skill = tmp_path / "fake-pkg" / "clauditor" / "skills" / "clauditor"
+        pkg_skill.mkdir(parents=True)
+        (pkg_skill / "SKILL.md").write_text("# sentinel\n")
+
+        # Run from a subdir with no project markers in its ancestry.
+        subdir = tmp_path / "nope"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+
+        def fake_files(pkg_name):
+            assert pkg_name == "clauditor"
+            return tmp_path / "fake-pkg" / "clauditor"
+
+        monkeypatch.setattr("clauditor.cli.files", fake_files)
+
+        rc = main(["setup"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "no project root" in err
+
+    def test_setup_project_dir_override(self, tmp_path, monkeypatch, capsys):
+        """--project-dir overrides cwd for project-root resolution."""
+        # Project root for the override.
+        override = tmp_path / "override-proj"
+        override.mkdir()
+        (override / ".git").mkdir()
+        # Fake package tree.
+        pkg_skill = tmp_path / "fake-pkg" / "clauditor" / "skills" / "clauditor"
+        pkg_skill.mkdir(parents=True)
+        (pkg_skill / "SKILL.md").write_text("# sentinel\n")
+
+        # cwd is a markerless subdir — without --project-dir it would fail.
+        sub = tmp_path / "elsewhere"
+        sub.mkdir()
+        monkeypatch.chdir(sub)
+
+        def fake_files(pkg_name):
+            assert pkg_name == "clauditor"
+            return tmp_path / "fake-pkg" / "clauditor"
+
+        monkeypatch.setattr("clauditor.cli.files", fake_files)
+
+        rc = main(["setup", "--project-dir", str(override)])
+
+        assert rc == 0
+        dest = override / ".claude" / "skills" / "clauditor"
+        assert dest.is_symlink()
+        assert dest.resolve() == pkg_skill.resolve()
+        assert "Installed /clauditor" in capsys.readouterr().out
+
+
 def _make_sections():
     """Create sample sections for Layer 2 testing."""
     return [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from clauditor import setup as clauditor_setup
 from clauditor.assertions import AssertionResult, AssertionSet
 from clauditor.cli import main
 from clauditor.quality_grader import GradingReport, GradingResult
@@ -3580,6 +3581,37 @@ class TestCmdSetup:
         err = capsys.readouterr().err
         assert "concurrent modification" in err
 
+    def test_setup_unlink_race_target_already_gone(
+        self, setup_env, monkeypatch, capsys
+    ):
+        """--unlink where the symlink was removed before our unlink call →
+        treat as success (user wanted it gone, it's gone). Symmetric with
+        the install-side retry loop (DEC-010).
+        """
+        dest = setup_env["dest"]
+        pkg_skill = setup_env["pkg_skill_root"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        import os as _os
+
+        _os.symlink(pkg_skill, dest)  # plan_setup sees it
+        # Race: remove the symlink right before cmd_setup dispatches
+        # the REMOVE_SYMLINK branch. We simulate this by chaining the
+        # side effect into the real dispatch via monkeypatch.
+        real_plan = clauditor_setup.plan_setup
+
+        def racy_plan(cwd, pkg_skill_root, *, force, unlink):
+            action = real_plan(cwd, pkg_skill_root, force=force, unlink=unlink)
+            if action is clauditor_setup.SetupAction.REMOVE_SYMLINK:
+                dest.unlink()  # concurrent peer gets there first
+            return action
+
+        monkeypatch.setattr("clauditor.cli.setup_module.plan_setup", racy_plan)
+
+        rc = main(["setup", "--unlink"])
+
+        assert rc == 0
+        assert "Removed .claude/skills/clauditor" in capsys.readouterr().out
+
     def test_setup_errors_when_no_project_root(self, tmp_path, monkeypatch, capsys):
         """No .git, no .claude → exit 2, stderr 'no project root'."""
         # Fake package skill tree outside any git checkout.
@@ -4170,7 +4202,9 @@ class TestCmdDoctor:
         ]
         assert len(lines) == 1
         assert lines[0].startswith("[info]")
-        assert "no project root" in lines[0]
+        assert "no project root found; run from a project directory" in lines[0]
+        # doctor has no --project-dir flag, so must not suggest one.
+        assert "--project-dir" not in lines[0]
 
 
 class TestCmdTrend:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3436,6 +3436,21 @@ class TestCmdSetup:
         assert "use --force" in err
         assert "regular file" in err
 
+    def test_setup_refuses_existing_real_dir(self, setup_env, capsys):
+        """Real directory at dest (not a symlink) without --force → exit 1."""
+        dest = setup_env["dest"]
+        dest.mkdir(parents=True)
+        (dest / "user-authored.txt").write_text("not ours\n")
+
+        rc = main(["setup"])
+
+        assert rc == 1
+        assert dest.is_dir()  # preserved — no silent clobber
+        assert not dest.is_symlink()
+        err = capsys.readouterr().err
+        assert "exists (directory)" in err
+        assert "--force" in err
+
     def test_setup_refuses_wrong_symlink(self, setup_env, capsys, tmp_path):
         """Dest is symlink → elsewhere → exit 1."""
         dest = setup_env["dest"]
@@ -3580,6 +3595,52 @@ class TestCmdSetup:
         assert rc == 1
         err = capsys.readouterr().err
         assert "concurrent modification" in err
+
+    def test_setup_rejects_zip_style_install(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """files() returning a non-Path (e.g. zip-style Traversable) → exit 2.
+        Symlinking into a zip extraction would leave a dangling pointer when
+        the as_file context exits, so we refuse up front.
+        """
+        # Fake cwd with project marker so project-root resolution succeeds
+        # if we ever reach it (we shouldn't — the early-return fires first).
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        class FakeTraversable:
+            """Not a Path subclass — simulates importlib.resources returning
+            a MultiplexedPath / zipfile.Path for a zipped install.
+            """
+
+            def __truediv__(self, _other):
+                return self
+
+        monkeypatch.setattr(
+            "clauditor.cli.files", lambda _pkg: FakeTraversable()
+        )
+
+        rc = main(["setup"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "stable filesystem path" in err
+        assert "zip" in err.lower() or "pex" in err.lower()
+
+    def test_remove_existing_tolerates_missing_path(self, tmp_path):
+        """_remove_existing on a path that does not exist is a no-op
+        (exotic/vanished type falls through to unlink(missing_ok=True)).
+        """
+        from clauditor import cli as cli_module
+
+        ghost = tmp_path / "never-existed"
+        assert not ghost.exists()
+
+        # Must not raise — exotic/missing type falls through to the
+        # missing-ok unlink branch.
+        cli_module._remove_existing(ghost)
+
+        assert not ghost.exists()
 
     def test_setup_unlink_race_target_already_gone(
         self, setup_env, monkeypatch, capsys

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,52 @@
+"""Tests for wheel packaging of the ``clauditor.skills`` subpackage."""
+
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def built_wheel(tmp_path_factory) -> Path:
+    out_dir = tmp_path_factory.mktemp("wheel")
+    try:
+        result = subprocess.run(
+            ["uv", "build", "--wheel", "--out-dir", str(out_dir), str(PROJECT_ROOT)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        pytest.skip("build tool unavailable: uv not on PATH")
+    if result.returncode != 0:
+        pytest.skip(
+            f"build tool unavailable: uv build failed "
+            f"(rc={result.returncode}): {result.stderr}"
+        )
+    wheels = list(out_dir.glob("clauditor-*.whl"))
+    if not wheels:
+        pytest.skip(f"build tool unavailable: no wheel produced in {out_dir}")
+    return wheels[0]
+
+
+@pytest.fixture(scope="module")
+def wheel_namelist(built_wheel: Path) -> list[str]:
+    with zipfile.ZipFile(built_wheel) as zf:
+        return zf.namelist()
+
+
+class TestWheelPackaging:
+    def test_wheel_contains_skills_subpackage(self, wheel_namelist: list[str]) -> None:
+        assert "clauditor/skills/__init__.py" in wheel_namelist
+
+    def test_wheel_contains_bundled_markdown(self, wheel_namelist: list[str]) -> None:
+        assert "clauditor/skills/.sentinel.md" in wheel_namelist
+
+    def test_wheel_excludes_pycache(self, wheel_namelist: list[str]) -> None:
+        offenders = [name for name in wheel_namelist if "__pycache__" in name]
+        assert offenders == [], f"wheel contains __pycache__ entries: {offenders}"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -44,8 +44,16 @@ class TestWheelPackaging:
     def test_wheel_contains_skills_subpackage(self, wheel_namelist: list[str]) -> None:
         assert "clauditor/skills/__init__.py" in wheel_namelist
 
-    def test_wheel_contains_bundled_markdown(self, wheel_namelist: list[str]) -> None:
-        assert "clauditor/skills/.sentinel.md" in wheel_namelist
+    def test_wheel_contains_bundled_skill_md(self, wheel_namelist: list[str]) -> None:
+        assert "clauditor/skills/clauditor/SKILL.md" in wheel_namelist
+
+    def test_wheel_contains_bundled_eval_json(
+        self, wheel_namelist: list[str]
+    ) -> None:
+        assert (
+            "clauditor/skills/clauditor/assets/clauditor.eval.json"
+            in wheel_namelist
+        )
 
     def test_wheel_excludes_pycache(self, wheel_namelist: list[str]) -> None:
         offenders = [name for name in wheel_namelist if "__pycache__" in name]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -30,13 +30,13 @@ def built_wheel(tmp_path_factory) -> Path:
     except FileNotFoundError:
         pytest.skip("build tool unavailable: uv not on PATH")
     if result.returncode != 0:
-        pytest.skip(
-            f"build tool unavailable: uv build failed "
-            f"(rc={result.returncode}): {result.stderr}"
+        pytest.fail(
+            f"uv build failed (rc={result.returncode}):\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
         )
     wheels = list(out_dir.glob("clauditor-*.whl"))
     if not wheels:
-        pytest.skip(f"build tool unavailable: no wheel produced in {out_dir}")
+        pytest.fail(f"uv build succeeded but no wheel produced in {out_dir}")
     return wheels[0]
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import subprocess
+import tomllib
 import zipfile
 from pathlib import Path
 
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _project_version() -> str:
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
 
 
 @pytest.fixture(scope="module")
@@ -58,3 +64,22 @@ class TestWheelPackaging:
     def test_wheel_excludes_pycache(self, wheel_namelist: list[str]) -> None:
         offenders = [name for name in wheel_namelist if "__pycache__" in name]
         assert offenders == [], f"wheel contains __pycache__ entries: {offenders}"
+
+    def test_wheel_skill_md_has_stamped_version(self, built_wheel: Path) -> None:
+        version = _project_version()
+        with zipfile.ZipFile(built_wheel) as zf:
+            skill_md = zf.read(
+                "clauditor/skills/clauditor/SKILL.md"
+            ).decode("utf-8")
+        expected_line = f'clauditor-version: "{version}"'
+        assert expected_line in skill_md, (
+            f"expected {expected_line!r} in wheel SKILL.md, got:\n{skill_md[:400]}"
+        )
+        # Defense-in-depth: the unstamped placeholder must NOT survive.
+        assert 'clauditor-version: "0.0.0-dev"' not in skill_md
+
+    def test_source_skill_md_remains_dev_placeholder(self) -> None:
+        src_skill = PROJECT_ROOT / "src/clauditor/skills/clauditor/SKILL.md"
+        assert 'clauditor-version: "0.0.0-dev"' in src_skill.read_text(
+            encoding="utf-8"
+        )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -119,6 +119,23 @@ class TestFindProjectRoot:
         sub.mkdir()
         assert find_project_root(sub) == fake_home
 
+    def test_find_project_root_tolerates_home_lookup_failure(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Path.home() raises on containerized envs with no HOME. The
+        # exception must not abort the walk — we just fall through to
+        # "no home exclusion" and let the walk proceed normally.
+        project = tmp_path / "p"
+        project.mkdir()
+        (project / ".claude").mkdir()
+
+        def _raise(cls):
+            raise RuntimeError("no HOME in this environment")
+
+        monkeypatch.setattr(Path, "home", classmethod(_raise))
+
+        assert find_project_root(project) == project
+
 
 class TestPlanSetupInstall:
     def test_plan_setup_returns_create_symlink(self, tmp_path: Path) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,256 @@
+"""Tests for the pure ``plan_setup`` decision layer.
+
+The module under test is strictly pure per
+``.claude/rules/pure-compute-vs-io-split.md``; these tests build a scratch
+filesystem with ``tmp_path`` to exercise every :class:`SetupAction` branch
+plus the :func:`find_project_root` marker walk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clauditor.setup import SetupAction, find_project_root, plan_setup
+
+
+def _make_pkg_skill_root(tmp_path: Path) -> Path:
+    """Create a scratch stand-in for the installed bundled skill dir."""
+    pkg = tmp_path / "site-packages" / "clauditor" / "skills" / "clauditor"
+    pkg.mkdir(parents=True)
+    (pkg / "SKILL.md").write_text("stub\n")
+    return pkg
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Create a scratch project root with a ``.git`` marker and the
+    ``.claude/skills/`` parent dir (but not the ``clauditor`` entry
+    itself — tests populate that per-branch).
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / ".claude" / "skills").mkdir(parents=True)
+    return project
+
+
+def _dest(project: Path) -> Path:
+    return project / ".claude" / "skills" / "clauditor"
+
+
+class TestFindProjectRoot:
+    def test_find_project_root_with_git_marker(self, tmp_path: Path) -> None:
+        proj = tmp_path / "p"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        assert find_project_root(proj) == proj
+
+    def test_find_project_root_with_claude_marker(self, tmp_path: Path) -> None:
+        proj = tmp_path / "p"
+        proj.mkdir()
+        (proj / ".claude").mkdir()
+        # No .git marker — .claude alone suffices.
+        assert find_project_root(proj) == proj
+
+    def test_find_project_root_walks_up_multiple_levels(
+        self, tmp_path: Path
+    ) -> None:
+        proj = tmp_path / "p"
+        proj.mkdir()
+        (proj / ".git").mkdir()
+        deep = proj / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        assert find_project_root(deep) == proj
+
+    def test_find_project_root_none_when_no_marker(self, tmp_path: Path) -> None:
+        # tmp_path has no .git or .claude anywhere in its ancestry;
+        # walk from a subdirectory and expect None.
+        sub = tmp_path / "nope"
+        sub.mkdir()
+        assert find_project_root(sub) is None
+
+    def test_find_project_root_git_as_file_counts(self, tmp_path: Path) -> None:
+        # git worktrees use a .git FILE, not dir. Both should count.
+        proj = tmp_path / "p"
+        proj.mkdir()
+        (proj / ".git").write_text("gitdir: /other\n")
+        assert find_project_root(proj) == proj
+
+    def test_find_project_root_claude_file_does_not_count(
+        self, tmp_path: Path
+    ) -> None:
+        # A stray file named .claude should NOT match — only a directory.
+        proj = tmp_path / "p"
+        proj.mkdir()
+        (proj / ".claude").write_text("not a marker\n")
+        assert find_project_root(proj) is None
+
+
+class TestPlanSetupInstall:
+    def test_plan_setup_returns_create_symlink(self, tmp_path: Path) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        # dest absent
+        result = plan_setup(project, pkg, force=False, unlink=False)
+        assert result is SetupAction.CREATE_SYMLINK
+
+    def test_plan_setup_returns_noop_already_installed(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.symlink_to(pkg)
+        result = plan_setup(project, pkg, force=False, unlink=False)
+        assert result is SetupAction.NOOP_ALREADY_INSTALLED
+
+    def test_plan_setup_returns_refuse_existing_file(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.touch()
+        result = plan_setup(project, pkg, force=False, unlink=False)
+        assert result is SetupAction.REFUSE_EXISTING_FILE
+
+    def test_plan_setup_returns_refuse_existing_dir(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.mkdir()
+        result = plan_setup(project, pkg, force=False, unlink=False)
+        assert result is SetupAction.REFUSE_EXISTING_DIR
+
+    def test_plan_setup_returns_refuse_wrong_symlink(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        # Point dest at something other than pkg.
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        dest.symlink_to(other)
+        result = plan_setup(project, pkg, force=False, unlink=False)
+        assert result is SetupAction.REFUSE_WRONG_SYMLINK
+
+    def test_plan_setup_returns_replace_with_force_for_file(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.touch()
+        result = plan_setup(project, pkg, force=True, unlink=False)
+        assert result is SetupAction.REPLACE_WITH_FORCE
+
+    def test_plan_setup_returns_replace_with_force_for_dir(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.mkdir()
+        result = plan_setup(project, pkg, force=True, unlink=False)
+        assert result is SetupAction.REPLACE_WITH_FORCE
+
+    def test_plan_setup_returns_replace_with_force_for_wrong_symlink(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        dest.symlink_to(other)
+        result = plan_setup(project, pkg, force=True, unlink=False)
+        assert result is SetupAction.REPLACE_WITH_FORCE
+
+    # Combined alias to satisfy the "one test per SetupAction enum member"
+    # naming convention. The three force-replace cases above cover the
+    # branches; this one asserts the enum value is reachable through the
+    # canonical file state.
+    def test_plan_setup_returns_replace_with_force(self, tmp_path: Path) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.touch()
+        result = plan_setup(project, pkg, force=True, unlink=False)
+        assert result is SetupAction.REPLACE_WITH_FORCE
+
+    def test_plan_setup_force_ignored_for_our_symlink(
+        self, tmp_path: Path
+    ) -> None:
+        # force does NOT replace an already-correct symlink — no-op wins.
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.symlink_to(pkg)
+        result = plan_setup(project, pkg, force=True, unlink=False)
+        assert result is SetupAction.NOOP_ALREADY_INSTALLED
+
+
+class TestPlanSetupUnlink:
+    def test_plan_setup_returns_remove_symlink(self, tmp_path: Path) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.symlink_to(pkg)
+        result = plan_setup(project, pkg, force=False, unlink=True)
+        assert result is SetupAction.REMOVE_SYMLINK
+
+    def test_plan_setup_returns_noop_nothing_to_unlink(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        # dest absent
+        result = plan_setup(project, pkg, force=False, unlink=True)
+        assert result is SetupAction.NOOP_NOTHING_TO_UNLINK
+
+    def test_plan_setup_returns_refuse_unlink_non_symlink(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.mkdir()  # real dir, not a symlink
+        result = plan_setup(project, pkg, force=False, unlink=True)
+        assert result is SetupAction.REFUSE_UNLINK_NON_SYMLINK
+
+    def test_plan_setup_returns_refuse_unlink_wrong_target(
+        self, tmp_path: Path
+    ) -> None:
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        dest.symlink_to(other)
+        result = plan_setup(project, pkg, force=False, unlink=True)
+        assert result is SetupAction.REFUSE_UNLINK_WRONG_TARGET
+
+    def test_plan_setup_force_ignored_in_unlink_mode(
+        self, tmp_path: Path
+    ) -> None:
+        # force=True must NOT override the refuse branch in unlink mode.
+        project = _make_project(tmp_path)
+        pkg = _make_pkg_skill_root(tmp_path)
+        dest = _dest(project)
+        dest.touch()  # regular file
+        result = plan_setup(project, pkg, force=True, unlink=True)
+        assert result is SetupAction.REFUSE_UNLINK_NON_SYMLINK
+
+
+class TestPlanSetupErrors:
+    def test_plan_setup_raises_when_no_project_root(self, tmp_path: Path) -> None:
+        # tmp_path has no .git or .claude anywhere in the walk.
+        sub = tmp_path / "nope"
+        sub.mkdir()
+        pkg = _make_pkg_skill_root(tmp_path / "sp")
+        with pytest.raises(ValueError, match="no project root found"):
+            plan_setup(sub, pkg, force=False, unlink=False)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -170,18 +170,6 @@ class TestPlanSetupInstall:
         result = plan_setup(project, pkg, force=True, unlink=False)
         assert result is SetupAction.REPLACE_WITH_FORCE
 
-    # Combined alias to satisfy the "one test per SetupAction enum member"
-    # naming convention. The three force-replace cases above cover the
-    # branches; this one asserts the enum value is reachable through the
-    # canonical file state.
-    def test_plan_setup_returns_replace_with_force(self, tmp_path: Path) -> None:
-        project = _make_project(tmp_path)
-        pkg = _make_pkg_skill_root(tmp_path)
-        dest = _dest(project)
-        dest.touch()
-        result = plan_setup(project, pkg, force=True, unlink=False)
-        assert result is SetupAction.REPLACE_WITH_FORCE
-
     def test_plan_setup_force_ignored_for_our_symlink(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -86,6 +86,39 @@ class TestFindProjectRoot:
         (proj / ".claude").write_text("not a marker\n")
         assert find_project_root(proj) is None
 
+    def test_find_project_root_skips_claude_at_home(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Regression guard: Claude Code ships ~/.claude as a user config
+        # dir. Without the home-exclusion, any setup run from a cwd under
+        # $HOME with no intermediate project marker would install the
+        # skill into ~/.claude/skills/clauditor — contaminating user
+        # config. Mirrors paths.py::resolve_clauditor_dir.
+        fake_home = tmp_path / "home" / "user"
+        fake_home.mkdir(parents=True)
+        (fake_home / ".claude").mkdir()  # the "stray" ~/.claude
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        sub = fake_home / "Downloads"
+        sub.mkdir()
+        # Walking up from ~/Downloads must skip the ~/.claude marker and
+        # keep walking — no project root at or above $HOME in this setup.
+        assert find_project_root(sub) is None
+
+    def test_find_project_root_accepts_git_at_home(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Home-exclusion is only for .claude; a bare .git at $HOME (rare
+        # but valid — user treats $HOME as a git repo) must still count.
+        fake_home = tmp_path / "home" / "user"
+        fake_home.mkdir(parents=True)
+        (fake_home / ".git").mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        sub = fake_home / "scratch"
+        sub.mkdir()
+        assert find_project_root(sub) == fake_home
+
 
 class TestPlanSetupInstall:
     def test_plan_setup_returns_create_symlink(self, tmp_path: Path) -> None:

--- a/tests/test_skill_validator.py
+++ b/tests/test_skill_validator.py
@@ -1,0 +1,185 @@
+"""Tests for the fallback SKILL.md frontmatter validator.
+
+The canonical CI validator is the upstream ``skills-ref`` package; this
+fallback at ``scripts/validate_skill_frontmatter.py`` exists because
+``skills-ref`` is stricter than our hybrid frontmatter (DEC-004 of
+``plans/super/43-setup-slash-command.md``) and rejects the Claude Code
+extension fields we legitimately ship. These tests guard the fallback's
+core-spec checks: name shape, description length, parent-dir match,
+frontmatter delimiter presence.
+
+Each test spawns the script as a subprocess via ``sys.executable`` to
+faithfully exercise the same entry point CI invokes, and uses
+``tmp_path`` fixtures to author disposable skill dirs so the real
+bundled skill is never at risk of being mutated by a failing test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "validate_skill_frontmatter.py"
+)
+
+VALID_FRONTMATTER = """\
+---
+name: myskill
+description: A valid test skill for exercising the fallback validator.
+---
+
+# Body text
+"""
+
+
+def _write_skill(skill_dir: Path, name: str, body: str) -> Path:
+    """Create a ``<skill_dir>/<name>/SKILL.md`` with the given body and return
+    the skill directory path."""
+    d = skill_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(body, encoding="utf-8")
+    return d
+
+
+def _run(skill_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke the validator script as a subprocess."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(skill_dir)],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestValidator:
+    def test_valid_skill_exits_zero(self, tmp_path: Path) -> None:
+        d = _write_skill(tmp_path, "myskill", VALID_FRONTMATTER)
+        result = _run(d)
+        assert result.returncode == 0, result.stderr
+        assert "frontmatter OK" in result.stdout
+
+    def test_real_bundled_skill_exits_zero(self) -> None:
+        """Sanity: the script passes on the actual shipped skill."""
+        bundled = (
+            Path(__file__).resolve().parent.parent
+            / "src"
+            / "clauditor"
+            / "skills"
+            / "clauditor"
+        )
+        result = _run(bundled)
+        assert result.returncode == 0, result.stderr
+
+    def test_missing_name_exits_one(self, tmp_path: Path) -> None:
+        body = (
+            "---\n"
+            "description: A skill with no name field.\n"
+            "---\n\n"
+            "# Body\n"
+        )
+        d = _write_skill(tmp_path, "myskill", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "'name' field missing" in result.stderr
+
+    def test_name_does_not_match_parent_dir_exits_one(
+        self, tmp_path: Path
+    ) -> None:
+        body = (
+            "---\n"
+            "name: wrongname\n"
+            "description: Name does not equal parent directory.\n"
+            "---\n\n"
+            "# Body\n"
+        )
+        d = _write_skill(tmp_path, "actualname", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "does not match parent directory name" in result.stderr
+
+    def test_name_with_uppercase_exits_one(self, tmp_path: Path) -> None:
+        body = (
+            "---\n"
+            "name: BadName\n"
+            "description: Uppercase in name violates the spec regex.\n"
+            "---\n\n"
+            "# Body\n"
+        )
+        d = _write_skill(tmp_path, "BadName", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "does not match" in result.stderr
+
+    def test_description_over_limit_exits_one(self, tmp_path: Path) -> None:
+        long_desc = "x" * 1025
+        body = f"---\nname: myskill\ndescription: {long_desc}\n---\n\n# Body\n"
+        d = _write_skill(tmp_path, "myskill", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "'description' length 1025" in result.stderr
+
+    def test_missing_description_exits_one(self, tmp_path: Path) -> None:
+        body = "---\nname: myskill\n---\n\n# Body\n"
+        d = _write_skill(tmp_path, "myskill", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "'description' field missing" in result.stderr
+
+    def test_no_frontmatter_delimiters_exits_one(self, tmp_path: Path) -> None:
+        body = "# Just a markdown file, no frontmatter at all\n"
+        d = _write_skill(tmp_path, "myskill", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "missing opening frontmatter delimiter" in result.stderr
+
+    def test_missing_closing_delimiter_exits_one(self, tmp_path: Path) -> None:
+        body = "---\nname: myskill\ndescription: No closing delimiter.\n\n# Body\n"
+        d = _write_skill(tmp_path, "myskill", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "missing closing frontmatter delimiter" in result.stderr
+
+    def test_skill_md_missing_exits_one(self, tmp_path: Path) -> None:
+        d = tmp_path / "myskill"
+        d.mkdir()
+        result = _run(d)
+        assert result.returncode == 1
+        assert "SKILL.md not found" in result.stderr
+
+    def test_non_directory_target_exits_one(self, tmp_path: Path) -> None:
+        target = tmp_path / "not-a-dir.txt"
+        target.write_text("hello")
+        result = _run(target)
+        assert result.returncode == 1
+        assert "not a directory" in result.stderr
+
+    def test_no_arguments_exits_two(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert "usage:" in result.stderr
+
+    def test_empty_description_exits_one(self, tmp_path: Path) -> None:
+        body = "---\nname: myskill\ndescription: \"\"\n---\n\n# Body\n"
+        d = _write_skill(tmp_path, "myskill", body)
+        result = _run(d)
+        assert result.returncode == 1
+        assert "'description' must be a non-empty string" in result.stderr
+
+    def test_empty_name_exits_one(self, tmp_path: Path) -> None:
+        # An empty-string `name` should fail the non-empty check. The parent
+        # dir is named "skill" so name-mismatch might also fire — we only
+        # assert on the non-empty message.
+        body = '---\nname: ""\ndescription: Valid description.\n---\n\n# Body\n'
+        d = tmp_path / "skill"
+        d.mkdir(exist_ok=True)
+        (d / "SKILL.md").write_text(body, encoding="utf-8")
+        result = _run(d)
+        assert result.returncode == 1
+        assert "'name' must be a non-empty string" in result.stderr

--- a/tests/test_skill_validator.py
+++ b/tests/test_skill_validator.py
@@ -1,8 +1,9 @@
 """Tests for the fallback SKILL.md frontmatter validator.
 
-The canonical CI validator is the upstream ``skills-ref`` package; this
-fallback at ``scripts/validate_skill_frontmatter.py`` exists because
-``skills-ref`` is stricter than our hybrid frontmatter (DEC-004 of
+The upstream reference validator is the ``skills-ref`` package; this
+repository's CI runs the fallback at
+``scripts/validate_skill_frontmatter.py`` because ``skills-ref`` is
+stricter than our hybrid frontmatter (DEC-004 of
 ``plans/super/43-setup-slash-command.md``) and rejects the Claude Code
 extension fields we legitimately ship. These tests guard the fallback's
 core-spec checks: name shape, description length, parent-dir match,


### PR DESCRIPTION
## Summary

Super plan for [#43](https://github.com/wjduenow/clauditor/issues/43) — `clauditor setup` installs a bundled slash-command skill into `.claude/skills/clauditor/`.

**Phase:** `detailing` (awaiting approval before devolve to beads)
**Stories:** 9 implementation + Quality Gate + Patterns & Memory = 11 total
**Decisions:** 17 captured with rationale

## Plan document

See [`plans/super/43-setup-slash-command.md`](../blob/feature/43-setup-slash-command/plans/super/43-setup-slash-command.md) for the full plan.

## Key reshape from the original ticket

The ticket's premise (install a single file at `.claude/commands/clauditor.md`) predates the Claude Code merge of custom commands into skills. The agentskills.io spec and current Claude Code docs both mandate:

- Skills are **directories** with `SKILL.md` as the required entrypoint
- Install target is `.claude/skills/<name>/SKILL.md`, not `.claude/commands/<name>.md`
- Directory name must equal frontmatter `name` field
- Supporting files (e.g. the dogfood eval spec) live under `assets/`

The plan uses a hybrid frontmatter (core agentskills.io fields + Claude Code extensions like `disable-model-invocation: true` and `argument-hint`) for portability + best-in-Claude-Code UX.

## Dogfood-as-shipping-gate (added requirement)

Per the ask to use clauditor to test the bundled skill as part of shipping, DEC-007 defers dogfood (L1 + L3) from CI to a pre-release checklist because the `clauditor_spec` pytest fixture shells out to live `claude -p`. CI stays hermetic: unit tests + wheel-contents test + `skills-ref validate`. Release tagging is gated on two explicit `uv run clauditor validate/grade` runs against the bundled skill.

## Dependency graph

US-001, US-004, and US-009 are independent kickoff stories. US-005 is the integration point that unblocks docs + doctor.

```
US-001 ─► US-002 ─► US-003 ─┐
                             │
              US-007 ◄───────┤
                             │
US-004 ───► US-005 ──► US-006┼► US-010 ─► US-011
                             │
      US-008 ────────────────┤
                             │
      US-009 ────────────────┘
```

## Next steps

- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (creates beads epic + tasks)
- Amend issue #43 body per DEC-017 (US-009)