### PR TITLE
docs: add /clauditor slash-command usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,54 @@ health (absent / installed / stale / wrong-target / unmanaged).
 **Maintainers:** the bundled skill has a pre-release dogfood gate — see
 [`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood).
 
+## Using /clauditor in Claude Code
+
+Once `clauditor setup` has installed the symlink, the bundled skill is
+available as a slash command in any Claude Code session rooted at this
+project. The command is manual-only — Claude won't auto-invoke it,
+because validating a skill has side effects (subprocess runs, sidecar
+writes, potential token spend on L3 grading).
+
+**Invoke with the path to the skill you want to evaluate:**
+
+```text
+/clauditor .claude/commands/my-skill.md
+```
+
+or, for a directory-layout skill:
+
+```text
+/clauditor .claude/skills/my-skill/SKILL.md
+```
+
+Running `/clauditor` without an argument prompts Claude to ask which
+skill to evaluate.
+
+**What Claude does:**
+
+1. Locates the skill's eval spec — a sibling `<skill-name>.eval.json`
+   file, or `<skill-dir>/assets/<skill-name>.eval.json` for directory
+   skills. If neither exists, Claude asks you to author one or stops.
+2. Runs L1 validation first (`clauditor validate`) — free, sub-second,
+   reports failing assertion ids.
+3. If L1 passes, asks before running L3 grading (`clauditor grade`) —
+   costs Sonnet tokens, writes a full `grading.json` sidecar.
+4. Summarizes: which layers ran, pass/fail counts, sidecar paths you
+   can open for details.
+
+**When to use `/clauditor` vs. the CLI directly:**
+
+- Use `/clauditor` when you're in a Claude Code conversation and want
+  conversational context (Claude can explain failures, suggest fixes,
+  iterate on the spec).
+- Use `clauditor validate` / `clauditor grade` directly in CI,
+  Makefiles, or scripted workflows where you want deterministic exit
+  codes and no LLM narration.
+
+The full skill playbook lives at
+[`src/clauditor/skills/clauditor/SKILL.md`](src/clauditor/skills/clauditor/SKILL.md)
+(what Claude reads when the slash command fires).
+
 ## Quick Start
 
 ### 1. Create an eval spec for your skill


### PR DESCRIPTION
## Summary

Add a `## Using /clauditor in Claude Code` section to the root README, between the install section and Quick Start.

Covers:
- Invocation syntax (with and without argument, file-layout and directory-layout skills)
- Step-by-step description of what Claude does when the slash command fires
- When to use the slash command vs. calling the clauditor CLI directly
- Pointer to \`src/clauditor/skills/clauditor/SKILL.md\` as the source-of-truth playbook

## Bead

clauditor-u8k

## Follow-up

A broader README restructure is queued after this (promote How It Works + detailed Quick Start content to \`docs/\`, add a TOC, use \`<details>\` for flag references). This PR is scoped to the user-facing usage content only.

## Test plan

- [ ] README renders correctly on GitHub (headings, code fences, links resolve)
- [ ] No existing content edited — purely additive between lines 110 and 112 of the pre-change README