### PR TITLE
#47: README restructure for navigability (plan)

### DIFF
--- a/.claude/rules/readme-promotion-recipe.md
+++ b/.claude/rules/readme-promotion-recipe.md
@@ -1,0 +1,226 @@
+# Rule: README promotion recipe — nav in root, reference in `docs/`
+
+When the root `README.md` grows past ~300 lines, or its first screen
+(top ~50 lines) no longer shows install + one success example,
+**promote deep-reference sections into `docs/<name>.md` and leave
+anchor-preserving teasers behind**. The root README's job is
+navigation + first-success landing; `docs/` is the full truth.
+Every piece of this recipe — the trigger, the teaser shape, the
+promoted-doc opener, the anchor-preservation via identical H2
+text — is load-bearing, and skipping any one of them breaks either
+readability, discoverability, or bookmarked external references.
+
+## The trigger
+
+Promote when either condition holds:
+
+- **Length**: root README exceeds ~300 lines AND a majority of those
+  lines are deep-reference material (dense JSON examples, full flag
+  tables, schema walkthroughs) rather than tutorial flow.
+- **First-screen miss**: the top ~50 lines do not contain all of:
+  a one-sentence tagline, install command, and one runnable success
+  example. Positioning prose ("why", "philosophy", "alignment with
+  X") pushing install below the fold is the canonical symptom.
+
+Classify every existing H2 into one of four categories:
+
+- **nav** — TOC, install, reference-docs list, license. Keep in root.
+- **tutorial** — Quick Start, "how to use it in Claude Code". Keep
+  in root as a tight version; promote the deep walkthrough.
+- **deep-ref** — CLI flag tables, full eval-spec schema, layer
+  internals, plugin surface. **Promote to `docs/<name>.md`.**
+- **explainer** — positioning, alignment-with-X, history. Collapse
+  to `<details>` in root, or promote if it is large.
+
+## The teaser shape (two variants by traffic)
+
+Every promoted H2 stays in `README.md` with the same heading text
+(so GitHub-generated anchors keep resolving — bookmarked
+`README.md#three-layers-of-validation` must not 404). The body of
+the teaser is either D3 rich or D2 lean based on traffic heuristic.
+
+**Traffic heuristic:**
+
+- **High-traffic (D3 rich)**: users revisit this section to look
+  something up. Examples: CLI reference, eval-spec schema, Quick
+  Start.
+- **Low-traffic (D2 lean)**: users hit it once during onboarding and
+  rarely return. Examples: niche conceptual overviews, plugin
+  surface for an audience that already writes tests.
+
+**D3 rich teaser (~12-15 lines)** — paragraph + code block + key
+topics list + link:
+
+```markdown
+## <Section Title>
+
+<One-paragraph what-it-is and when-you-use-it, ~3-5 lines.>
+
+<Short code block, ~5-8 lines, showing the most common invocation
+or shape.>
+
+**Covered in the full reference:** <topic 1>, <topic 2>, <topic 3>.
+Full reference: [docs/<file>.md](docs/<file>.md).
+```
+
+**D2 lean teaser (~4-6 lines)** — one sentence + small code block
++ link:
+
+```markdown
+## <Section Title>
+
+<One sentence.>
+
+`<5-line code example>`
+
+Full reference: [docs/<file>.md](docs/<file>.md).
+```
+
+## The promoted-doc opener template
+
+Every new file in `docs/` opens with the same four-element shape so
+a cold-entry reader (Google-landed on the deep doc, no README
+context) gets oriented immediately:
+
+```markdown
+# <Title>
+
+<One paragraph explaining the purpose and when you'd read this
+file. 2-4 sentences.>
+
+> Returning from the [root README](../README.md). This doc is the
+> full reference; the README has a summary with code examples.
+
+<body>
+```
+
+The breadcrumb blockquote is load-bearing: it is the only
+orientation a Google-landed reader gets. Without it they have no
+signal that the doc is reference material rather than standalone
+truth.
+
+## Why each piece matters
+
+- **Nav-vs-reference split**: the reader who lands on the README
+  from GitHub discovery wants "what is this / does it work / how do
+  I install it" — not a 150-line schema walkthrough. The reader who
+  needs the schema walkthrough is on a return visit and is happy to
+  click through. The promotion serves both by separating first-look
+  (root) from return-look (docs).
+- **Teaser preserves the anchor**: external bookmarks, old issues,
+  and prior commits link at `README.md#<anchor>`. Deleting the H2
+  breaks every one of those links. The teaser keeps the anchor live,
+  and the `docs/` link ensures the reader still finds the full
+  content.
+- **D3 vs D2 traffic tiering**: every teaser being rich-D3 would
+  reinflate the README (6 promotions × 15 lines = 90 lines of
+  teasers alone). Every teaser being lean-D2 loses the "preview
+  enough to decide whether to click" property for high-traffic
+  sections. Splitting by traffic keeps the budget tight where lean
+  is fine and informative where readers actually need the preview.
+- **Identical H2 text, not a rename**: GitHub derives anchors from
+  H2 text via slugification. `## Three Layers of Validation`
+  produces `#three-layers-of-validation`. Renaming to `## The Three
+  Layers` silently produces a different anchor and breaks every
+  external reference. Keep the text byte-identical.
+- **Promoted-doc breadcrumb**: cold-entry readers outnumber
+  README-path readers for any doc that accumulates inbound SEO. The
+  blockquote is the single line that tells them "this is reference
+  material — there is a summary with code in the README." Without
+  it, the reader has no idea whether the file is the authoritative
+  truth, a fragment of a larger story, or stale.
+- **Length budget as a forcing function**: a target like "≤150
+  lines" (or "≤165 with polish reserve") is not aesthetic — it is
+  the only discipline that keeps future authors from re-bloating
+  the root README one paragraph at a time. When a new feature lands
+  and adds 40 lines of reference material, the budget forces the
+  author to promote it rather than append.
+
+## What NOT to do
+
+- Do NOT rename the promoted H2 when writing the teaser. The
+  anchor-preservation invariant depends on byte-identical heading
+  text.
+- Do NOT promote a section by deleting it outright and adding a
+  one-line `See [docs/X.md]` link with no H2. That breaks every
+  bookmarked `#<anchor>` reference.
+- Do NOT omit the breadcrumb blockquote from the promoted doc "to
+  save a line." A Google-landed reader with no context is the
+  primary audience for a deep-ref file.
+- Do NOT mix D3 and D2 within a single teaser by "hedging". Pick
+  one shape per section based on the traffic heuristic; a
+  half-rich/half-lean teaser is worse than either.
+- Do NOT skip the length budget check during a restructure. If the
+  diff lands at >165 lines, trim D3 teasers to D2 or collapse
+  additional sections into `<details>` before merging.
+
+## Canonical implementation
+
+Epic #47 (`plans/super/47-readme-restructure.md`) — the restructure
+that took the root README from 770 lines to ~165 and codified this
+recipe. Concrete anchors:
+
+- **Trigger**: the plan's Section inventory table (lines 89-107)
+  showed three sections (Three Layers 274 lines, Eval Spec Format
+  152 lines, CLI Reference 56 lines) totalling 482 of 770 lines
+  (~63%) as deep-ref. First-screen install was at line 48.
+- **Teaser shape (D3 rich)**: `README.md`'s `## Quick Start`, `##
+  CLI Reference`, and `## Eval Spec Format` sections. Each is a
+  paragraph + short code block + "Covered in the full reference"
+  list + `docs/<file>.md` link.
+- **Teaser shape (D2 lean)**: `README.md`'s `## Three Layers of
+  Validation`, `## Pytest Integration`, and `## Using /clauditor in
+  Claude Code` sections. Each is one sentence + small code block +
+  `docs/<file>.md` link.
+- **Promoted-doc opener**: every new file under `docs/` (seven of
+  them: `cli-reference.md`, `eval-spec-reference.md`, `layers.md`,
+  `pytest-plugin.md`, `quick-start.md`, `skill-usage.md`, plus the
+  merged content in `architecture.md`) opens with the four-element
+  shape. `docs/pytest-plugin.md` lines 1-6 are the minimal example;
+  `docs/quick-start.md` lines 1-6 are the mid-length example.
+- **Anchor preservation**: every old README H2 text from the
+  promoted list (`## Quick Start`, `## Three Layers of Validation`,
+  `## CLI Reference`, `## Pytest Integration`, `## Eval Spec
+  Format`, `## Using /clauditor in Claude Code`) is preserved
+  byte-identical in the teaser. GitHub slug-derived anchors
+  (`#quick-start`, `#three-layers-of-validation`, etc.) keep
+  resolving.
+
+Plan decisions codifying the recipe: DEC-002 (expanded scope from
+the 6-item ticket to cover four deep-ref promotions), DEC-007
+(first-screen layout), DEC-008 (anchor preservation via teaser),
+DEC-009 (promoted-doc opener template), DEC-010 (mixed D3/D2 teaser
+strategy), DEC-011 (~155-line budget).
+
+## When this rule applies
+
+Any future README restructure or new top-level doc set: a project's
+README grows past 300 lines, or inbound SEO starts landing readers
+on `docs/*.md` files without context, or a new feature adds >40
+lines of reference material and the author must decide whether to
+append or promote. Apply the full recipe — trigger classification +
+teaser shape + opener template + anchor preservation — not just one
+piece.
+
+The rule also applies to derivative docs sets a future feature may
+introduce (e.g. a `docs/adr/` decision-record directory, a
+`docs/recipes/` how-to set). The opener template + breadcrumb
+invariant generalize; the teaser shape applies when each sub-doc has
+a matching summary in the parent index page.
+
+## When this rule does NOT apply
+
+- Single-file projects with no `docs/` directory, where the README
+  is the only doc and readers have no alternative landing page.
+  Length-trim in place instead.
+- Rule-protected docs (e.g. `docs/stream-json-schema.md`, which is
+  anchored by `.claude/rules/stream-json-schema.md`). Those have
+  their own update contract that takes precedence over this
+  restructure recipe.
+- Internal-only debug notes, session logs, or ephemeral planning
+  documents that no external reader will ever land on. The
+  breadcrumb + teaser machinery is for published reference content,
+  not for scratch files.
+- Cases where the "deep-ref" content is genuinely small (<20 lines)
+  and a full promotion would produce more ceremony than value.
+  Collapse to `<details>` in root instead.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License](https://img.shields.io/github/license/wjduenow/clauditor)](https://github.com/wjduenow/clauditor/blob/dev/LICENSE)
 [![codecov](https://codecov.io/gh/wjduenow/clauditor/branch/dev/graph/badge.svg)](https://codecov.io/gh/wjduenow/clauditor)
 
-Auditor for Claude Code skills and slash commands. Catches when your skill produces the wrong shape, not just the wrong answer — layered evaluation from free deterministic assertions through LLM-graded quality rubrics.
+Auditor for AgentSkills.io skills and Claude Integrations. Catches when your skill produces the wrong shape, not just the wrong answer — layered evaluation from free deterministic assertions through LLM-graded quality rubrics.
 
 <details>
 <summary>Contents</summary>

--- a/README.md
+++ b/README.md
@@ -10,760 +10,155 @@
 [![License](https://img.shields.io/github/license/wjduenow/clauditor)](https://github.com/wjduenow/clauditor/blob/dev/LICENSE)
 [![codecov](https://codecov.io/gh/wjduenow/clauditor/branch/dev/graph/badge.svg)](https://codecov.io/gh/wjduenow/clauditor)
 
-Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation — deterministic assertions, LLM-graded extraction, and quality regression testing. Catches when your skill produces the wrong shape, not just the wrong answer.
+Auditor for Claude Code skills and slash commands. Catches when your skill produces the wrong shape, not just the wrong answer — layered evaluation from free deterministic assertions through LLM-graded quality rubrics.
 
-When you build a skill — like a slash command that finds restaurants or generates reports — you need to know it keeps working correctly after every change. clauditor answers three questions at different cost/confidence levels:
+<details>
+<summary>Contents</summary>
 
-**"Does it have the right shape?"** (Layer 1 — free, instant)
-Did the output include URLs? At least 5 results? The word "Venues"? No error messages? These are deterministic checks that run in milliseconds with no API costs. Good for CI on every commit.
+[Install](#install) · [Why clauditor?](#why-clauditor) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Reference docs](#reference-docs)
 
-**"Did it extract the right fields?"** (Layer 2 — pennies, ~1 second)
-Uses a cheap, fast model (Haiku) to read the output and check: does each venue have a name, address, and phone number? Are there at least 3 entries in each section? Catches structural problems that string matching can't.
-
-**"Is the answer actually good?"** (Layer 3 — dollars, release-gating)
-Uses a stronger model (Sonnet) to grade output against a rubric you write: "Are venues within the specified distance? Are events on the right date?" Also does A/B testing (is the skill better than raw Claude?), variance measurement (does it give consistent results across runs?), and trigger precision testing (does the right query activate the right skill?).
-
-You ship AI features faster because you catch regressions automatically instead of manually spot-checking output. Layer 1 runs in CI on every push for free. Layer 3 runs before releases to catch quality problems that would otherwise reach users. The layered approach means you're not burning API dollars on every commit — just on the checks that need intelligence.
-
-## Alignment with agentskills.io
-
-clauditor implements (and in places extends) the skill evaluation workflow described at [agentskills.io/skill-creation/evaluating-skills](https://agentskills.io/skill-creation/evaluating-skills). If you're coming from that spec, this table maps the concepts to clauditor terminology:
-
-| agentskills.io concept | clauditor |
-|---|---|
-| Test case (prompt + expected + files) | `.eval.json` with `test_args`, `input_files`, `sections`, `fields`, `grading_criteria` |
-| Deterministic assertions | **Layer 1** — `assertions.py`, `FORMAT_REGISTRY` (20 canonical types), strict/extract invariants |
-| LLM-judged structural checks | **Layer 2** — `grader.py`, tiered schema extraction with per-tier field requirements |
-| Rubric quality grading | **Layer 3** — `quality_grader.py`, per-criterion scoring + variance measurement |
-| With-skill vs without-skill baseline | `compare_ab()` Python API (`clauditor.comparator`) |
-| Regression diff between runs | `clauditor compare <before> <after>` |
-| Timing + token capture | `SkillResult.input_tokens/output_tokens/duration_seconds`, persisted to `history.jsonl` and `.clauditor/iteration-N/<skill>/grading.json` under nested bucket keys (`skill`, `grader`, `quality`, `triggers`, `total`) |
-| Longitudinal history | `.clauditor/history.jsonl` + `clauditor trend --metric <dotted.path>` with ASCII sparklines |
-| Per-iteration workspace | `.clauditor/iteration-N/<skill>/` with `grading.json`, `timing.json`, and `run-*/output.{txt,jsonl}` captures |
-
-**Beyond the spec**, clauditor adds: trigger precision testing (`triggers.py`), a strict/extract `FORMAT_REGISTRY` invariant for canonical types, tiered section extraction (top-3 restaurants require more fields than the next 7), a reusable pytest plugin, an `AssertionResult.kind` enum for programmatic filtering, `input_files` staging into per-run CWDs, a blind A/B judge with position-swap debiasing (`clauditor compare --blind`), automated with/without baseline pair runs (`clauditor.comparator.compare_ab`), always-pass assertion auditing, execution-transcript capture for root-cause analysis, and an LLM-driven skill improvement proposer (`clauditor suggest`).
-
-**Deliberately out of scope**: human-in-the-loop feedback capture (`feedback.json`). clauditor is pure automation — it surfaces regressions and proposes edits, but the final skill-improvement loop is author-driven.
+</details>
 
 ## Install
 
 ```bash
-pip install clauditor
-
-# With LLM grading support (Layers 2 & 3):
-pip install clauditor[grader]
+pip install clauditor           # CLI only (Layer 1)
+pip install clauditor[grader]   # + LLM grading (Layers 2 & 3)
 ```
 
-Or install from source:
+Source install: `git clone https://github.com/wjduenow/clauditor.git && cd clauditor && uv sync --dev`.
+
+## Why clauditor?
+
+- **Does your skill hit the expected output shape?** L1 assertions — free, instant, CI-friendly.
+- **Does it pull the right fields?** L2 schema extraction — pennies, Haiku-graded.
+- **Is it actually useful?** L3 LLM-graded rubric — dollars, release-gating.
+
+## One-minute example
 
 ```bash
-git clone https://github.com/wjduenow/clauditor.git
-cd clauditor
-uv sync --dev
+clauditor init .claude/commands/my-skill.md       # generate starter eval spec
+clauditor validate .claude/commands/my-skill.md   # → "my-skill: 4 assertions, 4 passed, 0 failed"
 ```
+
+Swap `validate` for `grade` once you've added `grading_criteria` to the spec.
 
 ## Installing the /clauditor slash command
 
-clauditor ships a bundled Claude Code skill that exposes its
-capture/validate/grade workflow as a `/clauditor` slash command. After
-installing the CLI (pip/uv), run one command from your project root:
+From your project root, `uv run clauditor setup` creates a symlink at `.claude/skills/clauditor` pointing at the bundled Claude Code skill; `pip install --upgrade clauditor` then picks up skill updates automatically. Restart Claude Code once if `.claude/skills/` did not exist before.
 
-```bash
-uv run clauditor setup
-```
+<details>
+<summary>Flags and details</summary>
 
-Expected output:
+- `--unlink` — remove the `/clauditor` symlink. Refuses symlinks not pointing at the installed clauditor package, so it won't touch user-authored skills.
+- `--force` — overwrite an existing file or symlink at `.claude/skills/clauditor`.
+- `--project-dir PATH` — override project-root detection (default walks up for `.git/` or `.claude/`).
 
-```
-Installed /clauditor: <project root>/.claude/skills/clauditor -> <site-packages path>/clauditor/skills/clauditor
-```
+Edits under `.claude/skills/clauditor/` are [hot-reloaded](https://code.claude.com/docs/en/skills#live-change-detection) by Claude Code. `uv run clauditor doctor` reports the symlink's health (absent / installed / stale / wrong-target / unmanaged).
 
-`setup` creates a single symlink at `.claude/skills/clauditor` pointing
-at the bundled skill directory inside the installed clauditor package,
-so `pip install --upgrade clauditor` picks up skill updates automatically
-without re-running `setup`.
-
-**Flags:**
-
-- `--unlink` — remove the `/clauditor` symlink. Refuses to delete regular
-  files or symlinks that don't point at the installed clauditor package,
-  so it won't touch user-authored skills.
-- `--force` — overwrite an existing file or symlink at
-  `.claude/skills/clauditor`. Without `--force`, `setup` refuses to
-  clobber any pre-existing entry. Use `--force` only when you know the
-  entry is ours.
-- `--project-dir PATH` — override project-root detection. By default,
-  `setup` walks up from the current directory looking for a `.git/` or
-  `.claude/` marker; pass `--project-dir` to target a different root.
-
-**Restart note:** if `.claude/skills/` did not exist before
-`clauditor setup` ran, restart Claude Code once so it picks up the new
-directory. Subsequent edits under `.claude/skills/clauditor/` are
-hot-reloaded — see the Claude Code
-[live change detection](https://code.claude.com/docs/en/skills#live-change-detection)
-reference.
-
-**Diagnostic:** `uv run clauditor doctor` reports the skill symlink's
-health (absent / installed / stale / wrong-target / unmanaged).
-
-**Maintainers:** the bundled skill has a pre-release dogfood gate — see
-[`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood).
+</details>
 
 ## Using /clauditor in Claude Code
 
-Once `clauditor setup` has installed the symlink, the bundled skill is
-available as a slash command in any Claude Code session rooted at this
-project. The command is manual-only — Claude won't auto-invoke it,
-because validating a skill has side effects (subprocess runs, sidecar
-writes, potential token spend on L3 grading).
-
-**Invoke with the path to the skill you want to evaluate:**
+Invoke the slash command with a skill path — Claude locates the eval spec, runs L1, and asks before spending tokens on L3:
 
 ```text
 /clauditor .claude/commands/my-skill.md
 ```
 
-or, for a directory-layout skill:
-
-```text
-/clauditor .claude/skills/my-skill/SKILL.md
-```
-
-Running `/clauditor` without an argument prompts Claude to ask which
-skill to evaluate.
-
-**What Claude does:**
-
-1. Locates the skill's eval spec — a sibling `<skill-name>.eval.json`
-   file, or `<skill-dir>/assets/<skill-name>.eval.json` for directory
-   skills. If neither exists, Claude asks you to author one or stops.
-2. Runs L1 validation first (`clauditor validate`) — free, sub-second,
-   reports failing assertion ids.
-3. If L1 passes, asks before running L3 grading (`clauditor grade`) —
-   costs Sonnet tokens, writes a full `grading.json` sidecar.
-4. Summarizes: which layers ran, pass/fail counts, sidecar paths you
-   can open for details.
-
-**When to use `/clauditor` vs. the CLI directly:**
-
-- Use `/clauditor` when you're in a Claude Code conversation and want
-  conversational context (Claude can explain failures, suggest fixes,
-  iterate on the spec).
-- Use `clauditor validate` / `clauditor grade` directly in CI,
-  Makefiles, or scripted workflows where you want deterministic exit
-  codes and no LLM narration.
-
-The full skill playbook lives at
-[`src/clauditor/skills/clauditor/SKILL.md`](src/clauditor/skills/clauditor/SKILL.md)
-(what Claude reads when the slash command fires).
+Full reference: [docs/skill-usage.md](docs/skill-usage.md).
 
 ## Quick Start
 
-### 1. Create an eval spec for your skill
+A new skill goes from "untested" to "covered" in three steps: `clauditor init` generates an eval spec, `clauditor validate` tightens L1 assertions against a real capture, then the same spec wires into pytest for regression coverage.
 
 ```bash
 clauditor init .claude/commands/my-skill.md
-```
-
-This creates `my-skill.eval.json` alongside your skill file:
-
-```json
-{
-  "skill_name": "my-skill",
-  "test_args": "\"San Jose, CA\" --depth quick",
-  "assertions": [
-    {"type": "contains", "value": "Results"},
-    {"type": "has_entries", "value": "3"},
-    {"type": "has_urls", "value": "3"},
-    {"type": "min_length", "value": "500"}
-  ],
-  "sections": [
-    {
-      "name": "Results",
-      "min_entries": 3,
-      "fields": [
-        {"name": "name", "required": true},
-        {"name": "address", "required": true}
-      ]
-    }
-  ]
-}
-```
-
-### 2. Validate against captured output
-
-```bash
-# Run skill and validate in one step:
 clauditor validate .claude/commands/my-skill.md
-
-# Or validate against pre-captured output:
-clauditor validate .claude/commands/my-skill.md --output captured.txt
-
-# JSON output for CI:
-clauditor validate .claude/commands/my-skill.md --json
+clauditor validate .claude/commands/my-skill.md --json  # CI mode
 ```
 
-### 3. Use in pytest
-
-```python
-def test_my_skill(clauditor_runner, clauditor_asserter):
-    result = clauditor_runner.run("my-skill", '"San Jose, CA" --depth quick')
-    asserter = clauditor_asserter(result)
-    asserter.assert_contains("Results")
-    asserter.assert_has_entries(minimum=3)
-    asserter.assert_has_urls(minimum=3)
-
-def test_with_eval_spec(clauditor_spec):
-    spec = clauditor_spec(".claude/commands/my-skill.md")
-    results = spec.evaluate()
-    assert results.passed, results.summary()
-```
-
-## How It Works
-
-```mermaid
-flowchart LR
-    A["clauditor grade\nskill.md"] --> B["Run skill\n(claude -p)"]
-    B --> C["Skill output"]
-    C --> D["L1 Assertions\n(free)"]
-    C --> E["L2 Extraction\n(Haiku)"]
-    C --> F["L3 Quality\n(Sonnet)"]
-    D --> G["Persist + Report"]
-    E --> G
-    F --> G
-
-    style D fill:#c8e6c9
-    style E fill:#fff9c4
-    style F fill:#ffccbc
-```
-
-The skill output flows through three independent evaluation layers, each with different cost/fidelity tradeoffs. Results are persisted to `.clauditor/iteration-N/<skill>/` and appended to `history.jsonl` for trend tracking. See [docs/architecture.md](docs/architecture.md) for the full flow.
+**Covered in the full reference:** authoring `.eval.json`, captured-output mode (`--output captured.txt`), pytest fixtures (`clauditor_runner`, `clauditor_asserter`, `clauditor_spec`). Full reference: [docs/quick-start.md](docs/quick-start.md).
 
 ## Three Layers of Validation
 
-```mermaid
-flowchart TD
-    SPEC["eval.json"] --> L1_IN["assertions[]"]
-    SPEC --> L2_IN["sections[].tiers[].fields[]"]
-    SPEC --> L3_IN["grading_criteria[]"]
-
-    L1_IN --> L1["Layer 1\nString matching\nNo API calls"]
-    L2_IN --> L2["Layer 2\nSchema extraction\nHaiku"]
-    L3_IN --> L3["Layer 3\nRubric grading\nSonnet"]
-
-    L1 --> R1["assertions.json"]
-    L2 --> R2["extraction.json"]
-    L3 --> R3["grading.json"]
-
-    style L1 fill:#c8e6c9
-    style L2 fill:#fff9c4
-    style L3 fill:#ffccbc
-```
-
-### Layer 1: Deterministic Assertions (free, instant)
-
-No API calls. Regex, string matching, and counting.
-
-```python
-from clauditor import SkillAsserter
-
-asserter = SkillAsserter(result)
-asserter.assert_contains("Venues")           # substring check
-asserter.assert_not_contains("Error")        # absence check
-asserter.assert_matches(r"\*\*\d+\.")        # regex
-asserter.assert_has_entries(minimum=5)        # numbered entries
-asserter.assert_has_urls(minimum=3)           # URL count
-asserter.assert_min_length(500)              # output length
-```
-
-Or define in `eval.json`:
+L1 catches shape regressions for free, L2 uses Haiku to validate structured fields, L3 uses Sonnet to grade against a rubric — all three drive off the same eval spec:
 
 ```json
-{
-  "assertions": [
-    {"type": "contains", "value": "Venues"},
-    {"type": "regex", "value": "\\*\\*\\d+\\."},
-    {"type": "has_urls", "value": "3"},
-    {"type": "not_contains", "value": "Error"}
-  ]
-}
+{"assertions": [...], "sections": [...], "grading_criteria": [...]}
 ```
 
-### Layer 2: LLM Schema Extraction (cheap, ~1 sec)
-
-Uses Haiku to extract structured fields, then validates against your schema. Requires `pip install clauditor[grader]`.
-
-```python
-import asyncio
-from clauditor.grader import extract_and_grade
-from clauditor.schemas import EvalSpec
-
-spec = EvalSpec.from_file("my-skill.eval.json")
-results = asyncio.run(extract_and_grade(output_text, spec))
-assert results.passed, results.summary()
-```
-
-The eval spec defines what fields each section should have:
-
-```json
-{
-  "sections": [
-    {
-      "name": "Venues",
-      "min_entries": 3,
-      "fields": [
-        {"name": "name", "required": true},
-        {"name": "address", "required": true},
-        {"name": "hours", "required": true},
-        {"name": "website", "required": true},
-        {"name": "phone", "required": false}
-      ]
-    }
-  ]
-}
-```
-
-#### Field validation (`format`)
-
-Each field can declare a `format` that validates the extracted value. The `format` key accepts **either** a registered format name **or** an inline regex — clauditor looks up the string in `FORMAT_REGISTRY` first and falls back to compiling it as a regex if there's no match.
-
-Decision tree:
-
-- Is there a registered name in `FORMAT_REGISTRY` that fits? Use it (e.g. `"format": "phone_us"`).
-- Need something custom? Put a regex string directly in `format` (e.g. `"format": "^[a-z0-9-]+$"`).
-- Lookup is **registry-first, regex-fallback**. Invalid regexes raise `ValueError` at spec construction time, so typos fail fast.
-
-```json
-{"name": "phone", "format": "phone_us"}
-```
-
-```json
-{"name": "slug", "format": "^[a-z0-9-]+$"}
-```
-
-See [`FORMAT_REGISTRY` in `src/clauditor/formats.py`](src/clauditor/formats.py) for the full list of registered names (common entries: `phone_us`, `phone_intl`, `email`, `url`, `domain`, `date_iso`, `zip_us`, `uuid`).
-
-### Layer 3: Quality Grading (expensive, release-only)
-
-Uses Sonnet to grade skill output against a rubric you define. Requires `ANTHROPIC_API_KEY` and `pip install clauditor[grader]`.
-
-#### Quality Grading
-
-Define rubric criteria in your eval spec:
-
-```json
-{
-  "grading_criteria": [
-    "Are all venues within the specified distance?",
-    "Are events actually happening on the target date?",
-    "Do cost tiers match the budget filter?"
-  ],
-  "grade_thresholds": {
-    "min_pass_rate": 0.7,
-    "min_mean_score": 0.5
-  }
-}
-```
-
-`grade_thresholds` controls when grading passes overall. `min_pass_rate` (default 0.7) is the fraction of criteria that must pass. `min_mean_score` (default 0.5) is the minimum average score across all criteria. Both must be met. This differs from `variance.min_stability`, which measures consistency across multiple runs rather than quality of a single run.
-
-```bash
-clauditor grade .claude/commands/my-skill.md
-clauditor grade .claude/commands/my-skill.md --json
-clauditor grade .claude/commands/my-skill.md --dry-run      # Print prompt, no API call
-clauditor grade .claude/commands/my-skill.md --iteration 5  # Write to iteration-5/ explicitly
-clauditor grade .claude/commands/my-skill.md --iteration 5 --force  # Overwrite existing iteration-5/
-clauditor grade .claude/commands/my-skill.md --diff         # Compare against prior iteration
-```
-
-Every `grade` run is persisted to `.clauditor/iteration-N/<skill>/` automatically. By default the iteration number auto-increments to the next free slot. Pass `--iteration N` to target a specific slot; if `iteration-N/` already exists the command errors unless you also pass `--force` to overwrite.
-
-Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--diff` to compare against a prior iteration (flags regressions where a criterion's score drops by more than 0.1).
-
-#### Iteration workspace layout
-
-`.clauditor/` is anchored at the repository root (the nearest ancestor of your CWD containing `.git/` or `.claude/`), so `grade` from any subdirectory writes to the same place. Each run produces:
-
-```
-.clauditor/
-  iteration-1/
-    my-skill/
-      grading.json        # full GradingReport
-      timing.json         # skill name, iteration, n_runs, token + duration metrics
-      run-0/
-        output.txt        # rendered text blocks
-        output.jsonl      # raw stream-json events
-  iteration-2/
-    my-skill/
-      grading.json
-      timing.json
-      run-0/
-        output.txt
-        output.jsonl
-      run-1/              # additional runs appear under --variance N
-        output.txt
-        output.jsonl
-  history.jsonl
-```
-
-#### Regression Comparison
-
-Diffs two grade reports, printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression. `compare` accepts three input forms:
-
-```bash
-# 1. Numeric iteration refs (preferred — pairs with auto-incremented iterations)
-clauditor compare --skill my-skill --from 1 --to 2
-
-# 2. Iteration directory paths
-clauditor compare .clauditor/iteration-1/my-skill .clauditor/iteration-2/my-skill
-
-# 3. Saved grade-report files
-clauditor compare before.grade.json after.grade.json
-
-# Or re-grade two raw captures against a spec:
-clauditor compare before.txt after.txt --spec <skill.md>
-```
-
-For a true baseline A/B run (skill vs raw Claude against the same rubric), use the Python API `clauditor.comparator.compare_ab()` directly — the `grade --compare` CLI flag was removed in favor of the file-diff workflow above.
-
-##### Blind A/B comparison (`--blind`)
-
-Rubric-based grading can miss holistic regressions where two outputs pass every criterion but one visibly feels worse. For that, pass `--blind` to have a Sonnet judge compare the two outputs side-by-side without knowing which version is which:
-
-```bash
-clauditor compare before.txt after.txt --spec <skill.md> --blind
-```
-
-The judge runs twice with the A/B positions swapped so position bias shows up as disagreement. Output includes a preference (`BEFORE` / `AFTER` / `TIE`), confidence, per-output holistic score, whether the two runs agreed on the winner, and the judge's reasoning. Currently only the file-pair form is supported (iteration refs like `--from/--to` are rejected); `--blind` requires `--spec` with `eval_spec.user_prompt` set (the natural-language query the judge will see) and uses `grading_criteria` from the spec as an optional rubric hint to the judge.
-
-#### Variance Measurement
-
-Runs the skill N times and measures output stability across runs:
-
-```bash
-clauditor grade .claude/commands/my-skill.md --variance 5
-```
-
-Configure thresholds in the eval spec:
-
-```json
-{
-  "variance": {
-    "n_runs": 5,
-    "min_stability": 0.8
-  }
-}
-```
-
-Reports `score_mean`, `score_stddev`, `pass_rate_mean`, and `stability` (fraction of runs where all criteria passed). Fails if stability drops below `min_stability`.
-
-#### Trigger Precision Testing
-
-Tests whether an LLM correctly identifies which user queries should invoke your skill:
-
-```bash
-clauditor triggers .claude/commands/my-skill.md
-clauditor triggers .claude/commands/my-skill.md --json
-```
-
-Define test queries in the eval spec:
-
-```json
-{
-  "trigger_tests": {
-    "should_trigger": [
-      "Find kid activities in Cupertino",
-      "What are some things to do with kids near me?"
-    ],
-    "should_not_trigger": [
-      "What's the weather today?",
-      "Help me write a Python script"
-    ]
-  }
-}
-```
-
-Reports accuracy, precision, and recall. Passes only when every classification is correct.
-
-#### Python API
-
-```python
-import asyncio
-from clauditor.quality_grader import grade_quality, measure_variance
-from clauditor.comparator import compare_ab
-from clauditor.triggers import test_triggers
-from clauditor.spec import SkillSpec
-
-spec = SkillSpec.from_file(".claude/commands/my-skill.md")
-
-# Quality grading
-report = asyncio.run(grade_quality(output, spec.eval_spec))
-print(f"{report.pass_rate:.0%} passed, mean score {report.mean_score:.2f}")
-
-# A/B comparison
-ab = asyncio.run(compare_ab(spec))
-print(f"Regressions: {len(ab.regressions)}")
-
-# Variance
-var = asyncio.run(measure_variance(spec, n_runs=3))
-print(f"Stability: {var.stability:.0%}")
-
-# Trigger precision
-triggers = asyncio.run(test_triggers(spec.eval_spec))
-print(f"Accuracy: {triggers.accuracy:.0%}, Precision: {triggers.precision:.0%}")
-```
+Full reference: [docs/layers.md](docs/layers.md).
 
 ## CLI Reference
 
+Stable exit-code contract (0 = pass, 1 = skill failed, 2 = input error, 3 = Anthropic error). `grade` auto-increments iteration slots under `.clauditor/iteration-N/<skill>/` and appends metrics to `history.jsonl`.
+
 ```bash
-clauditor init <skill.md>              # Generate starter eval.json
-clauditor validate <skill.md>          # Run Layer 1 assertions
-clauditor validate <skill.md> --json   # JSON output for CI
-clauditor run <skill-name> --args "…"  # Run skill, print output
-clauditor extract <skill.md>           # Layer 2 schema extraction
-clauditor extract <skill.md> --dry-run # Print extraction prompt only
-clauditor grade <skill.md>                             # Layer 3 quality grading (auto-increments iteration)
-clauditor grade <skill.md> --variance 3                # Variance measurement
-clauditor grade <skill.md> --only-criterion clarity    # Run a subset (repeatable, substring match)
-clauditor grade <skill.md> --iteration 5               # Write to .clauditor/iteration-5/<skill>/
-clauditor grade <skill.md> --iteration 5 --force       # Overwrite an existing iteration-5/
-clauditor grade <skill.md> --diff                      # Compare against prior iteration
-clauditor compare --skill <skill> --from 1 --to 2      # Diff two iterations by number
-clauditor compare .clauditor/iteration-1/<skill> .clauditor/iteration-2/<skill>  # Diff by directory
-clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
-clauditor trend <skill> --metric total.total     # Tab-separated history + ASCII sparkline
-clauditor trend <skill> --list-metrics           # List available metric paths
-clauditor trend <skill> --metric grader.input_tokens --command extract  # Filter by subcommand
-clauditor triggers <skill.md>          # Trigger precision testing
-clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/
-clauditor suggest <skill.md>           # Propose SKILL.md edits from prior failing iterations
-clauditor doctor                       # Report environment diagnostics
+clauditor init <skill.md>             # Generate starter eval.json
+clauditor validate <skill.md>         # Layer 1 assertions
+clauditor grade <skill.md>            # Layer 3 quality grading
+clauditor compare --skill <s> --from 1 --to 2  # Diff iterations
+clauditor trend <skill> --metric total.total   # History + sparkline
 ```
 
-### Persistent metric history
-
-Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Each record carries a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`.
-
-```json
-{
-  "schema_version": 1,
-  "command": "grade",
-  "ts": "2026-04-13T15:00:00+00:00",
-  "skill": "find-restaurants",
-  "iteration": 4,
-  "workspace_path": ".clauditor/iteration-4/find-restaurants",
-  "pass_rate": 0.83,
-  "mean_score": 0.75,
-  "metrics": {
-    "skill":   {"input_tokens": 1200, "output_tokens": 800},
-    "quality": {"input_tokens": 900,  "output_tokens": 350},
-    "total":   {"input_tokens": 2100, "output_tokens": 1150, "total": 3250},
-    "duration_seconds": 12.3
-  }
-}
-```
-
-Token buckets: `skill` (subprocess), `grader` (Layer 2 extract), `quality` (Layer 3 rubric), `triggers` (trigger precision). Buckets are **absent** when the command doesn't invoke them — e.g. `extract` records have `skill` + `grader`, `validate` records have `skill` only. `total` aggregates across all present buckets.
-
-Use `clauditor trend <skill> --metric <dotted.path>` to view a series. Paths walk the nested `metrics` dict (`total.total`, `grader.input_tokens`, `skill.output_tokens`, `duration_seconds`) with `pass_rate` and `mean_score` as top-level shortcuts. `--command {grade,extract,validate,all}` filters by subcommand (default `grade`). `--list-metrics` prints every resolvable metric path for the skill.
-
-Runs with `--only-criterion` skip the history append to keep longitudinal data comparable.
-
-## Exit Codes
-
-clauditor uses structured exit codes so scripts and CI pipelines can distinguish "the tool itself failed" from "the tool ran fine but the skill under test failed its gate."
-
-| Code | Meaning                                                                                                                                              |
-| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0`  | Success. The command completed and, where applicable, the skill passed its gate (all assertions satisfied, all criteria above threshold, no regression detected, no trigger miss). |
-| `1`  | Signal failed. The tool ran fine, but the skill did not meet its bar: an L1 assertion failed, an L3 criterion scored below threshold, `clauditor compare` detected a regression relative to baseline, or a trigger classification was wrong. The on-disk artifacts are complete and valid; the skill needs fixing, not the tool. |
-| `2`  | Input error. A user-supplied argument was missing, malformed, or incompatible with another flag (e.g. `--iteration` without an integer value, a skill `.md` file that does not exist, an eval spec that fails schema validation). The command exited before doing work; re-run with corrected arguments. |
-| `3`  | Anthropic API error. `clauditor suggest` only. The Anthropic SDK returned a non-retriable failure (auth, malformed request, exhausted retries). No sidecar is written; re-run once the upstream issue is resolved. |
-
-Commands that only invoke the Anthropic API transiently (`extract`, `grade`, `triggers`) funnel API failures through the same retry policy as `suggest` but surface them as exit 1 with an `ERROR:` line on stderr rather than a distinct code.
+**Covered in the full reference:** every subcommand flag (`--variance`, `--iteration`, `--diff`, `--blind`, …), exit codes, `history.jsonl` shape, `clauditor trend` metric paths. Full reference: [docs/cli-reference.md](docs/cli-reference.md).
 
 ## Pytest Integration
 
-clauditor registers as a pytest plugin automatically. Available fixtures:
-
-- `clauditor_runner` — pre-configured `SkillRunner`
-- `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`
-- `clauditor_spec` — factory for loading `SkillSpec` from skill files
-- `clauditor_grader` — factory for Layer 3 quality grading
-- `clauditor_triggers` — factory for trigger precision testing
-- `clauditor_capture` — factory returning a `Path` to `tests/eval/captured/<skill>.txt` for captured-output tests
-
-Options:
-
-```bash
-pytest --clauditor-project-dir /path/to/project
-pytest --clauditor-timeout 300
-pytest --clauditor-claude-bin /usr/local/bin/claude
-pytest --clauditor-grade              # Enable Layer 3 tests (costs money)
-pytest --clauditor-model claude-sonnet-4-6  # Override grading model
+```python
+def test_my_skill(clauditor_runner, clauditor_asserter):
+    result = clauditor_runner.run("my-skill", '"San Jose, CA"')
+    clauditor_asserter(result).assert_contains("Results")
 ```
+
+Full reference: [docs/pytest-plugin.md](docs/pytest-plugin.md).
 
 ## Eval Spec Format
 
-Place `<skill-name>.eval.json` alongside your `.claude/commands/<skill-name>.md`:
-
-```
-.claude/commands/
-├── find-kid-activities.md
-├── find-kid-activities.eval.json    ← clauditor auto-discovers this
-├── find-restaurants.md
-└── find-restaurants.eval.json
-```
-
-**File-based output:** Many skills save results to files instead of printing to stdout. Use `output_file` for skills that write to one known path (e.g., `research/results.md`). Use `output_files` with glob patterns for skills that produce multiple files (e.g., `["research/*.md"]`). If both are set, `output_file` takes precedence. When set, clauditor reads the file(s) after running the skill instead of capturing stdout.
-
-### Input files
-
-Some skills need sample inputs — a CSV to clean, a log file to summarize, a PDF to extract. Declare them with `input_files` and clauditor will stage them into each variance run's working directory before invoking the skill:
-
-```json
-{
-  "skill_name": "csv-cleaner",
-  "test_args": "--strict",
-  "input_files": ["fixtures/sales.csv"]
-}
-```
-
-At grade time, `fixtures/sales.csv` is copied (via `shutil.copy2`) into `.clauditor/iteration-N/csv-cleaner/run-K/inputs/sales.csv` for each of the `variance.n_runs` runs, and the skill's subprocess is launched with that `inputs/` directory as its CWD. So `/csv-cleaner --strict` sees `sales.csv` as a plain basename in its own current directory — no path wrangling required. Each `run-K` gets its own fresh copy, so a skill that mutates its input in one run does not affect the next.
-
-Rules enforced at spec-load time (`EvalSpec.from_file`):
-
-- **Paths are relative to the eval spec's parent directory**, not the repo root. An `input_files` entry of `fixtures/sales.csv` next to `my-skill.eval.json` resolves to `<spec-dir>/fixtures/sales.csv`. This intentionally differs from `output_files`, which globs relative to the skill's working directory.
-- **Absolute paths are rejected.** Use a relative path under the spec directory.
-- **Source containment is enforced.** The resolved path (including symlink targets) must live under the spec's parent directory. Escapes via `..` or symlinks pointing outside the spec tree raise `ValueError`.
-- **Missing files fail loudly.** Paths are resolved with `Path.resolve(strict=True)` — a typo fails at load, not at grade time.
-- **Destinations are flattened to basenames.** `input_files: ["data/sales.csv"]` stages as `run-K/inputs/sales.csv`, not `run-K/inputs/data/sales.csv`. Two entries that would flatten to the same basename (e.g. `a/data.csv` and `b/data.csv`) raise `ValueError` at load.
-- **Collision guard with `output_files`.** Any literal `output_files` pattern whose basename matches an `input_files` basename raises `ValueError` at load. If your skill mutates `sales.csv` in place and you want to capture the result, either declare the output under a different basename / subdirectory in `output_files`, or read the post-run file back from the persisted `iteration-N/<skill>/run-K/inputs/` directory after grading.
-- **No file-size cap.** Files are copied verbatim — eval specs are author-controlled, so keep fixtures reasonable.
-
-**Captured-output mode:** `clauditor grade --output <file>` reads a pre-captured output file instead of running the skill. In that mode, staging is skipped. If a spec declares `input_files` and `--output` is passed, clauditor prints `WARNING: --output bypasses the runner; input_files declaration is ignored.` to stderr and continues.
-
-**Persistence:** staged inputs are preserved post-finalize under `.clauditor/iteration-N/<skill>/run-K/inputs/` alongside `output.txt` and `output.jsonl`, so you can inspect exactly what the skill saw (and what it did to the files) after each run.
-
-**Pytest plugin:** the `clauditor_spec` fixture transparently stages `input_files` into `tmp_path` when a loaded spec declares them, so existing tests need zero changes.
-
-**Security / trust model:** Eval specs are developer-authored and run with the repo owner's filesystem access. Clauditor resolves `input_files` paths under the spec's parent directory, enforces source containment, and rejects absolute paths — but the underlying assumption is that eval specs live in a repo you already trust. Do not run clauditor against eval specs from untrusted sources without reviewing them first.
-
-A complete eval spec with all three layers:
+An `<skill-name>.eval.json` lives next to the skill's `.md` file and drives all three layers: deterministic assertions, LLM schema extraction (sections + tiered fields), and rubric grading. Optional blocks (`input_files`, `output_files`, `variance`, `trigger_tests`) add staging, file-based output capture, variance measurement, and trigger precision.
 
 ```json
 {
   "skill_name": "find-kid-activities",
-  "description": "Finds kid-friendly activities near a location",
-  "test_args": "\"Cupertino, CA\" --ages 4-6 --count 5 --depth quick",
-  "input_files": ["fixtures/sample-venues.csv"],
-
-  "assertions": [
-    {"type": "contains", "value": "Venues"},
-    {"type": "has_entries", "value": "3"},
-    {"type": "has_urls", "value": "3"},
-    {"type": "min_length", "value": "500"},
-    {"type": "not_contains", "value": "Error"}
-  ],
-
-  "sections": [
-    {
-      "name": "Venues",
-      "min_entries": 3,
-      "fields": [
-        {"name": "name", "required": true},
-        {"name": "address", "required": true},
-        {"name": "website", "required": true}
-      ]
-    }
-  ],
-
-  "output_file": "research/results.md",
-  "output_files": ["research/*.md", "research/*.json"],
-
-  "grading_criteria": [
-    "Are all venues within the specified distance?",
-    "Are venues appropriate for the specified age range?",
-    "Do cost tiers match the budget filter?"
-  ],
-  "grading_model": "claude-sonnet-4-6",
-  "grade_thresholds": {
-    "min_pass_rate": 0.7,
-    "min_mean_score": 0.5
-  },
-
-  "trigger_tests": {
-    "should_trigger": [
-      "Find kid activities in Cupertino",
-      "What are some things to do with kids near me?"
-    ],
-    "should_not_trigger": [
-      "What's the weather today?",
-      "Help me write a Python script"
-    ]
-  },
-
-  "variance": {
-    "n_runs": 5,
-    "min_stability": 0.8
-  }
+  "test_args":  "\"Cupertino, CA\" --ages 4-6",
+  "assertions": [{"type": "contains", "value": "Venues"}],
+  "sections":   [{"name": "Venues", "min_entries": 3, "fields": [{"name": "name", "required": true}]}],
+  "grading_criteria": ["Are all venues within the specified distance?"]
 }
 ```
 
-See [`examples/`](examples/.claude/commands/example-skill.eval.json) for a complete working eval spec.
+**Covered in the full reference:** every top-level and nested field with validation rules, `input_files` staging, `output_file` / `output_files` capture, and the `format` DSL (`phone_us`, `url`, `domain`, … or inline regex). Full reference: [docs/eval-spec-reference.md](docs/eval-spec-reference.md).
 
-### Field validation with `format`
+<details>
+<summary>Alignment with agentskills.io</summary>
 
-Each `FieldRequirement` accepts a single `format` key that validates the
-extracted value. `format` does double duty:
+clauditor implements (and extends) the workflow at [agentskills.io/skill-creation/evaluating-skills](https://agentskills.io/skill-creation/evaluating-skills):
 
-1. **Registered format name** — a shorthand for a built-in regex in the
-   format registry. Run `python -c "from clauditor.formats import list_formats; print(list_formats())"`
-   to see the full list. Common entries: `phone_us`, `phone_intl`,
-   `email`, `url`, `domain`, `date_iso`, `date_us`, `currency_usd`,
-   `zip_us`, `percentage`, `ipv4`, `uuid`.
-2. **Inline regex** — any string that isn't a registered name is
-   compiled with `re.compile` and used as an anchored `fullmatch` against
-   the value. Invalid regexes raise `ValueError` at spec load time.
+| agentskills.io concept | clauditor |
+|---|---|
+| Test case (prompt + expected + files) | `.eval.json` with `test_args`, `input_files`, `sections`, `grading_criteria` |
+| Deterministic assertions | **Layer 1** — `assertions.py`, `FORMAT_REGISTRY` (20 types) |
+| LLM-judged structural checks | **Layer 2** — `grader.py`, tiered schema extraction |
+| Rubric quality grading | **Layer 3** — `quality_grader.py`, per-criterion scoring + variance |
+| Regression + longitudinal history | `clauditor compare`, `.clauditor/history.jsonl`, `clauditor trend --metric <dotted.path>` |
+| Per-iteration workspace | `.clauditor/iteration-N/<skill>/` with sidecars + `run-*/` transcripts |
 
-```json
-{
-  "sections": [
-    {
-      "name": "Restaurants",
-      "min_entries": 1,
-      "max_entries": 3,
-      "fields": [
-        {"name": "name",    "required": true},
-        {"name": "phone",   "required": true,  "format": "phone_us"},
-        {"name": "website", "required": true,  "format": "domain"},
-        {"name": "zip",     "required": false, "format": "^\\d{5}$"}
-      ]
-    }
-  ]
-}
-```
+**Beyond the spec**: trigger precision testing, tiered extraction, pytest plugin, `input_files` staging, blind A/B judge, baseline pair runs, transcript capture, LLM-driven skill improvement proposer (`clauditor suggest`). **Out of scope**: human-in-the-loop feedback capture.
 
-**`url` vs `domain`:** LLMs commonly extract the display text of markdown
-links (`[paesanosj.com](https://paesanosj.com/)` → `paesanosj.com`),
-which are valid domains but not URLs with a scheme. Use `format: "url"`
-only when you really need `https://…`; use `format: "domain"` to accept
-bare hostnames too.
-
-**`max_entries`:** A precision signal — when set, clauditor emits a
-`count_max` assertion if extraction returns more entries than the cap.
-Field-level checks still run over all extracted entries so you see both
-the count failure and any per-entry failures.
-
-## Notes
-
-- **`.clauditor/` is anchored at the repo root** (walking up for `.git/` or `.claude/`), so running `grade` from a subdirectory writes to the same workspace as running it from the top.
+</details>
 
 ## Reference docs
 
-- [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — authoritative
-  reference for the `claude` stream-json NDJSON fields clauditor parses,
-  with examples and error-handling rules.
+- [`docs/architecture.md`](docs/architecture.md) — how clauditor works under the hood (mermaid diagrams of the grade flow)
+- [`docs/quick-start.md`](docs/quick-start.md) — tutorial walkthrough from init → validate → pytest
+- [`docs/layers.md`](docs/layers.md) — the three-layer framework in depth
+- [`docs/cli-reference.md`](docs/cli-reference.md) — full subcommand + flag + exit-code reference
+- [`docs/eval-spec-reference.md`](docs/eval-spec-reference.md) — complete `.eval.json` schema
+- [`docs/pytest-plugin.md`](docs/pytest-plugin.md) — pytest fixtures and options
+- [`docs/skill-usage.md`](docs/skill-usage.md) — using `/clauditor` in Claude Code
+- [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — `claude` stream-json parser contract
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — maintainer pre-release dogfood gate + contribution workflow
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Source install: `git clone https://github.com/wjduenow/clauditor.git && cd claud
 
 ## Why clauditor?
 
-- **Does your skill hit the expected output shape?** L1 assertions — free, instant, CI-friendly.
-- **Does it pull the right fields?** L2 schema extraction — pennies, Haiku-graded.
-- **Is it actually useful?** L3 LLM-graded rubric — dollars, release-gating.
+- **Layer 1 — Does your skill hit the expected output shape?** Deterministic assertions — free, instant, CI-friendly.
+- **Layer 2 — Does it pull the right fields?** Haiku-graded schema extraction — pennies per run.
+- **Layer 3 — Is it actually useful?** Sonnet-graded rubric — dollars per run, release-gating.
 
 ## One-minute example
 
 ```bash
 clauditor init .claude/commands/my-skill.md       # generate starter eval spec
-clauditor validate .claude/commands/my-skill.md   # → "my-skill: 4 assertions, 4 passed, 0 failed"
+clauditor validate .claude/commands/my-skill.md   # → "4/4 assertions passed (100%)"
 ```
 
 Swap `validate` for `grade` once you've added `grading_criteria` to the spec.
@@ -102,7 +102,7 @@ clauditor compare --skill <s> --from 1 --to 2  # Diff iterations
 clauditor trend <skill> --metric total.total   # History + sparkline
 ```
 
-**Covered in the full reference:** every subcommand flag (`--variance`, `--iteration`, `--diff`, `--blind`, …), exit codes, `history.jsonl` shape, `clauditor trend` metric paths. Full reference: [docs/cli-reference.md](docs/cli-reference.md).
+**Covered in the full reference:** every subcommand flag (`--variance`, `--iteration`, `--diff`, …), exit codes, `history.jsonl` shape, `clauditor trend` metric paths. Full reference: [docs/cli-reference.md](docs/cli-reference.md).
 
 ## Pytest Integration
 
@@ -122,13 +122,13 @@ An `<skill-name>.eval.json` lives next to the skill's `.md` file and drives all 
 {
   "skill_name": "find-kid-activities",
   "test_args":  "\"Cupertino, CA\" --ages 4-6",
-  "assertions": [{"type": "contains", "value": "Venues"}],
-  "sections":   [{"name": "Venues", "min_entries": 3, "fields": [{"name": "name", "required": true}]}],
-  "grading_criteria": ["Are all venues within the specified distance?"]
+  "assertions": [{"id": "has_venues", "type": "contains", "value": "Venues"}],
+  "sections":   [{"name": "Venues", "tiers": [{"label": "default", "min_entries": 3, "fields": [{"id": "v_name", "name": "name", "required": true}]}]}],
+  "grading_criteria": [{"id": "distance_ok", "criterion": "Are all venues within the specified distance?"}]
 }
 ```
 
-**Covered in the full reference:** every top-level and nested field with validation rules, `input_files` staging, `output_file` / `output_files` capture, and the `format` DSL (`phone_us`, `url`, `domain`, … or inline regex). Full reference: [docs/eval-spec-reference.md](docs/eval-spec-reference.md).
+**Covered in the full reference:** the full eval-spec JSON shape, `input_files` staging rules, `output_file` / `output_files` capture, and the `format` validation DSL (`phone_us`, `url`, `domain`, … or inline regex). Full reference: [docs/eval-spec-reference.md](docs/eval-spec-reference.md).
 
 <details>
 <summary>Alignment with agentskills.io</summary>
@@ -158,7 +158,7 @@ clauditor implements (and extends) the workflow at [agentskills.io/skill-creatio
 - [`docs/pytest-plugin.md`](docs/pytest-plugin.md) — pytest fixtures and options
 - [`docs/skill-usage.md`](docs/skill-usage.md) — using `/clauditor` in Claude Code
 - [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — `claude` stream-json parser contract
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — maintainer pre-release dogfood gate + contribution workflow
+- [`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood) — maintainer pre-release dogfood gate + contribution workflow
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,9 @@
 # Architecture Diagrams
 
+Visual + narrative reference for how `clauditor grade` flows end-to-end and how the three evaluation layers compose. Read this when you want depth beyond the README's summary — the grade-command flow, the three-layer pipeline with subgraphs, and the cost/fidelity tradeoffs per layer.
+
+> Companion to the [root README](../README.md). This doc is the full architecture reference; the README has a summary with code examples.
+
 ## Overview
 
 At a glance, a `clauditor grade` run invokes the skill, then fans the
@@ -71,7 +75,7 @@ flowchart TD
 | L1 Assertions | Deterministic string matching — no API calls | `assertions.py::run_assertions` |
 | L2 Extraction | Schema field extraction via Haiku | `grader.py::extract_and_report` |
 | L3 Quality | Rubric-based grading via Sonnet | `quality_grader.py::grade_quality` |
-| Persistence | Atomic workspace with sidecars | `workspace.py` + `cli.py` |
+| Persistence | Atomic workspace with sidecars | `workspace.py` + `cli/grade.py` |
 | History | One JSONL line per run for `clauditor trend` | `history.py::append_record` |
 
 ### Optional phases

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Visual + narrative reference for how `clauditor grade` flows end-to-end and how the three evaluation layers compose. Read this when you want depth beyond the README's summary — the grade-command flow, the three-layer pipeline with subgraphs, and the cost/fidelity tradeoffs per layer.
 
-> Companion to the [root README](../README.md). This doc is the full architecture reference; the README has a summary with code examples.
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
 
 ## Overview
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,32 @@
 # Architecture Diagrams
 
+## Overview
+
+At a glance, a `clauditor grade` run invokes the skill, then fans the
+skill's output into three independent evaluation layers whose results
+are persisted and reported together:
+
+```mermaid
+flowchart LR
+    A["clauditor grade\nskill.md"] --> B["Run skill\n(claude -p)"]
+    B --> C["Skill output"]
+    C --> D["L1 Assertions\n(free)"]
+    C --> E["L2 Extraction\n(Haiku)"]
+    C --> F["L3 Quality\n(Sonnet)"]
+    D --> G["Persist + Report"]
+    E --> G
+    F --> G
+
+    style D fill:#c8e6c9
+    style E fill:#fff9c4
+    style F fill:#ffccbc
+```
+
+Results land under `.clauditor/iteration-N/<skill>/` and are appended to
+`history.jsonl` for trend tracking. The sections below expand each
+stage: §1 walks through the full command end-to-end, §2 details the
+three-layer pipeline.
+
 ## 1. Grade Command — End-to-End Flow
 
 What happens when you run `clauditor grade skill.md`:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,7 +54,7 @@ Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.
 
 Token buckets: `skill` (subprocess), `grader` (Layer 2 extract), `quality` (Layer 3 rubric), `triggers` (trigger precision). Buckets are **absent** when the command doesn't invoke them — e.g. `extract` records have `skill` + `grader`, `validate` records have `skill` only. `total` aggregates across all present buckets.
 
-Use `clauditor trend <skill> --metric <dotted.path>` to view a series. Paths walk the nested `metrics` dict (`total.total`, `grader.input_tokens`, `skill.output_tokens`, `duration_seconds`) with `pass_rate` and `mean_score` as top-level shortcuts. `--command {grade,extract,validate,all}` filters by subcommand (default `grade`). `--list-metrics` prints every resolvable metric path for the skill.
+Use `clauditor trend <skill> --metric <dotted.path>` to view a series. Paths walk the nested `metrics` dict (`total.total`, `skill.output_tokens`, `quality.input_tokens`, `duration_seconds` for grade records; `grader.input_tokens` for extract records) with `pass_rate` and `mean_score` as top-level shortcuts. `--command {grade,extract,validate,all}` filters by subcommand (default `grade`); pass `--command extract` to surface `grader.*` paths. `--list-metrics` prints every resolvable metric path for the skill.
 
 Runs with `--only-criterion` skip the history append to keep longitudinal data comparable.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,72 @@
+# CLI Reference
+
+Full reference for every `clauditor` subcommand: arguments, flags, the persistent metric history, and the exit codes scripts can key off of. Read this when you need to look up a specific option or wire clauditor into CI, not for the conceptual overview of the three-layer framework.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+```bash
+clauditor init <skill.md>              # Generate starter eval.json
+clauditor validate <skill.md>          # Run Layer 1 assertions
+clauditor validate <skill.md> --json   # JSON output for CI
+clauditor run <skill-name> --args "…"  # Run skill, print output
+clauditor extract <skill.md>           # Layer 2 schema extraction
+clauditor extract <skill.md> --dry-run # Print extraction prompt only
+clauditor grade <skill.md>                             # Layer 3 quality grading (auto-increments iteration)
+clauditor grade <skill.md> --variance 3                # Variance measurement
+clauditor grade <skill.md> --only-criterion clarity    # Run a subset (repeatable, substring match)
+clauditor grade <skill.md> --iteration 5               # Write to .clauditor/iteration-5/<skill>/
+clauditor grade <skill.md> --iteration 5 --force       # Overwrite an existing iteration-5/
+clauditor grade <skill.md> --diff                      # Compare against prior iteration
+clauditor compare --skill <skill> --from 1 --to 2      # Diff two iterations by number
+clauditor compare .clauditor/iteration-1/<skill> .clauditor/iteration-2/<skill>  # Diff by directory
+clauditor compare before.txt after.txt --spec <skill.md>  # Re-grade two captures
+clauditor trend <skill> --metric total.total     # Tab-separated history + ASCII sparkline
+clauditor trend <skill> --list-metrics           # List available metric paths
+clauditor trend <skill> --metric grader.input_tokens --command extract  # Filter by subcommand
+clauditor triggers <skill.md>          # Trigger precision testing
+clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/captured/
+clauditor suggest <skill.md>           # Propose SKILL.md edits from prior failing iterations
+clauditor doctor                       # Report environment diagnostics
+```
+
+## Persistent metric history
+
+Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Each record carries a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`.
+
+```json
+{
+  "schema_version": 1,
+  "command": "grade",
+  "ts": "2026-04-13T15:00:00+00:00",
+  "skill": "find-restaurants",
+  "iteration": 4,
+  "workspace_path": ".clauditor/iteration-4/find-restaurants",
+  "pass_rate": 0.83,
+  "mean_score": 0.75,
+  "metrics": {
+    "skill":   {"input_tokens": 1200, "output_tokens": 800},
+    "quality": {"input_tokens": 900,  "output_tokens": 350},
+    "total":   {"input_tokens": 2100, "output_tokens": 1150, "total": 3250},
+    "duration_seconds": 12.3
+  }
+}
+```
+
+Token buckets: `skill` (subprocess), `grader` (Layer 2 extract), `quality` (Layer 3 rubric), `triggers` (trigger precision). Buckets are **absent** when the command doesn't invoke them — e.g. `extract` records have `skill` + `grader`, `validate` records have `skill` only. `total` aggregates across all present buckets.
+
+Use `clauditor trend <skill> --metric <dotted.path>` to view a series. Paths walk the nested `metrics` dict (`total.total`, `grader.input_tokens`, `skill.output_tokens`, `duration_seconds`) with `pass_rate` and `mean_score` as top-level shortcuts. `--command {grade,extract,validate,all}` filters by subcommand (default `grade`). `--list-metrics` prints every resolvable metric path for the skill.
+
+Runs with `--only-criterion` skip the history append to keep longitudinal data comparable.
+
+## Exit codes
+
+clauditor uses structured exit codes so scripts and CI pipelines can distinguish "the tool itself failed" from "the tool ran fine but the skill under test failed its gate."
+
+| Code | Meaning                                                                                                                                              |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Success. The command completed and, where applicable, the skill passed its gate (all assertions satisfied, all criteria above threshold, no regression detected, no trigger miss). |
+| `1`  | Signal failed. The tool ran fine, but the skill did not meet its bar: an L1 assertion failed, an L3 criterion scored below threshold, `clauditor compare` detected a regression relative to baseline, or a trigger classification was wrong. The on-disk artifacts are complete and valid; the skill needs fixing, not the tool. |
+| `2`  | Input error. A user-supplied argument was missing, malformed, or incompatible with another flag (e.g. `--iteration` without an integer value, a skill `.md` file that does not exist, an eval spec that fails schema validation). The command exited before doing work; re-run with corrected arguments. |
+| `3`  | Anthropic API error. `clauditor suggest` only. The Anthropic SDK returned a non-retriable failure (auth, malformed request, exhausted retries). No sidecar is written; re-run once the upstream issue is resolved. |
+
+Commands that only invoke the Anthropic API transiently (`extract`, `grade`, `triggers`) funnel API failures through the same retry policy as `suggest` but surface them as exit 1 with an `ERROR:` line on stderr rather than a distinct code.

--- a/docs/eval-spec-reference.md
+++ b/docs/eval-spec-reference.md
@@ -58,21 +58,26 @@ A complete eval spec with all three layers:
   "input_files": ["fixtures/sample-venues.csv"],
 
   "assertions": [
-    {"type": "contains", "value": "Venues"},
-    {"type": "has_entries", "value": "3"},
-    {"type": "has_urls", "value": "3"},
-    {"type": "min_length", "value": "500"},
-    {"type": "not_contains", "value": "Error"}
+    {"id": "contains_venues", "type": "contains", "value": "Venues"},
+    {"id": "has_entries_3", "type": "has_entries", "value": "3"},
+    {"id": "has_urls_3", "type": "has_urls", "value": "3"},
+    {"id": "min_length_500", "type": "min_length", "value": "500"},
+    {"id": "no_error", "type": "not_contains", "value": "Error"}
   ],
 
   "sections": [
     {
       "name": "Venues",
-      "min_entries": 3,
-      "fields": [
-        {"name": "name", "required": true},
-        {"name": "address", "required": true},
-        {"name": "website", "required": true}
+      "tiers": [
+        {
+          "label": "default",
+          "min_entries": 3,
+          "fields": [
+            {"id": "venue_name", "name": "name", "required": true},
+            {"id": "venue_address", "name": "address", "required": true},
+            {"id": "venue_website", "name": "website", "required": true}
+          ]
+        }
       ]
     }
   ],
@@ -81,9 +86,9 @@ A complete eval spec with all three layers:
   "output_files": ["research/*.md", "research/*.json"],
 
   "grading_criteria": [
-    "Are all venues within the specified distance?",
-    "Are venues appropriate for the specified age range?",
-    "Do cost tiers match the budget filter?"
+    {"id": "distance_match", "criterion": "Are all venues within the specified distance?"},
+    {"id": "age_appropriate", "criterion": "Are venues appropriate for the specified age range?"},
+    {"id": "cost_tier_match", "criterion": "Do cost tiers match the budget filter?"}
   ],
   "grading_model": "claude-sonnet-4-6",
   "grade_thresholds": {
@@ -130,13 +135,18 @@ extracted value. `format` does double duty:
   "sections": [
     {
       "name": "Restaurants",
-      "min_entries": 1,
-      "max_entries": 3,
-      "fields": [
-        {"name": "name",    "required": true},
-        {"name": "phone",   "required": true,  "format": "phone_us"},
-        {"name": "website", "required": true,  "format": "domain"},
-        {"name": "zip",     "required": false, "format": "^\\d{5}$"}
+      "tiers": [
+        {
+          "label": "default",
+          "min_entries": 1,
+          "max_entries": 3,
+          "fields": [
+            {"id": "r_name",    "name": "name",    "required": true},
+            {"id": "r_phone",   "name": "phone",   "required": true,  "format": "phone_us"},
+            {"id": "r_website", "name": "website", "required": true,  "format": "domain"},
+            {"id": "r_zip",     "name": "zip",     "required": false, "format": "^\\d{5}$"}
+          ]
+        }
       ]
     }
   ]

--- a/docs/eval-spec-reference.md
+++ b/docs/eval-spec-reference.md
@@ -1,0 +1,155 @@
+# Eval Spec Format
+
+Complete schema walkthrough for `<skill-name>.eval.json`: discovery rules, every supported field, input-file staging, output-file capture, and the `format` validation DSL. Read this when you're authoring or debugging an eval spec; it's the full reference the shorter README teaser points at.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+Place `<skill-name>.eval.json` alongside your `.claude/commands/<skill-name>.md`:
+
+```
+.claude/commands/
+├── find-kid-activities.md
+├── find-kid-activities.eval.json    ← clauditor auto-discovers this
+├── find-restaurants.md
+└── find-restaurants.eval.json
+```
+
+**File-based output:** Many skills save results to files instead of printing to stdout. Use `output_file` for skills that write to one known path (e.g., `research/results.md`). Use `output_files` with glob patterns for skills that produce multiple files (e.g., `["research/*.md"]`). If both are set, `output_file` takes precedence. When set, clauditor reads the file(s) after running the skill instead of capturing stdout.
+
+## Input files
+
+Some skills need sample inputs — a CSV to clean, a log file to summarize, a PDF to extract. Declare them with `input_files` and clauditor will stage them into each variance run's working directory before invoking the skill:
+
+```json
+{
+  "skill_name": "csv-cleaner",
+  "test_args": "--strict",
+  "input_files": ["fixtures/sales.csv"]
+}
+```
+
+At grade time, `fixtures/sales.csv` is copied (via `shutil.copy2`) into `.clauditor/iteration-N/csv-cleaner/run-K/inputs/sales.csv` for each of the `variance.n_runs` runs, and the skill's subprocess is launched with that `inputs/` directory as its CWD. So `/csv-cleaner --strict` sees `sales.csv` as a plain basename in its own current directory — no path wrangling required. Each `run-K` gets its own fresh copy, so a skill that mutates its input in one run does not affect the next.
+
+Rules enforced at spec-load time (`EvalSpec.from_file`):
+
+- **Paths are relative to the eval spec's parent directory**, not the repo root. An `input_files` entry of `fixtures/sales.csv` next to `my-skill.eval.json` resolves to `<spec-dir>/fixtures/sales.csv`. This intentionally differs from `output_files`, which globs relative to the skill's working directory.
+- **Absolute paths are rejected.** Use a relative path under the spec directory.
+- **Source containment is enforced.** The resolved path (including symlink targets) must live under the spec's parent directory. Escapes via `..` or symlinks pointing outside the spec tree raise `ValueError`.
+- **Missing files fail loudly.** Paths are resolved with `Path.resolve(strict=True)` — a typo fails at load, not at grade time.
+- **Destinations are flattened to basenames.** `input_files: ["data/sales.csv"]` stages as `run-K/inputs/sales.csv`, not `run-K/inputs/data/sales.csv`. Two entries that would flatten to the same basename (e.g. `a/data.csv` and `b/data.csv`) raise `ValueError` at load.
+- **Collision guard with `output_files`.** Any literal `output_files` pattern whose basename matches an `input_files` basename raises `ValueError` at load. If your skill mutates `sales.csv` in place and you want to capture the result, either declare the output under a different basename / subdirectory in `output_files`, or read the post-run file back from the persisted `iteration-N/<skill>/run-K/inputs/` directory after grading.
+- **No file-size cap.** Files are copied verbatim — eval specs are author-controlled, so keep fixtures reasonable.
+
+**Captured-output mode:** `clauditor grade --output <file>` reads a pre-captured output file instead of running the skill. In that mode, staging is skipped. If a spec declares `input_files` and `--output` is passed, clauditor prints `WARNING: --output bypasses the runner; input_files declaration is ignored.` to stderr and continues.
+
+**Persistence:** staged inputs are preserved post-finalize under `.clauditor/iteration-N/<skill>/run-K/inputs/` alongside `output.txt` and `output.jsonl`, so you can inspect exactly what the skill saw (and what it did to the files) after each run.
+
+**Pytest plugin:** the `clauditor_spec` fixture transparently stages `input_files` into `tmp_path` when a loaded spec declares them, so existing tests need zero changes.
+
+**Security / trust model:** Eval specs are developer-authored and run with the repo owner's filesystem access. Clauditor resolves `input_files` paths under the spec's parent directory, enforces source containment, and rejects absolute paths — but the underlying assumption is that eval specs live in a repo you already trust. Do not run clauditor against eval specs from untrusted sources without reviewing them first.
+
+A complete eval spec with all three layers:
+
+```json
+{
+  "skill_name": "find-kid-activities",
+  "description": "Finds kid-friendly activities near a location",
+  "test_args": "\"Cupertino, CA\" --ages 4-6 --count 5 --depth quick",
+  "input_files": ["fixtures/sample-venues.csv"],
+
+  "assertions": [
+    {"type": "contains", "value": "Venues"},
+    {"type": "has_entries", "value": "3"},
+    {"type": "has_urls", "value": "3"},
+    {"type": "min_length", "value": "500"},
+    {"type": "not_contains", "value": "Error"}
+  ],
+
+  "sections": [
+    {
+      "name": "Venues",
+      "min_entries": 3,
+      "fields": [
+        {"name": "name", "required": true},
+        {"name": "address", "required": true},
+        {"name": "website", "required": true}
+      ]
+    }
+  ],
+
+  "output_file": "research/results.md",
+  "output_files": ["research/*.md", "research/*.json"],
+
+  "grading_criteria": [
+    "Are all venues within the specified distance?",
+    "Are venues appropriate for the specified age range?",
+    "Do cost tiers match the budget filter?"
+  ],
+  "grading_model": "claude-sonnet-4-6",
+  "grade_thresholds": {
+    "min_pass_rate": 0.7,
+    "min_mean_score": 0.5
+  },
+
+  "trigger_tests": {
+    "should_trigger": [
+      "Find kid activities in Cupertino",
+      "What are some things to do with kids near me?"
+    ],
+    "should_not_trigger": [
+      "What's the weather today?",
+      "Help me write a Python script"
+    ]
+  },
+
+  "variance": {
+    "n_runs": 5,
+    "min_stability": 0.8
+  }
+}
+```
+
+See [`examples/`](../examples/.claude/commands/example-skill.eval.json) for a complete working eval spec.
+
+## Field validation with `format`
+
+Each `FieldRequirement` accepts a single `format` key that validates the
+extracted value. `format` does double duty:
+
+1. **Registered format name** — a shorthand for a built-in regex in the
+   format registry. Run `python -c "from clauditor.formats import list_formats; print(list_formats())"`
+   to see the full list. Common entries: `phone_us`, `phone_intl`,
+   `email`, `url`, `domain`, `date_iso`, `date_us`, `currency_usd`,
+   `zip_us`, `percentage`, `ipv4`, `uuid`.
+2. **Inline regex** — any string that isn't a registered name is
+   compiled with `re.compile` and used as an anchored `fullmatch` against
+   the value. Invalid regexes raise `ValueError` at spec load time.
+
+```json
+{
+  "sections": [
+    {
+      "name": "Restaurants",
+      "min_entries": 1,
+      "max_entries": 3,
+      "fields": [
+        {"name": "name",    "required": true},
+        {"name": "phone",   "required": true,  "format": "phone_us"},
+        {"name": "website", "required": true,  "format": "domain"},
+        {"name": "zip",     "required": false, "format": "^\\d{5}$"}
+      ]
+    }
+  ]
+}
+```
+
+**`url` vs `domain`:** LLMs commonly extract the display text of markdown
+links (`[paesanosj.com](https://paesanosj.com/)` → `paesanosj.com`),
+which are valid domains but not URLs with a scheme. Use `format: "url"`
+only when you really need `https://…`; use `format: "domain"` to accept
+bare hostnames too.
+
+**`max_entries`:** A precision signal — when set, clauditor emits a
+`count_max` assertion if extraction returns more entries than the cap.
+Field-level checks still run over all extracted entries so you see both
+the count failure and any per-entry failures.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -44,10 +44,10 @@ Or define in `eval.json`:
 ```json
 {
   "assertions": [
-    {"type": "contains", "value": "Venues"},
-    {"type": "regex", "value": "\\*\\*\\d+\\."},
-    {"type": "has_urls", "value": "3"},
-    {"type": "not_contains", "value": "Error"}
+    {"id": "contains_venues", "type": "contains", "value": "Venues"},
+    {"id": "regex_numbered", "type": "regex", "value": "\\*\\*\\d+\\."},
+    {"id": "has_urls_3", "type": "has_urls", "value": "3"},
+    {"id": "no_error", "type": "not_contains", "value": "Error"}
   ]
 }
 ```
@@ -73,13 +73,18 @@ The eval spec defines what fields each section should have:
   "sections": [
     {
       "name": "Venues",
-      "min_entries": 3,
-      "fields": [
-        {"name": "name", "required": true},
-        {"name": "address", "required": true},
-        {"name": "hours", "required": true},
-        {"name": "website", "required": true},
-        {"name": "phone", "required": false}
+      "tiers": [
+        {
+          "label": "default",
+          "min_entries": 3,
+          "fields": [
+            {"id": "venue_name",    "name": "name",    "required": true},
+            {"id": "venue_address", "name": "address", "required": true},
+            {"id": "venue_hours",   "name": "hours",   "required": true},
+            {"id": "venue_website", "name": "website", "required": true},
+            {"id": "venue_phone",   "name": "phone",   "required": false}
+          ]
+        }
       ]
     }
   ]
@@ -117,9 +122,9 @@ Define rubric criteria in your eval spec:
 ```json
 {
   "grading_criteria": [
-    "Are all venues within the specified distance?",
-    "Are events actually happening on the target date?",
-    "Do cost tiers match the budget filter?"
+    {"id": "distance_match", "criterion": "Are all venues within the specified distance?"},
+    {"id": "events_on_date", "criterion": "Are events actually happening on the target date?"},
+    {"id": "cost_tier_match", "criterion": "Do cost tiers match the budget filter?"}
   ],
   "grade_thresholds": {
     "min_pass_rate": 0.7,
@@ -151,15 +156,20 @@ Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and 
 .clauditor/
   iteration-1/
     my-skill/
-      grading.json        # full GradingReport
+      assertions.json     # L1 AssertionSet
+      extraction.json     # L2 ExtractionReport (only when sections declared)
+      grading.json        # L3 GradingReport
       timing.json         # skill name, iteration, n_runs, token + duration metrics
       run-0/
         output.txt        # rendered text blocks
         output.jsonl      # raw stream-json events
   iteration-2/
     my-skill/
+      assertions.json
       grading.json
       timing.json
+      baseline_*.json     # with --baseline: L1/L2/L3 sidecars for the skill-less arm
+      benchmark.json      # with --baseline: delta block (pass_rate / time / tokens)
       run-0/
         output.txt
         output.jsonl
@@ -187,7 +197,7 @@ clauditor compare before.grade.json after.grade.json
 clauditor compare before.txt after.txt --spec <skill.md>
 ```
 
-For a true baseline A/B run (skill vs raw Claude against the same rubric), use the Python API `clauditor.comparator.compare_ab()` directly — the `grade --compare` CLI flag was removed in favor of the file-diff workflow above.
+For a true baseline A/B run (skill vs raw Claude against the same rubric), use `clauditor compare … --blind` on two captured outputs, or run the `compare` subcommand over two iteration folders to diff grading reports. The legacy `grade --compare` CLI flag and the `comparator.compare_ab()` Python entry point have both been removed.
 
 #### Blind A/B comparison (`--blind`)
 
@@ -253,19 +263,15 @@ Reports accuracy, precision, and recall. Passes only when every classification i
 ```python
 import asyncio
 from clauditor.quality_grader import grade_quality, measure_variance
-from clauditor.comparator import compare_ab
 from clauditor.triggers import test_triggers
 from clauditor.spec import SkillSpec
 
 spec = SkillSpec.from_file(".claude/commands/my-skill.md")
+output = spec.run().output  # or Path("captured.txt").read_text()
 
 # Quality grading
 report = asyncio.run(grade_quality(output, spec.eval_spec))
 print(f"{report.pass_rate:.0%} passed, mean score {report.mean_score:.2f}")
-
-# A/B comparison
-ab = asyncio.run(compare_ab(spec))
-print(f"Regressions: {len(ab.regressions)}")
 
 # Variance
 var = asyncio.run(measure_variance(spec, n_runs=3))

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -142,7 +142,10 @@ clauditor grade .claude/commands/my-skill.md --dry-run      # Print prompt, no A
 clauditor grade .claude/commands/my-skill.md --iteration 5  # Write to iteration-5/ explicitly
 clauditor grade .claude/commands/my-skill.md --iteration 5 --force  # Overwrite existing iteration-5/
 clauditor grade .claude/commands/my-skill.md --diff         # Compare against prior iteration
+clauditor grade .claude/commands/my-skill.md --baseline     # Also run without skill for A/B delta
 ```
+
+With `--baseline`, clauditor runs a second pass *without* the skill prefix, grades both arms against the same rubric, and writes an additional `baseline_*.json` sidecar bundle (`baseline_assertions.json`, `baseline_extraction.json`, `baseline_grading.json`) plus a `benchmark.json` delta summary (`{pass_rate, time_seconds, tokens}`) computed as *skill-arm minus baseline-arm*. Use this to quantify whether the skill is actually doing work on top of raw Claude.
 
 Every `grade` run is persisted to `.clauditor/iteration-N/<skill>/` automatically. By default the iteration number auto-increments to the next free slot. Pass `--iteration N` to target a specific slot; if `iteration-N/` already exists the command errors unless you also pass `--force` to overwrite.
 
@@ -207,7 +210,19 @@ Rubric-based grading can miss holistic regressions where two outputs pass every 
 clauditor compare before.txt after.txt --spec <skill.md> --blind
 ```
 
-The judge runs twice with the A/B positions swapped so position bias shows up as disagreement. Output includes a preference (`BEFORE` / `AFTER` / `TIE`), confidence, per-output holistic score, whether the two runs agreed on the winner, and the judge's reasoning. Currently only the file-pair form is supported (iteration refs like `--from/--to` are rejected); `--blind` requires `--spec` with `eval_spec.user_prompt` set (the natural-language query the judge will see) and uses `grading_criteria` from the spec as an optional rubric hint to the judge.
+The judge runs twice with the A/B positions swapped so position bias shows up as disagreement. Output includes a preference (`BEFORE` / `AFTER` / `TIE`), confidence, per-output holistic score, whether the two runs agreed on the winner, and the judge's reasoning. Currently only the file-pair form is supported (iteration refs like `--from/--to` are rejected); `--blind` requires `--spec` with `user_prompt` set on the eval spec (the natural-language query the judge will see) and uses `grading_criteria` from the spec as an optional rubric hint to the judge.
+
+Example eval spec snippet for `--blind`:
+
+```json
+{
+  "skill_name": "find-venues",
+  "user_prompt": "Find kid-friendly activities in Cupertino within 5 miles for ages 4-6.",
+  "grading_criteria": [
+    {"id": "distance_match", "criterion": "Are all venues within the specified distance?"}
+  ]
+}
+```
 
 ### Variance Measurement
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,277 @@
+# Three Layers of Validation
+
+The conceptual heart of clauditor: why it splits skill evaluation into three layers, what each layer costs, and when to use which one. Read this to understand the framework's design before authoring an eval spec or writing your first test. The layers are independent — use L1 alone on every PR, reach for L2/L3 when you need deeper signal.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+```mermaid
+flowchart TD
+    SPEC["eval.json"] --> L1_IN["assertions[]"]
+    SPEC --> L2_IN["sections[].tiers[].fields[]"]
+    SPEC --> L3_IN["grading_criteria[]"]
+
+    L1_IN --> L1["Layer 1\nString matching\nNo API calls"]
+    L2_IN --> L2["Layer 2\nSchema extraction\nHaiku"]
+    L3_IN --> L3["Layer 3\nRubric grading\nSonnet"]
+
+    L1 --> R1["assertions.json"]
+    L2 --> R2["extraction.json"]
+    L3 --> R3["grading.json"]
+
+    style L1 fill:#c8e6c9
+    style L2 fill:#fff9c4
+    style L3 fill:#ffccbc
+```
+
+## Layer 1: Deterministic Assertions (free, instant)
+
+No API calls. Regex, string matching, and counting.
+
+```python
+from clauditor import SkillAsserter
+
+asserter = SkillAsserter(result)
+asserter.assert_contains("Venues")           # substring check
+asserter.assert_not_contains("Error")        # absence check
+asserter.assert_matches(r"\*\*\d+\.")        # regex
+asserter.assert_has_entries(minimum=5)        # numbered entries
+asserter.assert_has_urls(minimum=3)           # URL count
+asserter.assert_min_length(500)              # output length
+```
+
+Or define in `eval.json`:
+
+```json
+{
+  "assertions": [
+    {"type": "contains", "value": "Venues"},
+    {"type": "regex", "value": "\\*\\*\\d+\\."},
+    {"type": "has_urls", "value": "3"},
+    {"type": "not_contains", "value": "Error"}
+  ]
+}
+```
+
+## Layer 2: LLM Schema Extraction (cheap, ~1 sec)
+
+Uses Haiku to extract structured fields, then validates against your schema. Requires `pip install clauditor[grader]`.
+
+```python
+import asyncio
+from clauditor.grader import extract_and_grade
+from clauditor.schemas import EvalSpec
+
+spec = EvalSpec.from_file("my-skill.eval.json")
+results = asyncio.run(extract_and_grade(output_text, spec))
+assert results.passed, results.summary()
+```
+
+The eval spec defines what fields each section should have:
+
+```json
+{
+  "sections": [
+    {
+      "name": "Venues",
+      "min_entries": 3,
+      "fields": [
+        {"name": "name", "required": true},
+        {"name": "address", "required": true},
+        {"name": "hours", "required": true},
+        {"name": "website", "required": true},
+        {"name": "phone", "required": false}
+      ]
+    }
+  ]
+}
+```
+
+### Field validation (`format`)
+
+Each field can declare a `format` that validates the extracted value. The `format` key accepts **either** a registered format name **or** an inline regex — clauditor looks up the string in `FORMAT_REGISTRY` first and falls back to compiling it as a regex if there's no match.
+
+Decision tree:
+
+- Is there a registered name in `FORMAT_REGISTRY` that fits? Use it (e.g. `"format": "phone_us"`).
+- Need something custom? Put a regex string directly in `format` (e.g. `"format": "^[a-z0-9-]+$"`).
+- Lookup is **registry-first, regex-fallback**. Invalid regexes raise `ValueError` at spec construction time, so typos fail fast.
+
+```json
+{"name": "phone", "format": "phone_us"}
+```
+
+```json
+{"name": "slug", "format": "^[a-z0-9-]+$"}
+```
+
+See [`FORMAT_REGISTRY` in `src/clauditor/formats.py`](../src/clauditor/formats.py) for the full list of registered names (common entries: `phone_us`, `phone_intl`, `email`, `url`, `domain`, `date_iso`, `zip_us`, `uuid`).
+
+## Layer 3: Quality Grading (expensive, release-only)
+
+Uses Sonnet to grade skill output against a rubric you define. Requires `ANTHROPIC_API_KEY` and `pip install clauditor[grader]`.
+
+### Quality Grading
+
+Define rubric criteria in your eval spec:
+
+```json
+{
+  "grading_criteria": [
+    "Are all venues within the specified distance?",
+    "Are events actually happening on the target date?",
+    "Do cost tiers match the budget filter?"
+  ],
+  "grade_thresholds": {
+    "min_pass_rate": 0.7,
+    "min_mean_score": 0.5
+  }
+}
+```
+
+`grade_thresholds` controls when grading passes overall. `min_pass_rate` (default 0.7) is the fraction of criteria that must pass. `min_mean_score` (default 0.5) is the minimum average score across all criteria. Both must be met. This differs from `variance.min_stability`, which measures consistency across multiple runs rather than quality of a single run.
+
+```bash
+clauditor grade .claude/commands/my-skill.md
+clauditor grade .claude/commands/my-skill.md --json
+clauditor grade .claude/commands/my-skill.md --dry-run      # Print prompt, no API call
+clauditor grade .claude/commands/my-skill.md --iteration 5  # Write to iteration-5/ explicitly
+clauditor grade .claude/commands/my-skill.md --iteration 5 --force  # Overwrite existing iteration-5/
+clauditor grade .claude/commands/my-skill.md --diff         # Compare against prior iteration
+```
+
+Every `grade` run is persisted to `.clauditor/iteration-N/<skill>/` automatically. By default the iteration number auto-increments to the next free slot. Pass `--iteration N` to target a specific slot; if `iteration-N/` already exists the command errors unless you also pass `--force` to overwrite.
+
+Each criterion gets a pass/fail, score (0.0-1.0), evidence (quoted output), and reasoning. Use `--diff` to compare against a prior iteration (flags regressions where a criterion's score drops by more than 0.1).
+
+### Iteration workspace layout
+
+`.clauditor/` is anchored at the repository root (the nearest ancestor of your CWD containing `.git/` or `.claude/`), so `grade` from any subdirectory writes to the same place. Each run produces:
+
+```
+.clauditor/
+  iteration-1/
+    my-skill/
+      grading.json        # full GradingReport
+      timing.json         # skill name, iteration, n_runs, token + duration metrics
+      run-0/
+        output.txt        # rendered text blocks
+        output.jsonl      # raw stream-json events
+  iteration-2/
+    my-skill/
+      grading.json
+      timing.json
+      run-0/
+        output.txt
+        output.jsonl
+      run-1/              # additional runs appear under --variance N
+        output.txt
+        output.jsonl
+  history.jsonl
+```
+
+### Regression Comparison
+
+Diffs two grade reports, printing `[REGRESSION]` for pass→fail flips and `[IMPROVEMENT]` for fail→pass. Exits 1 on any regression. `compare` accepts three input forms:
+
+```bash
+# 1. Numeric iteration refs (preferred — pairs with auto-incremented iterations)
+clauditor compare --skill my-skill --from 1 --to 2
+
+# 2. Iteration directory paths
+clauditor compare .clauditor/iteration-1/my-skill .clauditor/iteration-2/my-skill
+
+# 3. Saved grade-report files
+clauditor compare before.grade.json after.grade.json
+
+# Or re-grade two raw captures against a spec:
+clauditor compare before.txt after.txt --spec <skill.md>
+```
+
+For a true baseline A/B run (skill vs raw Claude against the same rubric), use the Python API `clauditor.comparator.compare_ab()` directly — the `grade --compare` CLI flag was removed in favor of the file-diff workflow above.
+
+#### Blind A/B comparison (`--blind`)
+
+Rubric-based grading can miss holistic regressions where two outputs pass every criterion but one visibly feels worse. For that, pass `--blind` to have a Sonnet judge compare the two outputs side-by-side without knowing which version is which:
+
+```bash
+clauditor compare before.txt after.txt --spec <skill.md> --blind
+```
+
+The judge runs twice with the A/B positions swapped so position bias shows up as disagreement. Output includes a preference (`BEFORE` / `AFTER` / `TIE`), confidence, per-output holistic score, whether the two runs agreed on the winner, and the judge's reasoning. Currently only the file-pair form is supported (iteration refs like `--from/--to` are rejected); `--blind` requires `--spec` with `eval_spec.user_prompt` set (the natural-language query the judge will see) and uses `grading_criteria` from the spec as an optional rubric hint to the judge.
+
+### Variance Measurement
+
+Runs the skill N times and measures output stability across runs:
+
+```bash
+clauditor grade .claude/commands/my-skill.md --variance 5
+```
+
+Configure thresholds in the eval spec:
+
+```json
+{
+  "variance": {
+    "n_runs": 5,
+    "min_stability": 0.8
+  }
+}
+```
+
+Reports `score_mean`, `score_stddev`, `pass_rate_mean`, and `stability` (fraction of runs where all criteria passed). Fails if stability drops below `min_stability`.
+
+### Trigger Precision Testing
+
+Tests whether an LLM correctly identifies which user queries should invoke your skill:
+
+```bash
+clauditor triggers .claude/commands/my-skill.md
+clauditor triggers .claude/commands/my-skill.md --json
+```
+
+Define test queries in the eval spec:
+
+```json
+{
+  "trigger_tests": {
+    "should_trigger": [
+      "Find kid activities in Cupertino",
+      "What are some things to do with kids near me?"
+    ],
+    "should_not_trigger": [
+      "What's the weather today?",
+      "Help me write a Python script"
+    ]
+  }
+}
+```
+
+Reports accuracy, precision, and recall. Passes only when every classification is correct.
+
+### Python API
+
+```python
+import asyncio
+from clauditor.quality_grader import grade_quality, measure_variance
+from clauditor.comparator import compare_ab
+from clauditor.triggers import test_triggers
+from clauditor.spec import SkillSpec
+
+spec = SkillSpec.from_file(".claude/commands/my-skill.md")
+
+# Quality grading
+report = asyncio.run(grade_quality(output, spec.eval_spec))
+print(f"{report.pass_rate:.0%} passed, mean score {report.mean_score:.2f}")
+
+# A/B comparison
+ab = asyncio.run(compare_ab(spec))
+print(f"Regressions: {len(ab.regressions)}")
+
+# Variance
+var = asyncio.run(measure_variance(spec, n_runs=3))
+print(f"Stability: {var.stability:.0%}")
+
+# Trigger precision
+triggers = asyncio.run(test_triggers(spec.eval_spec))
+print(f"Accuracy: {triggers.accuracy:.0%}, Precision: {triggers.precision:.0%}")
+```

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -1,0 +1,24 @@
+# Pytest Integration
+
+Reference for clauditor's pytest plugin: the fixtures it registers, the command-line options it adds, and how to wire Layer 3 grading into a test run. Read this when you're authoring tests against skills and want the plugin's full surface rather than the copy-paste-from-Quick-Start subset.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+clauditor registers as a pytest plugin automatically. Available fixtures:
+
+- `clauditor_runner` — pre-configured `SkillRunner`
+- `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`
+- `clauditor_spec` — factory for loading `SkillSpec` from skill files
+- `clauditor_grader` — factory for Layer 3 quality grading
+- `clauditor_triggers` — factory for trigger precision testing
+- `clauditor_capture` — factory returning a `Path` to `tests/eval/captured/<skill>.txt` for captured-output tests
+
+Options:
+
+```bash
+pytest --clauditor-project-dir /path/to/project
+pytest --clauditor-timeout 300
+pytest --clauditor-claude-bin /usr/local/bin/claude
+pytest --clauditor-grade              # Enable Layer 3 tests (costs money)
+pytest --clauditor-model claude-sonnet-4-6  # Override grading model
+```

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -7,10 +7,11 @@ Reference for clauditor's pytest plugin: the fixtures it registers, the command-
 clauditor registers as a pytest plugin automatically. Available fixtures:
 
 - `clauditor_runner` — pre-configured `SkillRunner`
-- `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`
+- `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_not_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`
 - `clauditor_spec` — factory for loading `SkillSpec` from skill files
 - `clauditor_grader` — factory for Layer 3 quality grading
 - `clauditor_triggers` — factory for trigger precision testing
+- `clauditor_blind_compare` — factory wrapping `blind_compare_from_spec` for A/B comparison of two skill outputs (requires `user_prompt` on the eval spec)
 - `clauditor_capture` — factory returning a `Path` to `tests/eval/captured/<skill>.txt` for captured-output tests
 
 Options:
@@ -22,3 +23,5 @@ pytest --clauditor-claude-bin /usr/local/bin/claude
 pytest --clauditor-grade              # Enable Layer 3 tests (costs money)
 pytest --clauditor-model claude-sonnet-4-6  # Override grading model
 ```
+
+Mark tests that need Layer 3 with `@pytest.mark.clauditor_grade`; they are skipped by default and only run under `--clauditor-grade`.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,65 @@
+# Quick Start
+
+End-to-end walkthrough from "I have a skill" to "it's validated, graded, and covered in pytest." Read this after installing clauditor when you want a concrete example of the init → validate → test loop. For a deeper dive into each layer's behavior, see [Three Layers of Validation](layers.md).
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+## 1. Create an eval spec for your skill
+
+```bash
+clauditor init .claude/commands/my-skill.md
+```
+
+This creates `my-skill.eval.json` alongside your skill file:
+
+```json
+{
+  "skill_name": "my-skill",
+  "test_args": "\"San Jose, CA\" --depth quick",
+  "assertions": [
+    {"type": "contains", "value": "Results"},
+    {"type": "has_entries", "value": "3"},
+    {"type": "has_urls", "value": "3"},
+    {"type": "min_length", "value": "500"}
+  ],
+  "sections": [
+    {
+      "name": "Results",
+      "min_entries": 3,
+      "fields": [
+        {"name": "name", "required": true},
+        {"name": "address", "required": true}
+      ]
+    }
+  ]
+}
+```
+
+## 2. Validate against captured output
+
+```bash
+# Run skill and validate in one step:
+clauditor validate .claude/commands/my-skill.md
+
+# Or validate against pre-captured output:
+clauditor validate .claude/commands/my-skill.md --output captured.txt
+
+# JSON output for CI:
+clauditor validate .claude/commands/my-skill.md --json
+```
+
+## 3. Use in pytest
+
+```python
+def test_my_skill(clauditor_runner, clauditor_asserter):
+    result = clauditor_runner.run("my-skill", '"San Jose, CA" --depth quick')
+    asserter = clauditor_asserter(result)
+    asserter.assert_contains("Results")
+    asserter.assert_has_entries(minimum=3)
+    asserter.assert_has_urls(minimum=3)
+
+def test_with_eval_spec(clauditor_spec):
+    spec = clauditor_spec(".claude/commands/my-skill.md")
+    results = spec.evaluate()
+    assert results.passed, results.summary()
+```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,18 +17,23 @@ This creates `my-skill.eval.json` alongside your skill file:
   "skill_name": "my-skill",
   "test_args": "\"San Jose, CA\" --depth quick",
   "assertions": [
-    {"type": "contains", "value": "Results"},
-    {"type": "has_entries", "value": "3"},
-    {"type": "has_urls", "value": "3"},
-    {"type": "min_length", "value": "500"}
+    {"id": "contains_results", "type": "contains", "value": "Results"},
+    {"id": "has_entries_3",    "type": "has_entries", "value": "3"},
+    {"id": "has_urls_3",       "type": "has_urls", "value": "3"},
+    {"id": "min_length_500",   "type": "min_length", "value": "500"}
   ],
   "sections": [
     {
       "name": "Results",
-      "min_entries": 3,
-      "fields": [
-        {"name": "name", "required": true},
-        {"name": "address", "required": true}
+      "tiers": [
+        {
+          "label": "default",
+          "min_entries": 3,
+          "fields": [
+            {"id": "result_name",    "name": "name",    "required": true},
+            {"id": "result_address", "name": "address", "required": true}
+          ]
+        }
       ]
     }
   ]

--- a/docs/skill-usage.md
+++ b/docs/skill-usage.md
@@ -1,0 +1,51 @@
+# Using /clauditor in Claude Code
+
+Walkthrough of the bundled `/clauditor` slash command: what it does when invoked inside Claude Code, how it differs from the CLI entry points, and when to reach for each. Read this when you want conversational evaluation inside a Claude session; reach for the CLI reference when you're scripting CI.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+Once `clauditor setup` has installed the symlink, the bundled skill is
+available as a slash command in any Claude Code session rooted at this
+project. The command is manual-only — Claude won't auto-invoke it,
+because validating a skill has side effects (subprocess runs, sidecar
+writes, potential token spend on L3 grading).
+
+**Invoke with the path to the skill you want to evaluate:**
+
+```text
+/clauditor .claude/commands/my-skill.md
+```
+
+or, for a directory-layout skill:
+
+```text
+/clauditor .claude/skills/my-skill/SKILL.md
+```
+
+Running `/clauditor` without an argument prompts Claude to ask which
+skill to evaluate.
+
+**What Claude does:**
+
+1. Locates the skill's eval spec — a sibling `<skill-name>.eval.json`
+   file, or `<skill-dir>/assets/<skill-name>.eval.json` for directory
+   skills. If neither exists, Claude asks you to author one or stops.
+2. Runs L1 validation first (`clauditor validate`) — free, sub-second,
+   reports failing assertion ids.
+3. If L1 passes, asks before running L3 grading (`clauditor grade`) —
+   costs Sonnet tokens, writes a full `grading.json` sidecar.
+4. Summarizes: which layers ran, pass/fail counts, sidecar paths you
+   can open for details.
+
+**When to use `/clauditor` vs. the CLI directly:**
+
+- Use `/clauditor` when you're in a Claude Code conversation and want
+  conversational context (Claude can explain failures, suggest fixes,
+  iterate on the spec).
+- Use `clauditor validate` / `clauditor grade` directly in CI,
+  Makefiles, or scripted workflows where you want deterministic exit
+  codes and no LLM narration.
+
+The full skill playbook lives at
+[`src/clauditor/skills/clauditor/SKILL.md`](../src/clauditor/skills/clauditor/SKILL.md)
+(what Claude reads when the slash command fires).

--- a/plans/super/47-readme-restructure.md
+++ b/plans/super/47-readme-restructure.md
@@ -4,8 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/47
 - **Branch:** `feature/47-readme-restructure`
 - **Worktree:** _n/a (working on branch directly)_
-- **Phase:** `detailing`
-- **PR:** _pending_
+- **Phase:** `devolved`
+- **PR:** https://github.com/wjduenow/clauditor/pull/49
 - **Sessions:** 1
 - **Last session:** 2026-04-17
 
@@ -705,7 +705,21 @@ commits.
 
 ## Beads Manifest
 
-_(Pending — populated in Phase 7.)_
+- **Epic:** `clauditor-8r1`
+- **Branch:** `feature/47-readme-restructure`
+- **PR:** https://github.com/wjduenow/clauditor/pull/49
+
+| Story | Bead ID | Depends on | Ready |
+|---|---|---|---|
+| US-001 Extract 6 docs files | `clauditor-8r1.1` | — | ✅ |
+| US-002 Merge into architecture | `clauditor-8r1.2` | — | ✅ |
+| US-003 Rewrite README | `clauditor-8r1.3` | US-001, US-002 | |
+| US-004 Link audit | `clauditor-8r1.4` | US-003 | |
+| US-005 Quality Gate | `clauditor-8r1.5` | US-001..US-004 | |
+| US-006 Patterns & Memory | `clauditor-8r1.6` (P4) | US-005 | |
+
+8 dependency edges wired. Kickoff set: `{clauditor-8r1.1,
+clauditor-8r1.2}` run in parallel.
 
 ---
 

--- a/plans/super/47-readme-restructure.md
+++ b/plans/super/47-readme-restructure.md
@@ -1,0 +1,728 @@
+# Super Plan: #47 — README restructure for navigability
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/47
+- **Branch:** `feature/47-readme-restructure`
+- **Worktree:** _n/a (working on branch directly)_
+- **Phase:** `detailing`
+- **PR:** _pending_
+- **Sessions:** 1
+- **Last session:** 2026-04-17
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Restructure the 770-line root `README.md` so it functions as
+navigation + first-success landing, with deep reference material
+promoted into `docs/` and gated behind links. Add a TOC and collapse
+rarely-read reference into `<details>` blocks.
+
+**Why:** First-screen content is positioning-heavy, not action-heavy.
+The Install CTA doesn't appear until line 48; terminology like "Layer 1/2/3"
+is used at line 18 without definition until line 222. Readers who land
+from GitHub discovery scroll past value before finding setup.
+
+**Done when:**
+- Root README is ≤ ~150 lines
+- First screen (top ~50 lines) contains: what it is, install, one success example
+- Deep reference sections live in `docs/` under stable file names
+- Existing external anchor references (if any) continue to resolve
+
+### Key Findings (reshape the ticket)
+
+**FINDING-1 — `docs/architecture.md` already exists with dense content.**
+The ticket says "promote How It Works → `docs/architecture.md`" but the
+file already has 4.6 KB of mermaid diagrams + a three-layer pipeline
+breakdown (grade command flow, cost/time/speed table). This is a
+**collision**, not a promotion target. Three possible resolutions:
+
+- A. Leave existing `docs/architecture.md` alone; the root README's
+  "How It Works" stays (it's only 20 lines, diagram + teaser) with a
+  "See [docs/architecture.md](docs/architecture.md) for depth" link.
+- B. Rename existing to `docs/technical-architecture.md`; repurpose
+  `architecture.md` for the conceptual overview.
+- C. Merge the README "How It Works" into the existing file as a new
+  top-level section.
+
+**FINDING-2 — Much larger promotion opportunity than the ticket listed.**
+The three biggest sections by line count are NOT in the ticket's scope:
+
+| Section | Lines | Density | Current placement |
+|---|---:|---|---|
+| Three Layers of Validation | 274 | 51% code | root README |
+| Eval Spec Format | 152 | 79% code | root README |
+| CLI Reference | 56 | 89% code | root README |
+
+Promoting these three = 482 lines out of 770 → ~63% reduction before
+adding nav teasers back. The original ticket scoped only Quick Start +
+How It Works + the setup flag collapse. The ticket's success criteria
+("≤150 lines") requires the bigger promotion.
+
+**FINDING-3 — One rule-protected docs file exists already.**
+`.claude/rules/stream-json-schema.md` mandates: "The human-readable
+schema reference lives at `docs/stream-json-schema.md`... update that
+function *and* this document *and* `.claude/rules/stream-json-schema.md`
+in the same commit." The existing `docs/stream-json-schema.md` is
+covered by that rule. We do NOT touch it in this ticket.
+
+**FINDING-4 — No markdown tooling.** No markdownlint, no link checker,
+no mkdocs/sphinx, no doc-deploy step. Link invariants must be
+preserved by hand. CI does not catch broken internal links; tests
+don't fail on them.
+
+**FINDING-5 — No existing TOC style in the repo** to anchor on. We
+pick a TOC shape as a design decision.
+
+**FINDING-6 — `AGENTS.md` is out of scope.** It's contributor workflow
+(beads + session-close protocol), does not duplicate README content,
+does not need restructuring.
+
+**FINDING-7 — Cross-file reference scan is clean.** No `README.md#…`
+anchor fragments found in `.claude/`, `plans/`, `.github/`, or `docs/`
+other than ordinary self-links within the README. The existing link
+`README → docs/architecture.md` must stay live; otherwise the blast
+radius of anchor changes is small.
+
+### Section inventory (770 lines total)
+
+| Heading | Lines | Category | Proposed default action |
+|---|---:|---|---|
+| (intro + badges) | 1-27 | nav | keep; tighten first screen |
+| Alignment with agentskills.io | 28-47 (20) | explainer | move to `docs/agentskills-alignment.md` or collapse to `<details>` |
+| Install | 48-64 (17) | nav | keep |
+| Installing the /clauditor slash command | 65-111 (47) | tutorial | keep; wrap flag reference in `<details>` |
+| Using /clauditor in Claude Code | 112-159 (48) | tutorial | shrink + link to `docs/skill-usage.md` |
+| Quick Start | 160-221 (62) | tutorial | shrink + link to `docs/quick-start.md` |
+| How It Works | 222-241 (20) | explainer | keep teaser; link to `docs/architecture.md` |
+| Three Layers of Validation | 242-515 (274) | deep-ref | **promote to `docs/layers.md`** |
+| CLI Reference | 516-571 (56) | deep-ref | **promote to `docs/cli-reference.md`** |
+| Exit Codes | 572-584 (13) | deep-ref | collapse to `<details>` or promote |
+| Pytest Integration | 585-605 (21) | deep-ref | **promote to `docs/pytest-plugin.md`** |
+| Eval Spec Format | 606-757 (152) | deep-ref | **promote to `docs/eval-spec-reference.md`** |
+| Notes | 758-761 (4) | misc | merge into nearest kept section |
+| Reference docs | 762-767 (6) | nav | expand into explicit nav list |
+| License | 768-770 (3) | nav | keep |
+
+### Applicable `.claude/rules/`
+
+- **`stream-json-schema.md`** — protects the existing
+  `docs/stream-json-schema.md`. Do not touch. Reference as a template
+  for the "root README is the nav; `docs/` is the truth" pattern.
+- All other 17 rules — none apply directly to this doc-only
+  restructure.
+
+### Proposed Scope (expanded beyond original ticket)
+
+1. Add a TOC near the top of README
+2. Tighten first screen (intro + install CTA visible without scrolling)
+3. Collapse "Alignment with agentskills.io" into `<details>` (or promote)
+4. Collapse the `clauditor setup` flag reference into `<details>`
+5. Promote "Three Layers of Validation" → `docs/layers.md` (+ teaser)
+6. Promote "CLI Reference" → `docs/cli-reference.md` (+ teaser)
+7. Promote "Eval Spec Format" → `docs/eval-spec-reference.md` (+ teaser)
+8. Promote "Pytest Integration" → `docs/pytest-plugin.md` (+ teaser)
+9. Promote "Quick Start" deep content → `docs/quick-start.md` (+ teaser)
+10. Shrink "Using /clauditor" to a short section + link to
+    `docs/skill-usage.md`
+11. Resolve the `docs/architecture.md` collision (decision below)
+12. Expand the "Reference docs" nav list to link every promoted file
+13. Verify every moved anchor / every internal link still resolves;
+    grep the whole repo for `README.md#…` patterns to catch breakage
+14. Keep `docs/stream-json-schema.md` untouched per its rule anchor
+
+### Scoping Questions
+
+**Q1 — `docs/architecture.md` collision resolution (FINDING-1).**
+- **A.** Leave existing `docs/architecture.md` alone. README's
+  "How It Works" stays as a 20-line teaser with a link. ← simplest
+- **B.** Rename existing → `docs/technical-architecture.md`; use
+  `architecture.md` for the conceptual overview.
+- **C.** Merge README "How It Works" into the existing
+  `docs/architecture.md` as a new section; remove it from README
+  entirely (link-only from root).
+
+**Q2 — Restructure scope — stick with the 6-item ticket or expand?**
+- **A.** Expanded scope (promote all 5 deep-ref sections; 13 items).
+  Hits the "≤150 lines" goal. ~63% README reduction. ← recommended
+- **B.** Original ticket only (6 items: How It Works + Quick Start +
+  flag collapse + TOC + usage section shrink + link audit). ~25%
+  reduction; won't hit the stated success criterion.
+- **C.** Somewhere in between — pick which sections to promote.
+
+**Q3 — TOC style (FINDING-5, no existing project convention).**
+- **A.** Flat markdown list with anchors:
+  ```
+  ## Contents
+  - [Install](#install)
+  - [Quick Start](#quick-start)
+  - [Reference docs](#reference-docs)
+  ```
+- **B.** GitHub-generated (`<!-- toc -->` via a generator) — adds
+  tooling dependency.
+- **C.** `<details><summary>Contents</summary>…</details>` collapsed
+  by default — saves first-screen room.
+
+**Q4 — "Alignment with agentskills.io" placement.**
+- **A.** Promote to `docs/agentskills-alignment.md` — positioning
+  content, not setup-path.
+- **B.** Collapse to `<details>` in root — kept near the top for trust
+  signaling but folded.
+- **C.** Leave as-is.
+
+**Q5 — Exit Codes table (13 lines).**
+- **A.** Promote to `docs/exit-codes.md` (referenced from
+  `docs/cli-reference.md`).
+- **B.** Merge into `docs/cli-reference.md` as a subsection.
+- **C.** Collapse to `<details>` in root README.
+
+**Q6 — Commit strategy for the restructure.**
+- **A.** One big commit — easy to review overall shape.
+- **B.** One commit per promoted section + one for TOC + one for the
+  link-audit verification. Gives bisect/revert granularity but more
+  noise. ← recommended by super-plan convention
+- **C.** One commit per phase (A: TOC + first-screen tighten, B:
+  promote 5 sections, C: link audit). Middle ground.
+
+---
+
+## Architecture Review
+
+### Resolved Scoping Choices (from Discovery)
+
+- **Q1 → C:** Merge README "How It Works" into the existing
+  `docs/architecture.md`; remove from README entirely (link-only).
+- **Q2 → A:** Expanded scope — 13 items including the 4 big deep-ref
+  promotions. Target ≤150-line README.
+- **Q3 → C:** `<details><summary>Contents</summary>…</details>`
+  collapsed hand-rolled TOC.
+- **Q4 → B:** Collapse "Alignment with agentskills.io" into
+  `<details>` in root.
+- **Q5 → B:** Merge "Exit Codes" table into `docs/cli-reference.md`
+  as a subsection.
+- **Q6 → A:** One big commit (accepting a ~500-line diff in exchange
+  for atomicity of the restructure).
+
+### Review Summary
+
+| Area | Verdict | Notes |
+|---|---|---|
+| Link integrity — external `README.md#…` refs | pass | Zero external refs found (grep of `src/`, `.github/`, `.claude/`, `CONTRIBUTING.md`, `AGENTS.md`, bundled skill, tests). The only live link into README is self-referential. |
+| Link integrity — anchor stability for bookmarked sections | concern | Users who bookmarked `#three-layers-of-validation`, `#cli-reference`, `#eval-spec-format`, `#pytest-integration` will 404 after promotion. Mitigation: leave a short teaser at each old H2 that links to the promoted file, preserving the anchor. |
+| Link integrity — promoted sections link back correctly | concern | Every promoted doc must open with a breadcrumb back to the root README so cold-entry readers can orient. Addressable via template. |
+| Rendering — GitHub | pass | `<details>`, mermaid, tables, relative links all native-supported. |
+| Rendering — PyPI long-description | pass | PyPI uses `readme_renderer` with GFM; `<details>`/`<summary>` are on the allowlist. Confirmed via PyPI policy. No images-in-details issues. |
+| Rendering — plain-text mirrors (e.g. vim `less`) | concern | `<details>` shows both summary and content unfolded in plain-text renderers. Acceptable for this project (no known plain-text audience) but worth acknowledging. |
+| First-screen check (top ~50 lines) | **BLOCKER** | Cannot verify until I draft the new header. Blocker because the stated success criterion ("first screen = install + one success example") depends on it. Resolved during refinement by committing to a concrete layout. |
+| Content quality — teaser sufficiency | concern | A promoted-section teaser must let a reader decide whether to click without opening the linked doc. Shape needs a convention (1 sentence + 1 code snippet + "See [link] for full reference"). |
+| `docs/` voice consistency | concern | Existing `docs/architecture.md` = prose + diagram + table. `docs/stream-json-schema.md` = prose + code examples. New promoted docs should open with the same shape (header → 1-paragraph purpose → link back to README → body). |
+| Reversibility | pass | Single-commit restructure per Q6 = atomic `git revert`. All content preserved in git history. |
+| Rule compliance — `stream-json-schema.md` | pass | We leave `docs/stream-json-schema.md` untouched; the rule's invariant (schema lives there, stays in lockstep with parser) is preserved. |
+| Rule compliance — `plan-contradiction-stop.md` | pass | Plan explicitly re-verified preconditions (Discovery phase). |
+| Rule compliance — all 16 other rules | N/A | None apply to doc-only restructures. |
+| Pre-commit / CI | pass | No markdown tooling; restructure cannot break a check that doesn't exist. Post-merge, links verified by hand. |
+
+### Blocker detail
+
+**BLOCKER-1 — First-screen layout undrafted.**
+The success criterion "first screen = what it is, install, one success
+example" is untestable until we've committed to a concrete top-50-lines
+shape. This isn't a real architecture blocker — it's a refinement
+question that must be resolved before Detailing (we can't write
+acceptance criteria for "first screen passes the check" without knowing
+what the check tests against).
+
+Resolution path: refinement Q-A below sketches three concrete first-
+screen shapes; picking one closes the blocker.
+
+### Concerns (to become refinement decisions)
+
+The architecture review surfaced four concerns worth pinning down
+explicitly before Detailing:
+
+- **Anchor stability** (old bookmarked anchors) → leave teaser + link
+  at each old H2? Or accept the break?
+- **Promoted-doc breadcrumb** (cold entry readers from Google) → open
+  with a "This is reference material from clauditor's README — return
+  to the root" line? Or just a link to `../README.md`?
+- **Teaser shape convention** → lock down a template so every
+  promoted section reads consistently.
+- **`docs/` file opener convention** → one-paragraph purpose + link
+  back to README is the shape; formalize it.
+
+---
+
+## Refinement Log
+
+### Resolved (full ledger)
+
+| Q | Choice | Intent |
+|---|---|---|
+| Q1 | C | Merge README "How It Works" into existing `docs/architecture.md` |
+| Q2 | A | Expanded scope — promote 4 big deep-ref sections |
+| Q3 | C | `<details>` collapsed TOC, hand-rolled |
+| Q4 | B | Collapse agentskills alignment to `<details>` in root |
+| Q5 | B | Merge Exit Codes into `docs/cli-reference.md` |
+| Q6 | A | Single-commit restructure |
+| R-A | A1 + short "Why clauditor?" | First screen = tagline, badges, TOC, Install, short Why, One-minute example, links |
+| R-B | B1 | Preserve every old H2 as a teaser with a link (anchor stability) |
+| R-C | C1 | Every promoted doc opens with `# <Title>` → purpose paragraph → breadcrumb blockquote → body |
+| R-D | D3 | Rich teaser: paragraph + short code block + list of key topics + link |
+
+### Decisions
+
+**DEC-001 — Collision resolution: merge into existing `docs/architecture.md`** (Q1=C)
+Root README's "How It Works" section (H2 at line 222, ~20 lines) is
+removed entirely. Its mermaid diagram and prose land in
+`docs/architecture.md` as a new top-level section or merged into the
+existing content. README keeps only a nav-list line pointing at
+`docs/architecture.md` from the Reference docs section.
+
+**DEC-002 — Scope: expanded to 13 items** (Q2=A)
+Promote all four deep-ref sections (Three Layers, CLI Reference +
+Exit Codes, Eval Spec Format, Pytest Integration) plus the three
+shrinks (Quick Start, Using /clauditor, agentskills alignment) plus
+TOC, plus link audit, plus architecture collision resolution. Target
+≤150 line README — see DEC-011 re: length budget.
+
+**DEC-003 — TOC: hand-rolled collapsed `<details>`** (Q3=C)
+```markdown
+<details>
+<summary>Contents</summary>
+
+- [Install](#install)
+- [Installing the /clauditor slash command](#installing-the-clauditor-slash-command)
+- [Using /clauditor in Claude Code](#using-clauditor-in-claude-code)
+- [One-minute example](#one-minute-example)
+- [Reference docs](#reference-docs)
+
+</details>
+```
+Lives at the top of README after the title + tagline + badges.
+
+**DEC-004 — Collapse agentskills alignment** (Q4=B)
+Wrap the existing 20-line section in `<details><summary>…</summary>`
+in root README. Do NOT promote to a separate file. The content stays
+near the top for trust signaling but is folded by default.
+
+**DEC-005 — Exit Codes → `docs/cli-reference.md`** (Q5=B)
+The 13-line Exit Codes table becomes a subsection of the promoted
+CLI reference file. No separate `docs/exit-codes.md`.
+
+**DEC-006 — Single-commit restructure** (Q6=A)
+One atomic commit. ~500 line diff. Accepts the reviewability tax for
+atomic `git revert` if the restructure lands poorly. Commit message
+will include the per-section promotion list for navigability.
+
+**DEC-007 — First-screen layout** (R-A=A1+Why)
+Top ~50 lines, in order:
+1. `<p align="center">` logo + title + badges (unchanged from today)
+2. One-sentence tagline
+3. `<details>Contents</details>` TOC
+4. `## Install` (3-line pip snippet)
+5. `## Why clauditor?` — short version of the current 3-paragraph
+   positioning content, tightened to ~6-8 lines (3 questions → 3
+   one-line bullets).
+6. `## One-minute example` — a runnable end-to-end snippet
+   (`clauditor init` → `clauditor validate`) with expected output
+   preview.
+
+Replaces the current header through "Install" span (lines 1-64, mostly
+positioning prose).
+
+**DEC-008 — Anchor preservation strategy** (R-B=B1)
+Every promoted section's original H2 stays in the README as a teaser
+(DEC-010 shape). The H2 text stays identical so GitHub-generated
+anchors (`#three-layers-of-validation`, `#cli-reference`,
+`#eval-spec-format`, `#pytest-integration`) continue to resolve.
+Bookmarked links land on the teaser instead of 404.
+
+**DEC-009 — Promoted-doc opener template** (R-C=C1)
+Each new file in `docs/` opens with:
+```markdown
+# <Title>
+
+<One paragraph explaining the purpose and when you'd read this file.>
+
+> Returning from the [root README](../README.md). This doc is the
+> full reference; the README has a summary with code examples.
+
+<body>
+```
+Matches the existing `docs/architecture.md` voice (prose-led).
+Google-landed readers see the breadcrumb immediately.
+
+**DEC-010 — Teaser shape: mixed D3 (high-traffic) + D2 (low-traffic)**
+(R-D=D3 revised to mixed strategy per length budget)
+
+**D3 rich teaser (~12-15 lines)** for high-traffic sections that
+reward a fuller preview:
+
+- Quick Start
+- CLI Reference
+- Eval Spec Format
+
+```markdown
+## <Section Title>
+
+<One-paragraph what-it-is and when-you-use-it, ~3-5 lines.>
+
+<Short code block, ~5-8 lines, showing the most common invocation
+or shape. Enough to anchor the reader.>
+
+**Covered in the full reference:**
+- <topic 1>
+- <topic 2>
+- <topic 3>
+
+Full reference: [docs/<file>.md](docs/<file>.md).
+```
+
+**D2 lean teaser (~4-6 lines)** for lower-traffic sections where a
+pointer is sufficient:
+
+- Three Layers of Validation (conceptual; most readers hit it once)
+- Pytest Integration (niche audience — users who already write tests)
+- Using /clauditor in Claude Code (already-short section just merged
+  in #46; don't re-expand)
+
+```markdown
+## <Section Title>
+
+<One sentence.>
+
+```<5-line code example>```
+
+Full reference: [docs/<file>.md](docs/<file>.md).
+```
+
+Traffic heuristic: a section is "high-traffic" if users revisit it
+to look something up (reference material). A section is "low-traffic"
+if users hit it once during onboarding and rarely return (conceptual
+or niche).
+
+**DEC-011 — Length budget: target ~155 lines**
+*(refined from accepting-over to strict-budget-with-mixed-strategy)*
+
+With DEC-010's mixed strategy:
+
+- 3 D3 rich teasers × ~13 lines = ~39 lines
+- 3 D2 lean teasers × ~5 lines = ~15 lines
+- First-screen content (DEC-007) = ~50 lines
+- Install (unchanged) = ~17 lines
+- Installing the /clauditor slash command (with flag collapse) = ~25 lines
+- Using /clauditor (D2 lean) = already in D2 bucket
+- Reference docs (expanded nav list) = ~10 lines
+- License = ~3 lines
+
+Projected total: **~155 lines.** Close to the ticket's stated
+success criterion (≤150) with a small reserve for polish.
+
+If the actual diff lands at >165, trim D3 teasers or collapse
+additional sections into `<details>` during Quality Gate.
+
+---
+
+## Detailed Breakdown
+
+Natural ordering: extract docs files first → merge into existing
+architecture → rewrite README → audit → quality gate → patterns.
+All stories land in **one feature branch** (`feature/47-readme-restructure`)
+and merge to `dev` as a **squash-merge** per DEC-006 (single commit
+on dev).
+
+**Validation command** per story: `uv run ruff check src/ tests/`
+(no-op for doc-only stories but confirms no accidental drift) plus
+`uv run pytest --cov=clauditor --cov-report=term-missing` (80%
+global gate) plus manual link-resolution check on any rendered file.
+
+---
+
+### US-001 — Extract deep-ref sections into new `docs/*.md` files
+
+**Description:** Lift the six deep-ref and tutorial sections out of
+`README.md` into dedicated files under `docs/`. Pure extraction — no
+content rewrite. Each new file follows DEC-009's opener template
+(title + purpose paragraph + breadcrumb blockquote + body).
+
+**Traces to:** DEC-002 (expanded scope), DEC-005 (Exit Codes merge),
+DEC-009 (opener template)
+
+**Acceptance criteria:**
+- Six new files created, each with DEC-009 opener:
+  - `docs/cli-reference.md` — contents of `## CLI Reference` (lines
+    516-571) plus `## Exit Codes` (lines 572-584) merged as a
+    subsection per DEC-005. Preserve mermaid/tables.
+  - `docs/eval-spec-reference.md` — contents of `## Eval Spec Format`
+    (lines 606-757). Full schema walkthrough with all 12+ JSON
+    examples intact.
+  - `docs/layers.md` — contents of `## Three Layers of Validation`
+    (lines 242-515). Preserve the TD mermaid diagram.
+  - `docs/pytest-plugin.md` — contents of `## Pytest Integration`
+    (lines 585-605).
+  - `docs/quick-start.md` — contents of `## Quick Start` (lines
+    160-221) plus the "Notes" (lines 758-761) if relevant to Quick
+    Start.
+  - `docs/skill-usage.md` — contents of `## Using /clauditor in
+    Claude Code` (lines 112-159).
+- No content changes during extraction — byte-for-byte preservation
+  where possible. Opener template is the only addition.
+- `README.md` is not yet modified (US-003's job).
+- Ruff + pytest still pass (smoke test; nothing Python changed).
+- `ls docs/` shows 8 files (5 pre-existing + 6 new = 11? — check the
+  actual pre-existing count: architecture, stream-json-schema, temp/,
+  assets/. So 6 new files + 2 pre-existing `.md` = 8 `.md` files total).
+
+**Done when:** All six new `docs/*.md` files exist with DEC-009
+openers, each containing the complete extracted content from the
+matching README section.
+
+**Files:**
+- `docs/cli-reference.md` (new)
+- `docs/eval-spec-reference.md` (new)
+- `docs/layers.md` (new)
+- `docs/pytest-plugin.md` (new)
+- `docs/quick-start.md` (new)
+- `docs/skill-usage.md` (new)
+
+**Depends on:** none
+
+---
+
+### US-002 — Merge "How It Works" into existing `docs/architecture.md`
+
+**Description:** The README's `## How It Works` section (lines
+222-241, ~20 lines, includes mermaid flowchart) gets merged into the
+existing `docs/architecture.md`. DEC-001 resolves the collision by
+folding the README content *into* the existing file rather than
+overwriting.
+
+**Traces to:** DEC-001 (collision resolution)
+
+**Acceptance criteria:**
+- `docs/architecture.md` preserves all its existing content.
+- The README "How It Works" mermaid diagram + prose lands in
+  `docs/architecture.md` as an appropriate section (top-level H2 or
+  merged into an existing section — worker picks based on the existing
+  file's shape).
+- The merged content reads coherently; no duplicated explanations of
+  the three-layer pipeline.
+- `README.md` is not yet modified (US-003 removes the section).
+- Pytest + ruff still pass.
+
+**Done when:** `docs/architecture.md` contains the README's "How It
+Works" content integrated without redundancy.
+
+**Files:**
+- `docs/architecture.md` (modified)
+
+**Depends on:** none (can run in parallel with US-001)
+
+---
+
+### US-003 — Rewrite README
+
+**Description:** Largest story. Rewrite `README.md` top-to-bottom
+per DEC-007 (first-screen), DEC-003 (TOC), DEC-004 (agentskills
+collapse), DEC-008 (anchor preservation), DEC-010 (teaser shapes),
+plus the `setup` flag-reference `<details>` collapse. Also move the
+"Maintainers" line (README:109-110) fully into `CONTRIBUTING.md`.
+
+**Traces to:** DEC-003, DEC-004, DEC-007, DEC-008, DEC-010, DEC-011
+
+**Acceptance criteria:**
+- **First screen (DEC-007):** top ~50 lines contain title + badges
+  + tagline + `<details>Contents</details>` + Install (3-line pip
+  snippet) + short "Why clauditor?" (≤8 lines, 3 bullets or a
+  tight paragraph) + One-minute example (runnable snippet with
+  expected-output preview).
+- **TOC (DEC-003):** hand-rolled list of README section anchors
+  wrapped in `<details><summary>Contents</summary>…</details>`.
+- **Agentskills alignment (DEC-004):** the existing 20-line section
+  wrapped in `<details><summary>…</summary>`. Text unchanged.
+- **`setup` flag reference:** flags (`--unlink`, `--force`,
+  `--project-dir`) + restart note + diagnostic pointer wrapped in a
+  `<details>` inside the install section.
+- **Teasers (DEC-008 + DEC-010):** every old H2 from the promoted
+  list preserved as a teaser pointing at its `docs/` file:
+  - `## Quick Start` — D3 rich (paragraph + code block + 3 topics +
+    link to `docs/quick-start.md`).
+  - `## Three Layers of Validation` — D2 lean (one sentence + 5-line
+    snippet + link to `docs/layers.md`).
+  - `## CLI Reference` — D3 rich (paragraph + code block + topics +
+    link to `docs/cli-reference.md`).
+  - `## Pytest Integration` — D2 lean (one sentence + 5-line snippet
+    + link to `docs/pytest-plugin.md`).
+  - `## Eval Spec Format` — D3 rich (paragraph + JSON snippet +
+    topics + link to `docs/eval-spec-reference.md`).
+  - `## Using /clauditor in Claude Code` — D2 lean (one sentence +
+    5-line snippet + link to `docs/skill-usage.md`).
+- **"How It Works" deleted** — mermaid + prose now live in
+  `docs/architecture.md` (US-002); README mentions it only from the
+  Reference docs nav list.
+- **Reference docs nav** expanded to list every promoted file with
+  a one-line description of each.
+- **Maintainers line** (README:109-110 pointing at `CONTRIBUTING.md`)
+  removed from README; content moved into `CONTRIBUTING.md` if not
+  already there.
+- **Line count target:** README ≤ ~165 lines (DEC-011 budget).
+- Ruff + pytest pass.
+
+**Done when:** README renders with the new shape in GitHub's preview;
+all teasers link to files that US-001 created; line count within
+budget.
+
+**Files:**
+- `README.md` (full rewrite)
+- `CONTRIBUTING.md` (ensure maintainer-pointer content is there)
+
+**Depends on:** US-001 (teasers link to the new files), US-002
+(implicit — "How It Works" removed because content moved)
+
+---
+
+### US-004 — Link audit + anchor verification
+
+**Description:** Mechanical verification that no links are broken.
+The restructure moved hundreds of lines of content; anchor drift is
+the main risk per the architecture review.
+
+**Traces to:** anchor stability commitment in DEC-008; ticket success
+criterion "verify all internal links still resolve"
+
+**Acceptance criteria:**
+- Grep the whole repo for `README.md#…` patterns; every one still
+  resolves to a live anchor (teasers preserved per DEC-008).
+- Grep for `docs/…\.md` patterns; every target file exists.
+- Every internal link in `README.md` and every new `docs/*.md` file
+  resolves (spot-check rendered in GitHub preview or by hand).
+- Every mermaid diagram that was in README still renders after its
+  relocation (to `docs/architecture.md` or `docs/layers.md`).
+- `docs/stream-json-schema.md` untouched (rule compliance).
+- Ruff + pytest pass.
+- Worker reports line count of final README.
+
+**Done when:** Link audit passes; report lists any anchors that
+changed and confirms external links are preserved.
+
+**Files:** none modified (verification only); any link fixes discovered
+during audit land as part of this story.
+
+**Depends on:** US-001, US-002, US-003
+
+---
+
+### US-005 — Quality Gate
+
+**Description:** Run code-reviewer agent 4 times across the full
+changeset, fixing every real finding each pass. Run CodeRabbit
+locally. Re-verify validation gate.
+
+**Traces to:** all implementation DECs
+
+**Acceptance criteria:**
+- Code-reviewer agent invoked 4 times; findings fixed or rationalized
+  as false positives.
+- CodeRabbit run via `coderabbit review --plain --base dev --type
+  committed`; findings addressed, review threads resolved on the PR.
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+  with ≥80% coverage.
+- README renders correctly on GitHub (spot-check), `<details>` blocks
+  expand, mermaid diagrams render in `docs/`, internal links resolve.
+- Line count within DEC-011 budget (~155 target, ≤165 accepted;
+  trim if over).
+
+**Done when:** 4 reviewer passes + CodeRabbit clean + validation
+gate green + PR threads resolved.
+
+**Depends on:** US-001 through US-004
+
+---
+
+### US-006 — Patterns & Memory
+
+**Description:** Distill any reusable patterns from this restructure
+into `.claude/rules/` or `bd remember`.
+
+**Traces to:** novel patterns from this ticket
+
+**Acceptance criteria:**
+- Evaluate whether any of these are new-rule-worthy:
+  - "Root README is navigation; `docs/` is reference" as an explicit
+    convention (candidate rule if likely to apply to future repos
+    or sub-features).
+  - DEC-009 opener template for `docs/*.md` files (candidate if we
+    expect more promoted docs).
+  - DEC-010 teaser template — useful reference for future doc churn.
+  - Anchor preservation via teaser (DEC-008) — generalizable pattern
+    for any future doc restructure.
+- If any warrant a rule, author it in `.claude/rules/<name>.md`
+  following the existing file shape (problem → pattern → why →
+  canonical → when applies → when not).
+- Run `bd remember` for transient insights worth searching later
+  but not rule-worthy.
+- Validation gate still passes.
+
+**Done when:** rule files (if any) committed; `bd remember` insights
+recorded; plan's Session Notes closed out.
+
+**Files:**
+- Potentially new `.claude/rules/*.md` file(s)
+- `bd remember` invocations
+
+**Depends on:** US-005
+
+---
+
+### Dependency graph
+
+```
+US-001 (extract 6 docs files) ─┐
+                                │
+US-002 (merge into architecture)┤
+                                ├─► US-003 (rewrite README) ──► US-004 (link audit)
+                                │                                      │
+                                │                                      ▼
+                                │                              US-005 (Quality Gate) ──► US-006 (Patterns)
+```
+
+US-001 and US-002 run in parallel. US-003 depends on both (needs new
+files to link from and architecture content moved). US-004 depends on
+US-003. QG and Patterns close out sequentially.
+
+### Single-commit commitment (DEC-006)
+
+Per DEC-006, all implementation stories land on the feature branch
+across multiple commits (one per story per Ralph convention), and the
+PR-to-dev merge uses **squash** so dev gets one atomic commit. The
+squash message summarizes the per-section work from the merged
+commits.
+
+---
+
+## Beads Manifest
+
+_(Pending — populated in Phase 7.)_
+
+---
+
+## Session Notes
+
+### Session 1 — 2026-04-17
+
+**Discovery complete.** Ticket fetched. Parallel scouts surfaced:
+- A collision on `docs/architecture.md` (already exists with dense
+  content).
+- A much larger promotion opportunity than the 6-item ticket scope —
+  Three Layers (274 lines), Eval Spec Format (152 lines), CLI
+  Reference (56 lines), and Pytest Integration (21 lines) are all
+  deep-ref sections that fit the pattern.
+- One rule-protected docs file (`docs/stream-json-schema.md`) — do
+  not touch.
+- No markdown tooling. Link invariants must be hand-verified.
+
+Awaiting user answers on Q1-Q6 before proceeding to Architecture
+Review.


### PR DESCRIPTION
## Summary

Super plan for [#47](https://github.com/wjduenow/clauditor/issues/47) — restructure the 770-line root README so it serves as navigation + first-success landing, with deep reference material promoted into `docs/`.

**Phase:** \`detailing\` (awaiting approval before devolve to beads)
**Stories:** 4 implementation + Quality Gate + Patterns & Memory = 6 total
**Decisions:** 11 captured with rationale

## Plan document

See [\`plans/super/47-readme-restructure.md\`](../blob/feature/47-readme-restructure/plans/super/47-readme-restructure.md).

## Key scope shifts from the original ticket

- **Expanded from 6 items to 13** (DEC-002). Original ticket scoped How It Works + Quick Start + flag collapse + TOC + usage shrink + link audit. Scouts found that the actual line-count bloat is in Three Layers (274), Eval Spec Format (152), CLI Reference (56), Pytest Integration (21) — all previously unmentioned. Promoting those is what hits the stated \`~150-line README\` goal.
- **Collision resolution** (DEC-001): \`docs/architecture.md\` already exists with content. The "How It Works" section merges *into* the existing file rather than clobbering it.
- **Mixed teaser strategy** (DEC-010): D3 rich teasers for high-traffic sections (Quick Start, CLI Reference, Eval Spec Format); D2 lean for low-traffic (Three Layers, Pytest Integration, Using /clauditor). Keeps the README at ~155 lines while maintaining navigation signal.
- **Anchor preservation** (DEC-008): every promoted section's old H2 stays as a teaser, so bookmarked \`README.md#…\` links continue to resolve.

## Dependency graph

\`\`\`
US-001 (extract 6 docs files) ─┐
                                │
US-002 (merge architecture)    ─┤
                                ├─► US-003 (rewrite README) ─► US-004 (link audit)
                                │                                      │
                                │                                      ▼
                                │                              US-005 (Quality Gate) ─► US-006 (Patterns)
\`\`\`

US-001 and US-002 run in parallel. US-003 is the integration point.

## Next steps

- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (creates beads epic + tasks)

Generated with [Claude Code](https://claude.com/claude-code)