### PR TITLE
audit-quality followups: scrub api_error + triggers exit-1 + SkillAsserter migration doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to clauditor are tracked here. Pre-1.0 releases may
+contain breaking changes without a deprecation shim; see the
+**Breaking changes** sections below for migration guidance.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking changes
+
+- **`SkillResult.assert_*` methods moved to `SkillAsserter`.** The
+  `assert_contains` / `assert_not_contains` / `assert_matches` /
+  `assert_has_urls` / `assert_has_entries` / `assert_min_count` /
+  `assert_min_length` / `run_assertions` helpers previously lived
+  directly on `SkillResult`. They now live on a separate
+  `SkillAsserter` class (`src/clauditor/asserters.py`) to preserve the
+  data/asserter split per `.claude/rules/data-vs-asserter-split.md`.
+  No deprecation shim ships — pre-1.0 accepts the hard break.
+
+  **Migration:** update tests that use the pytest plugin's
+  `clauditor_runner` fixture to wrap the result through
+  `clauditor_asserter`:
+
+  ```python
+  # Before
+  def test_my_skill(clauditor_runner):
+      result = clauditor_runner.run("my-skill", args="...")
+      result.assert_contains("Results")
+
+  # After
+  def test_my_skill(clauditor_runner, clauditor_asserter):
+      result = clauditor_runner.run("my-skill", args="...")
+      clauditor_asserter(result).assert_contains("Results")
+  ```
+
+  See [`docs/pytest-plugin.md`](docs/pytest-plugin.md) for the full
+  fixture list and assertion-method reference.
+
+### Added
+
+- Privacy: `SuggestReport.to_json()` scrubs `api_error` through
+  `transcripts.redact()` before emitting so secret-shaped substrings
+  (Anthropic keys, GitHub PATs, Bearer tokens) are redacted on disk.
+  In-memory `self.api_error` is unchanged (non-mutating scrub per
+  `.claude/rules/non-mutating-scrub.md`).
+- `cmd_triggers` now exits 1 with `ERROR: No trigger_tests defined in
+  eval spec` when the spec is missing `trigger_tests` (previously
+  printed an empty `Trigger Precision:` block and exited 0 — a
+  CI-silent-failure hazard).
+- Root README restructured: deep-reference content promoted into
+  `docs/*.md` files with teasers + anchor preservation. README is now
+  ~165 lines (was 770). See
+  [`.claude/rules/readme-promotion-recipe.md`](.claude/rules/readme-promotion-recipe.md)
+  for the codified recipe.
+- Bundled `/clauditor` Claude Code slash command installable via
+  `clauditor setup`.

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -7,7 +7,7 @@ Reference for clauditor's pytest plugin: the fixtures it registers, the command-
 clauditor registers as a pytest plugin automatically. Available fixtures:
 
 - `clauditor_runner` — pre-configured `SkillRunner`
-- `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_not_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`
+- `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_not_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`. **Migration note:** the `assert_*` methods previously lived directly on `SkillResult`; they now live on a separate `SkillAsserter` class (`src/clauditor/asserters.py`). Existing test code calling `result.assert_contains(...)` must switch to `clauditor_asserter(result).assert_contains(...)` — this is a hard break with no deprecation shim (pre-1.0 project; see `CHANGELOG.md` for details).
 - `clauditor_spec` — factory for loading `SkillSpec` from skill files
 - `clauditor_grader` — factory for Layer 3 quality grading
 - `clauditor_triggers` — factory for trigger precision testing

--- a/src/clauditor/cli/triggers.py
+++ b/src/clauditor/cli/triggers.py
@@ -55,13 +55,18 @@ def cmd_triggers(args: argparse.Namespace) -> int:
         )
         return 2
 
+    # Both the dry-run and non-dry-run paths need trigger_tests. Without
+    # this guard, the non-dry-run path would print an empty 'Trigger
+    # Precision:' block and exit 0 — indistinguishable in CI from a
+    # genuine pass with zero triggers.
+    trigger_tests = spec.eval_spec.trigger_tests
+    if not trigger_tests:
+        print("ERROR: No trigger_tests defined in eval spec", file=sys.stderr)
+        return 1
+
     if args.dry_run:
         from clauditor.triggers import build_trigger_prompt
 
-        trigger_tests = spec.eval_spec.trigger_tests
-        if not trigger_tests:
-            print("ERROR: No trigger_tests defined in eval spec", file=sys.stderr)
-            return 1
         print(f"Model: {model}")
         queries = [
             (q, True) for q in trigger_tests.should_trigger

--- a/src/clauditor/suggest.py
+++ b/src/clauditor/suggest.py
@@ -647,7 +647,18 @@ class SuggestReport:
     schema_version: int = _SCHEMA_VERSION
 
     def to_json(self) -> str:
-        """Serialize to JSON with ``schema_version`` as the first key."""
+        """Serialize to JSON with ``schema_version`` as the first key.
+
+        Scrubs ``api_error`` through :func:`clauditor.transcripts.redact`
+        before emitting so on-disk secrets (e.g. an Anthropic key echoed
+        back in a 401 body) are redacted per
+        ``.claude/rules/non-mutating-scrub.md``. In-memory ``self.api_error``
+        stays full-fidelity — downstream consumers can still read the
+        original for debugging.
+        """
+        scrubbed_api_error = (
+            redact(self.api_error)[0] if self.api_error is not None else None
+        )
         payload: dict = {
             "schema_version": self.schema_version,
             "skill_name": self.skill_name,
@@ -673,7 +684,7 @@ class SuggestReport:
             ],
             "validation_errors": list(self.validation_errors),
             "parse_error": self.parse_error,
-            "api_error": self.api_error,
+            "api_error": scrubbed_api_error,
         }
         return json.dumps(payload, indent=2) + "\n"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2719,6 +2719,21 @@ class TestCmdTriggers:
         assert "No grading model specified" in err
         assert "--model" in err
 
+    def test_triggers_missing_trigger_tests_exits_1(self, capsys):
+        """Non-dry-run with no trigger_tests on the spec must exit 1 with a
+        clear error, matching the --dry-run branch. Otherwise CI cannot
+        distinguish 'passed zero triggers' from 'spec forgot trigger_tests'.
+        """
+        eval_spec = _make_eval_spec(trigger_tests=None)
+        spec = _make_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["triggers", "skill.md"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "No trigger_tests defined" in err
+
 
 class TestCmdInit:
     """Tests for the init subcommand."""

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -1354,6 +1354,7 @@ def _make_report(
     parse_error: str | None = None,
     validation_errors: list[str] | None = None,
     summary_rationale: str = "overall summary",
+    api_error: str | None = None,
 ) -> SuggestReport:
     return SuggestReport(
         skill_name="find",
@@ -1368,6 +1369,7 @@ def _make_report(
         summary_rationale=summary_rationale,
         validation_errors=validation_errors or [],
         parse_error=parse_error,
+        api_error=api_error,
     )
 
 
@@ -1413,6 +1415,44 @@ class TestSuggestReportToJson:
         assert first["id"] == "edit-0"
         assert first["motivated_by"] == ["a1", "g1"]
         assert first["applies_to_file"] == "SKILL.md"
+
+    def test_api_error_scrubbed_on_disk_not_in_memory(self) -> None:
+        """Per .claude/rules/non-mutating-scrub.md, api_error containing a
+        secret-shaped substring (e.g. an Anthropic key echoed in a 401
+        body) is redacted before writing to disk, while the in-memory
+        report keeps the full-fidelity copy for debugging.
+        """
+        secret = "sk-ant-api03-" + "A" * 95
+        raw = f"anthropic API error: 401 body={{\"error\": \"{secret}\"}}"
+        report = _make_report(api_error=raw)
+
+        text = report.to_json()
+        data = json.loads(text)
+
+        # On-disk copy: secret replaced with [REDACTED] marker.
+        assert data["api_error"] is not None
+        assert secret not in data["api_error"]
+        assert "[REDACTED]" in data["api_error"]
+        # Surrounding context is preserved; only the secret span was replaced.
+        assert "anthropic API error: 401" in data["api_error"]
+
+        # In-memory copy is unchanged — downstream consumers (stderr prints,
+        # debugger inspection) still see the full original.
+        assert report.api_error == raw
+
+    def test_api_error_none_stays_none(self) -> None:
+        """Redaction helper must preserve None rather than coerce to string."""
+        report = _make_report(api_error=None)
+        data = json.loads(report.to_json())
+        assert data["api_error"] is None
+
+    def test_api_error_without_secrets_unchanged(self) -> None:
+        """A benign api_error string should round-trip verbatim."""
+        raw = "anthropic API error: timeout after 3 retries"
+        report = _make_report(api_error=raw)
+        data = json.loads(report.to_json())
+        assert data["api_error"] == raw
+        assert report.api_error == raw
 
 
 class TestCheckSchemaVersion:


### PR DESCRIPTION
## Summary

Clears three pre-existing P3 backlog beads from the clauditor-24h audit-quality epic. All three were deferred from that epic's Quality Gate; none are large; they share an \"audit-quality followups\" theme which is why they're bundled here.

## Beads addressed

| Bead | Concern | Changes |
|---|---|---|
| \`clauditor-8l0\` | Privacy | \`SuggestReport.to_json()\` scrubs \`api_error\` through \`transcripts.redact()\` before emitting. In-memory \`self.api_error\` stays full-fidelity per \`.claude/rules/non-mutating-scrub.md\`. 3 new tests. |
| \`clauditor-t9s\` | CI hazard | \`cmd_triggers\` non-dry-run with missing \`trigger_tests\` now exits 1 with a clear error, matching the \`--dry-run\` branch. Previously printed an empty block and exited 0 — CI couldn't distinguish \"pass\" from \"misconfigured\". 1 new test. |
| \`clauditor-bvb\` | Docs | New \`CHANGELOG.md\` + migration note in \`docs/pytest-plugin.md\` documenting the \`SkillResult.assert_* → SkillAsserter\` API break. No deprecation shim (pre-1.0, bead-recommended option B). |

## Test plan

- [ ] \`uv run ruff check src/ tests/\` clean
- [ ] \`uv run pytest --cov=clauditor\` — 1407 passed, 97.46% coverage
- [ ] CHANGELOG.md renders correctly on GitHub
- [ ] \`docs/pytest-plugin.md\` migration note renders in the fixture list

## Test plan summary

1407 tests pass, 97.46% coverage, ruff clean.