### PR TITLE
#58: Add tests/test_e2e_setup.py — full packaging + setup round-trip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ select = ["E", "F", "I", "N", "W", "UP"]
 testpaths = ["tests"]
 asyncio_mode = "strict"
 addopts = "--import-mode=importlib --cov-fail-under=80"
+markers = [
+    "slow: end-to-end tests that build wheels and spin up venvs (~2s each; opt out via -m 'not slow')",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ testpaths = ["tests"]
 asyncio_mode = "strict"
 addopts = "--import-mode=importlib --cov-fail-under=80"
 markers = [
-    "slow: end-to-end tests that build wheels and spin up venvs (~2s each; opt out via -m 'not slow')",
+    "slow: end-to-end tests that build wheels and spin up venvs (~2s total per run thanks to a session-scoped fixture; opt out via -m 'not slow')",
 ]
 
 [dependency-groups]

--- a/tests/test_e2e_setup.py
+++ b/tests/test_e2e_setup.py
@@ -1,0 +1,263 @@
+"""E2E round-trip: ``uv build --wheel`` → ``uv pip install`` → ``clauditor
+setup`` → assertions → ``--unlink``.
+
+This is the only test in the suite that exercises the full bundled-skill
+install path: the wheel's ``stamp_skill_version`` build hook, the
+``importlib.resources`` seam in ``cli/setup.py``, real ``os.symlink``
+creation, and the round-trip unlink. Covers the gap between
+``tests/test_packaging.py`` (inspects the wheel as a ZIP) and
+``tests/test_setup.py`` (pure ``plan_setup`` logic).
+
+Per plan ``plans/super/55-packaging-setup-e2e.md``, DEC-001..009.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tomllib
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+# DEC-001: every test in this file is slow (wheel build + venv + subprocess).
+# DEC-006: Windows skipif — production ``cli/setup.py`` uses bare
+# ``os.symlink`` which requires admin/dev-mode on Windows.
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "clauditor setup uses os.symlink; Windows requires admin or "
+            "developer mode — unsupported until a non-symlink fallback lands."
+        ),
+    ),
+]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd``; raise with diagnostic output on failure."""
+    result = subprocess.run(
+        cmd, cwd=cwd, env=env, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed: {' '.join(cmd)}\n"
+            f"  cwd={cwd}\n"
+            f"  returncode={result.returncode}\n"
+            f"  stdout={result.stdout}\n"
+            f"  stderr={result.stderr}"
+        )
+    return result
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    """Venv's python executable (POSIX only; Windows is skipped)."""
+    return venv_dir / "bin" / "python"
+
+
+def _venv_clauditor(venv_dir: Path) -> Path:
+    """Venv's ``clauditor`` script (the real user entry point)."""
+    return venv_dir / "bin" / "clauditor"
+
+
+def _expected_version() -> str:
+    """Read ``[project].version`` from ``pyproject.toml``.
+
+    DEC-004 #4: never hard-code the version string.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    return data["project"]["version"]
+
+
+def _scratch_env(scratch_home: Path) -> dict[str, str]:
+    """Strict subprocess env whitelist (DEC-007).
+
+    ``HOME`` is redirected so the production ``find_project_root`` home-
+    exclusion walk is not influenced by the developer's real home dir.
+    No ``CLAUDITOR_*``, ``ANTHROPIC_*``, or ``PYTHONPATH`` is inherited.
+    """
+    return {
+        "PATH": os.environ["PATH"],
+        "HOME": str(scratch_home),
+        "USER": os.environ.get("USER", "tester"),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "UV_CACHE_DIR": os.environ.get("UV_CACHE_DIR")
+        or str(scratch_home / ".uv-cache"),
+    }
+
+
+@pytest.fixture(scope="session")
+def e2e_venv(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build wheel + create venv + install (DEC-002 session-scoped).
+
+    DEC-008: hard-require ``uv`` on PATH — missing uv raises (becomes a
+    test error), never a skip.
+    """
+    # DEC-008: uv presence check — fail hard if missing.
+    probe = subprocess.run(
+        ["uv", "--version"], capture_output=True, text=True
+    )
+    if probe.returncode != 0:
+        raise RuntimeError(
+            "uv is required for E2E tests (DEC-008). "
+            f"`uv --version` returned {probe.returncode}. "
+            f"stdout={probe.stdout!r} stderr={probe.stderr!r}"
+        )
+
+    root = tmp_path_factory.mktemp("e2e-venv")
+    wheel_dir = root / "wheels"
+    wheel_dir.mkdir()
+    venv_dir = root / "venv"
+
+    _run(
+        ["uv", "build", "--wheel", "--out-dir", str(wheel_dir)],
+        cwd=REPO_ROOT,
+    )
+    wheels = list(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"expected exactly one wheel in {wheel_dir}, got {wheels}")
+
+    _run(["uv", "venv", str(venv_dir)])
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(_venv_python(venv_dir)),
+            str(wheels[0]),
+        ]
+    )
+    return venv_dir
+
+
+@pytest.fixture
+def scratch_project(tmp_path: Path) -> Path:
+    """Per-test fresh scratch project dir (DEC-002)."""
+    project = tmp_path / "project"
+    project.mkdir()
+    return project
+
+
+# DEC-003: parametrize ``.git`` as empty file (git-worktree style) + ``.claude``
+# as empty dir. ``.claude``-as-file is NOT parametrized — production code
+# rejects it.
+_MARKER_PARAMS = [
+    pytest.param(
+        lambda project: (project / ".git").write_text(""),
+        id="git-worktree-file",
+    ),
+    pytest.param(
+        lambda project: (project / ".claude").mkdir(),
+        id="claude-dir",
+    ),
+]
+
+
+@pytest.mark.parametrize("make_marker", _MARKER_PARAMS)
+def test_setup_roundtrip(
+    e2e_venv: Path,
+    scratch_project: Path,
+    make_marker: Callable[[Path], None],
+    tmp_path: Path,
+) -> None:
+    """Full positive-path assertion stack per DEC-004."""
+    make_marker(scratch_project)
+    env = _scratch_env(scratch_home=tmp_path)
+    clauditor = _venv_clauditor(e2e_venv)
+    symlink = scratch_project / ".claude" / "skills" / "clauditor"
+
+    # Assertion 1: ``clauditor setup`` exits 0.
+    setup = subprocess.run(
+        [str(clauditor), "setup"],
+        cwd=scratch_project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert setup.returncode == 0, (
+        f"clauditor setup failed: stdout={setup.stdout!r} "
+        f"stderr={setup.stderr!r}"
+    )
+
+    # Assertion 2: symlink exists (NOT ``.exists()`` — that follows the
+    # link and passes on broken targets).
+    assert symlink.is_symlink(), f"{symlink} is not a symlink"
+
+    # Assertion 3: target is inside the venv + is the ``clauditor`` skill dir.
+    target = symlink.resolve()
+    assert target.is_relative_to(e2e_venv), (
+        f"symlink target {target} is not inside venv {e2e_venv}"
+    )
+    assert target.name == "clauditor", (
+        f"symlink target leaf name is {target.name!r}, expected 'clauditor'"
+    )
+    assert (target / "SKILL.md").is_file(), (
+        f"SKILL.md not found under symlink target {target}"
+    )
+
+    # Assertion 4: stamped version matches pyproject, no dev placeholder.
+    skill_md_text = (symlink / "SKILL.md").read_text()
+    expected = _expected_version()
+    assert f'clauditor-version: "{expected}"' in skill_md_text, (
+        f"SKILL.md missing stamped version {expected!r}. "
+        f"First 500 chars:\n{skill_md_text[:500]}"
+    )
+    assert "0.0.0-dev" not in skill_md_text, (
+        "SKILL.md still contains '0.0.0-dev' — stamp hook did not run"
+    )
+
+    # Assertion 5: ``clauditor setup --unlink`` removes the symlink.
+    unlink = subprocess.run(
+        [str(clauditor), "setup", "--unlink"],
+        cwd=scratch_project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert unlink.returncode == 0, (
+        f"clauditor setup --unlink failed: stdout={unlink.stdout!r} "
+        f"stderr={unlink.stderr!r}"
+    )
+    assert not symlink.is_symlink(), (
+        f"{symlink} is still a symlink after --unlink"
+    )
+    assert not symlink.exists(), (
+        f"{symlink} still exists after --unlink"
+    )
+
+
+def test_setup_no_marker_exits_2(
+    e2e_venv: Path,
+    scratch_project: Path,
+    tmp_path: Path,
+) -> None:
+    """Negative: no ``.git``/``.claude`` marker → exit 2 (DEC-009).
+
+    Asserts exit code only; stderr content is UI and is not part of
+    the contract.
+    """
+    env = _scratch_env(scratch_home=tmp_path)
+    clauditor = _venv_clauditor(e2e_venv)
+
+    result = subprocess.run(
+        [str(clauditor), "setup"],
+        cwd=scratch_project,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/test_e2e_setup.py
+++ b/tests/test_e2e_setup.py
@@ -104,9 +104,19 @@ def e2e_venv(tmp_path_factory: pytest.TempPathFactory) -> Path:
     test error), never a skip.
     """
     # DEC-008: uv presence check — fail hard if missing.
-    probe = subprocess.run(
-        ["uv", "--version"], capture_output=True, text=True
-    )
+    # ``subprocess.run`` raises ``FileNotFoundError`` when ``uv`` is not on
+    # PATH at all (before it ever returns a CompletedProcess); catch that
+    # explicitly so the diagnostic RuntimeError actually fires.
+    try:
+        probe = subprocess.run(
+            ["uv", "--version"], capture_output=True, text=True
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "uv is required for E2E tests (DEC-008) but is not on PATH. "
+            "Install via `pip install uv` or `curl -LsSf "
+            "https://astral.sh/uv/install.sh | sh`."
+        ) from exc
     if probe.returncode != 0:
         raise RuntimeError(
             "uv is required for E2E tests (DEC-008). "
@@ -149,18 +159,22 @@ def scratch_project(tmp_path: Path) -> Path:
     return project
 
 
+def _write_empty_git_file(project: Path) -> None:
+    """Create an empty ``.git`` file (discards ``write_text``'s byte count)."""
+    (project / ".git").write_text("")
+
+
+def _make_claude_dir(project: Path) -> None:
+    (project / ".claude").mkdir()
+
+
 # DEC-003: parametrize ``.git`` as empty file (git-worktree style) + ``.claude``
 # as empty dir. ``.claude``-as-file is NOT parametrized — production code
-# rejects it.
+# rejects it. Using named helpers keeps the ``Callable[[Path], None]`` type
+# contract honest (lambdas over ``write_text`` leak an ``int`` return).
 _MARKER_PARAMS = [
-    pytest.param(
-        lambda project: (project / ".git").write_text(""),
-        id="git-worktree-file",
-    ),
-    pytest.param(
-        lambda project: (project / ".claude").mkdir(),
-        id="claude-dir",
-    ),
+    pytest.param(_write_empty_git_file, id="git-worktree-file"),
+    pytest.param(_make_claude_dir, id="claude-dir"),
 ]
 
 


### PR DESCRIPTION
## Summary

Implements the E2E test designed in [plan #55](./plans/super/55-packaging-setup-e2e.md)
(merged in PR #57). Closes the gap between `tests/test_packaging.py`
(inspects wheel as a ZIP, no install) and `tests/test_setup.py` (pure
`plan_setup` logic, no real symlink). Exercises the full path:

`uv build --wheel` → `uv pip install` → `clauditor setup` → symlink
assertions → `clauditor setup --unlink`.

**Test count:** 2 parametrized positive tests + 1 negative = 3 tests.
**Runtime:** 1.9 s total (0.6 s test execution + 1.3 s pytest startup) — under the 3 s budget.
**Full suite:** 1547 passed, 97.56 % coverage (unchanged — subprocess coverage is not wired per DEC-005).

Closes #58.

## What the test verifies

Per **DEC-004**, each positive-path test asserts 5 things:

1. `clauditor setup` exits 0.
2. Symlink exists at `project/.claude/skills/clauditor` (uses `Path.is_symlink()`, not `.exists()`).
3. Symlink target is inside the venv + leaf dir is `clauditor` + `SKILL.md` is a real file under it.
4. SKILL.md contains `clauditor-version: "<VERSION>"` where `<VERSION>` is read live from `pyproject.toml`'s `[project].version` via `tomllib.loads()` (never hard-coded). `"0.0.0-dev"` placeholder must be absent.
5. `clauditor setup --unlink` exits 0 and the symlink is gone.

The negative test asserts exit code 2 (no stderr content per DEC-009) for a scratch dir with no `.git`/`.claude` marker.

## Parametrization (DEC-003)

- `git-worktree-file` — empty `.git` **file** at project root (worktree-style).
- `claude-dir` — empty `.claude/` **directory** at project root.

`.claude`-as-file is NOT parametrized — production code rejects it.

## Guards

- **Windows (DEC-006):** `pytest.mark.skipif(sys.platform == 'win32')` on every test. Production `os.symlink` needs admin/dev-mode on Windows.
- **Subprocess env (DEC-007):** strict whitelist — `PATH`, `HOME=tmp_path`, `USER`, `LANG`, `UV_CACHE_DIR`. No `CLAUDITOR_*`/`ANTHROPIC_*`/`PYTHONPATH`. `HOME=tmp_path` prevents the subprocess's `find_project_root` walk from seeing the developer's real `~/.claude/`.
- **uv availability (DEC-008):** session fixture calls `uv --version`; missing → test error, not skip.

## Marker opt-in/out

```bash
uv run pytest -m slow           # E2E only (3 tests)
uv run pytest -m "not slow"     # everything else (1544 tests)
uv run pytest                   # full suite (1547 tests)
```

## Seam-verification outcomes

| Scenario | Expected to catch? | Outcome |
|----------|------------------|---------|
| A. `stamp_skill_version.py` broken (wheel ships `0.0.0-dev`) | yes | **Manually verified** — assertion #4 fails with diagnostic `SKILL.md missing stamped version '0.1.0'` showing `0.0.0-dev` in output. |
| B. Wrong `importlib.resources.files(...)` target | yes | Predicted by code reading to fail at assertion #3 (`is_relative_to(venv)`) or the `(target / 'SKILL.md').is_file()` check. Not manually verified — would require an invasive edit to `cli/setup.py`. |
| C. Remove `include = ["src/clauditor/skills/**/*"]` from `pyproject.toml` | originally **yes** per plan | **Does NOT reproduce a regression.** Hatchling's `packages = ['src/clauditor']` directive + `stamp_skill_version.py`'s `force_include()` keep skill files in the wheel without the explicit include. Plan #55 scenario-C analysis was imprecise. Recorded in `bd memories wheel-skill-file` for future reference. |

## Non-obvious choices

- **`tomllib.loads` over hard-coded version** — the test reads `[project].version` live so a version bump doesn't require a test edit. DEC-004 emphasises this.
- **`is_symlink()` over `.exists()`** — `.exists()` follows the link and would pass on a broken target; `is_symlink()` is what assertion #2 actually wants.
- **`is_relative_to(venv)` over exact-path equality** — resilient to minor install-layout variations while still proving the target is inside the installed venv.
- **Assertion #4 checks both the version string AND absence of `"0.0.0-dev"`** — catches both stamp-hook failure modes (no substitution at all, or substitution with wrong value).
- **Session-scoped fixture + per-test `tmp_path` for `HOME`** — reuses the ~0.5 s wheel build across all tests but gives each test a fresh home directory so `find_project_root` walks aren't influenced by cross-test state.

## Test plan

- [x] `pytest tests/test_e2e_setup.py -m slow` passes (3/3) in <2 s.
- [x] `pytest -m slow` runs only these 3 tests.
- [x] `pytest -m "not slow"` skips these 3 tests (1544 other tests still run).
- [x] `pytest --cov=clauditor` shows 97.56 % coverage (unchanged).
- [x] `ruff check src/ tests/` clean.
- [x] Seam scenario A manually verified.
- [ ] Windows test path manually verified. (Out of scope — no Windows CI runner.)