### PR TITLE
README: close propose-eval coverage gaps (greenfield vs brownfield)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Auditor for AgentSkills.io skills and Claude Integrations. Catches when your ski
 
 ```bash
 pip install clauditor           # CLI only (Layer 1)
-pip install clauditor[grader]   # + LLM grading (Layers 2 & 3)
+pip install clauditor[grader]   # + LLM grading (Layers 2 & 3) and `propose-eval`
 ```
 
 Source install: `git clone https://github.com/wjduenow/clauditor.git && cd clauditor && uv sync --dev`.
@@ -36,9 +36,19 @@ Source install: `git clone https://github.com/wjduenow/clauditor.git && cd claud
 
 ## One-minute example
 
+**Greenfield (no SKILL.md yet):**
+
 ```bash
 clauditor init .claude/commands/my-skill.md       # generate starter eval spec
 clauditor validate .claude/commands/my-skill.md   # → "4/4 assertions passed (100%)"
+```
+
+**Brownfield (SKILL.md already exists):**
+
+```bash
+clauditor propose-eval .claude/skills/my-skill/SKILL.md --dry-run  # preview (no tokens)
+clauditor propose-eval .claude/skills/my-skill/SKILL.md            # LLM writes the spec
+clauditor validate    .claude/skills/my-skill/SKILL.md             # run it
 ```
 
 Swap `validate` for `grade` once you've added `grading_criteria` to the spec.
@@ -69,7 +79,7 @@ Full reference: [docs/skill-usage.md](docs/skill-usage.md).
 
 ## Quick Start
 
-A new skill goes from "untested" to "covered" in three steps: `clauditor init` generates an eval spec, `clauditor validate` tightens L1 assertions against a real capture, then the same spec wires into pytest for regression coverage.
+A new skill goes from "untested" to "covered" in three steps: `clauditor init` generates an eval spec, `clauditor validate` tightens L1 assertions against a real capture, then the same spec wires into pytest for regression coverage. If the SKILL.md already exists, substitute `clauditor propose-eval` for `init` to have Sonnet bootstrap a full three-layer spec from the skill (plus any captured run).
 
 ```bash
 clauditor init .claude/commands/my-skill.md


### PR DESCRIPTION
## Summary

Three small edits to close README gaps around `clauditor propose-eval` that surfaced after the propose-eval feature (#52) and the bundled `/clauditor` skill update (#54) shipped. Sonnet and propose-eval are solid; the README just hadn't caught up with the two onboarding paths.

Closes `clauditor-l5g`.

## Changes

| Line area | Before | After |
|-----------|--------|-------|
| `Install` (~line 26) | `[grader]` flagged as needed only for L2/L3 grading | `[grader]` also needed for `propose-eval` (fixes silent `ImportError` for base-install users who try `propose-eval`) |
| `One-minute example` (~line 37) | Single snippet showing `init` → `validate` (greenfield only) | Split into **Greenfield (no SKILL.md yet)** and **Brownfield (SKILL.md already exists)** sub-snippets with separate code blocks |
| `Quick Start` (~line 72) | Prose says "a new skill" — greenfield-only framing | Paragraph extended with one sentence pointing existing-skill users to `propose-eval` as a substitute for `init` |

## Size impact

README: **164 → 174 lines** (+10). Over the `readme-promotion-recipe` ~155-line budget by 9 lines, intentional: propose-eval is a net-new onboarding entry point (a genuinely second-path use case), not polish inside an existing concept. The rule's budget is a soft target, not a hard cap.

## Why not a bigger restructure

- Deep reference for `propose-eval` already lives in `docs/cli-reference.md#propose-eval` (including the `Relationship to init and capture` subsection).
- The bundled SKILL.md's `Workflow` Step 3 is the canonical procedural guide.
- `docs/skill-usage.md` already mentions propose-eval.
- All three promoted-doc pointers survive this change unchanged.

These README edits are teaser-level updates, not new reference material — within the recipe's allowance for D3-rich teasers gaining 1–2 lines as features land.

## Test plan

- [x] `git diff --stat` shows only README.md changed (12 insertions, 2 deletions).
- [x] Links (`docs/skill-usage.md`, `docs/cli-reference.md`, `docs/quick-start.md`) unchanged and still valid.
- [x] H2 text unchanged (anchor-preservation invariant from readme-promotion-recipe).
- [x] Rendered locally — the greenfield vs brownfield sub-snippets scan cleanly.