### PR TITLE
#62: Support modern <name>/SKILL.md layout

### DIFF
--- a/.claude/rules/skill-identity-from-frontmatter.md
+++ b/.claude/rules/skill-identity-from-frontmatter.md
@@ -35,14 +35,11 @@ def derive_skill_name(
     except ValueError:
         return fs_name, None  # malformed frontmatter → treat as absent
 
-    if not isinstance(parsed, dict):
-        return fs_name, None
+    if not isinstance(parsed, dict) or "name" not in parsed:
+        return fs_name, None  # no name: key → silent fallback
 
-    fm_name = parsed.get("name")
-    if not isinstance(fm_name, str):
-        return fs_name, None  # missing or non-string → silent fallback
-
-    if not re.fullmatch(SKILL_NAME_RE, fm_name):
+    fm_name = parsed["name"]
+    if not isinstance(fm_name, str) or re.fullmatch(SKILL_NAME_RE, fm_name) is None:
         return fs_name, (
             f"clauditor.spec: frontmatter name {fm_name!r} is not a "
             f"valid skill identifier — using {fs_name!r}"

--- a/.claude/rules/skill-identity-from-frontmatter.md
+++ b/.claude/rules/skill-identity-from-frontmatter.md
@@ -1,0 +1,207 @@
+# Rule: Derive skill identity from frontmatter first, filesystem second, lenient on failure
+
+When a feature needs to derive a skill's identity (its `skill_name`)
+from a `SKILL.md` file, consult the YAML frontmatter `name:` field
+first, validate it against `SKILL_NAME_RE`, and fall back to a
+**layout-aware** filesystem-derived name when frontmatter is absent or
+invalid. The helper is pure — it takes the already-loaded Markdown
+text, emits no stderr, and returns a `(name, warning_or_None)` tuple
+so the caller can emit warnings at the I/O boundary. Malformed
+frontmatter and regex failures are lenient: fall back, warn, keep
+going. A typo in YAML should never make a skill uncallable.
+
+## The pattern
+
+```python
+# src/clauditor/paths.py — pure, no I/O
+SKILL_NAME_RE: str = r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"
+
+
+def _filesystem_name(skill_path: Path) -> str:
+    """Layout-aware filesystem fallback."""
+    if skill_path.name == "SKILL.md":
+        return skill_path.parent.name   # modern: <dir>/SKILL.md
+    return skill_path.stem              # legacy: <name>.md
+
+
+def derive_skill_name(
+    skill_path: Path, skill_md_text: str,
+) -> tuple[str, str | None]:
+    fs_name = _filesystem_name(skill_path)
+
+    from clauditor._frontmatter import parse_frontmatter
+    try:
+        parsed, _body = parse_frontmatter(skill_md_text)
+    except ValueError:
+        return fs_name, None  # malformed frontmatter → treat as absent
+
+    if not isinstance(parsed, dict):
+        return fs_name, None
+
+    fm_name = parsed.get("name")
+    if not isinstance(fm_name, str):
+        return fs_name, None  # missing or non-string → silent fallback
+
+    if not re.fullmatch(SKILL_NAME_RE, fm_name):
+        return fs_name, (
+            f"clauditor.spec: frontmatter name {fm_name!r} is not a "
+            f"valid skill identifier — using {fs_name!r}"
+        )
+
+    if fm_name != fs_name:
+        return fm_name, (
+            f"clauditor.spec: frontmatter name {fm_name!r} overrides "
+            f"filesystem name {fs_name!r} — using {fm_name!r}"
+        )
+
+    return fm_name, None
+```
+
+At the call site, the I/O layer owns `read_text` and stderr:
+
+```python
+# src/clauditor/spec.py::SkillSpec.from_file
+text = skill_path.read_text(encoding="utf-8")
+skill_name, warning = derive_skill_name(skill_path, text)
+if warning is not None:
+    print(warning, file=sys.stderr)
+return cls(..., skill_name_override=skill_name)
+```
+
+## Why each piece matters
+
+- **Frontmatter `name:` wins when present and valid**: matches
+  Anthropic's documented shape for skills shared via plugins and
+  agentskills.io, where `<name>/SKILL.md` is the canonical on-disk
+  layout and the frontmatter `name:` is the authoritative identity.
+  The path is secondary (a skill can be symlinked, renamed, or
+  packaged under a different directory without changing its identity).
+- **Layout-aware filesystem fallback**: uniform `skill_path.stem`
+  returns the literal string `"SKILL"` for the modern `<dir>/SKILL.md`
+  layout. Branching on `skill_path.name == "SKILL.md"` is the
+  minimum-viable layout classifier. Legacy `.claude/commands/<name>.md`
+  and modern `.claude/skills/<name>/SKILL.md` are both first-class.
+- **Regex validation against `SKILL_NAME_RE`**: the derived name flows
+  into `f"/{skill_name}"` which becomes the Claude Code slash-command
+  argument, and may also be interpolated into filesystem path segments
+  (capture output files, iteration dir names). The regex
+  (`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`) blocks command injection,
+  argument injection, and path-traversal via hostile `name:` values
+  like `"foo; rm -rf /"` or `"../../../etc/passwd"`. `SKILL_NAME_RE`
+  lives in `paths.py` as a shared constant; every caller uses
+  `re.fullmatch` (not `re.match`) so trailing newlines don't pass.
+- **Lenient on regex failure, not strict**: a malformed frontmatter
+  value shouldn't make the skill uncallable — the filesystem fallback
+  is the already-validated path segment (the parent dir / stem went
+  through the OS). Fall back, warn, keep going. The warning names
+  both the bad value and the fallback so the author notices without
+  being blocked.
+- **Malformed frontmatter treated as absent**: `parse_frontmatter`
+  raises `ValueError` on structural errors (missing closing `---`,
+  empty key, etc.). A hard failure would be hostile to authors
+  iterating on a skill; silent fallback preserves load-bearing
+  behavior. A future `--strict` mode could escalate if needed.
+- **Pure `(str, str | None)` tuple return**: the helper emits no
+  stderr, touches no disk. Callers emit warnings at the I/O boundary
+  (`SkillSpec.from_file`, `cli/init.py`). Satisfies
+  `.claude/rules/pure-compute-vs-io-split.md` — tests can assert on
+  both tuple elements without `capsys`, and the integration tests that
+  use `capsys` are a separate class from the pure-helper tests.
+- **Disagreement wins for frontmatter + warns**: when `fm_name !=
+  fs_name`, frontmatter wins but the user sees a stderr line. This
+  future-proofs against accidental renames (someone moves
+  `<dir>/SKILL.md` to `<other-dir>/SKILL.md` but forgets to update the
+  frontmatter): the skill still loads under its frontmatter-declared
+  identity, and the warning alerts the author to the mismatch.
+- **`SKILL_NAME_RE` is a shared constant, not inlined**: two callers
+  currently validate against it (`paths.py::derive_skill_name` and
+  `propose_eval.py::_derive_skill_name_from_path_or_frontmatter`). A
+  third caller — e.g. a future rubric proposer, a plugin uploader, or
+  a registry client — should import the constant, not copy the regex.
+  A drift between two inlined regexes is a silent security footgun.
+
+## What NOT to do
+
+- Do NOT hard-fail `from_file` when frontmatter is malformed or `name:`
+  fails the regex. The fallback path is the minimum-viable identity;
+  hard-failing is hostile to authors and masks the real fix site.
+- Do NOT emit stderr from inside `derive_skill_name`. The helper is
+  pure; stderr belongs to the caller (see
+  `.claude/rules/pure-compute-vs-io-split.md`).
+- Do NOT return a uniform `skill_path.stem` for both layouts. That is
+  the bug this rule codifies around — `stem` returns `"SKILL"` for the
+  modern layout.
+- Do NOT omit the `isinstance(fm_name, str)` guard. `parsed.get("name")`
+  can return `None` or a non-string depending on what the YAML subset
+  parsed; `re.fullmatch` on a non-string raises `TypeError`, which
+  would escape.
+- Do NOT loosen `SKILL_NAME_RE` without rewriting every interpolation
+  site to escape the name. The regex is the single anchor keeping
+  `f"/{skill_name}"` and any `skill_name`-as-path-segment safe.
+
+## Canonical implementation
+
+- Shared regex: `src/clauditor/paths.py::SKILL_NAME_RE`.
+- Pure helpers: `src/clauditor/paths.py::_filesystem_name` +
+  `derive_skill_name`.
+- I/O caller: `src/clauditor/spec.py::SkillSpec.from_file` — reads the
+  file, calls the helper, emits any warning to stderr, passes the
+  resolved name to `SkillSpec.__init__` via the keyword-only
+  `skill_name_override=` kwarg.
+- Back-compat shape: `SkillSpec.__init__` accepts
+  `skill_name_override: str | None = None` and falls back to a
+  layout-aware no-I/O derivation when the override is `None` (preserves
+  the direct-constructor path used by `tests/test_quality_grader.py`'s
+  `SkillSpec(Path("dummy.md"), ...)` fixture).
+- Second caller: `src/clauditor/cli/init.py::cmd_init` — reads the
+  file, calls the same helper, emits the warning, uses the name in the
+  starter eval's `skill_name` and `description` fields.
+- Tests: `tests/test_paths.py::TestDeriveSkillName` (seven pure-helper
+  cases, no `tmp_path`) and `tests/test_spec.py::TestFromFile` (five
+  integration cases covering both layouts + `capsys` for warning
+  emission).
+- Regression test: `tests/test_bundled_skill.py::TestBundledSkillViaSpec`
+  loads the project's own modern-layout bundled `SKILL.md` through
+  `SkillSpec.from_file` — a real-file self-validation.
+
+Traces to DEC-001, DEC-002, DEC-008, DEC-009, DEC-012 of
+`plans/super/62-skill-md-layout.md`. Companion rules:
+`.claude/rules/pure-compute-vs-io-split.md` (the pure-helper shape),
+`.claude/rules/path-validation.md` (the regex-and-containment style
+for user-provided paths from JSON, though this rule covers
+Markdown-frontmatter identity rather than JSON paths).
+
+## When this rule applies
+
+Any future feature that needs to derive a skill's `skill_name` from a
+`SKILL.md` file. Examples:
+
+- A plugin uploader that reads a skill directory and posts it to a
+  registry under its frontmatter-declared name.
+- A rubric proposer or trigger classifier that needs to reference the
+  skill by name in prompts.
+- An auto-generated eval spec writer (`clauditor init`, `clauditor
+  propose-eval`, a future `clauditor propose-triggers`).
+- A skill registry client or local cache keyed by skill name.
+
+The rule also generalizes, shape-wise, to reading other frontmatter
+fields (`description:`, `allowed-tools:`, `argument-hint:`) where the
+author-provided value is authoritative and a filesystem or spec-local
+fallback exists — though each new field needs its own validation
+invariant.
+
+## When this rule does NOT apply
+
+- CLI flags or already-validated config where the user types the
+  skill name directly on the command line — the regex validation
+  belongs at the CLI-arg layer, not at a frontmatter-reader.
+- Non-skill Markdown files with YAML frontmatter (blog posts,
+  README teasers, ADRs). The `SKILL.md`-specific fallback assumptions
+  (parent dir, stem) don't generalize.
+- Direct-constructor test fixtures that bypass `from_file`
+  (`SkillSpec(Path("dummy.md"), ...)`). Those use the `__init__`
+  no-I/O fallback documented above, not `derive_skill_name`.
+- One-off diagnostic scripts in `scripts/` that open a SKILL.md and
+  just want `path.stem`. Those should use the helper if they touch
+  production identity plumbing, but ad-hoc shell-script-style
+  diagnostics are fine with inline logic.

--- a/docs/skill-usage.md
+++ b/docs/skill-usage.md
@@ -10,6 +10,8 @@ project. The command is manual-only — Claude won't auto-invoke it,
 because validating a skill has side effects (subprocess runs, sidecar
 writes, potential token spend on L3 grading).
 
+clauditor works with both the legacy `.claude/commands/<name>.md` layout and the modern `.claude/skills/<name>/SKILL.md` layout.
+
 **Invoke with the path to the skill you want to evaluate:**
 
 ```text

--- a/plans/super/62-skill-md-layout.md
+++ b/plans/super/62-skill-md-layout.md
@@ -4,8 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/62
 - **Branch:** `feature/62-skill-md-layout`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/62-skill-md-layout`
-- **Phase:** `detailing`
-- **PR:** _not yet created_
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/66
 - **Sessions:** 1
 - **Last session:** 2026-04-20
 

--- a/plans/super/62-skill-md-layout.md
+++ b/plans/super/62-skill-md-layout.md
@@ -1,0 +1,590 @@
+# Super Plan: #62 — Support the modern `<name>/SKILL.md` layout in `SkillSpec`
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/62
+- **Branch:** `feature/62-skill-md-layout`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/62-skill-md-layout`
+- **Phase:** `detailing`
+- **PR:** _not yet created_
+- **Sessions:** 1
+- **Last session:** 2026-04-20
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Teach `SkillSpec.__init__` (and `cli/init.py`'s starter-eval
+writer) to handle the modern Anthropic skills layout
+`.claude/skills/<name>/SKILL.md` alongside the legacy
+`.claude/commands/<name>.md` layout. Today, both sites derive
+`skill_name` via `skill_path.stem`, which produces the literal string
+`"SKILL"` for a modern-layout path — so the CLI invokes `/SKILL`
+(unknown command) and the subprocess returns `"Skill failed to run:
+None"` after a wasted 37-second round trip.
+
+**Why:** Anthropic's documented shape for skills shared via plugins
+and agentskills.io is `<name>/SKILL.md`. Any skill authored against
+that spec is currently untestable with clauditor without a manual
+symlink workaround. The project's own bundled skill lives at
+`src/clauditor/skills/clauditor/SKILL.md` in the modern layout —
+meaning we cannot even self-validate.
+
+**Done when:**
+- `clauditor validate .claude/skills/<name>/SKILL.md` succeeds on a
+  skill that has declared `name:` in its frontmatter (no workaround).
+- `clauditor init .claude/skills/<name>/SKILL.md` writes a starter
+  eval at the right path with `skill_name = <name>`, not `"SKILL"`.
+- `clauditor validate .claude/commands/<name>.md` (legacy layout)
+  continues to work byte-identically.
+- Coverage stays ≥80%; ruff passes.
+
+### Key findings — codebase scout
+
+#### Bug site 1: `src/clauditor/spec.py`
+
+```python
+# src/clauditor/spec.py:30–39
+def __init__(
+    self,
+    skill_path: Path,
+    eval_spec: EvalSpec | None = None,
+    runner: SkillRunner | None = None,
+):
+    self.skill_path = skill_path
+    self.skill_name = skill_path.stem                              # BUG
+    self.eval_spec = eval_spec
+    self.runner = runner or SkillRunner(
+        project_dir=skill_path.parent.parent.parent                # BUG
+    )
+```
+
+- **Line 37 (skill_name):** For `/repo/.claude/skills/foo/SKILL.md`
+  → `"SKILL"`. For `/repo/.claude/commands/foo.md` → `"foo"`
+  (legacy: correct).
+- **Line 39 (project_dir):** 3-deep ascent assumes legacy.
+  `.claude/commands/foo.md` → `/repo` (correct). For modern
+  `.claude/skills/foo/SKILL.md` — one extra dir level —
+  `parent.parent.parent` = `/repo/.claude`, which is **not** the
+  project root. The runner then launches `claude` with the wrong
+  CWD, and relative paths (input_files, output_files) resolve
+  against `.claude/` instead of the project.
+
+#### Bug site 2: `src/clauditor/cli/init.py` lines 35–36
+
+```python
+starter = {
+    "skill_name": skill_path.stem,                            # BUG
+    "description": f"Eval spec for /{skill_path.stem}",       # BUG
+    ...
+}
+```
+
+Same pattern — writes `"skill_name": "SKILL"` and
+`"description": "Eval spec for /SKILL"` into the starter eval.json.
+Note: line 25 (`skill_path.with_suffix(".eval.json")`) produces
+`SKILL.eval.json` for the modern layout, which loads fine but has
+an ugly on-disk filename.
+
+#### Frontmatter parser already exists and is pure
+
+`src/clauditor/_frontmatter.py::parse_frontmatter(text) -> (dict | None, str)`
+is stateless, returns top-level scalars as strings. The bundled
+`src/clauditor/skills/clauditor/SKILL.md` declares `name: clauditor`
+in its frontmatter — the idiomatic source of truth for modern
+skills.
+
+#### Eval-spec auto-discovery
+
+`spec.py:62` uses `skill_path.with_suffix(".eval.json")`:
+- Legacy `/foo/my-skill.md` → `/foo/my-skill.eval.json` ✓
+- Modern `/foo/SKILL.md` → `/foo/SKILL.eval.json` (works but odd
+  filename — coexists with SKILL.md in the same dir)
+
+#### Callers and blast radius
+
+- `src/clauditor/cli/__init__.py` — `_load_spec_or_report` calls
+  `from_file`.
+- `src/clauditor/cli/compare.py` — two calls.
+- `src/clauditor/pytest_plugin.py` — `clauditor_spec` fixture wraps
+  `from_file`.
+- 20+ test sites in `tests/test_spec.py`, `tests/test_cli.py`,
+  `tests/test_pytest_plugin.py`, etc.
+- **All test fixtures today use legacy `.md` shape**
+  (`tmp_skill_file` writes `tmp_path/<name>.md`). No test
+  currently covers the modern `<name>/SKILL.md` layout — that's
+  the test gap that let this ship.
+
+#### Setup / project-root walk
+
+`src/clauditor/setup.py::find_project_root` already walks up for a
+`.claude/` marker and has the home-exclusion guard
+(`.claude/rules/project-root-home-exclusion.md`). Not affected by
+this fix — the bug lives in a different code path (spec
+construction, not project-root discovery).
+
+### Applicable `.claude/rules/`
+
+| Rule | Applies? | Constraint on this plan |
+|---|---|---|
+| `pure-compute-vs-io-split.md` | **yes** | Extract `derive_skill_name(skill_path, skill_md_text) -> str` as a pure function — frontmatter-first, stem fallback, zero I/O. Caller does `read_text()`. Testable without `tmp_path` for the logic. |
+| `in-memory-dict-loader-path.md` | yes (satisfied) | `parse_frontmatter` is already pure in-memory (no `from_file` wrapper needed). New helper consumes its output. |
+| `path-validation.md` | no | Not accepting user path-lists from JSON; only reclassifying already-validated SKILL paths. |
+| `json-schema-version.md` | no | No new persisted sidecar — only a loader fix. (`init.py`'s starter already has `schema_version` via `EvalSpec`.) |
+| `llm-cli-exit-code-taxonomy.md` | no | Not an LLM command. |
+| `bundled-skill-docs-sync.md` | conditional | Only if we edit the bundled SKILL.md workflow. This fix shouldn't require it. |
+| `readme-promotion-recipe.md` | conditional | Modern-layout support is worth a line in README + docs if we also let `init` handle it. |
+| `project-root-home-exclusion.md` | no | `find_project_root` untouched. |
+| `eval-spec-stable-ids.md` | no | No changes to eval schema. |
+| `monotonic-time-indirection.md` | no | No timing code. |
+| CLAUDE.md | yes | Use `bd`, not TodoWrite. Validation = `uv run ruff check src/ tests/` + `uv run pytest --cov=clauditor --cov-report=term-missing` (80% gate). |
+
+### Proposed scope
+
+A) **Core fix** (must):
+   1. New pure helper `derive_skill_name(skill_path, skill_md_text)`
+      in `spec.py` (or a new small module if we prefer isolation).
+      Frontmatter `name:` wins; fallback is layout-aware
+      (modern → `parent.name`, legacy → `stem`).
+   2. New pure helper `derive_project_dir(skill_path)` — layout-aware
+      ascent (4-deep for modern, 3-deep for legacy). Or route
+      through `find_project_root` with skill_path as starting cwd.
+   3. Refactor `SkillSpec.__init__` to call both helpers (thin I/O
+      wrapper around the pure layer).
+   4. Fix `cli/init.py` to use `derive_skill_name` (same skill-path
+      input).
+B) **Tests** (must):
+   - `TestDeriveSkillName` — unit tests for the pure helper (modern,
+     legacy, missing frontmatter, malformed frontmatter, name field
+     present/absent).
+   - `TestDeriveProjectDir` — unit tests for the pure helper.
+   - `TestSkillSpecFromFile` — integration tests covering both
+     layouts via `tmp_path` fixtures.
+   - Extend `tmp_skill_file` fixture (conftest.py) to support
+     modern layout, OR add a sibling `tmp_skill_dir` fixture.
+   - Regression test asserting the bundled skill itself loads
+     cleanly through `SkillSpec.from_file` (validates #7 of the
+     scout report).
+C) **Docs** (likely):
+   - `docs/skill-usage.md` — add a line noting both layouts work.
+   - `README.md` — one-sentence mention in the Quick Start or
+     CLI reference if the modern layout is the primary audience.
+
+### Open questions for the user
+
+See _Scoping Questions_ below.
+
+---
+
+## Scoping Questions
+
+**Answered 2026-04-20:**
+- **Q1 = A** — Frontmatter `name:` first, layout-aware fallback, silent.
+- **Q2 = B** — Frontmatter wins on disagreement with a stderr warning
+  (so an accidental rename never silently goes unnoticed).
+- **Q3 = C** — Try marker-walk via `find_project_root` first, fall
+  back to layout-aware count (so `tmp_path` fixtures without a
+  `.git`/`.claude` marker still resolve a sensible root).
+- **Q4 = A** — Fix `cli/init.py` in the same PR via the shared helper.
+- **Q5 = C** — Unit + integration + bundled-skill regression test.
+
+### Q1 — Source of truth for `skill_name`
+
+Which derivation order should the helper use?
+
+- **A.** Frontmatter `name:` first (authoritative if present),
+  layout-aware fallback (modern → parent dir name, legacy → stem).
+  Silent fallback — no warning when `name:` is absent.
+- **B.** Layout-aware only — modern uses `parent.name`, legacy uses
+  `stem`. Frontmatter ignored. Simpler, but loses the "frontmatter
+  is the canonical identity" property.
+- **C.** Frontmatter `name:` required for modern layout; hard-fail
+  if missing. Legacy uses `stem`. Strictest, surfaces missing
+  frontmatter loudly.
+- **D.** Frontmatter-first with a stderr warning when falling back.
+  Informative but noisy for well-behaved legacy skills that never
+  declare frontmatter.
+
+### Q2 — Disagreement policy when frontmatter `name:` ≠ filesystem-derived
+
+If a SKILL.md sits at `.claude/skills/foo/SKILL.md` but declares
+`name: bar` in frontmatter:
+
+- **A.** Frontmatter wins silently.
+- **B.** Frontmatter wins with a stderr warning.
+- **C.** Hard-fail — refuse to load.
+- **D.** Filesystem wins silently (frontmatter is metadata, not
+  identity).
+
+### Q3 — `project_dir` derivation
+
+- **A.** Layout-aware ascent: detect modern vs legacy by
+  `parent.name == "skills"` (modern) vs `parent.name == "commands"`
+  (legacy), then ascend the correct number of levels.
+- **B.** Marker-walk via `find_project_root(skill_path.parent)` —
+  walks up for `.git` / `.claude`. Most robust (handles future
+  layouts). Requires importing from `setup.py`.
+- **C.** Both: try marker-walk first, fall back to layout-aware
+  count if marker-walk fails (e.g., `tmp_path` fixtures with no
+  `.git`/`.claude`).
+- **D.** Thread `project_dir` as an explicit `__init__` param with
+  a default of `None` → use current logic; callers that know their
+  root (CLI, pytest plugin) pass it explicitly. Breaking-change for
+  programmatic callers, but most explicit.
+
+### Q4 — Scope: fix `cli/init.py` in the same PR?
+
+- **A.** Yes — route `cli/init.py` through the same
+  `derive_skill_name` helper (same bug, same fix).
+- **B.** No — split into a follow-up ticket. Keep this PR focused
+  on `SkillSpec`.
+- **C.** Yes for the name derivation, but leave
+  `skill_path.with_suffix(".eval.json")` alone (i.e., accept the
+  `SKILL.eval.json` filename for the modern layout).
+- **D.** Yes, including a smarter eval.json path — for modern
+  layout, write `<name>/SKILL.eval.json`; for legacy, keep
+  `<name>.eval.json`.
+
+### Q5 — Test coverage depth
+
+- **A.** Unit tests on the pure helpers only.
+- **B.** Unit + integration (SkillSpec.from_file round-trip via
+  `tmp_path` for both layouts).
+- **C.** B + a regression test asserting the bundled
+  `src/clauditor/skills/clauditor/SKILL.md` loads through
+  `SkillSpec.from_file` (real file, self-validation).
+- **D.** C + end-to-end via `pytester` subprocess mode (avoid the
+  `pytester + --cov + mock.patch` hazard from
+  `.claude/rules/pytester-inprocess-coverage-hazard.md`).
+
+---
+
+## Architecture Review
+
+### Ratings
+
+| Area | Rating | Note |
+|---|---|---|
+| Back-compat: direct `SkillSpec(...)` callers | **concern** | `tests/test_quality_grader.py:1902` passes `Path("dummy.md")` (non-existent). Any `read_text()` inside `__init__` would fail. |
+| `__init__` vs `from_file` split | **concern** | Resolves Concern 1: frontmatter read lives in `from_file`, passed to `__init__` via optional `skill_name_override=None`. |
+| Pytest-plugin impact | pass | `clauditor_spec` always uses `SkillSpec.from_file`. No direct-constructor fixtures. |
+| Legacy `name:` collision risk | pass | Scan: no `.claude/commands/*.md` or bundled skill declares a frontmatter `name:` that disagrees with filesystem. Bundled `src/clauditor/skills/clauditor/SKILL.md` declares `name: clauditor` matching its parent dir. |
+| Runner CWD change for modern layout | pass | Intended — today `SkillRunner.project_dir` points at `.claude/` for a modern skill, which is the bug. |
+| Circular-import risk | pass | `setup.py` imports only stdlib; safe for `spec.py` to import from it. |
+| Helper home | **concern** | Recommendation: put pure helpers in `src/clauditor/paths.py` (already home to `resolve_clauditor_dir`). Move `find_project_root` there from `setup.py` with a back-import for compatibility. |
+| Frontmatter parser robustness | pass | `parse_frontmatter` raises `ValueError` on malformed input; bounded, single-pass. No DoS vector. |
+| Untrusted `name:` injection | **concern** | `propose_eval.py` already defines `_SKILL_NAME_RE = r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"`. We should reuse it (promote to a shared location, e.g. `paths.py`) and reject frontmatter `name:` values that fail the regex — fall back to layout-derived name with a warning. |
+| `name:` used as filesystem segment | pass | Grep shows two uses — `cli/capture.py` (user-provided skill_name, pre-validated) and `pytest_plugin.py` display only. No path-traversal surface. |
+| Warning format | **concern** | No canonical format today. Adopt `"clauditor.spec: "` prefix (consistent with existing `runner.py` `"clauditor.runner: "` style). |
+| Verbose/quiet interaction | pass | Emit warning unconditionally; it's informational, not debug. |
+| Silent fallback on missing `name:` | pass | Q1=A agreed. Forward-compat: a future `--debug` flag can log it without signature changes. |
+| I/O error reporting | **concern** (was blocker) | `cli/__init__.py::_load_spec_or_report` catches only `FileNotFoundError`. A new `read_text()` can raise `OSError` (permission denied, I/O error). Expand the except to `(FileNotFoundError, OSError)` with a clear message. |
+| Test-class organization | pass | Add `TestDeriveSkillName` + `TestDeriveProjectDir`; extend `TestFromFile` with modern-layout cases. |
+| Fixture extension | **concern** | Extend `tmp_skill_file(layout="legacy" \| "modern")` — single factory, both layouts. |
+| Integration matrix | pass | 6 cases: modern+match, modern+disagree (warn), modern+missing-name, legacy+match, legacy+missing-name, bundled-skill regression. |
+| Bundled-skill regression test | pass | New `TestBundledSkillViaSpec` class in `tests/test_bundled_skill.py` — round-trip through `SkillSpec.from_file`. |
+| Reload hazard | pass | `tests/test_spec.py` already reloads `clauditor.spec`. |
+| Pytester+cov hazard | pass | No `pytester` + inner `mock.patch` in planned tests. |
+
+### Concerns to resolve in refinement
+- **C1.** Keep `SkillSpec(...)` direct constructor safe — move frontmatter read into `from_file`, pass name as optional kwarg.
+- **C2.** Pick a single home for the pure helpers (`paths.py` recommended). Decide whether to move `find_project_root` too.
+- **C3.** Reuse/promote `_SKILL_NAME_RE` for frontmatter `name:` validation.
+- **C4.** Pin the stderr warning format.
+- **C5.** Expand `_load_spec_or_report` except clause.
+- **C6.** Confirm fixture approach (`layout=` kwarg vs sibling fixture).
+
+---
+
+## Refinement Log
+
+### DEC-001 — Source of truth for `skill_name`: frontmatter-first, layout-aware fallback, silent on missing
+Frontmatter `name:` is authoritative when present and valid. When absent, fall back to `skill_path.parent.name` for the modern `<name>/SKILL.md` layout and `skill_path.stem` for the legacy `<name>.md` layout. No warning on missing — keeps legacy skills (which don't declare `name:`) quiet. (Q1=A.)
+
+### DEC-002 — Disagreement policy: frontmatter wins + stderr warning
+If frontmatter `name:` disagrees with the filesystem-derived name, use the frontmatter value and emit a stderr warning. Scanning the repo confirmed no current file disagrees, so the warning is future-proofing against accidental rename. (Q2=B.)
+
+### DEC-003 — `project_dir` derivation: `find_project_root` first, layout-aware ascent fallback
+Try `find_project_root(skill_path.parent)` (the existing marker-walk with home-exclusion). If it returns `None` (e.g., `tmp_path` with no `.git`/`.claude`), fall back to: 4-deep ascent for modern `<name>/SKILL.md`, 3-deep for legacy `<name>.md`. This preserves byte-identical legacy behavior when markers are absent. (Q3=C.)
+
+### DEC-004 — Fix `cli/init.py` in the same PR
+`cli/init.py` has the same `skill_path.stem` bug. Route it through the shared helper so `clauditor init .claude/skills/foo/SKILL.md` writes `"skill_name": "foo"` instead of `"skill_name": "SKILL"`. (Q4=A.)
+
+### DEC-005 — Test depth: unit + integration + bundled-skill regression
+Unit tests on the pure helpers, integration via extended `tmp_skill_file` fixture covering both layouts, and a regression test in `tests/test_bundled_skill.py` asserting the bundled `src/clauditor/skills/clauditor/SKILL.md` loads cleanly through `SkillSpec.from_file`. No `pytester`. (Q5=C.)
+
+### DEC-006 — Frontmatter read lives in `from_file`, not `__init__`
+`SkillSpec.__init__` gains an optional `skill_name_override: str | None = None` kwarg. When provided (the `from_file` path), it's used directly. When `None` (direct-constructor path used by `tests/test_quality_grader.py:1902` with a non-existent path), `__init__` falls back to layout-aware filesystem derivation with no `read_text()` call. Preserves back-compat for any test or programmatic caller that constructs `SkillSpec` with a non-existent path. (Resolves C1.)
+
+### DEC-007 — Pure helpers live in `src/clauditor/paths.py`; `find_project_root` stays in `setup.py`
+`paths.py` already hosts `resolve_clauditor_dir` — it's the natural home for path-classifier helpers. `find_project_root` stays in `setup.py` (where it's co-located with its other callers); `paths.py` and `spec.py` import it from there. Keeps this PR's diff smaller; no module-move cascade. (Resolves C2, R1=B.)
+
+### DEC-008 — Promote `SKILL_NAME_RE` to `paths.py`; lenient fallback when regex fails
+Move `_SKILL_NAME_RE = r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"` from `propose_eval.py` to `paths.py` as `SKILL_NAME_RE`. `propose_eval.py` re-imports it. When the frontmatter `name:` value fails the regex, `derive_skill_name` treats it as absent, falls back to the layout-aware filesystem name, and emits a warning naming the bad value and the chosen fallback. Lenient beats strict: a malformed frontmatter shouldn't make the whole skill uncallable. (Resolves C3, R2=A.)
+
+### DEC-009 — Stderr warning format: `"clauditor.spec: ..."`
+Consistent with existing `"clauditor.runner: ..."` prefix convention. Two canonical messages:
+- Disagreement: `clauditor.spec: frontmatter name 'bar' overrides filesystem name 'foo' — using 'bar'`
+- Regex failure: `clauditor.spec: frontmatter name 'bad;name' is not a valid skill identifier — using 'foo'`
+
+Always emitted; no `--quiet` suppression. (Resolves C4.)
+
+### DEC-010 — `_load_spec_or_report`: branch on exception type
+Expand `cli/__init__.py::_load_spec_or_report`'s except clause to `(FileNotFoundError, OSError)`. Keep the existing "not found → suggest `clauditor init`" hint for `FileNotFoundError`. For other `OSError`, emit `ERROR: cannot read {path}: {exc}` (shows "Permission denied", "Input/output error", etc.). Two distinct messages, one except clause. (Resolves C5, R3=B.)
+
+### DEC-011 — Extend `tmp_skill_file` with `layout="legacy" | "modern"` kwarg
+Single factory handles both layouts. `layout="legacy"` (default) writes `tmp_path/<name>.md` (byte-identical to today). `layout="modern"` writes `tmp_path/.claude/skills/<name>/SKILL.md`. New tests opt in via the kwarg; all existing tests keep working untouched. Avoids the plugin-fixture-shadowing hazard in `tests/conftest.py`. (Resolves C6.)
+
+### DEC-012 — Helper return type: pure `(str, str | None)` tuple; caller emits
+`derive_skill_name(skill_path, skill_md_text) -> tuple[str, str | None]` — returns `(skill_name, warning_message_or_None)`. The helper never touches stderr; the `SkillSpec.from_file` caller emits the warning when the second tuple element is not `None`. Keeps the pure-compute-vs-io-split rule intact: the helper is unit-testable without capturing stderr; integration tests capture stderr to verify emission.
+
+---
+
+## Detailed Breakdown
+
+Natural ordering: shared primitives → pure helpers → integration → adjacent fixes → hardening → regression/docs → quality gate → patterns.
+
+---
+
+### US-001 — Promote `SKILL_NAME_RE` to `paths.py`
+
+**Description.** Move the skill-identifier regex from `src/clauditor/propose_eval.py` to `src/clauditor/paths.py` as the public constant `SKILL_NAME_RE`. Update `propose_eval.py` to import from `paths.py`. Pure refactor, no behavior change — unblocks US-002 from needing its own regex.
+
+**Traces to:** DEC-008.
+
+**Acceptance criteria:**
+- `src/clauditor/paths.py` declares `SKILL_NAME_RE: str = r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"` at module scope.
+- `src/clauditor/propose_eval.py` imports `SKILL_NAME_RE` from `paths.py`; the local `_SKILL_NAME_RE` is removed.
+- Every existing test in `tests/test_propose_eval.py` passes byte-identically (same error messages, same behavior).
+- `uv run ruff check src/ tests/` passes; `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥80% coverage.
+
+**Done when:** grep finds exactly one definition of the regex (in `paths.py`), `propose_eval.py` imports it, and all existing tests pass.
+
+**Files:**
+- `src/clauditor/paths.py` — add `SKILL_NAME_RE`.
+- `src/clauditor/propose_eval.py` — replace `_SKILL_NAME_RE` usage with the imported symbol; remove the local.
+- `tests/test_paths.py` — one test asserting `SKILL_NAME_RE` matches a known-good identifier and rejects a known-bad one.
+
+**Depends on:** none.
+
+---
+
+### US-002 — Pure skill-identity helpers in `paths.py`
+
+**Description.** Add two pure functions to `src/clauditor/paths.py`:
+
+- `derive_skill_name(skill_path: Path, skill_md_text: str) -> tuple[str, str | None]`
+- `derive_project_dir(skill_path: Path) -> Path`
+
+Both are pure — no stderr, no disk side effects. `derive_skill_name` parses frontmatter via `parse_frontmatter`, validates `name:` against `SKILL_NAME_RE`, applies the DEC-001/DEC-002 rules, and returns `(name, warning_or_None)`. `derive_project_dir` wraps `find_project_root` and falls back to layout-aware ascent per DEC-003. TDD: tests first.
+
+**Traces to:** DEC-001, DEC-002, DEC-003, DEC-007, DEC-008, DEC-012.
+
+**Acceptance criteria:**
+- `derive_skill_name`:
+  - Returns `(frontmatter_name, None)` when `name:` is present, valid per `SKILL_NAME_RE`, and matches the filesystem-derived name.
+  - Returns `(frontmatter_name, "clauditor.spec: frontmatter name '<fm>' overrides filesystem name '<fs>' — using '<fm>'")` on disagreement.
+  - Returns `(filesystem_name, None)` when `name:` is absent (no frontmatter, or frontmatter has no `name:` key).
+  - Returns `(filesystem_name, "clauditor.spec: frontmatter name '<bad>' is not a valid skill identifier — using '<fs>'")` when `name:` fails `SKILL_NAME_RE`.
+  - Returns `(filesystem_name, None)` when `parse_frontmatter` raises `ValueError` (malformed frontmatter — treat as absent).
+  - Modern layout (`<dir>/SKILL.md`): filesystem name = `skill_path.parent.name`.
+  - Legacy layout (`<name>.md` where `<name> != "SKILL"`): filesystem name = `skill_path.stem`.
+- `derive_project_dir`:
+  - Returns `find_project_root(skill_path.parent)` when it returns a non-None value.
+  - Falls back to `skill_path.parent.parent.parent.parent` when layout is modern (`skill_path.name == "SKILL.md"`).
+  - Falls back to `skill_path.parent.parent.parent` otherwise (legacy).
+- Zero stderr writes inside either function. Zero `read_text` calls — `derive_skill_name` takes text as input.
+- Ruff passes; coverage ≥80% on the new code.
+
+**Done when:** `TestDeriveSkillName` (≥7 tests) and `TestDeriveProjectDir` (≥4 tests) pass; every branch of both helpers is hit by at least one test.
+
+**Files:**
+- `src/clauditor/paths.py` — add `derive_skill_name`, `derive_project_dir`. Import `find_project_root` from `clauditor.setup` and `parse_frontmatter` from `clauditor._frontmatter`.
+- `tests/test_paths.py` — add `TestDeriveSkillName`, `TestDeriveProjectDir`.
+
+**TDD:** write these tests first, in this order:
+- `test_frontmatter_name_matches_filesystem` — modern layout, `name: foo`, parent dir `foo`, no warning.
+- `test_frontmatter_name_overrides_filesystem_with_warning` — modern layout, `name: bar`, parent dir `foo`, returns `("bar", <warn>)`.
+- `test_missing_frontmatter_falls_back_modern` — modern SKILL.md with no frontmatter, returns `("<parent.name>", None)`.
+- `test_missing_name_field_falls_back_legacy` — legacy `.md` file with frontmatter but no `name:`, returns `(stem, None)`.
+- `test_invalid_regex_falls_back_with_warning` — `name: bad;value`, returns `(filesystem_name, <warn>)`.
+- `test_malformed_frontmatter_treated_as_absent` — frontmatter text that raises `ValueError`, returns `(filesystem_name, None)`.
+- `test_legacy_without_frontmatter` — plain `.md` file, no frontmatter block at all.
+- `test_project_dir_via_find_project_root` — when a `.git` marker is present, uses it.
+- `test_project_dir_fallback_modern_ascent` — in a `tmp_path` with no markers, modern path returns 4-deep.
+- `test_project_dir_fallback_legacy_ascent` — in a `tmp_path` with no markers, legacy path returns 3-deep.
+
+**Depends on:** US-001.
+
+---
+
+### US-003 — Wire helpers into `SkillSpec`; extend fixture; integration tests
+
+**Description.** Rewire `SkillSpec.from_file` to read the skill file, call `derive_skill_name` and `derive_project_dir`, emit the stderr warning when non-None, and pass `skill_name_override=` to `__init__`. `SkillSpec.__init__` accepts the new optional kwarg, and when it's `None` falls back to a minimal layout-aware name derivation (no file I/O — this path is for direct construction with non-existent paths). Extend `tmp_skill_file` with `layout=` kwarg. Add integration tests.
+
+**Traces to:** DEC-001, DEC-002, DEC-003, DEC-006, DEC-009, DEC-011.
+
+**Acceptance criteria:**
+- `SkillSpec.__init__` signature:
+  ```python
+  def __init__(
+      self,
+      skill_path: Path,
+      eval_spec: EvalSpec | None = None,
+      runner: SkillRunner | None = None,
+      *,
+      skill_name_override: str | None = None,
+  ):
+  ```
+  When `skill_name_override` is provided, use it directly. When `None`, derive name layout-aware without reading the file (modern → `parent.name`, legacy → `stem`), and derive project_dir via `derive_project_dir`.
+- `SkillSpec.from_file` reads the file with `skill_path.read_text(encoding="utf-8")`, calls `derive_skill_name`, emits any warning to stderr, and passes the name via `skill_name_override`. Eval auto-discovery logic unchanged.
+- `tests/conftest.py::tmp_skill_file` accepts `layout="legacy" | "modern"` (default `"legacy"`). `"modern"` writes `tmp_path/.claude/skills/<name>/SKILL.md` and the sibling eval (if any) at `tmp_path/.claude/skills/<name>/SKILL.eval.json`.
+- `TestFromFile` gains ≥5 new tests covering the DEC-005 matrix: modern+match, modern+disagree (captures stderr), modern+missing-name, legacy+match, legacy+missing-name.
+- Every existing test in `tests/test_spec.py` passes untouched. `tests/test_quality_grader.py:1902` (direct `SkillSpec(Path("dummy.md"), ...)` construction) still passes.
+- Coverage on modified code ≥80%.
+
+**Done when:** `clauditor validate .claude/skills/<name>/SKILL.md` on a manually-constructed modern skill succeeds end-to-end (no `/SKILL` slash command). Legacy validate path byte-identical.
+
+**Files:**
+- `src/clauditor/spec.py` — modify `__init__` and `from_file`.
+- `tests/conftest.py` — extend `tmp_skill_file`.
+- `tests/test_spec.py` — new cases in `TestFromFile`.
+
+**TDD:** tests for the new `TestFromFile` cases + a regression test for the direct-constructor path first. Implementation follows.
+
+**Depends on:** US-002.
+
+---
+
+### US-004 — Fix `cli/init.py` via the shared helper
+
+**Description.** Replace `cli/init.py`'s `skill_path.stem` derivation with a call to `derive_skill_name`. Requires reading the skill file (which the command does not do today). Preserve the existing flag set and output format.
+
+**Traces to:** DEC-001, DEC-004, DEC-008.
+
+**Acceptance criteria:**
+- `clauditor init .claude/skills/foo/SKILL.md` writes a starter eval with `"skill_name": "foo"` and `"description": "Eval spec for /foo"`.
+- `clauditor init .claude/commands/foo.md` writes `"skill_name": "foo"` (unchanged).
+- If the skill file is missing, the command returns the existing error message (exit 1, per its current behavior). If the file is unreadable, emit `ERROR: cannot read {path}: {exc}` and return 1 (consistent with DEC-010 style, at the command level).
+- The stderr warning from `derive_skill_name` (disagreement / invalid regex) is emitted to stderr by the command before writing the starter.
+- Existing tests in `tests/test_cli.py` for `init` pass; add ≥2 new tests: one for modern layout, one asserting the warning is emitted on a disagreement.
+
+**Done when:** `TestInit` tests pass for both layouts; grep confirms `skill_path.stem` is no longer used in `cli/init.py`.
+
+**Files:**
+- `src/clauditor/cli/init.py` — route through `derive_skill_name`.
+- `tests/test_cli.py` — add `TestInit` modern-layout cases.
+
+**Depends on:** US-002.
+
+---
+
+### US-005 — Harden `_load_spec_or_report` I/O error handling
+
+**Description.** Expand `cli/__init__.py::_load_spec_or_report`'s except clause to `(FileNotFoundError, OSError)`. Branch on exception type: keep the existing "not found → suggest `clauditor init`" message for `FileNotFoundError`; emit `ERROR: cannot read {path}: {exc}` for other `OSError`.
+
+**Traces to:** DEC-010.
+
+**Acceptance criteria:**
+- `FileNotFoundError` still produces the existing message (byte-identical).
+- `PermissionError` (subclass of `OSError`) produces `ERROR: cannot read {path}: Permission denied` (or whatever the OS error formats as).
+- Other `OSError` subclasses (e.g., `IsADirectoryError`) produce the same format.
+- Both branches return the same non-zero exit code that the existing path does.
+- Tests: one for `FileNotFoundError` (existing test still passes), one for `PermissionError` via monkey-patching `Path.read_text` to raise, one for `IsADirectoryError` via passing a directory path.
+
+**Done when:** three test cases in `tests/test_cli.py::TestLoadSpecOrReport` pass; existing callers unaffected.
+
+**Files:**
+- `src/clauditor/cli/__init__.py` — expand the except clause.
+- `tests/test_cli.py` — add tests.
+
+**Depends on:** US-003.
+
+---
+
+### US-006 — Bundled-skill regression test + docs polish
+
+**Description.** Add a regression test asserting `SkillSpec.from_file(src/clauditor/skills/clauditor/SKILL.md)` returns a spec with `skill_name == "clauditor"` and auto-discovers the sibling eval. Add one line to `docs/skill-usage.md` documenting that both layouts are supported.
+
+**Traces to:** DEC-005.
+
+**Acceptance criteria:**
+- New class `TestBundledSkillViaSpec` in `tests/test_bundled_skill.py`, one test method: `test_bundled_skill_loads_via_skillspec` — asserts `spec.skill_name == "clauditor"`, `spec.skill_path` resolves to the real bundled SKILL.md, and `spec.eval_spec is not None`.
+- `docs/skill-usage.md` mentions both layouts: one sentence under an existing section ("clauditor works with both `.claude/commands/<name>.md` and `.claude/skills/<name>/SKILL.md`.").
+- README unchanged (internal fix; no teaser update warranted per DEC-005 scoping).
+- Bundled skill `SKILL.md` is NOT modified — the `bundled-skill-docs-sync.md` rule does not trigger.
+
+**Done when:** the new test passes; the docs diff is one sentence.
+
+**Files:**
+- `tests/test_bundled_skill.py` — add `TestBundledSkillViaSpec`.
+- `docs/skill-usage.md` — add one sentence.
+
+**Depends on:** US-003.
+
+---
+
+### US-007 — Quality Gate — code review x4 + CodeRabbit
+
+**Description.** Run the code-reviewer agent four times across the full changeset, fixing every real bug each pass. Run CodeRabbit review if available on the PR. Ruff + pytest + coverage ≥80% must pass after all fixes.
+
+**Acceptance criteria:**
+- Four code-reviewer passes completed; every actionable finding either fixed or explicitly documented as a false positive.
+- CodeRabbit (if configured) review triaged the same way.
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with coverage ≥80%.
+- No new TODO/FIXME comments landed.
+
+**Done when:** all implementation stories are complete and quality gates pass cleanly.
+
+**Depends on:** US-001 through US-006.
+
+---
+
+### US-008 — Patterns & Memory — update conventions and docs (priority 99)
+
+**Description.** If new patterns emerged during this work, record them in `.claude/rules/` or docs. Candidate additions: (a) a rule about reading SKILL.md frontmatter as the identity source, (b) a note on layout-aware ascent patterns, (c) memory updates if new user/feedback memories surfaced.
+
+**Acceptance criteria:**
+- Any new `.claude/rules/*.md` file is self-contained with canonical implementation pointers and "when this rule applies / does NOT apply" sections matching existing rules' shape.
+- If no new patterns emerged, the story closes as "no-op, verified during Quality Gate" — no file churn.
+
+**Done when:** explicit decision (write rule OR skip) documented in the PR description.
+
+**Depends on:** US-007.
+
+---
+
+### Rules-compliance gate for all stories
+
+Validated against `.claude/rules/` identified in Discovery:
+
+- **`pure-compute-vs-io-split.md`** ✓ — US-002's helpers are pure (take text, return tuples); US-003 is the I/O wrapper.
+- **`in-memory-dict-loader-path.md`** ✓ — `parse_frontmatter` already pure in-memory; no split needed.
+- **`path-validation.md`** ✓ — not applicable (no user path-lists from JSON; only reclassifying known paths).
+- **`json-schema-version.md`** ✓ — no new sidecar.
+- **`llm-cli-exit-code-taxonomy.md`** ✓ — not applicable (not LLM commands; `cli/init.py` retains its existing 0/1 taxonomy).
+- **`bundled-skill-docs-sync.md`** ✓ — SKILL.md not modified (trigger: workflow edit); rule does not fire.
+- **`readme-promotion-recipe.md`** ✓ — no README change (internal fix).
+- **`project-root-home-exclusion.md`** ✓ — `find_project_root` logic untouched; exclusion guard inherited as-is.
+- **`pytester-inprocess-coverage-hazard.md`** ✓ — no `pytester` in planned tests.
+- **CLAUDE.md test conventions** ✓ — class-based tests; `tmp_path`; no fixture-name shadowing; existing `importlib.reload` in `test_spec.py` covers the reload hazard.
+
+---
+
+## Beads Manifest
+_(filled in Phase 7 on devolve)_
+
+---
+
+## Session Notes
+
+### Session 1 — 2026-04-20
+- Fetched ticket #62.
+- Created worktree `/home/wesd/dev/worktrees/clauditor/62-skill-md-layout` on branch `feature/62-skill-md-layout` from `dev@e1f4e19`.
+- Parallel scout + convention-check complete.
+- Scope sized: core fix is ~2 pure helpers + `SkillSpec.__init__` +
+  `cli/init.py`. Test surface is ~2 new test classes plus one
+  bundled-skill regression.
+- Awaiting user answers to Q1–Q5 before architecture review.

--- a/plans/super/62-skill-md-layout.md
+++ b/plans/super/62-skill-md-layout.md
@@ -4,7 +4,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/62
 - **Branch:** `feature/62-skill-md-layout`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/62-skill-md-layout`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/66
 - **Sessions:** 1
 - **Last session:** 2026-04-20
@@ -574,7 +574,28 @@ Validated against `.claude/rules/` identified in Discovery:
 ---
 
 ## Beads Manifest
-_(filled in Phase 7 on devolve)_
+
+- **Epic:** `clauditor-600` — #62: modern `<name>/SKILL.md` layout support (P1)
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/62-skill-md-layout`
+- **Branch:** `feature/62-skill-md-layout`
+- **PR:** https://github.com/wjduenow/clauditor/pull/66
+
+### Tasks (priority P2 unless noted)
+
+| ID | Title | Depends on |
+|---|---|---|
+| `clauditor-600.1` | US-001 — Promote `SKILL_NAME_RE` to `paths.py` | — |
+| `clauditor-600.2` | US-002 — Pure skill-identity helpers in `paths.py` (TDD) | `.1` |
+| `clauditor-600.3` | US-003 — Wire helpers into `SkillSpec`; extend `tmp_skill_file`; integration tests | `.2` |
+| `clauditor-600.4` | US-004 — Fix `cli/init.py` via shared helper | `.2` |
+| `clauditor-600.5` | US-005 — Harden `_load_spec_or_report` I/O error handling | `.3` |
+| `clauditor-600.6` | US-006 — Bundled-skill regression test + docs polish | `.3` |
+| `clauditor-600.7` | Quality Gate — code review x4 + CodeRabbit | `.1`, `.2`, `.3`, `.4`, `.5`, `.6` |
+| `clauditor-600.8` | Patterns & Memory (P4) | `.7` |
+
+### Ready at devolve
+
+`bd ready` shows `clauditor-600.1` (US-001) as the only unblocked implementation task. US-003 and US-004 will unblock after US-002 completes; the two stories can run in parallel against separate worker contexts since neither depends on the other.
 
 ---
 

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -83,13 +83,20 @@ def _append_validate_history(
 def _load_spec_or_report(
     skill_path: str, eval_path: str | None
 ) -> SkillSpec | None:
-    """Load a :class:`SkillSpec`, printing an actionable error if missing.
+    """Load a :class:`SkillSpec`, printing an actionable error if unreadable.
 
     Returns the loaded spec on success. On ``FileNotFoundError`` (the
     skill ``.md`` is missing), prints an ``ERROR:`` line to stderr that
     names the path AND suggests ``clauditor init`` as the next step,
-    then returns ``None``. Callers map ``None`` to exit code 2 (input
-    error, per DEC-008) rather than letting the traceback escape.
+    then returns ``None``. On other ``OSError`` subclasses
+    (``PermissionError``, ``IsADirectoryError``, etc.), prints
+    ``ERROR: cannot read {path}: {exc}`` to stderr and returns
+    ``None``. Callers map ``None`` to exit code 2 (input error, per
+    DEC-008 / DEC-010) rather than letting the traceback escape.
+
+    Note the ``except`` order: ``FileNotFoundError`` is a subclass of
+    ``OSError``, so its branch must come first to preserve the
+    byte-identical "suggest init" message for the missing-file case.
     """
     try:
         return SkillSpec.from_file(skill_path, eval_path=eval_path)
@@ -97,6 +104,12 @@ def _load_spec_or_report(
         print(
             f"ERROR: Skill file not found: {skill_path}. "
             f"Run 'clauditor init {skill_path}' to create one.",
+            file=sys.stderr,
+        )
+        return None
+    except OSError as exc:
+        print(
+            f"ERROR: cannot read {skill_path}: {exc}",
             file=sys.stderr,
         )
         return None

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -107,7 +107,7 @@ def _load_spec_or_report(
             file=sys.stderr,
         )
         return None
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         print(
             f"ERROR: cannot read {skill_path}: {exc}",
             file=sys.stderr,

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -88,11 +88,14 @@ def _load_spec_or_report(
     Returns the loaded spec on success. On ``FileNotFoundError`` (the
     skill ``.md`` is missing), prints an ``ERROR:`` line to stderr that
     names the path AND suggests ``clauditor init`` as the next step,
-    then returns ``None``. On other ``OSError`` subclasses
-    (``PermissionError``, ``IsADirectoryError``, etc.), prints
-    ``ERROR: cannot read {path}: {exc}`` to stderr and returns
-    ``None``. Callers map ``None`` to exit code 2 (input error, per
-    DEC-008 / DEC-010) rather than letting the traceback escape.
+    then returns ``None``. On other unreadable-file errors — any
+    ``OSError`` subclass (``PermissionError``, ``IsADirectoryError``,
+    etc.) and ``UnicodeDecodeError`` (for example, a non-UTF-8 skill
+    file, which ``SkillSpec.from_file`` surfaces via
+    ``read_text(encoding="utf-8")``) — prints ``ERROR: cannot read
+    {path}: {exc}`` to stderr and returns ``None``. Callers map
+    ``None`` to exit code 2 (input error, per DEC-008 / DEC-010)
+    rather than letting the traceback escape.
 
     Note the ``except`` order: ``FileNotFoundError`` is a subclass of
     ``OSError``, so its branch must come first to preserve the

--- a/src/clauditor/cli/init.py
+++ b/src/clauditor/cli/init.py
@@ -39,7 +39,7 @@ def cmd_init(args: argparse.Namespace) -> int:
 
     try:
         skill_md_text = skill_path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         print(f"ERROR: cannot read {skill_path}: {exc}", file=sys.stderr)
         return 1
 

--- a/src/clauditor/cli/init.py
+++ b/src/clauditor/cli/init.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+from clauditor.paths import derive_skill_name
+
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``init`` subparser."""
@@ -31,9 +33,23 @@ def cmd_init(args: argparse.Namespace) -> int:
         )
         return 1
 
+    if not skill_path.is_file():
+        print(f"ERROR: skill file not found: {skill_path}", file=sys.stderr)
+        return 1
+
+    try:
+        skill_md_text = skill_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"ERROR: cannot read {skill_path}: {exc}", file=sys.stderr)
+        return 1
+
+    skill_name, warning = derive_skill_name(skill_path, skill_md_text)
+    if warning is not None:
+        print(warning, file=sys.stderr)
+
     starter = {
-        "skill_name": skill_path.stem,
-        "description": f"Eval spec for /{skill_path.stem}",
+        "skill_name": skill_name,
+        "description": f"Eval spec for /{skill_name}",
         "test_args": "",
         "assertions": [
             {"id": "min_length_500", "type": "min_length", "value": "500"},

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -16,6 +16,13 @@ from pathlib import Path
 _MARKERS = (".git", ".claude")
 _CLAUDITOR_DIRNAME = ".clauditor"
 
+# Shared skill-identifier regex. Skill names are interpolated into
+# filesystem paths (e.g. `<project_dir>/tests/eval/captured/<name>.txt`);
+# clamping to basename-style tokens matching Claude Code's own convention
+# for skill directory names blocks path-traversal via a malicious
+# frontmatter `name:` field like `../../../etc/passwd`.
+SKILL_NAME_RE: str = r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"
+
 
 def resolve_clauditor_dir() -> Path:
     """Return the ``.clauditor`` directory anchored at the nearest repo root.

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -1,15 +1,26 @@
-"""Repo-root detection helpers for clauditor.
+"""Repo-root detection and skill-identity helpers for clauditor.
 
 Provides :func:`resolve_clauditor_dir` which walks up from the current
 working directory looking for a ``.git/`` or ``.claude/`` marker and
 returns ``<repo_root>/.clauditor``. If no marker is found, falls back to
 ``Path.cwd() / ".clauditor"`` and emits a single-line warning to stderr.
 
-Traces to DEC-009 (see ``plans/super/22-iteration-workspace.md``).
+Also hosts the pure skill-identity helpers :func:`derive_skill_name` and
+:func:`derive_project_dir`, which classify a SKILL.md path as modern
+(``<dir>/SKILL.md``) or legacy (``<name>.md``) and surface the
+authoritative skill identity from frontmatter with a layout-aware
+fallback. The helpers are strictly pure (no stderr writes, no disk I/O)
+per ``.claude/rules/pure-compute-vs-io-split.md``; the caller owns any
+warning emission or file reads.
+
+Traces to DEC-009 (see ``plans/super/22-iteration-workspace.md``) and
+DEC-001, DEC-002, DEC-003, DEC-007, DEC-008, DEC-012 (see
+``plans/super/62-skill-md-layout.md``).
 """
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -60,3 +71,116 @@ def resolve_clauditor_dir() -> Path:
         file=sys.stderr,
     )
     return cwd / _CLAUDITOR_DIRNAME
+
+
+def _filesystem_name(skill_path: Path) -> str:
+    """Return the layout-aware filesystem-derived name.
+
+    - Modern layout (``<dir>/SKILL.md``) → ``skill_path.parent.name``.
+    - Legacy layout (``<name>.md`` where ``<name> != "SKILL"``) →
+      ``skill_path.stem``.
+
+    The modern/legacy distinction is made by the literal filename:
+    ``SKILL.md`` is modern, anything else is legacy. DEC-001.
+    """
+    if skill_path.name == "SKILL.md":
+        return skill_path.parent.name
+    return skill_path.stem
+
+
+def derive_skill_name(
+    skill_path: Path, skill_md_text: str
+) -> tuple[str, str | None]:
+    """Return ``(skill_name, warning_or_None)`` — pure, no I/O.
+
+    Authority order (DEC-001, DEC-002, DEC-008):
+
+    1. Parse ``skill_md_text`` frontmatter via :func:`parse_frontmatter`.
+       Any :class:`ValueError` from the parser is treated as "frontmatter
+       absent" — a malformed YAML block is not a reason to refuse the
+       skill, and legacy ``.md`` files that never declare frontmatter
+       are the common case.
+    2. If the parsed dict has a ``name:`` key whose value passes
+       :data:`SKILL_NAME_RE`, the frontmatter value wins. A disagreement
+       with the filesystem-derived name returns a warning string so the
+       caller (``SkillSpec.from_file``) can emit it to stderr.
+    3. If the parsed ``name:`` value fails the regex, fall back to the
+       filesystem-derived name and return a warning naming both the bad
+       value and the chosen fallback.
+    4. If ``name:`` is absent (no frontmatter, or frontmatter has no
+       ``name:`` key), return the filesystem-derived name silently.
+
+    Warning strings are formatted per DEC-009. The helper never writes
+    to stderr; it hands the warning to the caller.
+    """
+    # Local import avoids a circular dependency at module import time —
+    # ``clauditor._frontmatter`` is a leaf module with no clauditor
+    # imports, so importing it here is safe and cheap.
+    from clauditor._frontmatter import parse_frontmatter
+
+    fs_name = _filesystem_name(skill_path)
+
+    try:
+        parsed, _body = parse_frontmatter(skill_md_text)
+    except ValueError:
+        # Malformed frontmatter → treat as absent. The caller's
+        # validation layer (if any) is responsible for surfacing a
+        # stricter error; identity derivation stays lenient.
+        return fs_name, None
+
+    if not isinstance(parsed, dict) or "name" not in parsed:
+        return fs_name, None
+
+    fm_name = parsed["name"]
+    if not isinstance(fm_name, str) or re.fullmatch(SKILL_NAME_RE, fm_name) is None:
+        warning = (
+            f"clauditor.spec: frontmatter name {fm_name!r} is not a "
+            f"valid skill identifier — using {fs_name!r}"
+        )
+        return fs_name, warning
+
+    if fm_name == fs_name:
+        return fm_name, None
+
+    warning = (
+        f"clauditor.spec: frontmatter name {fm_name!r} overrides "
+        f"filesystem name {fs_name!r} — using {fm_name!r}"
+    )
+    return fm_name, warning
+
+
+def derive_project_dir(skill_path: Path) -> Path:
+    """Return the project dir the runner should launch ``claude`` in.
+
+    Authority order (DEC-003):
+
+    1. :func:`clauditor.setup.find_project_root` walks up from
+       ``skill_path.parent`` looking for a ``.git``/``.claude`` marker
+       (with the home-dir exclusion guard). If it returns a non-``None``
+       value, use it.
+    2. Otherwise, fall back to layout-aware ascent:
+
+       - Modern (``skill_path.name == "SKILL.md"``): 4 levels up from
+         ``skill_path`` (``parent.parent.parent.parent``). The typical
+         modern layout is
+         ``<project>/.claude/skills/<name>/SKILL.md`` and the 4-deep
+         ascent lands at ``<project>``.
+       - Legacy (any other filename): 3 levels up (``parent.parent.parent``).
+         The typical legacy layout is
+         ``<project>/.claude/commands/<name>.md`` and the 3-deep ascent
+         lands at ``<project>``.
+
+    Pure — no I/O beyond the marker-walk inside ``find_project_root``.
+    """
+    # Local import avoids a circular dependency: ``clauditor.setup``
+    # does not import ``clauditor.paths``, but future refactors could
+    # wire that link; the local import makes the direction explicit
+    # and keeps module import order resilient.
+    from clauditor.setup import find_project_root
+
+    found = find_project_root(skill_path.parent)
+    if found is not None:
+        return found
+    if skill_path.name == "SKILL.md":
+        return skill_path.parent.parent.parent.parent
+    return skill_path.parent.parent.parent

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -170,6 +170,13 @@ def derive_project_dir(skill_path: Path) -> Path:
          ``<project>/.claude/commands/<name>.md`` and the 3-deep ascent
          lands at ``<project>``.
 
+    Note: the fallback assumes the documented layout depth. A skill
+    placed at an unusually shallow path (e.g. ``/a/SKILL.md``) would
+    see the ascent saturate at the filesystem root — but such a
+    placement is not valid under either layout convention, and the
+    marker-walk step normally short-circuits the fallback anyway for
+    any real repo.
+
     Pure — no I/O beyond the marker-walk inside ``find_project_root``.
     """
     # Local import avoids a circular dependency: ``clauditor.setup``

--- a/src/clauditor/propose_eval.py
+++ b/src/clauditor/propose_eval.py
@@ -38,17 +38,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from clauditor._frontmatter import parse_frontmatter
+from clauditor.paths import SKILL_NAME_RE
 from clauditor.schemas import EvalSpec
 from clauditor.transcripts import redact
-
-# Skill names are interpolated into `<project_dir>/tests/eval/captured/
-# <name>.txt` and `<project_dir>/.clauditor/captures/<name>.txt` to find
-# an optional captured run. An attacker-authored SKILL.md with a
-# `name:` frontmatter field like `../../../etc/issue` or `/etc/passwd`
-# would otherwise escape the capture directory and leak arbitrary `.txt`
-# files into the Sonnet prompt. Clamp to basename-style tokens matching
-# Claude Code's own convention for skill directory names.
-_SKILL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 
 # Module-level alias lets tests patch this without clobbering the
 # asyncio event loop's own time.monotonic() calls. See
@@ -173,7 +165,7 @@ def _skill_name_from_frontmatter(
     (which is the convention for Claude Code skills living under
     ``.claude/skills/<skill_name>/SKILL.md``).
 
-    Values are validated against :data:`_SKILL_NAME_RE` — a name that
+    Values are validated against :data:`~clauditor.paths.SKILL_NAME_RE` — a name that
     contains path separators, leading dots, or non-ASCII-word
     characters is rejected in favor of the directory basename, which
     is itself only used if it also passes the regex. If neither
@@ -188,7 +180,7 @@ def _skill_name_from_frontmatter(
             candidates.append(raw.strip())
     candidates.append(skill_md_path.parent.name)
     for candidate in candidates:
-        if candidate and _SKILL_NAME_RE.match(candidate):
+        if candidate and re.match(SKILL_NAME_RE, candidate):
             return candidate
     return "skill"
 

--- a/src/clauditor/propose_eval.py
+++ b/src/clauditor/propose_eval.py
@@ -180,7 +180,7 @@ def _skill_name_from_frontmatter(
             candidates.append(raw.strip())
     candidates.append(skill_md_path.parent.name)
     for candidate in candidates:
-        if candidate and re.match(SKILL_NAME_RE, candidate):
+        if candidate and re.fullmatch(SKILL_NAME_RE, candidate):
             return candidate
     return "skill"
 

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -6,9 +6,11 @@ Combines the skill file, eval spec, and runner into a single interface.
 from __future__ import annotations
 
 import glob
+import sys
 from pathlib import Path
 
 from clauditor.assertions import AssertionSet, run_assertions
+from clauditor.paths import derive_project_dir, derive_skill_name
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.schemas import EvalSpec
 from clauditor.workspace import stage_inputs
@@ -32,11 +34,31 @@ class SkillSpec:
         skill_path: Path,
         eval_spec: EvalSpec | None = None,
         runner: SkillRunner | None = None,
+        *,
+        skill_name_override: str | None = None,
     ):
         self.skill_path = skill_path
-        self.skill_name = skill_path.stem
+        # Name derivation: `skill_name_override` is the happy path from
+        # `from_file`, which has already read the file and consulted
+        # frontmatter. When omitted (direct-constructor callers that may
+        # pass a non-existent path, e.g. tests/test_quality_grader.py
+        # uses `Path("dummy.md")`), fall back to layout-aware filesystem
+        # derivation without any file I/O. Modern (`SKILL.md` under a
+        # named dir) → parent.name; legacy → stem. See DEC-006.
+        if skill_name_override is not None:
+            self.skill_name = skill_name_override
+        elif skill_path.name == "SKILL.md":
+            self.skill_name = skill_path.parent.name
+        else:
+            self.skill_name = skill_path.stem
         self.eval_spec = eval_spec
-        self.runner = runner or SkillRunner(project_dir=skill_path.parent.parent.parent)
+        # Layout-aware project_dir derivation. `derive_project_dir`
+        # walks up for a `.git`/`.claude` marker first (with home-dir
+        # exclusion) and falls back to the appropriate ascent depth for
+        # modern vs legacy layouts. Replaces the previous hardcoded
+        # 3-deep ascent, which landed inside `.claude/` for modern
+        # skills. See DEC-003.
+        self.runner = runner or SkillRunner(project_dir=derive_project_dir(skill_path))
 
     @classmethod
     def from_file(
@@ -48,11 +70,25 @@ class SkillSpec:
         """Load a skill spec from a skill .md file.
 
         Automatically looks for a sibling eval.json if eval_path
-        is not specified. For `my-skill.md`, looks for `my-skill.eval.json`.
+        is not specified. For `my-skill.md`, looks for `my-skill.eval.json`;
+        for the modern `<dir>/SKILL.md` layout, looks for
+        `<dir>/SKILL.eval.json` (sibling of SKILL.md).
+
+        The skill's identity (``skill_name``) is derived from the file's
+        frontmatter ``name:`` field when present and valid; otherwise
+        from the filesystem (parent dir for modern, stem for legacy).
+        When frontmatter disagrees with the filesystem name, the
+        frontmatter wins and a warning is emitted to stderr. See DEC-001,
+        DEC-002, DEC-009.
         """
         skill_path = Path(skill_path)
         if not skill_path.exists():
             raise FileNotFoundError(f"Skill file not found: {skill_path}")
+
+        text = skill_path.read_text(encoding="utf-8")
+        skill_name, warning = derive_skill_name(skill_path, text)
+        if warning is not None:
+            print(warning, file=sys.stderr)
 
         # Auto-discover eval spec
         eval_spec = None
@@ -63,7 +99,12 @@ class SkillSpec:
             if default_eval.exists():
                 eval_spec = EvalSpec.from_file(default_eval)
 
-        return cls(skill_path=skill_path, eval_spec=eval_spec, runner=runner)
+        return cls(
+            skill_path=skill_path,
+            eval_spec=eval_spec,
+            runner=runner,
+            skill_name_override=skill_name,
+        )
 
     def run(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,9 +223,17 @@ def make_eval_spec():
 
 @pytest.fixture
 def tmp_skill_file(tmp_path):
-    """Factory fixture that creates a temporary .md skill file.
+    """Factory fixture that creates a temporary skill file.
 
-    Optionally creates a sibling .eval.json file.
+    Supports two layouts (DEC-011 of ``plans/super/62-skill-md-layout.md``):
+
+    - ``layout="legacy"`` (default): writes ``tmp_path/<name>.md``. The
+      sibling eval lives at ``tmp_path/<name>.eval.json``. Byte-identical
+      to the pre-DEC-011 behavior so every existing test keeps working.
+    - ``layout="modern"``: writes
+      ``tmp_path/.claude/skills/<name>/SKILL.md``. The sibling eval lives
+      at ``tmp_path/.claude/skills/<name>/SKILL.eval.json`` — next to the
+      SKILL.md, which is what :func:`SkillSpec.from_file` auto-discovers.
 
     Usage:
         def test_something(tmp_skill_file):
@@ -235,18 +243,32 @@ def tmp_skill_file(tmp_path):
                 content="# My Skill",
                 eval_data={"skill_name": "my-skill", "assertions": []},
             )
+            # Modern layout:
+            skill_path = tmp_skill_file("foo", layout="modern")
     """
 
     def _factory(
         name: str = "test-skill",
         content: str = "# Test Skill\n\nA test skill for unit tests.",
+        layout: str = "legacy",
         eval_data: dict | None = None,
     ) -> Path | tuple[Path, Path]:
-        skill_path = tmp_path / f"{name}.md"
+        if layout == "legacy":
+            skill_path = tmp_path / f"{name}.md"
+        elif layout == "modern":
+            skill_dir = tmp_path / ".claude" / "skills" / name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            skill_path = skill_dir / "SKILL.md"
+        else:
+            raise ValueError(
+                f"tmp_skill_file: layout must be 'legacy' or 'modern', "
+                f"got {layout!r}"
+            )
+
         skill_path.write_text(content)
 
         if eval_data is not None:
-            eval_path = tmp_path / f"{name}.eval.json"
+            eval_path = skill_path.with_suffix(".eval.json")
             eval_path.write_text(json.dumps(eval_data, indent=2))
             return skill_path, eval_path
 

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from clauditor.schemas import EvalSpec, criterion_text
+from clauditor.spec import SkillSpec
 
 SKILL_DIR = (
     Path(__file__).resolve().parent.parent
@@ -213,6 +214,22 @@ class TestSkillMdBody:
             "bundled SKILL.md body must mention 'propose-eval' "
             "(DEC-007 regression guard)"
         )
+
+
+class TestBundledSkillViaSpec:
+    def test_bundled_skill_loads_via_skillspec(self) -> None:
+        # Regression guard (DEC-005 of plans/super/62-skill-md-layout.md):
+        # the bundled SKILL.md must load cleanly through
+        # ``SkillSpec.from_file`` with modern-layout name derivation —
+        # ``skill_name`` comes from the frontmatter ``name:`` field, not
+        # the file stem. We do NOT assert on ``spec.eval_spec`` here
+        # because auto-discovery looks for a sibling ``SKILL.eval.json``
+        # and the bundled eval intentionally lives at
+        # ``assets/clauditor.eval.json`` (covered by ``TestBundledEvalSpec``).
+        spec = SkillSpec.from_file(SKILL_MD)
+        assert spec.skill_name == "clauditor"
+        assert spec.skill_path.name == "SKILL.md"
+        assert spec.skill_path.parent.name == "clauditor"
 
 
 class TestBundledEvalSpec:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5221,3 +5221,71 @@ class TestCmdSuggest:
         assert rc == 1
         err = capsys.readouterr().err
         assert "UTF-8" in err or "decode" in err
+
+
+class TestLoadSpecOrReport:
+    """Direct tests for ``cli._load_spec_or_report`` I/O error handling.
+
+    US-005 (#62) expanded the except clause from ``FileNotFoundError``
+    only to ``(FileNotFoundError, OSError)`` with branched messages:
+    missing file keeps the existing ``clauditor init`` hint, other
+    ``OSError`` subclasses get a generic ``ERROR: cannot read ...``
+    message. Traces to DEC-010 of ``plans/super/62-skill-md-layout.md``.
+    """
+
+    def test_file_not_found_keeps_init_hint_message(self, capsys):
+        """FileNotFoundError preserves the byte-identical init-hint message."""
+        from clauditor.cli import _load_spec_or_report
+
+        with patch(
+            "clauditor.cli.SkillSpec.from_file",
+            side_effect=FileNotFoundError(
+                "Skill file not found: missing.md"
+            ),
+        ):
+            result = _load_spec_or_report("missing.md", None)
+
+        assert result is None
+        err = capsys.readouterr().err
+        # Byte-identical to the pre-US-005 message: name the path and
+        # suggest `clauditor init` as the next step.
+        assert (
+            "ERROR: Skill file not found: missing.md. "
+            "Run 'clauditor init missing.md' to create one."
+        ) in err
+
+    def test_permission_error_emits_cannot_read_message(self, capsys):
+        """PermissionError (OSError subclass) routes to the generic branch."""
+        from clauditor.cli import _load_spec_or_report
+
+        with patch(
+            "clauditor.cli.SkillSpec.from_file",
+            side_effect=PermissionError("Permission denied"),
+        ):
+            result = _load_spec_or_report("protected.md", None)
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "ERROR: cannot read protected.md: Permission denied" in err
+        # The init hint must NOT appear on the generic-OSError branch —
+        # the file exists, it's just unreadable.
+        assert "clauditor init" not in err
+
+    def test_is_a_directory_error_emits_cannot_read_message(
+        self, tmp_path, capsys
+    ):
+        """IsADirectoryError (OSError subclass) routes to the generic branch.
+
+        Pass ``tmp_path`` itself (a directory) as the skill path; the
+        real ``SkillSpec.from_file`` will try to ``read_text()`` it and
+        raise ``IsADirectoryError``. This exercises the helper against
+        a real OS error rather than a mocked one.
+        """
+        from clauditor.cli import _load_spec_or_report
+
+        result = _load_spec_or_report(str(tmp_path), None)
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert f"ERROR: cannot read {tmp_path}:" in err
+        assert "clauditor init" not in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2828,6 +2828,25 @@ class TestCmdInit:
         assert "cannot read" in err
         assert "Permission denied" in err
 
+    def test_init_non_utf8_skill_file(self, tmp_path, capsys):
+        """UnicodeDecodeError (non-UTF-8 skill file) exits 1 with a clean
+        message instead of an uncaught traceback. ``read_text`` is called
+        with ``encoding='utf-8'`` and ``UnicodeDecodeError`` is a
+        ``ValueError`` subclass (not ``OSError``), so the except clause
+        must catch both explicitly."""
+        skill_path = tmp_path / "bogus.md"
+        # Raw bytes that don't decode as UTF-8 (a Latin-1 é followed by
+        # high-range bytes).
+        skill_path.write_bytes(b"\xc3\x28\xa0\xa1")
+
+        rc = main(["init", str(skill_path)])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert f"cannot read {skill_path}" in err
+        # The underlying codec error is appended to the message.
+        assert "utf-8" in err or "codec" in err
+
     def test_init_warns_on_frontmatter_disagreement(self, tmp_path, capsys):
         """When frontmatter ``name:`` disagrees with the filesystem-derived
         name, stderr carries the DEC-009 warning and frontmatter wins."""
@@ -5288,4 +5307,28 @@ class TestLoadSpecOrReport:
         assert result is None
         err = capsys.readouterr().err
         assert f"ERROR: cannot read {tmp_path}:" in err
+        assert "clauditor init" not in err
+
+    def test_unicode_decode_error_emits_cannot_read_message(self, capsys):
+        """UnicodeDecodeError (ValueError subclass) routes to the generic branch.
+
+        ``SkillSpec.from_file`` reads the skill file with
+        ``encoding="utf-8"``; a non-UTF-8 file raises
+        ``UnicodeDecodeError``, which is NOT an ``OSError`` subclass.
+        The except clause explicitly catches both so the user sees a
+        clean error message instead of an uncaught traceback.
+        """
+        from clauditor.cli import _load_spec_or_report
+
+        with patch(
+            "clauditor.cli.SkillSpec.from_file",
+            side_effect=UnicodeDecodeError(
+                "utf-8", b"\xff\xfe", 0, 1, "invalid start byte"
+            ),
+        ):
+            result = _load_spec_or_report("weird.md", None)
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "ERROR: cannot read weird.md:" in err
         assert "clauditor init" not in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2778,6 +2778,83 @@ class TestCmdInit:
         data = json.loads(eval_path.read_text())
         assert data["skill_name"] == "my-skill"
 
+    def test_init_modern_layout_uses_parent_dir_name(self, tmp_path):
+        """Modern layout (``<dir>/SKILL.md``) derives name from parent dir
+        via frontmatter ``name:`` — not the ``"SKILL"`` file stem."""
+        skill_dir = tmp_path / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text(
+            "---\n"
+            "name: foo\n"
+            "description: A test skill\n"
+            "---\n"
+            "\n"
+            "# Body\n"
+        )
+
+        rc = main(["init", str(skill_path)])
+
+        assert rc == 0
+        eval_path = skill_dir / "SKILL.eval.json"
+        assert eval_path.exists()
+        data = json.loads(eval_path.read_text())
+        assert data["skill_name"] == "foo"
+        assert data["description"] == "Eval spec for /foo"
+
+    def test_init_missing_skill_file(self, tmp_path, capsys):
+        """Missing skill file exits 1 with a descriptive stderr error."""
+        skill_path = tmp_path / "does-not-exist.md"
+
+        rc = main(["init", str(skill_path)])
+
+        assert rc == 1
+        assert "skill file not found" in capsys.readouterr().err
+
+    def test_init_unreadable_skill_file(self, tmp_path, capsys):
+        """OSError while reading the skill file exits 1 with an error message
+        that includes the underlying exception string."""
+        skill_path = tmp_path / "foo.md"
+        skill_path.write_text("# foo")
+
+        with patch(
+            "clauditor.cli.init.Path.read_text",
+            side_effect=OSError("Permission denied"),
+        ):
+            rc = main(["init", str(skill_path)])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "cannot read" in err
+        assert "Permission denied" in err
+
+    def test_init_warns_on_frontmatter_disagreement(self, tmp_path, capsys):
+        """When frontmatter ``name:`` disagrees with the filesystem-derived
+        name, stderr carries the DEC-009 warning and frontmatter wins."""
+        skill_dir = tmp_path / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text(
+            "---\n"
+            "name: bar\n"
+            "description: Disagreement test\n"
+            "---\n"
+            "\n"
+            "# Body\n"
+        )
+
+        rc = main(["init", str(skill_path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "clauditor.spec:" in captured.err
+        assert "'bar'" in captured.err
+        assert "'foo'" in captured.err
+        eval_path = skill_dir / "SKILL.eval.json"
+        data = json.loads(eval_path.read_text())
+        assert data["skill_name"] == "bar"
+        assert data["description"] == "Eval spec for /bar"
+
 
 @pytest.fixture
 def setup_env(tmp_path, monkeypatch):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,12 +2,18 @@
 
 import importlib
 import re
+from pathlib import Path
 
 import clauditor.paths as _paths_mod
 
 importlib.reload(_paths_mod)
 
-from clauditor.paths import SKILL_NAME_RE, resolve_clauditor_dir  # noqa: E402
+from clauditor.paths import (  # noqa: E402
+    SKILL_NAME_RE,
+    derive_project_dir,
+    derive_skill_name,
+    resolve_clauditor_dir,
+)
 
 
 class TestResolveClauditorDir:
@@ -71,3 +77,112 @@ class TestSkillNameRe:
     def test_rejects_known_bad_identifier(self):
         assert re.fullmatch(SKILL_NAME_RE, "bad;name") is None
         assert re.fullmatch(SKILL_NAME_RE, "") is None
+
+
+class TestDeriveSkillName:
+    """Unit tests for the pure ``derive_skill_name`` helper.
+
+    The helper takes the skill path and the SKILL.md text as input and
+    returns a ``(name, warning_or_None)`` tuple without touching disk or
+    stderr. Every branch of the DEC-001/DEC-002/DEC-008 decision tree
+    has a dedicated test here per US-002.
+    """
+
+    def test_frontmatter_name_matches_filesystem(self, tmp_path):
+        parent = tmp_path / "foo"
+        parent.mkdir()
+        skill_path = parent / "SKILL.md"
+        text = "---\nname: foo\n---\n\n# Body\n"
+        assert derive_skill_name(skill_path, text) == ("foo", None)
+
+    def test_frontmatter_name_overrides_filesystem_with_warning(self, tmp_path):
+        parent = tmp_path / "foo"
+        parent.mkdir()
+        skill_path = parent / "SKILL.md"
+        text = "---\nname: bar\n---\n\n# Body\n"
+        name, warning = derive_skill_name(skill_path, text)
+        assert name == "bar"
+        assert warning is not None
+        assert (
+            "frontmatter name 'bar' overrides filesystem name 'foo' "
+            "— using 'bar'"
+        ) in warning
+        assert warning.startswith("clauditor.spec:")
+
+    def test_missing_frontmatter_falls_back_modern(self, tmp_path):
+        parent = tmp_path / "foo"
+        parent.mkdir()
+        skill_path = parent / "SKILL.md"
+        text = "# Body without any frontmatter\n"
+        assert derive_skill_name(skill_path, text) == ("foo", None)
+
+    def test_missing_name_field_falls_back_legacy(self, tmp_path):
+        skill_path = tmp_path / "my-skill.md"
+        text = "---\ndescription: a skill\n---\n\n# Body\n"
+        assert derive_skill_name(skill_path, text) == ("my-skill", None)
+
+    def test_invalid_regex_falls_back_with_warning(self, tmp_path):
+        parent = tmp_path / "foo"
+        parent.mkdir()
+        skill_path = parent / "SKILL.md"
+        text = "---\nname: bad;value\n---\n"
+        name, warning = derive_skill_name(skill_path, text)
+        assert name == "foo"
+        assert warning is not None
+        assert "not a valid skill identifier" in warning
+        assert warning.startswith("clauditor.spec:")
+        assert "'bad;value'" in warning
+        assert "'foo'" in warning
+
+    def test_malformed_frontmatter_treated_as_absent(self, tmp_path):
+        parent = tmp_path / "foo"
+        parent.mkdir()
+        skill_path = parent / "SKILL.md"
+        # Opening '---' with no closing delimiter → parse_frontmatter
+        # raises ValueError; derive_skill_name treats as absent.
+        text = "---\nname: foo\n\n(no closing delimiter)\n"
+        assert derive_skill_name(skill_path, text) == ("foo", None)
+
+    def test_legacy_without_frontmatter(self, tmp_path):
+        skill_path = tmp_path / "my-skill.md"
+        text = "# Plain legacy skill file with no frontmatter block\n"
+        assert derive_skill_name(skill_path, text) == ("my-skill", None)
+
+
+class TestDeriveProjectDir:
+    """Unit tests for the pure ``derive_project_dir`` helper.
+
+    The helper tries marker-walk first (``find_project_root``) and falls
+    back to layout-aware ascent when no marker is found. Per US-002 we
+    cover both the marker-found and marker-missing paths for both
+    layouts.
+    """
+
+    def test_project_dir_via_find_project_root(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        skills_dir = tmp_path / ".claude" / "skills" / "foo"
+        skills_dir.mkdir(parents=True)
+        skill_path = skills_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+        assert derive_project_dir(skill_path) == tmp_path
+
+    def test_project_dir_fallback_modern_ascent(self):
+        # Non-existent path is fine — helper only does path arithmetic
+        # once find_project_root returns None (no markers above `/`).
+        skill_path = Path("/a/b/c/d/e/SKILL.md")
+        assert derive_project_dir(skill_path) == Path("/a/b")
+
+    def test_project_dir_fallback_legacy_ascent(self):
+        skill_path = Path("/a/b/c/d/foo.md")
+        assert derive_project_dir(skill_path) == Path("/a/b")
+
+    def test_project_dir_fallback_modern_when_no_marker(self, tmp_path):
+        # tmp_path lives under /tmp with no .git/.claude up the tree;
+        # find_project_root returns None and the helper falls back to
+        # 4-deep ascent for the modern SKILL.md layout.
+        skills_dir = tmp_path / "a" / "b" / "c" / "d" / "foo"
+        skills_dir.mkdir(parents=True)
+        skill_path = skills_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+        # parent.parent.parent.parent = tmp_path / "a" / "b"
+        assert derive_project_dir(skill_path) == tmp_path / "a" / "b"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,12 +1,13 @@
 """Tests for repo-root detection in clauditor.paths."""
 
 import importlib
+import re
 
 import clauditor.paths as _paths_mod
 
 importlib.reload(_paths_mod)
 
-from clauditor.paths import resolve_clauditor_dir  # noqa: E402
+from clauditor.paths import SKILL_NAME_RE, resolve_clauditor_dir  # noqa: E402
 
 
 class TestResolveClauditorDir:
@@ -61,3 +62,12 @@ class TestResolveClauditorDir:
         # current working directory because no valid marker was found.
         assert result != fake_home / ".clauditor"
         assert result == project / ".clauditor"
+
+
+class TestSkillNameRe:
+    def test_matches_known_good_identifier(self):
+        assert re.fullmatch(SKILL_NAME_RE, "my-skill_123") is not None
+
+    def test_rejects_known_bad_identifier(self):
+        assert re.fullmatch(SKILL_NAME_RE, "bad;name") is None
+        assert re.fullmatch(SKILL_NAME_RE, "") is None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -69,6 +69,54 @@ class TestResolveClauditorDir:
         assert result != fake_home / ".clauditor"
         assert result == project / ".clauditor"
 
+    def test_home_lookup_failure_falls_through(
+        self, tmp_path, monkeypatch
+    ):
+        """``Path.home().resolve()`` failure degrades to ``home = None``.
+
+        Exercises the defensive ``except (RuntimeError, OSError)`` guard
+        at the top of :func:`resolve_clauditor_dir`. In containerized or
+        rootless environments where ``$HOME`` is unset, ``Path.home()``
+        raises ``RuntimeError``; the walk continues without the
+        home-exclusion and the legitimate ``.git`` marker still wins.
+        """
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "clauditor.paths.Path.home",
+            lambda: (_ for _ in ()).throw(RuntimeError("no HOME")),
+        )
+        assert resolve_clauditor_dir() == tmp_path / ".clauditor"
+
+    def test_candidate_resolve_failure_uses_unresolved(
+        self, tmp_path, monkeypatch
+    ):
+        """``candidate.resolve()`` failure degrades to the raw candidate.
+
+        Exercises the defensive ``except OSError`` guard in the marker-
+        walk loop. On filesystems where ``resolve()`` fails mid-walk
+        (transient I/O error, broken symlink chain), the helper falls
+        back to the unresolved candidate for the home comparison and
+        keeps walking.
+        """
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        real_resolve = Path.resolve
+
+        def flaky_resolve(self, strict=False):
+            # Raise only for the candidate passed to the loop's resolve;
+            # let Path.home().resolve() succeed so the home lookup lands
+            # and the at_home guard still runs.
+            if self == tmp_path:
+                raise OSError("I/O error")
+            return real_resolve(self, strict=strict)
+
+        monkeypatch.setattr(
+            "clauditor.paths.Path.resolve", flaky_resolve
+        )
+        assert resolve_clauditor_dir() == tmp_path / ".clauditor"
+
 
 class TestSkillNameRe:
     def test_matches_known_good_identifier(self):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -166,20 +166,34 @@ class TestDeriveProjectDir:
         skill_path.write_text("---\nname: foo\n---\n")
         assert derive_project_dir(skill_path) == tmp_path
 
-    def test_project_dir_fallback_modern_ascent(self):
-        # Non-existent path is fine — helper only does path arithmetic
-        # once find_project_root returns None (no markers above `/`).
+    def test_project_dir_fallback_modern_ascent(self, monkeypatch):
+        # Non-existent path; force find_project_root to return None so
+        # the layout-aware fallback is exercised deterministically
+        # regardless of `.git`/`.claude` markers that may exist at `/`
+        # or other ancestors on the host.
+        monkeypatch.setattr(
+            "clauditor.setup.find_project_root", lambda _p: None
+        )
         skill_path = Path("/a/b/c/d/e/SKILL.md")
         assert derive_project_dir(skill_path) == Path("/a/b")
 
-    def test_project_dir_fallback_legacy_ascent(self):
+    def test_project_dir_fallback_legacy_ascent(self, monkeypatch):
+        monkeypatch.setattr(
+            "clauditor.setup.find_project_root", lambda _p: None
+        )
         skill_path = Path("/a/b/c/d/foo.md")
         assert derive_project_dir(skill_path) == Path("/a/b")
 
-    def test_project_dir_fallback_modern_when_no_marker(self, tmp_path):
-        # tmp_path lives under /tmp with no .git/.claude up the tree;
-        # find_project_root returns None and the helper falls back to
-        # 4-deep ascent for the modern SKILL.md layout.
+    def test_project_dir_fallback_modern_when_no_marker(
+        self, tmp_path, monkeypatch
+    ):
+        # tmp_path may have unexpected ancestors with `.git`/`.claude`
+        # (some CI sandboxes do). Force the marker-walk to return None
+        # so the 4-deep fallback for the modern SKILL.md layout is
+        # exercised deterministically.
+        monkeypatch.setattr(
+            "clauditor.setup.find_project_root", lambda _p: None
+        )
         skills_dir = tmp_path / "a" / "b" / "c" / "d" / "foo"
         skills_dir.mkdir(parents=True)
         skill_path = skills_dir / "SKILL.md"

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -54,6 +55,101 @@ class TestFromFile:
         )
         assert spec.eval_spec is not None
         assert spec.eval_spec.test_args == "--depth quick"
+
+    # ── Layout-aware identity derivation (DEC-001, DEC-002, DEC-009) ──
+
+    def test_from_file_modern_layout_matching_frontmatter(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Modern layout, frontmatter ``name:`` matches parent dir → silent."""
+        skill_path = tmp_skill_file(
+            "foo",
+            content="---\nname: foo\n---\n# Foo\n",
+            layout="modern",
+        )
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_name == "foo"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_from_file_modern_layout_disagreement_warns(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Modern layout, frontmatter ``name:`` disagrees → frontmatter
+        wins, stderr warning emitted per DEC-002 / DEC-009."""
+        skill_path = tmp_skill_file(
+            "foo",
+            content="---\nname: bar\n---\n# Bar\n",
+            layout="modern",
+        )
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_name == "bar"
+        captured = capsys.readouterr()
+        assert (
+            "frontmatter name 'bar' overrides filesystem name 'foo'"
+            in captured.err
+        )
+
+    def test_from_file_modern_layout_missing_name_silent(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Modern layout with no frontmatter → falls back to parent dir
+        name silently (DEC-001)."""
+        skill_path = tmp_skill_file(
+            "foo",
+            content="# Foo\n\nNo frontmatter here.\n",
+            layout="modern",
+        )
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_name == "foo"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_from_file_legacy_layout_matching_frontmatter(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Legacy layout, frontmatter ``name:`` matches stem → silent."""
+        skill_path = tmp_skill_file(
+            "foo",
+            content="---\nname: foo\n---\n# Foo\n",
+            layout="legacy",
+        )
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_name == "foo"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_from_file_legacy_layout_missing_name_silent(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Legacy layout with no frontmatter → falls back to stem
+        silently (DEC-001). This mirrors today's default legacy skill
+        shape (no frontmatter)."""
+        skill_path = tmp_skill_file(
+            "my-skill",
+            content="# My Skill\n\nNo frontmatter here.\n",
+            layout="legacy",
+        )
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_name == "my-skill"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_init_with_nonexistent_path_uses_layout_fallback(self):
+        """Direct ``SkillSpec(...)`` construction with a non-existent path
+        must not call ``read_text`` and must derive ``skill_name`` from
+        the layout (modern → parent dir, legacy → stem). Regression guard
+        for DEC-006 — the path taken by
+        ``tests/test_quality_grader.py`` when building a spec with a
+        placeholder ``Path("dummy.md")``.
+        """
+        # Modern fallback: path is a named dir / SKILL.md.
+        spec_modern = SkillSpec(skill_path=Path("/nonexistent/foo/SKILL.md"))
+        assert spec_modern.skill_name == "foo"
+
+        # Legacy fallback: path is <stem>.md.
+        spec_legacy = SkillSpec(skill_path=Path("/nonexistent/bar.md"))
+        assert spec_legacy.skill_name == "bar"
 
 
 class TestRun:


### PR DESCRIPTION
## Summary

Teaches `SkillSpec` and `cli/init.py` to handle the modern Anthropic skills layout `.claude/skills/<name>/SKILL.md` alongside the legacy `.claude/commands/<name>.md`. Before this, `skill_path.stem` returned the literal string `"SKILL"` for the modern layout, producing a bogus `/SKILL` slash command and a 37-second "failed to run: None" with zero tokens used. The project's own bundled skill at `src/clauditor/skills/clauditor/SKILL.md` was affected — we couldn't even self-validate.

Fixes #62.

## What changed

- New `src/clauditor/paths.py` helpers:
  - `SKILL_NAME_RE` — promoted from `propose_eval.py`; single source of truth for name validation.
  - `derive_skill_name(skill_path, skill_md_text) -> tuple[str, str | None]` — frontmatter `name:` first, layout-aware filesystem fallback, lenient on regex failure, pure (caller emits warning).
  - `derive_project_dir(skill_path) -> Path` — `find_project_root` marker-walk first, 4-deep/3-deep ascent fallback.
- `SkillSpec.__init__` gained keyword-only `skill_name_override=None`; `from_file` reads the file, calls the helpers, emits the stderr warning, threads the override. Direct-constructor callers with non-existent paths still work.
- `cli/init.py` routes through the shared helper, fixing the parallel `skill_path.stem` bug.
- `_load_spec_or_report` and `cli/init.py` now catch `(OSError, UnicodeDecodeError)` so a non-UTF-8 skill file shows a clean error instead of an uncaught traceback.
- `tmp_skill_file` fixture gained a `layout="legacy" | "modern"` kwarg.
- New regression test loads the bundled `src/clauditor/skills/clauditor/SKILL.md` through `SkillSpec.from_file`.
- New `.claude/rules/skill-identity-from-frontmatter.md` codifying the frontmatter-first + layout-aware-fallback + lenient-on-failure pattern.

## Plan & decisions

Full plan: [`plans/super/62-skill-md-layout.md`](./plans/super/62-skill-md-layout.md). Twelve decisions captured (DEC-001 … DEC-012).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest --cov=clauditor --cov-report=term-missing` — 1576 passed, 97.59% coverage (gate 80%)
- [x] Modern-layout end-to-end: `SkillSpec.from_file` on the bundled `src/clauditor/skills/clauditor/SKILL.md` returns `skill_name="clauditor"` with no warning
- [x] Legacy-layout regression: every existing `tmp_skill_file(<name>)` test continues to pass byte-identically (default `layout="legacy"`)
- [x] Disagreement warning: frontmatter `name: bar` with parent dir `foo` emits `clauditor.spec: frontmatter name 'bar' overrides filesystem name 'foo' — using 'bar'` to stderr
- [x] Invalid-regex fallback: `name: bad;value` falls back to filesystem name with a warning, does not hard-fail
- [x] Non-UTF-8 skill file: shows `ERROR: cannot read {path}: ...` instead of a traceback
- [x] Quality gate: 4 code-reviewer passes + local CodeRabbit review, all findings addressed

## Bead manifest

Epic `clauditor-600` closed. All 8 tasks (US-001 through US-006 + Quality Gate + Patterns & Memory) closed.