### PR TITLE
#67: Redesign assertion schema with per-type semantic keys

### DIFF
--- a/.claude/rules/constant-with-type-info.md
+++ b/.claude/rules/constant-with-type-info.md
@@ -1,0 +1,217 @@
+# Rule: Single-source-of-truth constants carry per-key type info
+
+When a loader's key-presence constant (the `dict[type, KeySpec]`
+that declares "type X requires these keys, optionally accepts
+these") governs payload fields that are not all strings — some
+ints, some bools, some floats — extend the `KeySpec` dataclass with
+a `field_types: dict[str, type]` member and enforce `isinstance` at
+load time from the same validator that checks presence. One
+constant, one validator, one error path. Do NOT split type-checking
+off into a second pass that a future caller might forget to run, and
+do NOT rely on handler-side runtime coercion (`int(a.get(key, ""))`)
+to reject wrong types — by then the bad value has already been
+accepted, and downstream callers have already built partial state
+around it.
+
+## The pattern
+
+```python
+# schemas.py — the spec dataclass carries presence AND type info.
+@dataclass(frozen=True)
+class AssertionKeySpec:
+    required: frozenset[str]
+    optional: frozenset[str] = frozenset()
+    field_types: dict[str, type] = field(default_factory=dict)
+
+
+# Single source of truth: every type's required/optional keys AND
+# the expected native JSON type for each payload key.
+ASSERTION_TYPE_REQUIRED_KEYS: dict[str, AssertionKeySpec] = {
+    "contains": AssertionKeySpec(
+        required=frozenset({"needle"}),
+        field_types={"needle": str},
+    ),
+    "min_length": AssertionKeySpec(
+        required=frozenset({"length"}),
+        field_types={"length": int},
+    ),
+    "has_urls": AssertionKeySpec(
+        optional=frozenset({"count"}),
+        field_types={"count": int},
+    ),
+    "has_format": AssertionKeySpec(
+        required=frozenset({"format"}),
+        optional=frozenset({"count"}),
+        field_types={"format": str, "count": int},
+    ),
+    # ...
+}
+
+
+def _require_assertion_keys(entry: dict, ctx: str) -> None:
+    spec = ASSERTION_TYPE_REQUIRED_KEYS[entry["type"]]
+    # ... presence checks (unknown key, missing required) ...
+
+    # Type-check every declared field_types entry that is present.
+    for key, expected in spec.field_types.items():
+        if key not in entry:
+            continue
+        val = entry[key]
+        if val is None:
+            raise ValueError(
+                f"{ctx}: key {key!r} must be {expected.__name__}, "
+                f"not null (omit the key to use the default)"
+            )
+        # bool is a subclass of int in Python — guard explicitly,
+        # otherwise {"count": True} would silently pass isinstance(val, int).
+        ok = isinstance(val, expected) and not (
+            expected is int and isinstance(val, bool)
+        )
+        if not ok:
+            raise ValueError(
+                f"{ctx}: key {key!r} must be {expected.__name__}, "
+                f"got {type(val).__name__} {val!r}"
+            )
+```
+
+## Why this shape
+
+- **One constant, one validator, one error path.** Splitting
+  type-checking off into a separate `_validate_types(entry)` pass
+  means a future caller might forget to run it, or run it in the
+  wrong order relative to the presence-check. Co-locating type
+  info on the same `KeySpec` and looping through `spec.field_types`
+  inside `_require_assertion_keys` guarantees every load goes
+  through both checks together.
+- **Reject string-typed ints at load time, not runtime.** The
+  pre-#67 loader accepted `{"value": "500"}` (a JSON string) and
+  relied on `int(a.get("value", ""))` inside the handler to coerce.
+  That shifted the error from "bad spec" (surface at load, exit 2)
+  to "runtime crash in the handler" (surface mid-run, opaque
+  traceback). With `field_types` declared and enforced in the
+  loader, `{"length": "500"}` rejects with a crisp
+  `"key 'length' must be int, got str '500'"` before any grading
+  run spins up.
+- **Explicit `bool is not int` guard.** Python's `isinstance(True,
+  int)` returns `True`. A naive `isinstance(val, int)` silently
+  accepts `{"count": True}` as a legal count, which then flows
+  through arithmetic as `1` without complaint. The explicit
+  `not (expected is int and isinstance(val, bool))` branch rejects
+  bool-for-int with the same "got bool" error message an author
+  would actually recognize.
+- **`None` gets its own branch with an actionable message.** A
+  `val is None` check ahead of the `isinstance` call produces
+  `"must be int, not null (omit the key to use the default)"`
+  instead of the technically-correct-but-confusing `"got NoneType
+  None"`. Hand-authors default-write `null` when unsure; the
+  friendlier error tells them to delete the key instead.
+- **Skip keys the author omitted.** `if key not in entry: continue`
+  means optional-with-default keys stay optional — the `count` key
+  on `has_urls` can be absent, and the handler's `a.get("count", 1)`
+  supplies the default. Type-checking only fires on keys the author
+  actually wrote.
+- **Natural extension of presence info, not a parallel universe.**
+  Every required-or-optional key has a type; every field_types
+  key must also appear in required or optional. A test-side
+  drift guard (`test_field_types_match`) can assert that
+  invariant at load time, so a future contributor who adds a
+  field_types entry without updating required/optional gets a
+  red test rather than silent skew.
+
+## What NOT to do
+
+- Do NOT declare `field_types` as a `dict[str, tuple[type, ...]]`
+  to support "int OR string" permissive reads. That is the
+  pre-#67 behavior this rule explicitly tightens against. If you
+  need a permissive read, do it with two distinct `type` values
+  (one for int, one for string) rather than a union-typed field.
+- Do NOT put the type-check pass before the presence check. The
+  error-path order matters: unknown type → unknown key → missing
+  required → wrong type. A user who typed `pattern` instead of
+  `needle` on a `contains` assertion should see the `"did you mean
+  'needle'?"` hint (unknown-key path), not a `"missing required
+  key 'needle'"` confusing side-effect of a presence-first order.
+- Do NOT `isinstance(val, int)` without the `bool` guard. Bool is
+  an int subclass in Python; silently accepting `True` / `False`
+  for a numeric field is a specific Python foot-gun, not a rare
+  edge case. The guard is two lines and anchors every `int` type.
+- Do NOT skip the `test_field_types_match` drift guard. Without
+  it, a future contributor can add a `field_types` entry without
+  a matching `required`/`optional` entry (or vice versa), and the
+  constant quietly drifts out of lockstep with the validator's
+  iteration order.
+
+## Canonical implementation
+
+`src/clauditor/schemas.py::AssertionKeySpec.field_types` + the
+per-key `isinstance` loop inside `_require_assertion_keys`. The
+`field_types` field was added in #67 (DEC-012 of
+`plans/super/67-per-type-assertion-keys.md`) as a natural
+consequence of switching from stringly-typed ints on disk
+(`{"value": "500"}`) to native JSON ints (`{"length": 500}`).
+Before this split, types were enforced implicitly by handler-side
+coercion (`int(a.get(...))`), which accepted strings, rejected
+them at runtime, and produced opaque errors.
+
+Tests:
+
+- `tests/test_schemas.py::TestAssertionKeySpec::test_field_types_match`
+  — drift guard asserting every `required ∪ optional` key has a
+  matching `field_types` entry and vice versa, for every type
+  in `ASSERTION_TYPE_REQUIRED_KEYS`.
+- `tests/test_schemas.py::TestRequireAssertionKeys` — parametrized
+  wrong-type cases (`{"type": "min_length", "length": "500"}`,
+  `{"type": "contains", "needle": 123}`, `{"type": "has_urls",
+  "count": True}`) verify each branch of the type-check loop.
+
+Companion rules:
+
+- `.claude/rules/per-type-drift-hints.md` — the sibling hint
+  table keyed on the same discriminator. A `KeySpec` extension
+  that adds type info often needs a hint-table extension in the
+  same change.
+- `.claude/rules/eval-spec-stable-ids.md` — the `id` uniqueness
+  validator lives in the same `from_dict` context and runs
+  alongside the key/type validator.
+- `.claude/rules/pre-llm-contract-hard-validate.md` — the broader
+  "fail loudly at load, never silently accept a bad spec" shape.
+
+## When this rule applies
+
+When a new `dict[type, KeySpec]` (or `list[KeySpec]`) constant
+governs payload fields of mixed primitive types — ints alongside
+strings, floats alongside bools — AND the loader already has (or is
+gaining) per-type key-presence validation. Plausible future callers:
+
+- A grading-criteria constant with a `score_type` discriminator
+  (`numeric` takes `float` fields, `tiered` takes `str` fields,
+  `binary` takes `bool`).
+- A section-field constant where `required: bool` lives next to
+  `format: str`, `name: str`, and a future `min_length: int`.
+- A trigger-test constant with mixed-type slots (`pattern: str`,
+  `max_tokens: int`, `strict: bool`).
+
+The rule also applies retroactively: any existing
+`{required, optional}`-only constant that governs mixed-type payload
+fields is a latent foot-gun. Add `field_types` during the next
+touch that adds or renames a key.
+
+## When this rule does NOT apply
+
+- Monotyped constants where every payload field is a string (or
+  every field is an int). A single-pass `isinstance(val, str)`
+  sweep at the validator level is enough; a per-key map is
+  over-engineering.
+- Dataclass-wrapped structured fields where the loader builds a
+  nested dataclass from the dict. The dataclass's `__init__` type
+  annotations already carry the type info; re-declaring in
+  `field_types` would drift. Validate by constructing the
+  dataclass instead.
+- Constants consumed only by generated code (e.g. JSON Schema
+  exported to an external validator). The external validator owns
+  type-checking; a second in-process copy is redundant and
+  drift-prone. Emit the types from the constant into the external
+  schema rather than re-enforcing in-process.
+- One-off scripts or diagnostic tools that load a spec for
+  display only and do not hand the result to the grading pipeline.
+  Those can tolerate loose typing.

--- a/.claude/rules/per-type-drift-hints.md
+++ b/.claude/rules/per-type-drift-hints.md
@@ -1,0 +1,168 @@
+# Rule: Per-type drift hints for polymorphic-dict loaders
+
+When a loader validates polymorphic dicts — entries discriminated by
+a `type` (or other discriminator) field where each type value accepts
+a different set of payload keys — the "unknown key" error path must
+consult a **per-type** hint table, NOT a global one. A global hint
+table is correct until the schema is renamed and some of the
+"wrong" keys become valid for a subset of types; after that point a
+global hint silently mis-suggests. The per-type table carries
+`dict[type, dict[wrong-key, right-key]]` and is keyed by the
+discriminator so the same "wrong" key (e.g. `pattern`) can be hinted
+differently depending on which type the author wrote.
+
+## The pattern
+
+```python
+# schemas.py — sibling constant to the required-keys table.
+_ASSERTION_DRIFT_HINTS: dict[str, dict[str, str]] = {
+    "contains":       {"value": "needle", "pattern": "needle"},
+    "not_contains":   {"value": "needle", "pattern": "needle"},
+    "regex":          {"value": "pattern"},
+    # `pattern` intentionally absent here — it's a VALID key on
+    # `regex` and `min_count`, so hinting on it would be wrong.
+    "min_count":      {"value": "pattern", "minimum": "count",
+                       "min_count": "count", "threshold": "count"},
+    "min_length":     {"value": "length", "min": "length"},
+    "max_length":     {"value": "length", "max": "length"},
+    "has_urls":       {"value": "count", "minimum": "count",
+                       "min_count": "count", "threshold": "count"},
+    # ... per-type entries continue ...
+}
+
+
+def _require_assertion_keys(entry: dict, ctx: str) -> None:
+    type_val = entry["type"]
+    spec = ASSERTION_TYPE_REQUIRED_KEYS[type_val]
+    allowed = {"id", "type", "name"} | spec.required | spec.optional
+    for key in entry:
+        if key in allowed:
+            continue
+        # Per-type lookup — no global fallback.
+        suggestion = _ASSERTION_DRIFT_HINTS.get(type_val, {}).get(key)
+        hint = (
+            f" — did you mean {suggestion!r}?"
+            if suggestion is not None
+            else ""
+        )
+        raise ValueError(
+            f"{ctx} (type={type_val!r}): unknown key {key!r}{hint}"
+        )
+```
+
+## Why this shape
+
+- **Per-type keying survives renames.** The motivating bug: after
+  #67 renamed `value` to per-type semantic keys (`needle`, `pattern`,
+  `length`, `count`), `pattern` became VALID for `regex` and
+  `min_count` but remained WRONG for `contains`. A global
+  `{"pattern": "value"}` hint would mis-suggest in both directions —
+  telling a `regex` author to rename a valid key back to `value`,
+  and giving no hint to a `contains` author who typed `pattern`.
+  The per-type table carries exactly the right asymmetry: `pattern`
+  appears under `contains`/`not_contains` (suggest `needle`) and is
+  absent under `regex`/`min_count` (where it is already valid).
+- **Sibling constant, not inlined map.** The hint table lives next
+  to the required-keys table so reviewers diffing one notice the
+  other. Inlining the hints into the validator function body hides
+  them from a `git blame` on the constant and makes the per-type
+  asymmetry easy to miss during a rename.
+- **`.get(type, {}).get(key)` double-default.** Both levels fall
+  through to `None` cleanly: an unknown type (already rejected by
+  the type-validation branch, but the validator runs unknown-key
+  BEFORE missing-required — see below) yields no hint rather than
+  a `KeyError`, and an unknown key not in the hint table yields no
+  hint rather than a spurious suggestion.
+- **Unknown-key fires BEFORE missing-required.** The error-path
+  order is: (a) unknown/missing `type` → (b) unknown key →
+  (c) missing required → (d) wrong type. A user who wrote an old
+  alias (`value` on `contains`) gets the actionable `"did you mean
+  'needle'?"` hint instead of the opaque `"missing required key
+  'needle'"` that would hide the rename from them.
+- **Drift-hint coverage includes ALL common legacy aliases, not
+  just the most recent rename.** The `min_count` entry hints
+  `minimum`, `min_count`, AND `threshold` — three keys a hand-
+  author might reach for when they've seen any of those in adjacent
+  code or tool docs. The goal is migration UX, not a minimal table.
+
+## What NOT to do
+
+- Do NOT use a global `dict[wrong-key, right-key]` table that
+  applies across all types. After the first rename where some of
+  the "wrong" keys become valid for a subset of types, the global
+  table silently mis-suggests. Start per-type from day one.
+- Do NOT hint on a key that is VALID for the current type. The
+  `pattern` key is intentionally absent from
+  `_ASSERTION_DRIFT_HINTS["regex"]` and
+  `_ASSERTION_DRIFT_HINTS["min_count"]` — hinting would be factually
+  wrong and confusing.
+- Do NOT add a "default" entry (e.g. `_ASSERTION_DRIFT_HINTS["*"]`
+  as a fallback). The whole point of per-type keying is that a
+  key's meaning depends on context; a default re-introduces the
+  global problem under a different name.
+- Do NOT emit hints as stderr warnings or logging. The hint is part
+  of the `ValueError` message so it reaches the CLI's single error-
+  rendering seam (see `.claude/rules/llm-cli-exit-code-taxonomy.md`)
+  and is never silently swallowed.
+
+## Canonical implementation
+
+`src/clauditor/schemas.py::_ASSERTION_DRIFT_HINTS` + the consultation
+inside `_require_assertion_keys`. Sibling to
+`ASSERTION_TYPE_REQUIRED_KEYS` (the single source of truth for which
+keys each type accepts). The hint table was introduced alongside the
+#67 per-type key redesign (DEC-009 of
+`plans/super/67-per-type-assertion-keys.md`) specifically to handle
+the rename asymmetry — where the global `{"pattern","min","max"} →
+"value"` hint from #61's first-pass validator became incorrect after
+`pattern` gained legitimate per-type meaning.
+
+Tests: `tests/test_schemas.py::TestRequireAssertionKeys` — one hint
+test per `(type, wrong-key, expected-right-key)` triple in
+`_ASSERTION_DRIFT_HINTS`. Coverage should walk the table.
+
+Companion rules:
+
+- `.claude/rules/pre-llm-contract-hard-validate.md` — the broader
+  "assert in the prompt, enforce in the parser" shape. This rule
+  refines the UX layer of the parser-side enforcement.
+- `.claude/rules/constant-with-type-info.md` — the required-keys
+  constant this table sits alongside carries per-key type info
+  that the same validator also enforces.
+
+## When this rule applies
+
+Any loader validating a polymorphic dict (a discriminator field +
+per-discriminator-value payload-key sets). Plausible future callers:
+
+- A grading-criteria validator growing per-scale-type keys
+  (`numeric` scale uses `min`/`max`, `tiered` uses `levels`,
+  `binary` uses neither).
+- A section-field validator growing per-format keys (`regex`
+  format uses `pattern`, `registered` format uses `name`, `range`
+  format uses `low`/`high`).
+- A trigger-test validator with `should_trigger` /
+  `should_not_trigger` sub-types that each accept different slot
+  shapes.
+- Any future DSL-style JSON/YAML config with discriminated variants.
+
+The rule also generalizes to **any** discriminated-union dict loader
+that has to reject unknown keys with author-friendly hints, even
+outside clauditor — the shape is language-agnostic and table-driven.
+
+## When this rule does NOT apply
+
+- Monomorphic dict loaders where every entry accepts the same
+  keys. A single global hint table is fine there — there is no
+  per-type asymmetry to preserve.
+- Loaders that silently ignore unknown keys (permissive passthrough).
+  Those have no error path to attach a hint to. A future tightening
+  from "permissive" to "strict unknown-key rejection" would trigger
+  this rule's applicability.
+- Validators where all hints are always correct regardless of type
+  (e.g. pure case-correction: `"ID" → "id"`, `"Type" → "type"`). A
+  global table suffices — the hints are not type-dependent.
+- Loaders where the discriminator itself is optional or inferred.
+  The per-type lookup has no anchor without a reliable type value;
+  resolve the type-required question first (see
+  `.claude/rules/pre-llm-contract-hard-validate.md`).

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ An `<skill-name>.eval.json` lives next to the skill's `.md` file and drives all 
 {
   "skill_name": "find-kid-activities",
   "test_args":  "\"Cupertino, CA\" --ages 4-6",
-  "assertions": [{"id": "has_venues", "type": "contains", "value": "Venues"}],
+  "assertions": [{"id": "has_venues", "type": "contains", "needle": "Venues"}],
   "sections":   [{"name": "Venues", "tiers": [{"label": "default", "min_entries": 3, "fields": [{"id": "v_name", "name": "name", "required": true}]}]}],
   "grading_criteria": [{"id": "distance_ok", "criterion": "Are all venues within the specified distance?"}]
 }

--- a/docs/eval-spec-reference.md
+++ b/docs/eval-spec-reference.md
@@ -58,11 +58,11 @@ A complete eval spec with all three layers:
   "input_files": ["fixtures/sample-venues.csv"],
 
   "assertions": [
-    {"id": "contains_venues", "type": "contains", "value": "Venues"},
-    {"id": "has_entries_3", "type": "has_entries", "value": "3"},
-    {"id": "has_urls_3", "type": "has_urls", "value": "3"},
-    {"id": "min_length_500", "type": "min_length", "value": "500"},
-    {"id": "no_error", "type": "not_contains", "value": "Error"}
+    {"id": "contains_venues", "type": "contains", "needle": "Venues"},
+    {"id": "has_entries_3", "type": "has_entries", "count": 3},
+    {"id": "has_urls_3", "type": "has_urls", "count": 3},
+    {"id": "min_length_500", "type": "min_length", "length": 500},
+    {"id": "no_error", "type": "not_contains", "needle": "Error"}
   ],
 
   "sections": [
@@ -116,6 +116,46 @@ A complete eval spec with all three layers:
 
 See [`examples/`](../examples/.claude/commands/example-skill.eval.json) for a complete working eval spec.
 
+## Assertion types and per-type keys
+
+Each Layer 1 assertion carries a `type` plus the per-type semantic keys
+listed below (in addition to `id`, `type`, and optional `name`). Integer
+fields are native JSON ints, not strings — `{"length": 500}`, not
+`{"length": "500"}`. Unknown keys raise `ValueError` at load time with a
+"did you mean?" migration hint.
+
+| Type | Required keys | Optional keys | Description |
+|---|---|---|---|
+| `contains` | `needle` (str) | — | Output contains the needle substring |
+| `not_contains` | `needle` (str) | — | Output does NOT contain the needle |
+| `regex` | `pattern` (str) | — | Output matches the regex pattern (search, not fullmatch) |
+| `min_count` | `pattern` (str), `count` (int) | — | Regex pattern appears at least `count` times |
+| `min_length` | `length` (int) | — | Output length is at least `length` chars |
+| `max_length` | `length` (int) | — | Output length is at most `length` chars |
+| `has_urls` | — | `count` (int, default 1) | Output contains at least `count` URLs |
+| `has_entries` | — | `count` (int, default 1) | Output contains at least `count` numbered entries |
+| `urls_reachable` | — | `count` (int, default 1) | At least `count` URLs in output return 2xx on HEAD |
+| `has_format` | `format` (str) | `count` (int, default 1) | Output contains at least `count` strings matching the format (see [format registry](#field-validation-with-format)) |
+
+Example — one of each shape:
+
+```json
+{
+  "assertions": [
+    {"id": "has_title",      "type": "contains",       "needle": "Results"},
+    {"id": "no_error",       "type": "not_contains",   "needle": "Error"},
+    {"id": "numbered",       "type": "regex",          "pattern": "\\*\\*\\d+\\."},
+    {"id": "three_bullets",  "type": "min_count",      "pattern": "^- ", "count": 3},
+    {"id": "long_enough",    "type": "min_length",     "length": 500},
+    {"id": "not_too_long",   "type": "max_length",     "length": 5000},
+    {"id": "has_3_urls",     "type": "has_urls",       "count": 3},
+    {"id": "has_3_entries",  "type": "has_entries",    "count": 3},
+    {"id": "urls_work",      "type": "urls_reachable", "count": 2},
+    {"id": "two_phones",     "type": "has_format",     "format": "phone_us", "count": 2}
+  ]
+}
+```
+
 ## Field validation with `format`
 
 Each `FieldRequirement` accepts a single `format` key that validates the
@@ -163,3 +203,17 @@ bare hostnames too.
 `count_max` assertion if extraction returns more entries than the cap.
 Field-level checks still run over all extracted entries so you see both
 the count failure and any per-entry failures.
+
+## Schema history
+
+**Issue #67 — per-type assertion keys.** Assertion dicts previously
+carried a single overloaded `value` key whose meaning depended on
+`type` — a string needle for `contains`, a regex pattern for `regex`, a
+stringly-typed count for `has_urls`, and so on. Issue #67 replaced
+`value` with per-type semantic keys (`needle`, `pattern`, `length`,
+`count`, `format`) and switched integer fields from stringly-typed
+(`"value": "500"`) to native JSON ints (`"length": 500`). The loader
+rejects the old shape at load time with a "did you mean?" hint pointing
+at the correct per-type key. No back-compat window: hand-edit old specs
+to the new shape, or run the spec through `clauditor propose-eval
+--force` to regenerate it.

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -44,10 +44,10 @@ Or define in `eval.json`:
 ```json
 {
   "assertions": [
-    {"id": "contains_venues", "type": "contains", "value": "Venues"},
-    {"id": "regex_numbered", "type": "regex", "value": "\\*\\*\\d+\\."},
-    {"id": "has_urls_3", "type": "has_urls", "value": "3"},
-    {"id": "no_error", "type": "not_contains", "value": "Error"}
+    {"id": "contains_venues", "type": "contains", "needle": "Venues"},
+    {"id": "regex_numbered", "type": "regex", "pattern": "\\*\\*\\d+\\."},
+    {"id": "has_urls_3", "type": "has_urls", "count": 3},
+    {"id": "no_error", "type": "not_contains", "needle": "Error"}
   ]
 }
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,10 +17,10 @@ This creates `my-skill.eval.json` alongside your skill file:
   "skill_name": "my-skill",
   "test_args": "\"San Jose, CA\" --depth quick",
   "assertions": [
-    {"id": "contains_results", "type": "contains", "value": "Results"},
-    {"id": "has_entries_3",    "type": "has_entries", "value": "3"},
-    {"id": "has_urls_3",       "type": "has_urls", "value": "3"},
-    {"id": "min_length_500",   "type": "min_length", "value": "500"}
+    {"id": "contains_results", "type": "contains", "needle": "Results"},
+    {"id": "has_entries_3",    "type": "has_entries", "count": 3},
+    {"id": "has_urls_3",       "type": "has_urls", "count": 3},
+    {"id": "min_length_500",   "type": "min_length", "length": 500}
   ],
   "sections": [
     {

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -15,12 +15,13 @@ This creates `my-skill.eval.json` alongside your skill file:
 ```json
 {
   "skill_name": "my-skill",
-  "test_args": "\"San Jose, CA\" --depth quick",
+  "description": "Eval spec for /my-skill",
+  "test_args": "",
   "assertions": [
-    {"id": "contains_results", "type": "contains", "needle": "Results"},
-    {"id": "has_entries_3",    "type": "has_entries", "count": 3},
-    {"id": "has_urls_3",       "type": "has_urls", "count": 3},
-    {"id": "min_length_500",   "type": "min_length", "length": 500}
+    {"id": "min_length_500", "type": "min_length", "length": 500},
+    {"id": "has_urls_3", "type": "has_urls", "count": 3},
+    {"id": "has_entries_3", "type": "has_entries", "count": 3},
+    {"id": "no_error", "type": "not_contains", "needle": "Error"}
   ],
   "sections": [
     {
@@ -30,15 +31,30 @@ This creates `my-skill.eval.json` alongside your skill file:
           "label": "default",
           "min_entries": 3,
           "fields": [
-            {"id": "result_name",    "name": "name",    "required": true},
-            {"id": "result_address", "name": "address", "required": true}
+            {"id": "results_name", "name": "name", "required": true},
+            {"id": "results_address", "name": "address", "required": true}
           ]
         }
       ]
     }
-  ]
+  ],
+  "grading_criteria": [
+    {"id": "relevant", "criterion": "Are results relevant to the query?"},
+    {"id": "specific", "criterion": "Are descriptions specific (not generic filler)?"}
+  ],
+  "grading_model": "claude-sonnet-4-6",
+  "trigger_tests": {
+    "should_trigger": [],
+    "should_not_trigger": []
+  },
+  "variance": {
+    "n_runs": 3,
+    "min_stability": 0.8
+  }
 }
 ```
+
+Fill in `test_args` and customize assertions, sections, and grading criteria for your skill.
 
 ## 2. Validate against captured output
 

--- a/examples/.claude/commands/example-skill.eval.json
+++ b/examples/.claude/commands/example-skill.eval.json
@@ -9,42 +9,42 @@
   "assertions": [
     {
       "type": "contains",
-      "value": "Venues",
+      "needle": "Venues",
       "id": "contains_venues"
     },
     {
       "type": "contains",
-      "value": "Events",
+      "needle": "Events",
       "id": "contains_events"
     },
     {
       "type": "has_entries",
-      "value": "3",
+      "count": 3,
       "id": "has_entries_3"
     },
     {
       "type": "has_urls",
-      "value": "3",
+      "count": 3,
       "id": "has_urls_3"
     },
     {
       "type": "min_length",
-      "value": "500",
+      "length": 500,
       "id": "min_length_500"
     },
     {
       "type": "not_contains",
-      "value": "AskUserQuestion",
+      "needle": "AskUserQuestion",
       "id": "no_ask_user_question"
     },
     {
       "type": "regex",
-      "value": "\\*\\*\\d+\\.\\s+",
+      "pattern": "\\*\\*\\d+\\.\\s+",
       "id": "regex_numbered_bold"
     },
     {
       "type": "regex",
-      "value": "https?://[^\\s]+",
+      "pattern": "https?://[^\\s]+",
       "id": "regex_url"
     }
   ],

--- a/plans/super/67-per-type-assertion-keys.md
+++ b/plans/super/67-per-type-assertion-keys.md
@@ -45,9 +45,10 @@ regression risk between now and landing.
 **Done when:**
 1. Every assertion type's parameter is read from a semantic
    per-type key, not `value`.
-2. `EvalSpec` carries an explicit `schema_version` field; the
-   loader rejects version mismatches per
-   `.claude/rules/json-schema-version.md`.
+2. The per-type `_require_assertion_keys` validator rejects legacy
+   `value`-shape specs at load time with an actionable "did you
+   mean …?" hint (DEC-003 deferred `schema_version` on EvalSpec;
+   the hard-validator is the safety net).
 3. All in-repo `*.eval.json` files migrated to the new shape and
    loadable without warnings.
 4. All in-repo test fixtures use the new keys.
@@ -656,16 +657,16 @@ test-mechanical and belongs with the constant change).
     in DEC-009 above).
   - `_require_assertion_keys` rewritten:
     1. Unknown-key branch consults `_ASSERTION_DRIFT_HINTS[type].get(key)` for the hint; emit `" — did you mean {suggestion!r}?"` if present, else empty. Remove the current global `{"pattern","min","max"} → "value"` and `"threshold" → "minimum"` branches.
-    2. New type-check pass: for each present key (required OR optional) in `spec.field_types`, verify `isinstance(val, expected)` — if mismatch, raise `ValueError(f"{ctx} (type={type!r}): key {key!r} must be {expected.__name__}, got {type(val).__name__} {val!r}")`.
+    2. New type-check pass: for each present key (required OR optional) in `spec.field_types`, verify `isinstance(val, expected)` — if mismatch, raise `ValueError(f"{ctx} (type={type!r}): key {key!r} must be {expected.__name__}, got {type(val).__name__} {val!r}")`. **`bool` is a subclass of `int` in Python**, so when `expected is int`, the check must also reject `bool` values (e.g., `{"length": True}`) — implemented as `isinstance(val, expected) and not (expected is int and isinstance(val, bool))`.
   - Error-message path order: unknown type → missing required → wrong type → unknown key. (Each is a distinct branch; no cascading noise.)
 - `src/clauditor/assertions.py`:
-  - `_ASSERTION_HANDLERS` updated to read new keys, with native int access (no `int(a.get(...))` coercion):
-    - `contains`, `not_contains` → `a.get("needle", "")`
-    - `regex` → `a.get("pattern", "")`
-    - `min_count` → `a.get("pattern", "")` + `a.get("count", 1)` (note: native int default, not `"" → 1`)
-    - `min_length`, `max_length` → `a.get("length", 0)` (native int)
-    - `has_urls`, `has_entries`, `urls_reachable` → `a.get("count", 1)` (native int)
-    - `has_format` → `a.get("format", "")` + `a.get("count", 1)` (native int)
+  - `_ASSERTION_HANDLERS` updated to read new keys, with native int access (no `int(a.get(...))` coercion). **Required keys use direct `a[key]` access** so loader-bypass (test-only path) fails loudly with `KeyError` instead of silently returning a bogus default (e.g. `max_length` with default 0 would fail every output — CodeRabbit finding). Optional keys keep `.get(key, default)` for the legitimate "omitted → use default" case:
+    - `contains`, `not_contains` → `a["needle"]`
+    - `regex` → `a["pattern"]`
+    - `min_count` → `a["pattern"]` + `a["count"]` (both required per DEC-001)
+    - `min_length`, `max_length` → `a["length"]`
+    - `has_urls`, `has_entries`, `urls_reachable` → `a.get("count", 1)` (optional, default 1)
+    - `has_format` → `a["format"]` + `a.get("count", 1)` (format required, count optional)
   - The docstring at `assertions.py:463` (if it references `value` / schema shape) updated to mention the new keys.
 - `tests/test_schemas.py`:
   - `TestAssertionKeySpec::test_contains_required_keys` parametrize table updated to the new per-type keys.

--- a/plans/super/67-per-type-assertion-keys.md
+++ b/plans/super/67-per-type-assertion-keys.md
@@ -1,0 +1,1023 @@
+# Super Plan: #67 — Redesign assertion schema with per-type semantic keys
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/67
+- **Branch:** `feature/67-per-type-assertion-keys`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/67-per-type-assertion-keys`
+- **Phase:** `detailing`
+- **PR:** TBD
+- **Sessions:** 1
+- **Last session:** 2026-04-20
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** The `value` slot on `EvalSpec` assertions is semantically
+overloaded — one key, five distinct meanings depending on assertion
+`type`:
+- string **needle** for `contains` / `not_contains`
+- string **pattern** for `regex`
+- int **length threshold** for `min_length` / `max_length`
+- int **minimum count** for `has_urls` / `has_entries` /
+  `urls_reachable`
+- string **pattern** for `min_count` (with separate `minimum` field
+  holding the actual count)
+
+Proposal: replace `value` with per-type semantic keys that name what
+they hold (`needle`, `pattern`, `length`, `count`, `min_count`,
+`format`). An LLM proposer (or hand author) reading the schema
+can't accidentally emit `min` for `min_length` because the expected
+key is `length` — and the hard-validator landed in #61 rejects
+mismatches loudly at load time.
+
+**Why:** The overloaded `value` is what invited the propose-eval
+proposer in #61 to reach for `pattern`/`min`/`max` — the LLM's
+guesses were semantically correct, the schema just happened to call
+all of them `value`. Fixing the schema eliminates the class of
+ambiguity that caused #61's silent false-positive bug in the first
+place. The #61 hard-validator (`_require_assertion_keys`) is now
+the safety net that makes this redesign shippable without silent-
+regression risk between now and landing.
+
+**Done when:**
+1. Every assertion type's parameter is read from a semantic
+   per-type key, not `value`.
+2. `EvalSpec` carries an explicit `schema_version` field; the
+   loader rejects version mismatches per
+   `.claude/rules/json-schema-version.md`.
+3. All in-repo `*.eval.json` files migrated to the new shape and
+   loadable without warnings.
+4. All in-repo test fixtures use the new keys.
+5. `docs/eval-spec-reference.md`, `README.md` examples, bundled
+   `clauditor.eval.json` rubric, `cli/init.py` scaffolding, and
+   `propose_eval.py` prompt all reflect the new keys.
+6. `ASSERTION_TYPE_REQUIRED_KEYS` + `AssertionKeySpec` updated so
+   the validator, proposer prompt, and tests all agree on the new
+   key set.
+
+**Who benefits:** Every future author (hand or LLM) of an eval
+spec — intuitive key names prevent the next wave of "I guessed
+`pattern` but the schema says `value`" errors. Also: every
+maintainer reading an existing spec, who no longer has to remember
+which of five meanings `value` holds in context.
+
+### Codebase Findings
+
+**Schema infrastructure (the gift from #61):**
+- `src/clauditor/schemas.py:14-32` — `AssertionKeySpec` frozen
+  dataclass with `required: frozenset[str]` and `optional:
+  frozenset[str]`.
+- `src/clauditor/schemas.py:47-73` — `ASSERTION_TYPE_REQUIRED_KEYS`
+  dict, single source of truth for 10 types' required/optional
+  keys. The proposer prompt, loader validator, and cross-check
+  tests all import this constant. **This is exactly the seam #67
+  modifies — change the key names in the dict, everything
+  downstream picks them up automatically.**
+- `src/clauditor/schemas.py:345-391` — `_require_assertion_keys`
+  nested in `EvalSpec.from_dict`. Rejects unknown keys; emits
+  drift-alias hints (`pattern`→`value`, `min`→`value`,
+  `max`→`value`, `threshold`→`minimum`). These drift-hints will
+  be rewritten to reflect the new keys.
+- `src/clauditor/propose_eval.py` — the proposer prompt renders
+  a per-type enumeration table from
+  `ASSERTION_TYPE_REQUIRED_KEYS`. **Rebuilds automatically when
+  the constant changes.**
+
+**Current `value` reader — the 10 handlers:**
+
+| Type | Extraction | `value` semantics today | Proposed key(s) |
+|---|---|---|---|
+| `contains` | `a.get("value", "")` | string needle | `needle` |
+| `not_contains` | `a.get("value", "")` | string needle | `needle` |
+| `regex` | `a.get("value", "")` | regex pattern | `pattern` |
+| `min_count` | `a.get("value", "")` + `a.get("minimum", 1)` | pattern + count | `pattern` + `count` |
+| `min_length` | `int(a.get("value", ""))` | length int | `length` |
+| `max_length` | `int(a.get("value", ""))` | length int | `length` |
+| `has_urls` | `int(a.get("value", "")) or 1` | optional min count | `min_count` (optional, default 1) |
+| `has_entries` | `int(a.get("value", "")) or 1` | optional min count | `min_count` (optional, default 1) |
+| `urls_reachable` | `int(a.get("value", "")) or 1` | optional min count | `min_count` (optional, default 1) |
+| `has_format` | `a.get("format", "")` + `int(a.get("value","")) or 1` | format name + optional min count | `format` + `min_count` |
+
+Note the dual-pattern use: `regex` AND `min_count` both want a
+regex-string key. The ticket proposes `pattern` for both, which is
+shared-key naming (same semantic, same key name) — reconciled in
+DEC-001 below.
+
+**Stringly-typed ints on disk:** checked-in specs store counts and
+lengths as JSON **strings** (e.g. `"value": "500"`, `"value": "3"`),
+coerced at runtime via `int(a.get(...))`. A schema-version bump is
+the natural moment to switch to native JSON ints.
+
+**EvalSpec has NO `schema_version` today.** Grep of `schemas.py`:
+zero matches. The ticket says "bump schema_version" but there is
+nothing to bump — we introduce it fresh. The loader today accepts
+unversioned JSON; all `schema_version` usage in the codebase is on
+**output** sidecars (grading.json, benchmark.json, etc.), never on
+the EvalSpec **input**.
+
+**Migration surface — only 2 in-repo `*.eval.json` files:**
+- `src/clauditor/skills/clauditor/assets/clauditor.eval.json` — 3
+  assertions (`contains`×2, `min_length`×1).
+- `examples/.claude/commands/example-skill.eval.json` — 8
+  assertions across 6 types.
+
+**Migration surface — test fixtures (hand-written dicts):**
+~100+ `"value":` occurrences across 12 test files. Heavy hitters:
+- `tests/test_schemas.py` (~35 inline assertion dicts)
+- `tests/test_propose_eval.py` (~15)
+- `tests/test_cli.py` (~10)
+- `tests/test_assertions.py` (~20 inline dicts with `"value":`)
+Plus scattered fixtures in `conftest.py`, `test_spec.py`,
+`test_baseline.py`, `test_cli_transcript_slice.py`,
+`test_cli_propose_eval.py`, `test_asserters.py`.
+
+**Documentation surface:**
+- `README.md:125` — one assertion example
+- `docs/quick-start.md:20-23` — four inline examples
+- `docs/eval-spec-reference.md:61-65` — five examples inside a
+  complete spec
+- `src/clauditor/cli/init.py:55-58` — scaffolding starter
+  assertions (imported into every `clauditor init` output)
+- `src/clauditor/assertions.py:463` — docstring mentions schema
+- `SKILL.md` — no current `value` examples (safe)
+
+### Applicable `.claude/rules/`
+
+- **`json-schema-version.md`** — LOAD-BEARING. We must (a)
+  introduce `schema_version` on EvalSpec as the first top-level
+  key, and (b) have loaders verify it via hard numeric comparison
+  with a skip+log on mismatch. Given this is the FIRST
+  introduction of version on EvalSpec, DEC-003 below captures how
+  to treat unversioned files.
+- **`eval-spec-stable-ids.md`** — assertion `id` uniqueness is
+  load-bearing for audit history. The key redesign does NOT
+  change id validation; all migrations preserve existing ids
+  verbatim.
+- **`pre-llm-contract-hard-validate.md`** — the proposer prompt
+  gets a new per-type enumeration table automatically (rendered
+  from the updated constant); the hard-validator in `from_dict`
+  inherits the new required-key sets.
+- **`in-memory-dict-loader-path.md`** — `EvalSpec.from_dict(data,
+  spec_dir=...)` is the path the proposer uses. Already compliant;
+  the new validation rules land inside `from_dict` the same way
+  #61's did.
+- **`llm-cli-exit-code-taxonomy.md`** — if we add a migration CLI
+  command, it follows the 0/1/2 taxonomy (no API call → no
+  exit 3). Pure migration = 0 on success, 1 on write failure, 2
+  on unrecognized input shape.
+- **`pure-compute-vs-io-split.md`** — the migration logic (old-
+  shape dict → new-shape dict) is a pure compute function.
+  Wrapper scripts / CLI do I/O.
+- **`readme-promotion-recipe.md`** — anchor text in `README.md`
+  and `docs/eval-spec-reference.md` must stay byte-identical
+  across edits (GitHub anchors).
+- **`bundled-skill-docs-sync.md`** — NOT applicable. The SKILL.md
+  `## Workflow` does not change. Only the bundled
+  `clauditor.eval.json` rubric does, which is NOT the SKILL.md
+  workflow.
+- **`path-validation.md`** — NOT applicable. No new path-bearing
+  fields; `input_files` validation is untouched.
+- **`positional-id-zip-validation.md`** — NOT applicable. No new
+  judge; assertion evaluation is per-entry.
+- **`mock-side-effect-for-distinct-calls.md`** — if new tests mock
+  a function called multiple times, use `side_effect=[...]`.
+  Preventive; no current blocker.
+- **`data-vs-asserter-split.md`** — NOT applicable. `Assertion`
+  data-vs-asserter shape is untouched.
+- **`centralized-sdk-call.md`** — NOT applicable. No new SDK
+  usage.
+- **`subprocess-cwd.md`** / **`monotonic-time-indirection.md`** /
+  **`stream-json-schema.md`** / **`non-mutating-scrub.md`** — all
+  N/A (no new subprocess, timing, streaming, or redaction
+  surface).
+- **`skill-identity-from-frontmatter.md`** /
+  **`project-root-home-exclusion.md`** /
+  **`pytester-inprocess-coverage-hazard.md`** — all N/A.
+
+### Project validation commands
+
+- Lint: `uv run ruff check src/ tests/`
+- Test + coverage: `uv run pytest --cov=clauditor --cov-report=term-missing`
+- Coverage gate: 80% (enforced).
+
+### Ambiguities → Phase 1 scoping questions
+
+Several key-naming and migration-scope choices in the ticket are
+underdetermined. Questions below become DEC-### during refinement.
+
+---
+
+## Scoping Questions (Phase 1)
+
+**Q1 (DEC-001) — Field-name reconciliation across the 10 types.**
+
+The ticket proposes specific keys per type, but two naming
+collisions need resolving:
+
+- `pattern` is proposed for both `regex` and `min_count` (the
+  type). Same semantic ("a regex string"), so sharing a key name
+  is fine, but worth confirming.
+- `count` is proposed as the field on `min_count`-the-type,
+  while `min_count` is proposed as the field name on
+  `has_urls` / `has_entries` / `urls_reachable` / `has_format`.
+  That is, `min_count` is both a **type name** AND a **field name
+  on other types**, and the threshold-int field is named `count`
+  in one place and `min_count` in another.
+
+Resolution options:
+
+- **A)** **Accept ticket naming verbatim.** `regex` → `pattern`;
+  `min_count` type → `pattern` + `count`; `min_length` /
+  `max_length` → `length`; `has_urls` / `has_entries` /
+  `urls_reachable` → `min_count`; `has_format` → `format` +
+  `min_count`; `contains` / `not_contains` → `needle`. Accept the
+  `count`/`min_count` naming asymmetry because each field name is
+  read in context (inside a `min_count` type entry, a `count` key
+  is unambiguous).
+- **B)** **Unify on `count` everywhere.** `min_count`-the-type →
+  `pattern` + `count`; `has_urls` / `has_entries` / etc. →
+  `count`; `has_format` → `format` + `count`. Shorter, uniform,
+  one fewer thing to remember. Field meaning still clear from
+  context (`has_urls` with `count: 3` = "at least 3 URLs").
+- **C)** **Unify on `min_count` everywhere.** `min_count`-the-
+  type → `pattern` + `min_count`; `has_urls` / `has_entries` /
+  etc. → `min_count`; `has_format` → `format` + `min_count`.
+  Field name echoes the semantic ("minimum count") but now the
+  type and field share a name on `min_count`-the-type entries —
+  `{"type": "min_count", "pattern": "...", "min_count": 5}` —
+  which is legal but awkward.
+- **D)** **Rename `min_count`-the-type to remove the clash.**
+  e.g. `pattern_min_count` or `regex_count` with field `count`;
+  `has_urls` etc. use `min_count` as the field (uniform with
+  `has_format`). Eliminates any shared-name ambiguity, but the
+  type rename touches more surface (handlers, prompt, docs).
+
+*Recommendation:* **B (unify on `count`).** Field meaning is clear
+from context; uniform naming keeps the prompt-table and
+documentation tight; avoids both collisions without renaming a
+type. Explicit mapping per type below.
+
+**Q2 (DEC-002) — Integer typing: accept JSON ints, strings, or
+both?**
+
+Today, counts/lengths are stored on disk as JSON strings
+(`"value": "500"`) and coerced at runtime (`int(a.get("value"))`).
+The schema-version bump is a natural moment to tighten this.
+
+- **A)** **Accept JSON ints only.** `{"length": 500}` (int) is
+  valid; `{"length": "500"}` (string) raises `ValueError` at load
+  time with a helpful hint. Cleanest — native types for native
+  data.
+- **B)** **Accept both JSON ints and numeric strings.** Same
+  permissive behavior as today, applied to the new keys. Lowest
+  friction for hand authors.
+- **C)** **Accept both, but emit a deprecation warning on string
+  ints.** Accept both; warn to stderr when strings are used.
+  Intermediate nudge.
+
+*Recommendation:* **A (ints only).** Schema version 2 is the
+right moment to tighten; pre-1.0 project; migration tooling can
+bulk-fix the two in-repo specs. String-typed ints on disk have
+no defender.
+
+**Q3 (DEC-003) — `schema_version` introduction strategy.**
+
+EvalSpec has no `schema_version` today. Introducing one is itself
+a breaking change for loaders (anything that reads the JSON must
+now check it), though the rule says tolerate mismatches with
+skip+log, not hard-fail.
+
+- **A)** **Introduce `schema_version: 1` in a prep PR/commit,
+  THEN bump to 2 for the key redesign in a second step.**
+  Cleaner history; two small diffs. Prep PR: add field, update
+  writers, update loaders to expect it (v1), reject unknown
+  versions with skip+log.
+- **B)** **Introduce `schema_version: 2` directly as part of the
+  redesign.** Single breaking change. Loader reads v2 with the
+  new keys; unversioned files treated as v1 (legacy shape) and
+  either (i) auto-migrated in-memory or (ii) rejected with a
+  migration hint.
+- **C)** **Skip `schema_version` entirely on EvalSpec.** Trust
+  the per-type required-key validator from #61 to reject old-
+  shape specs loudly (unknown key `value` → error with hint
+  "did you mean `needle` / `pattern` / `length` / ..."). No
+  version field, no version check.
+
+*Recommendation:* **B** with a twist — introduce
+`schema_version: 2` directly, but the loader's missing-version
+branch treats the file as **v1 legacy** and emits a clear
+`ValueError` pointing at the migration tool (per DEC-004). This
+way, any hand-authored file with the old `value` keys gets an
+explicit, on-topic error rather than a noisy cascade of "unknown
+key `value`" errors from the per-type validator.
+
+**Q4 (DEC-004) — Migration tooling: CLI command, one-shot
+script, or none?**
+
+Two in-repo `.eval.json` files + ~100 inline test dicts need
+migrating. External users are few/none pre-1.0.
+
+- **A)** **One-shot internal script** at
+  `scripts/migrate_evalspec_v1_to_v2.py`. Converts old-shape
+  dicts to new-shape in place for any target path. Used once
+  by us to bulk-migrate in-repo files; thrown away after the
+  ticket lands (or kept as a reference for external users).
+- **B)** **Public `clauditor migrate-eval-spec <path>` CLI
+  subcommand.** Discoverable by external users; matches the
+  `clauditor ...` command idiom. Takes `--write` vs `--dry-run`
+  flags. Follows the exit-code taxonomy (0 success / 1 write
+  error / 2 unrecognized shape).
+- **C)** **Both** — the public CLI uses the same pure helper as
+  the internal bulk script.
+- **D)** **No migration tool.** Hand-edit the two files; test
+  fixtures are migrated as part of individual story diffs;
+  external users follow the loader's error hints.
+
+*Recommendation:* **C**. The pure migration function is ~30
+lines; exposing it as a CLI command is cheap and means external
+users with hand-authored specs get a first-class migration path.
+Matches `pure-compute-vs-io-split.md` (pure helper, thin I/O
+wrappers). Stories: the CLI command + migration helper is one
+story; the internal bulk-migration application is another.
+
+**Q5 (DEC-005) — Optional/default semantics for the new
+`min_count` (or `count` per DEC-001) field on
+`has_urls`/`has_entries`/`urls_reachable`/`has_format`.**
+
+Today `value` is optional on these four types, defaulting to 1.
+
+- **A)** **Preserve optional-with-default-1.** New key is
+  optional; missing defaults to 1. Zero user-facing semantic
+  change.
+- **B)** **Make required.** Every assertion must explicitly
+  state its threshold. Breaking, but enforces intent.
+- **C)** **Preserve optional-with-default-1, but log a
+  deprecation warning when omitted.** Intermediate nudge
+  toward explicit thresholds.
+
+*Recommendation:* **A**. Don't change two things at once.
+Redesign the keys; leave semantics alone. A future ticket can
+tighten to required-only if we see real-world usage trends
+that warrant it.
+
+**Q6 (DEC-006) — Test fixture migration shape.**
+
+~100 inline assertion dicts across 12 test files. Options:
+
+- **A)** **Hand-migrate every fixture.** Each test file's diff
+  updates the key names. Straightforward.
+- **B)** **Hand-migrate + add a pytest fixture factory**
+  (e.g. `make_assertion(type, id, **kwargs) -> dict`) in
+  `conftest.py`. New tests use the factory; existing tests
+  migrate to use it opportunistically. Prevents future
+  hand-construction drift.
+- **C)** **Introduce a test-time shim that accepts old-shape
+  dicts and silently rewrites to new shape.** Tests stay
+  unchanged. Bad idea — tests should reflect the new schema,
+  not hide it.
+
+*Recommendation:* **A**. Pure hand-migration is honest and
+auditable. Factory (option B) is a nice-to-have that can
+follow in a Patterns & Memory story if the pattern's value
+survives contact with the migration.
+
+**Q7 (DEC-007) — Docs + README + bundled-rubric update
+cadence.**
+
+Breaking schema change requires doc updates in lockstep.
+
+- **A)** **Everything in one PR.** README, docs/*.md, bundled
+  `clauditor.eval.json`, `cli/init.py` scaffolding,
+  `examples/.claude/commands/example-skill.eval.json`, and
+  `propose_eval.py` prompt (automatic from the constant)
+  all land together. Atomic, no divergence window.
+- **B)** **Docs follow code.** Code lands first; docs PR is a
+  follow-up. Short divergence window is tolerable for a
+  pre-1.0 project.
+- **C)** **Docs lead code.** Write docs first (showing the
+  target shape), then implement. Forcing function.
+
+*Recommendation:* **A** (atomic). Breaking schema changes that
+touch docs should always be atomic — any divergence window is
+exactly when readers hit "the docs say one thing, the code
+says another" confusion. Each doc update is a small diff; no
+reason to split.
+
+**Q8 (DEC-008) — Back-compat window for unversioned / v1
+specs.**
+
+Once v2 lands, a user who clones clauditor + has an old
+`*.eval.json` in their skill dir will hit the "unversioned or
+v1" loader branch. What's the experience?
+
+- **A)** **Hard-reject, point at migration tool.** Error:
+  `"EvalSpec: unversioned or v1 schema detected in <path>.
+  Run `clauditor migrate-eval-spec <path>` to update to v2."`
+  No auto-migration; user must act explicitly. Clean.
+- **B)** **Auto-migrate at load time (in-memory, not on
+  disk).** Load succeeds silently; user never sees the error.
+  Hidden magic; one class of future confusion ("why does the
+  loaded spec not match my file?").
+- **C)** **Auto-migrate and rewrite the file on disk.**
+  Transparent but destructive (modifies user files without
+  explicit consent).
+
+*Recommendation:* **A**. Hard-reject with a clear next step.
+Explicit migration is the right contract; this is what the
+`schema_version` field is for.
+
+---
+
+## Scoping Answers (Session 1)
+
+Revised in light of "no external users of clauditor":
+
+- **DEC-001 (Q1=B) — Unify on `count`.** Per-type field mapping:
+  - `contains` / `not_contains` → `needle` (required)
+  - `regex` → `pattern` (required)
+  - `min_count` (type) → `pattern` + `count` (both required)
+  - `min_length` / `max_length` → `length` (required)
+  - `has_urls` / `has_entries` / `urls_reachable` → `count` (optional, default 1)
+  - `has_format` → `format` (required) + `count` (optional, default 1)
+- **DEC-002 (Q2=A) — Native JSON ints only.** `{"length": 500}`
+  valid; `{"length": "500"}` rejected at load with a helpful error.
+  Migration updates the two in-repo specs to use native ints.
+- **DEC-003 (Q3=C) — Skip `schema_version` on EvalSpec.**
+  `.claude/rules/json-schema-version.md` anchors on clauditor's
+  **output** sidecars; EvalSpec is user-authored **input**. With
+  no external users, the per-type validator's "unknown key" error
+  is sufficient to surface a stale-shape spec. Defer versioning
+  until a real-world need arises.
+- **DEC-004 (Q4=D) — No migration tool.** Two in-repo specs
+  hand-edit. Test fixtures migrate as part of each story's diff.
+- **DEC-005 (Q5=A) — Preserve optional-with-default-1.** The
+  `count` field on `has_urls` / `has_entries` / `urls_reachable` /
+  `has_format` stays optional. Missing → default 1. No semantic
+  change; redesign the keys only.
+- **DEC-006 (Q6=A) — Hand-migrate test fixtures.** Per-story
+  diffs update each test file. No test-time shim, no bulk
+  rewriter.
+- **DEC-007 (Q7=A) — Atomic single-PR.** Code + docs + README +
+  bundled rubric + `cli/init.py` scaffolding all land together.
+
+---
+
+## Architecture Review
+
+Scope is bounded (rename keys in one constant + flip handler
+reads + update 2 specs + rewrite per-type drift-hints + update
+~100 test fixtures + docs). Review areas that are trivially
+`pass` for this shape are compressed into one-line findings; the
+two concerns drive Phase 3 decisions.
+
+| Area | Rating | Finding |
+|---|---|---|
+| Security | pass | No new inputs. Proposer prompt's per-type table re-renders from the updated constant; untrusted-content framing (`llm-judge-prompt-injection.md`) is unchanged. |
+| Performance | pass | Loader is still O(n) over assertions. `int(a.get("value", ""))` runtime coercion in handlers goes away when JSON ints replace stringly-typed ints — trivial speedup, noise-level. No hot-path reshape. |
+| Data Model | pass | Persisted sidecars (`grading.json`, `assertions.json`, `baseline_*.json`, benchmark) serialize `AssertionResult` (id + status + evidence + raw_data), NOT the assertion dict itself — so historical audit records remain readable after the rename. `EvalSpec.to_dict` passes `self.assertions` through verbatim, so after migration it emits new-shape dicts. No other caller serializes the spec shape. DEC-003 (skip `schema_version`) accepted as an internal-project risk. |
+| API Design | pass | No CLI flag changes. Exit-code taxonomy unchanged. `clauditor init` scaffolds new-shape starter assertions but command surface is untouched. |
+| Observability | pass | Validator error messages tighten via per-type drift-hints (see Drift-Hint Redesign concern). No new stderr lines; no new logging surface. |
+| **Testing Strategy** | concern | Three sub-concerns: **(a)** existing #61 drift-hint tests assert literals like `"unknown key 'pattern' — did you mean 'value'?"` which become stale (in the new world, `pattern` is a valid key for `regex` and `min_count`-type); **(b)** the `test_handler_signature_agrees_with_constant` cross-check from #61 must continue to pass after handler lambdas are edited to read the new keys — handler-introspection regex may need updating; **(c)** prompt-builder tests that pin the literal row `"min_count → required: value · optional: minimum"` must be updated to the new rendering (e.g. `"min_count → required: count, pattern"`). |
+| **Drift-Hint Redesign** | concern | The current `_require_assertion_keys` drift-hints are **globally** keyed (`pattern`/`min`/`max` → suggest `value`; `threshold` → suggest `minimum`). After the rename, `pattern` becomes a VALID key for two types, `minimum`/`threshold` are obsolete, and `value` itself is the canonical stale key every hand-author with muscle memory will type. The right shape is a **per-type drift-hint table** — for each type, a map from common-wrong-keys → correct-key-for-that-type. This is the single meaningful design task in the ticket. |
+
+No blockers. Both concerns resolve as design decisions in the
+Refinement Log (DEC-009, DEC-010).
+
+---
+
+## Refinement Log
+
+### Decisions
+
+- **DEC-009 — Per-type drift-hint table (Q9=A).**
+  Introduce `_ASSERTION_DRIFT_HINTS: dict[str, dict[str, str]]`
+  in `schemas.py` as a sibling constant to
+  `ASSERTION_TYPE_REQUIRED_KEYS`. For each type, a map of
+  `common-wrong-key → correct-key-for-this-type`. Concrete
+  shape:
+  ```python
+  _ASSERTION_DRIFT_HINTS: dict[str, dict[str, str]] = {
+      "contains":       {"value": "needle", "pattern": "needle"},
+      "not_contains":   {"value": "needle", "pattern": "needle"},
+      "regex":          {"value": "pattern"},
+      "min_count":      {"value": "pattern", "minimum": "count",
+                         "min_count": "count", "threshold": "count"},
+      "min_length":     {"value": "length", "min": "length"},
+      "max_length":     {"value": "length", "max": "length"},
+      "has_urls":       {"value": "count", "minimum": "count",
+                         "min_count": "count", "threshold": "count"},
+      "has_entries":    {"value": "count", "minimum": "count",
+                         "min_count": "count", "threshold": "count"},
+      "urls_reachable": {"value": "count", "minimum": "count",
+                         "min_count": "count", "threshold": "count"},
+      "has_format":     {"value": "count", "minimum": "count",
+                         "min_count": "count"},
+  }
+  ```
+  `_require_assertion_keys` consults this table when flagging
+  unknown keys: emit `" — did you mean {suggestion!r}?"` if the
+  key is hinted, else empty suffix. Per-type keying is the
+  single design nuance: after the rename, `pattern` is VALID
+  for `regex` / `min_count`-type (so NO hint there), but
+  `pattern` on `contains` should suggest `needle`.
+
+- **DEC-010 — Keep the #61 handler-signature cross-check
+  (Q10=A).** The test
+  `test_handler_signature_agrees_with_constant` already iterates
+  the constant and verifies each required key appears in the
+  handler lambda source. After the rename, if both
+  `ASSERTION_TYPE_REQUIRED_KEYS[type].required = {"needle"}`
+  AND the handler reads `a.get("needle", "")`, the test passes
+  without any test-file edit. We update the handler lambdas to
+  read the new keys; the test follows automatically. If the
+  introspection regex proves too rigid (e.g. fails on
+  `a["needle"]` bracket access), we widen the regex in the same
+  story — but expected outcome is no test-file change.
+
+- **DEC-011 — Six-story breakdown with atomic docs landing
+  (Q11=A).** See Detailed Breakdown below. Story order:
+  (1) constant + handlers + drift-hints,
+  (2) in-repo `.eval.json` migration + `init.py` scaffolding,
+  (3) test-fixture migration + stale-hint-test updates,
+  (4) docs + README + rubric,
+  (5) Quality Gate,
+  (6) Patterns & Memory.
+
+- **DEC-012 — Extend `AssertionKeySpec` with per-key type info
+  (natural consequence of DEC-002).** To enforce "native JSON
+  ints only" at load time, `AssertionKeySpec` grows a
+  `field_types: dict[str, type]` field. `_require_assertion_keys`
+  adds a type-check pass: for each present key that has a
+  declared type, verify `isinstance(val, expected)` and raise a
+  helpful `ValueError` on mismatch (`"assertions[{i}]
+  (type={type!r}): key 'length' must be int, got str 'abc'"`).
+  Types: `needle`/`pattern`/`format` → `str`; `length`/`count`
+  → `int`. String-typed ints on disk (`{"length": "500"}`)
+  reject loudly.
+
+### Session Notes
+
+**Session 1 (2026-04-20)** — Discovery + scoping (Q1-Q8) +
+Architecture (two concerns: Testing Strategy + Drift-Hint
+Redesign) + Refinement (Q9-Q11 + DEC-012 as a natural
+consequence of DEC-002). All in one session. User clarified
+"no external users" which trimmed `schema_version` and
+migration-tool scope (DEC-003=C, DEC-004=D). Architecture
+review surfaced the per-type drift-hint design as the one
+genuine design task; captured as DEC-009.
+
+---
+
+## Detailed Breakdown (Stories)
+
+Ordering: core rename (handler + constant + hints) → in-repo
+spec migration → test-fixture migration → docs → Quality Gate
+→ Patterns & Memory. US-002 / US-003 / US-004 can run in
+parallel after US-001 lands.
+
+Every story's acceptance criteria include the project
+validation command from CLAUDE.md:
+`uv run ruff check src/ tests/ && uv run pytest --cov=clauditor
+--cov-report=term-missing` must pass with the 80% coverage
+gate.
+
+### US-001 — Rename assertion keys in constant, handlers, and drift-hints
+
+**Description:** Flip the per-type key names across the three
+code sites that share them: `ASSERTION_TYPE_REQUIRED_KEYS`
+(schemas.py), `_ASSERTION_HANDLERS` (assertions.py), and the
+new `_ASSERTION_DRIFT_HINTS` table. Extend `AssertionKeySpec`
+with a `field_types` field per DEC-012 so native-int
+validation lands atomically. The propose-eval prompt's per-type
+table renders automatically from the updated constant — no
+prompt code change needed (but one prompt-test string
+assertion gets updated here, not in US-003, because it's
+test-mechanical and belongs with the constant change).
+
+**Traces to:** DEC-001, DEC-002, DEC-009, DEC-010, DEC-012.
+
+**Acceptance Criteria:**
+
+- `src/clauditor/schemas.py`:
+  - `AssertionKeySpec` grows `field_types:
+    dict[str, type] = field(default_factory=dict)` — frozen
+    dataclass-compatible shape.
+  - `ASSERTION_TYPE_REQUIRED_KEYS` rewritten per DEC-001 with
+    DEC-012 types:
+    - `contains`, `not_contains` → `AssertionKeySpec(required={"needle"}, field_types={"needle": str})`
+    - `regex` → `AssertionKeySpec(required={"pattern"}, field_types={"pattern": str})`
+    - `min_count` → `AssertionKeySpec(required={"pattern", "count"}, field_types={"pattern": str, "count": int})`
+    - `min_length`, `max_length` → `AssertionKeySpec(required={"length"}, field_types={"length": int})`
+    - `has_urls`, `has_entries`, `urls_reachable` → `AssertionKeySpec(optional={"count"}, field_types={"count": int})`
+    - `has_format` → `AssertionKeySpec(required={"format"}, optional={"count"}, field_types={"format": str, "count": int})`
+  - `_ASSERTION_DRIFT_HINTS` added per DEC-009 (concrete shape
+    in DEC-009 above).
+  - `_require_assertion_keys` rewritten:
+    1. Unknown-key branch consults `_ASSERTION_DRIFT_HINTS[type].get(key)` for the hint; emit `" — did you mean {suggestion!r}?"` if present, else empty. Remove the current global `{"pattern","min","max"} → "value"` and `"threshold" → "minimum"` branches.
+    2. New type-check pass: for each present key (required OR optional) in `spec.field_types`, verify `isinstance(val, expected)` — if mismatch, raise `ValueError(f"{ctx} (type={type!r}): key {key!r} must be {expected.__name__}, got {type(val).__name__} {val!r}")`.
+  - Error-message path order: unknown type → missing required → wrong type → unknown key. (Each is a distinct branch; no cascading noise.)
+- `src/clauditor/assertions.py`:
+  - `_ASSERTION_HANDLERS` updated to read new keys, with native int access (no `int(a.get(...))` coercion):
+    - `contains`, `not_contains` → `a.get("needle", "")`
+    - `regex` → `a.get("pattern", "")`
+    - `min_count` → `a.get("pattern", "")` + `a.get("count", 1)` (note: native int default, not `"" → 1`)
+    - `min_length`, `max_length` → `a.get("length", 0)` (native int)
+    - `has_urls`, `has_entries`, `urls_reachable` → `a.get("count", 1)` (native int)
+    - `has_format` → `a.get("format", "")` + `a.get("count", 1)` (native int)
+  - The docstring at `assertions.py:463` (if it references `value` / schema shape) updated to mention the new keys.
+- `tests/test_schemas.py`:
+  - `TestAssertionKeySpec::test_contains_required_keys` parametrize table updated to the new per-type keys.
+  - `TestAssertionKeySpec::test_handler_signature_agrees_with_constant` — verify it passes without edit (or widen the regex if introspection fails on the new key names).
+  - New `TestAssertionKeySpec::test_field_types_match` — assert every `required ∪ optional` key has an entry in `field_types`, and every `field_types` key is in `required ∪ optional`.
+  - `TestRequireAssertionKeys` — rewrite parametrize table:
+    - Missing-required tests updated to new keys (e.g. `contains` missing `needle`).
+    - Unknown-key tests updated: `pattern` on `contains` → hint `needle`; `value` on `regex` → hint `pattern`; `min` on `min_length` → hint `length`; `threshold` on `has_urls` → hint `count`; etc. Coverage: one hint test per (type, hinted wrong-key) pair in `_ASSERTION_DRIFT_HINTS`.
+    - Two new wrong-type tests: `{"type":"min_length","length":"500"}` → `ValueError` mentioning "must be int, got str"; `{"type":"contains","needle":123}` → `ValueError` mentioning "must be str, got int".
+  - Drop tests that asserted the OLD global hints (`"did you mean 'value'?"`, `"did you mean 'minimum'?"`) — replaced by the per-type hint tests above.
+- `tests/test_propose_eval.py`:
+  - `TestBuildProposeEvalPrompt::test_prompt_contains_per_type_table` — update pinned literal from `"min_count → required: value · optional: minimum"` to the new rendering (e.g. `"min_count → required: count, pattern"`).
+  - `test_prompt_has_no_alias_keys` — update assertion: the prompt should NOT contain the strings `"'value'"`, `"'minimum'"` (anywhere suggesting the old keys are legit). `pattern` / `min` / `max` absence-assertions are relaxed — `pattern` IS now a valid key for two types and legitimately appears in the rendered table.
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥80% coverage.
+
+**Done when:** `{"type":"contains", "id":"x", "needle":"foo"}`
+loads cleanly via `EvalSpec.from_dict`; `{"type":"contains",
+"id":"x", "value":"foo"}` raises `ValueError` at load with
+`"assertions[0] (type='contains'): unknown key 'value' — did
+you mean 'needle'?"`; `{"type":"min_length","id":"x","length":"500"}`
+raises with `"key 'length' must be int, got str '500'"`.
+
+**Files:**
+- `src/clauditor/schemas.py` — `AssertionKeySpec` extension,
+  constant rewrite, `_ASSERTION_DRIFT_HINTS`,
+  `_require_assertion_keys` rewrite.
+- `src/clauditor/assertions.py` — `_ASSERTION_HANDLERS` rewrite
+  + docstring update.
+- `tests/test_schemas.py` — `TestAssertionKeySpec`,
+  `TestRequireAssertionKeys` updates.
+- `tests/test_propose_eval.py` — two prompt-table assertion
+  updates.
+
+**Depends on:** none.
+
+**TDD:**
+1. Rewrite `TestAssertionKeySpec::test_contains_required_keys`
+   parametrize table first (drives the constant change).
+2. Rewrite `TestRequireAssertionKeys` parametrize table with
+   the new (type, bad_entry, expected_substring) triples —
+   covers missing / unknown / wrong-type for every type.
+3. Add `test_field_types_match` before implementing the
+   `field_types` field.
+4. Run tests → fail → implement schema-side changes (constant,
+   drift-hint table, validator logic) → tests pass.
+5. Update handlers last (tests don't directly exercise the
+   handler bodies until production-code tests run, but the
+   `test_handler_signature_agrees_with_constant` will fail if
+   the handler reads the wrong key).
+6. Update the two prompt tests; verify they pass.
+
+**Rules applied:**
+- `pre-llm-contract-hard-validate.md` — the per-type validator
+  (now also type-checking) is the canonical "prompt-side
+  invariant + loader-side hard-fail" shape.
+- `eval-spec-stable-ids.md` — same load-time hard-fail style
+  as `_require_id`.
+- `in-memory-dict-loader-path.md` — validator lives in
+  `from_dict`; LLM path and on-disk path both inherit.
+- `llm-cli-exit-code-taxonomy.md` — new validation errors
+  route to exit 2 at the CLI via the existing
+  `validation_errors` plumbing.
+
+---
+
+### US-002 — Migrate in-repo `.eval.json` files + `cli/init.py` scaffolding
+
+**Description:** Hand-rewrite the two checked-in eval specs
+and the `clauditor init` starter-assertion scaffolding to use
+the new keys + native JSON ints. No tooling; the surface is
+small (11 assertions + 4 scaffold entries).
+
+**Traces to:** DEC-001, DEC-002, DEC-006.
+
+**Acceptance Criteria:**
+
+- `src/clauditor/skills/clauditor/assets/clauditor.eval.json`:
+  - Every `value` key replaced with its per-type semantic key
+    (`needle` for `contains`/`not_contains`; `length` for
+    `min_length`). Length values switched from string
+    (`"500"`) to native int (`500`).
+  - No `value`, `minimum`, `threshold` keys remain anywhere
+    in the file.
+  - The file loads cleanly via `EvalSpec.from_file` (verify
+    by running `uv run clauditor validate` on the bundled
+    skill or equivalent).
+- `examples/.claude/commands/example-skill.eval.json`:
+  - Same migration: every assertion entry uses per-type
+    semantic keys with native JSON ints.
+  - All 8 assertions migrated: `contains` (2), `not_contains` (1),
+    `regex` (2), `min_length` (1), `has_urls` (1), `has_entries` (1).
+  - File loads cleanly.
+- `src/clauditor/cli/init.py`:
+  - Starter assertions at lines 55-58 rewritten to the new
+    key shape.
+  - The docstring or comment (if any) describing the starter
+    assertions reflects the new keys.
+- Add a regression test in `tests/test_bundled_skill.py`
+  (extend existing class) that loads
+  `clauditor.eval.json` via `EvalSpec.from_file` and asserts
+  zero validation errors. This catches future migrations
+  that miss the bundled spec.
+- Add a regression test for the example spec: load
+  `examples/.claude/commands/example-skill.eval.json` and
+  assert zero validation errors. Prefer adding to
+  `tests/test_spec.py` (existing integration coverage lives
+  there).
+- Add a regression test for `cli/init.py`: invoke
+  `cmd_init` in a `tmp_path`, verify the generated
+  `<skill>.eval.json` loads via `EvalSpec.from_file` without
+  errors, AND verify the file does NOT contain the literal
+  string `"value"` as a JSON key (simple substring check).
+- Project validation passes.
+
+**Done when:** `EvalSpec.from_file` returns without errors on
+both checked-in specs AND on `cli/init.py`'s generated output.
+No string-typed ints remain. `grep -rn '"value"'
+src/clauditor/skills/ examples/.claude/commands/
+src/clauditor/cli/init.py` returns zero matches (ignoring
+grading_criteria and section field `format: "..."` which are
+unrelated).
+
+**Files:**
+- `src/clauditor/skills/clauditor/assets/clauditor.eval.json`
+- `examples/.claude/commands/example-skill.eval.json`
+- `src/clauditor/cli/init.py`
+- `tests/test_bundled_skill.py` (new regression test)
+- `tests/test_spec.py` OR a new `tests/test_examples.py` (new
+  regression test for example spec)
+- Extend or add to existing `tests/test_cli_init.py` if it
+  exists, otherwise add regression there in the appropriate
+  CLI test module.
+
+**Depends on:** US-001.
+
+**TDD:**
+1. Write the three regression tests first (load each spec,
+   assert no errors).
+2. Run → all three fail (old specs still have `value` keys
+   which the new validator rejects).
+3. Hand-edit the three files to the new shape.
+4. Run → all three pass.
+
+**Rules applied:**
+- `json-schema-version.md` — NOT applicable (DEC-003=C).
+- `path-validation.md` — any `input_files` on the migrated
+  specs stay unchanged (validator already enforces).
+
+---
+
+### US-003 — Migrate all test fixtures + drop stale hint tests
+
+**Description:** Hand-migrate every inline assertion dict in
+the test suite (~100 occurrences across 12 files) to the new
+keys. Drop or rewrite tests that pinned old drift-hint literals
+or old `value` semantics.
+
+**Traces to:** DEC-006, DEC-009.
+
+**Acceptance Criteria:**
+
+- Every `"value":` key inside an assertion-dict literal in
+  `tests/**/*.py` replaced with the correct per-type key for
+  its enclosing `type`. Integer values switched from string to
+  native int where applicable.
+- Test files in scope (heaviest first):
+  - `tests/test_schemas.py` (~35 dicts)
+  - `tests/test_assertions.py` (~20 dicts)
+  - `tests/test_propose_eval.py` (~15 dicts — fixture shapes,
+    NOT prompt strings)
+  - `tests/test_cli.py` (~10 dicts)
+  - `tests/conftest.py` (~3 dicts)
+  - `tests/test_spec.py` (~5 dicts)
+  - `tests/test_baseline.py` (~1 dict)
+  - `tests/test_cli_transcript_slice.py` (~3 dicts)
+  - `tests/test_cli_propose_eval.py` (~1 dict)
+  - `tests/test_asserters.py` (~1 dict)
+  - Any others surfaced by `grep -rn '"value"' tests/`.
+- Stale tests dropped or rewritten:
+  - Any test asserting `"did you mean 'value'?"` verbatim →
+    drop or rewrite to assert the new per-type hints (already
+    covered in US-001's rewrite of `TestRequireAssertionKeys`;
+    sweep ensures no other file pins the old string).
+  - Any test that relied on `value` being missing → defaults-
+    to-1 behavior — update to use the new `count` key (with
+    the optional-default-1 semantic preserved per DEC-005).
+- Verify no test file contains the literal `"value":` inside
+  an assertion dict by running a sweep grep (allowing
+  `"value"` in rubric / trigger / other non-assertion
+  contexts).
+- Project validation passes with ≥80% coverage.
+- Every test that existed before this story still passes
+  after it, OR has been explicitly replaced by a new
+  equivalent (document in commit message).
+
+**Done when:** `uv run pytest` runs green; `grep -rn
+'"value"' tests/ | grep -v grading_criteria | grep -v
+'"value".*#.*rubric'` (or similar filter) returns only non-
+assertion-dict hits.
+
+**Files:** All test files under `tests/` that touch assertion
+dicts — enumerated above. Plus any missed by the enumeration
+but surfaced by the grep sweep.
+
+**Depends on:** US-001.
+
+**TDD:** Not pure TDD — this is a mechanical migration. Use
+the existing test pass (green suite) as the regression guard.
+Workflow:
+1. Pick one test file at a time.
+2. Update all `"value"` → per-type key, string ints → native
+   ints.
+3. Run the single file's tests; fix breakage.
+4. Commit per file (or per small group) for reviewability.
+5. Final grep sweep to confirm zero remaining `"value"` in
+   assertion dicts.
+
+**Rules applied:**
+- `pytester-inprocess-coverage-hazard.md` — if any test uses
+  `pytester.runpytest_inprocess` AND patches `clauditor.*`
+  modules, remember the hazard. Preventive; unlikely to hit.
+- `mock-side-effect-for-distinct-calls.md` — any test that
+  mocks a function called multiple times with distinct values
+  uses `side_effect=[...]`. Preventive.
+
+---
+
+### US-004 — Update docs, README, and the propose-eval prompt assertion-schema block
+
+**Description:** Update every human-facing doc site that shows
+an assertion JSON example to use the new keys. The propose-eval
+prompt's per-type table renders automatically from the
+(already-updated) constant, but the prompt also contains
+hand-written example JSON and prose describing the schema —
+those strings are updated here. Atomic with US-001/US-002/US-003
+per DEC-007.
+
+**Traces to:** DEC-007, DEC-001.
+
+**Acceptance Criteria:**
+
+- `README.md`:
+  - The single assertion example at line ~125 updated to the
+    new shape with native int.
+  - No `"value":` strings remain in any assertion example.
+  - Anchor text of any surrounding H2 (e.g. `## Eval Spec
+    Format`, `## Quick Start`) stays byte-identical per
+    `readme-promotion-recipe.md`.
+- `docs/quick-start.md`:
+  - Four inline assertion examples at lines 20-23 updated.
+- `docs/eval-spec-reference.md`:
+  - The complete-spec example at lines 61-65 updated.
+  - If the doc has a per-type field table, it's regenerated
+    or hand-updated to the new keys. If no such table
+    exists, ADD one (small section) — the redesign is an
+    excellent reason to have explicit per-type docs.
+  - Add a short "Schema history" note documenting the
+    rename (one paragraph, in a `## Changelog`-style
+    section at the bottom if one doesn't exist, else append).
+- `src/clauditor/propose_eval.py`:
+  - Any hand-written example assertion JSON inside the
+    prompt (outside the auto-rendered table) updated to the
+    new keys.
+  - Any prose description of what keys an assertion carries
+    updated.
+  - Prompt-builder tests from US-001 still pass.
+- `src/clauditor/assertions.py`:
+  - Docstring at line ~463 (or wherever the schema shape is
+    documented) updated.
+- `src/clauditor/skills/clauditor/SKILL.md`:
+  - No current `value` references in assertion examples —
+    verify via grep. No change expected; this is a sanity
+    check per `bundled-skill-docs-sync.md` ("workflow
+    unchanged → no cascade").
+- Doc-example regression test: add a test
+  `tests/test_docs_examples.py` (new file) or extend an
+  existing one that greps the in-tree markdown for
+  assertion dict literals and verifies any it finds parse
+  cleanly via `EvalSpec.from_dict` (minimal spec wrapping).
+  Alternative: if this is too finicky, settle for a simpler
+  grep-based test that asserts no markdown file under
+  `README.md` / `docs/` contains the string `"value":`
+  inside a code fence labeled `json` that also contains
+  `"type":`.
+- Project validation passes.
+
+**Done when:** Every markdown file is `"value":`-free in
+assertion contexts, all prompt tests still pass, and the
+bundled SKILL.md is unchanged (zero doc-sync cascade per
+`bundled-skill-docs-sync.md`).
+
+**Files:**
+- `README.md`
+- `docs/quick-start.md`
+- `docs/eval-spec-reference.md`
+- `src/clauditor/propose_eval.py` (hand-written assertion
+  examples / prose, NOT the auto-rendered table)
+- `src/clauditor/assertions.py` (docstring)
+- `tests/test_docs_examples.py` (new) or extension to
+  existing doc-lint tests.
+
+**Depends on:** US-001 (the validator must already accept the
+new keys before the docs can show them).
+
+**TDD:**
+1. Write the doc-grep regression test first (asserting no
+   `"value":` in assertion JSON examples).
+2. Run → fails (current docs all have `"value"`).
+3. Hand-edit each doc file to the new shape.
+4. Run → passes.
+
+**Rules applied:**
+- `readme-promotion-recipe.md` — anchor-preservation:
+  heading text stays byte-identical when editing
+  content underneath. No H2 renames.
+- `bundled-skill-docs-sync.md` — verified NOT applicable
+  (SKILL.md workflow unchanged; only reference-material
+  docs change).
+
+---
+
+### US-005 — Quality Gate
+
+**Description:** Run code reviewer 4× across the full
+changeset (US-001 through US-004). Address every real bug.
+Run CodeRabbit after PR is non-draft. Re-run project
+validation.
+
+**Traces to:** project-wide quality standards.
+
+**Acceptance Criteria:**
+- Code-reviewer agent run 4 times across the full diff. Each
+  pass's findings triaged and fixed (or documented as false
+  positive in a session note) before the next pass.
+- CodeRabbit review triaged if PR is out of draft.
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-report=term-missing`
+  passes with ≥80% coverage.
+- No failing tests, no new lint findings, no open reviewer
+  objections.
+
+**Done when:** All reviewer passes clean (or false-positive-
+documented), CodeRabbit satisfied if applicable, project
+validation green.
+
+**Files:** Whatever reviewer passes surface.
+
+**Depends on:** US-001, US-002, US-003, US-004.
+
+---
+
+### US-006 — Patterns & Memory
+
+**Description:** Evaluate patterns worth codifying after the
+redesign lands. Candidates (to be evaluated, not pre-
+committed):
+- Per-type drift-hints as a general pattern for "loader
+  rejects unknown keys with type-specific guidance". If a
+  future feature's loader wants the same shape (e.g. a
+  grading_criteria validator, a section-field validator),
+  codify as a `.claude/rules/` rule.
+- The `field_types` extension on `AssertionKeySpec` as a
+  "single-source-of-truth constant with type info" pattern.
+  Candidate rule file if useful elsewhere.
+- Update `.claude/rules/eval-spec-stable-ids.md` if it
+  mentions old keys (verify and fix).
+- Update or add a per-type-key section to
+  `docs/eval-spec-reference.md` if US-004 did not already.
+
+**Traces to:** standard closeout pattern.
+
+**Acceptance Criteria:**
+- Every candidate pattern has been (a) codified in
+  `.claude/rules/<name>.md`, (b) documented in `docs/`, or
+  (c) explicitly evaluated and rejected with a one-line
+  note in this plan's Session Notes.
+- No regression in existing rules — new rules are additive.
+- If docs update lands, README teaser (if any) adjusted per
+  `readme-promotion-recipe.md`.
+
+**Done when:** New rule/docs files committed OR Session
+Notes contain "evaluated X, Y, Z — chose to defer because …".
+
+**Files:** `.claude/rules/*.md`, `docs/*.md` (TBD),
+`plans/super/67-per-type-assertion-keys.md` (Session Notes).
+
+**Depends on:** US-005.
+
+---
+
+## Beads Manifest
+
+*(Phase 7 — populated on devolve.)*

--- a/plans/super/67-per-type-assertion-keys.md
+++ b/plans/super/67-per-type-assertion-keys.md
@@ -569,6 +569,45 @@ migration-tool scope (DEC-003=C, DEC-004=D). Architecture
 review surfaced the per-type drift-hint design as the one
 genuine design task; captured as DEC-009.
 
+**Session 2 (2026-04-20) — US-006 Patterns & Memory closeout.**
+Evaluated four candidates from the US-006 description:
+
+- **Codified: `.claude/rules/per-type-drift-hints.md`** — the
+  `dict[type, dict[wrong-key, right-key]]` shape generalizes to
+  any future polymorphic-dict validator (grading_criteria scale
+  types, section-field format types, trigger-test sub-types).
+  The global-hint failure mode that motivated DEC-009's per-type
+  keying is a genuine foot-gun — after a rename, some "wrong"
+  keys become valid for a subset of types, and a global table
+  silently mis-suggests in both directions.
+- **Codified: `.claude/rules/constant-with-type-info.md`** — the
+  `field_types: dict[str, type]` extension on `AssertionKeySpec`
+  (DEC-012) generalizes to any mixed-primitive-type payload
+  constant. Captured two concrete foot-guns specific enough to
+  prevent drift: (a) `isinstance(True, int)` silently accepts
+  bool-for-int without an explicit `bool is not int` guard, and
+  (b) handler-side runtime coercion (`int(a.get(...))`) shifts
+  error surfacing from load-time to opaque mid-run tracebacks.
+- **Rejected update: `.claude/rules/eval-spec-stable-ids.md`** —
+  verified the rule discusses only the `id` field, not payload
+  keys. Zero mentions of `value`/`needle`/`pattern`/etc. No edit
+  needed; the rule remains correctly scoped to id uniqueness.
+- **Verified: per-type-key section in
+  `docs/eval-spec-reference.md`** — US-004 already added
+  "## Assertion types and per-type keys" (lines 119-157) with a
+  complete per-type table and an example of each shape. The
+  "Schema history" section (lines 207-219) documents the #67
+  rename. Accurate and comprehensive; no edit needed.
+
+The two new rule files reference each other as companion rules
+(both live on the same validator seam in `schemas.py`) and each
+names `plans/super/67-per-type-assertion-keys.md` as the
+canonical implementation anchor. The rules are written
+specifically enough to prevent future drift (named constants,
+DEC-### pointers, test class names) and generically enough to
+apply beyond #67 (framed around "polymorphic-dict loaders" and
+"mixed-primitive-type payload constants").
+
 ---
 
 ## Detailed Breakdown (Stories)

--- a/plans/super/67-per-type-assertion-keys.md
+++ b/plans/super/67-per-type-assertion-keys.md
@@ -4,7 +4,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/67
 - **Branch:** `feature/67-per-type-assertion-keys`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/67-per-type-assertion-keys`
-- **Phase:** `devolved`
+- **Phase:** `done`
 - **PR:** https://github.com/wjduenow/clauditor/pull/69
 - **Sessions:** 1
 - **Last session:** 2026-04-20

--- a/plans/super/67-per-type-assertion-keys.md
+++ b/plans/super/67-per-type-assertion-keys.md
@@ -4,7 +4,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/67
 - **Branch:** `feature/67-per-type-assertion-keys`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/67-per-type-assertion-keys`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/69
 - **Sessions:** 1
 - **Last session:** 2026-04-20
@@ -1020,4 +1020,22 @@ Notes contain "evaluated X, Y, Z — chose to defer because …".
 
 ## Beads Manifest
 
-*(Phase 7 — populated on devolve.)*
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/67-per-type-assertion-keys`
+- **Branch:** `feature/67-per-type-assertion-keys`
+- **PR:** https://github.com/wjduenow/clauditor/pull/69
+
+### Task graph
+
+| Bead ID | Story | Priority | Depends on |
+|---|---|---|---|
+| `clauditor-xo7` | Epic — #67: Redesign assertion schema with per-type semantic keys | P2 | — |
+| `clauditor-xo7.1` | US-001 — Rename assertion keys in constant, handlers, and drift-hints | P2 | none (ready) |
+| `clauditor-xo7.2` | US-002 — Migrate in-repo eval specs and cli/init.py scaffolding | P2 | US-001 |
+| `clauditor-xo7.3` | US-003 — Migrate test fixtures and drop stale hint tests | P2 | US-001 |
+| `clauditor-xo7.4` | US-004 — Update docs, README, and propose-eval prompt prose | P2 | US-001 |
+| `clauditor-xo7.5` | US-005 — Quality Gate (code-reviewer ×4 + CodeRabbit + validation) | P2 | US-001, US-002, US-003, US-004 |
+| `clauditor-xo7.6` | US-006 — Patterns & Memory (rules and docs from redesign) | P3 | US-005 |
+
+### Ready to work
+
+- `clauditor-xo7.1` (US-001) — **entry point; US-002, US-003, US-004 unblock in parallel once this lands.**

--- a/plans/super/67-per-type-assertion-keys.md
+++ b/plans/super/67-per-type-assertion-keys.md
@@ -4,8 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/67
 - **Branch:** `feature/67-per-type-assertion-keys`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/67-per-type-assertion-keys`
-- **Phase:** `detailing`
-- **PR:** TBD
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/69
 - **Sessions:** 1
 - **Last session:** 2026-04-20
 

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -427,32 +427,31 @@ def assert_has_format(
 # that takes (output, assertion_dict) and returns an AssertionResult, so
 # the dispatcher body stays a single lookup + call. Adding a new
 # assertion type means adding one entry here — no edits to run_assertions.
+#
+# Per-type keys (DEC-001 of #67): every handler reads the semantic key
+# for its type (``needle`` for contains, ``pattern`` for regex, etc.).
+# Integer payloads are native JSON ints now — DEC-002/DEC-012 of #67
+# move the isinstance-check for native-int-only to the loader, so the
+# handlers can trust ``a.get("length", 0)`` without an ``int(...)``
+# coercion wrapper.
 _ASSERTION_HANDLERS: dict[str, Callable[[str, dict], AssertionResult]] = {
-    "contains": lambda out, a: assert_contains(out, a.get("value", "")),
-    "not_contains": lambda out, a: assert_not_contains(out, a.get("value", "")),
-    "regex": lambda out, a: assert_regex(out, a.get("value", "")),
+    "contains": lambda out, a: assert_contains(out, a.get("needle", "")),
+    "not_contains": lambda out, a: assert_not_contains(
+        out, a.get("needle", "")
+    ),
+    "regex": lambda out, a: assert_regex(out, a.get("pattern", "")),
     "min_count": lambda out, a: assert_min_count(
-        out, a.get("value", ""), a.get("minimum", 1)
+        out, a.get("pattern", ""), a.get("count", 1)
     ),
-    "min_length": lambda out, a: assert_min_length(
-        out, int(a.get("value", "")) if a.get("value", "") else 0
-    ),
-    "max_length": lambda out, a: assert_max_length(
-        out, int(a.get("value", "")) if a.get("value", "") else 0
-    ),
-    "has_urls": lambda out, a: assert_has_urls(
-        out, int(a.get("value", "")) if a.get("value", "") else 1
-    ),
-    "has_entries": lambda out, a: assert_has_entries(
-        out, int(a.get("value", "")) if a.get("value", "") else 1
-    ),
+    "min_length": lambda out, a: assert_min_length(out, a.get("length", 0)),
+    "max_length": lambda out, a: assert_max_length(out, a.get("length", 0)),
+    "has_urls": lambda out, a: assert_has_urls(out, a.get("count", 1)),
+    "has_entries": lambda out, a: assert_has_entries(out, a.get("count", 1)),
     "urls_reachable": lambda out, a: assert_urls_reachable(
-        out, int(a.get("value", "")) if a.get("value", "") else 1
+        out, a.get("count", 1)
     ),
     "has_format": lambda out, a: assert_has_format(
-        out,
-        a.get("format", ""),
-        int(a.get("value", "")) if a.get("value", "") else 1,
+        out, a.get("format", ""), a.get("count", 1),
     ),
 }
 
@@ -460,7 +459,11 @@ _ASSERTION_HANDLERS: dict[str, Callable[[str, dict], AssertionResult]] = {
 def run_assertions(output: str, assertions: list[dict]) -> AssertionSet:
     """Run a list of assertion dicts against output.
 
-    Each dict has: {"type": "contains", "value": "Venues"} etc.
+    Each dict carries ``type`` plus the per-type semantic key(s)
+    (DEC-001 of #67). Examples:
+    ``{"type": "contains", "needle": "Venues"}``;
+    ``{"type": "min_length", "length": 500}``;
+    ``{"type": "has_format", "format": "phone_us", "count": 2}``.
     Supported types: see ``_ASSERTION_HANDLERS`` keys (contains,
     not_contains, regex, min_count, min_length, max_length, has_urls,
     has_entries, urls_reachable, has_format).

--- a/src/clauditor/assertions.py
+++ b/src/clauditor/assertions.py
@@ -431,27 +431,31 @@ def assert_has_format(
 # Per-type keys (DEC-001 of #67): every handler reads the semantic key
 # for its type (``needle`` for contains, ``pattern`` for regex, etc.).
 # Integer payloads are native JSON ints now — DEC-002/DEC-012 of #67
-# move the isinstance-check for native-int-only to the loader, so the
-# handlers can trust ``a.get("length", 0)`` without an ``int(...)``
-# coercion wrapper.
+# move the isinstance-check for native-int-only to the loader.
+#
+# Required vs optional access style: required keys use direct ``a[key]``
+# access so loader-bypass (e.g., a test constructing an assertion dict
+# and calling ``run_assertions`` directly) fails loudly with a
+# ``KeyError`` instead of silently returning a bogus default — e.g.,
+# ``max_length`` with ``length=0`` would fail every output
+# (CodeRabbit finding). Optional keys keep ``.get(key, default)`` for
+# the legitimate "omitted → use default" case preserved by DEC-005.
 _ASSERTION_HANDLERS: dict[str, Callable[[str, dict], AssertionResult]] = {
-    "contains": lambda out, a: assert_contains(out, a.get("needle", "")),
-    "not_contains": lambda out, a: assert_not_contains(
-        out, a.get("needle", "")
-    ),
-    "regex": lambda out, a: assert_regex(out, a.get("pattern", "")),
+    "contains": lambda out, a: assert_contains(out, a["needle"]),
+    "not_contains": lambda out, a: assert_not_contains(out, a["needle"]),
+    "regex": lambda out, a: assert_regex(out, a["pattern"]),
     "min_count": lambda out, a: assert_min_count(
-        out, a.get("pattern", ""), a.get("count", 1)
+        out, a["pattern"], a["count"]
     ),
-    "min_length": lambda out, a: assert_min_length(out, a.get("length", 0)),
-    "max_length": lambda out, a: assert_max_length(out, a.get("length", 0)),
+    "min_length": lambda out, a: assert_min_length(out, a["length"]),
+    "max_length": lambda out, a: assert_max_length(out, a["length"]),
     "has_urls": lambda out, a: assert_has_urls(out, a.get("count", 1)),
     "has_entries": lambda out, a: assert_has_entries(out, a.get("count", 1)),
     "urls_reachable": lambda out, a: assert_urls_reachable(
         out, a.get("count", 1)
     ),
     "has_format": lambda out, a: assert_has_format(
-        out, a.get("format", ""), a.get("count", 1),
+        out, a["format"], a.get("count", 1),
     ),
 }
 

--- a/src/clauditor/cli/init.py
+++ b/src/clauditor/cli/init.py
@@ -22,7 +22,15 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    """Generate a starter eval.json for a skill."""
+    """Generate a starter eval.json for a skill.
+
+    The starter ``assertions`` list uses the per-type semantic keys
+    introduced in #67 (DEC-001 of ``plans/super/67-per-type-assertion-keys.md``):
+    ``needle`` for ``contains``/``not_contains``, ``length`` for
+    ``min_length``/``max_length``, and ``count`` for the optional
+    threshold on ``has_urls``/``has_entries``. Counts and lengths are
+    written as native JSON ints (DEC-002), not strings.
+    """
     skill_path = Path(args.skill)
     eval_path = skill_path.with_suffix(".eval.json")
 
@@ -52,10 +60,10 @@ def cmd_init(args: argparse.Namespace) -> int:
         "description": f"Eval spec for /{skill_name}",
         "test_args": "",
         "assertions": [
-            {"id": "min_length_500", "type": "min_length", "value": "500"},
-            {"id": "has_urls_3", "type": "has_urls", "value": "3"},
-            {"id": "has_entries_3", "type": "has_entries", "value": "3"},
-            {"id": "no_error", "type": "not_contains", "value": "Error"},
+            {"id": "min_length_500", "type": "min_length", "length": 500},
+            {"id": "has_urls_3", "type": "has_urls", "count": 3},
+            {"id": "has_entries_3", "type": "has_entries", "count": 3},
+            {"id": "no_error", "type": "not_contains", "needle": "Error"},
         ],
         "sections": [
             {

--- a/src/clauditor/propose_eval.py
+++ b/src/clauditor/propose_eval.py
@@ -454,7 +454,7 @@ def build_propose_eval_prompt(propose_input: ProposeEvalInput) -> str:
     # ``plans/super/61-propose-eval-key-mismatch.md``). The word
     # "required" appears in every row so the prompt-builder tests
     # can anchor on literal substrings like
-    # ``"min_count → required: value · optional: minimum"``. Rows
+    # ``"min_count → required: count, pattern"`` (post-#67 rename). Rows
     # with no required keys render ``required: (none)`` so the
     # model sees the type is still known, just fully-optional.
     parts.append(

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -414,8 +414,10 @@ class EvalSpec:
             :data:`_ASSERTION_DRIFT_HINTS` for a per-type
             ``"did you mean X?"`` hint so hand-authors get a quick
             migration nudge when renaming legacy aliases
-            (``value``, ``pattern``, ``min``, ``max``, ``threshold``,
-            ``minimum``).
+            (``value``, ``min``, ``max``, ``threshold``,
+            ``minimum``; ``pattern`` is a drift alias on
+            ``contains`` / ``not_contains`` only — it is a VALID
+            key for ``regex`` and ``min_count``).
 
             Error-path order: (a) unknown/missing type →
             (b) unknown key → (c) missing required → (d) wrong
@@ -466,22 +468,30 @@ class EvalSpec:
                         f"(type={type_val!r}): missing required key {key!r}"
                     )
             # (d) Wrong-typed payload keys. Check every declared
-            # ``field_types`` entry that is present in the user's
-            # dict (None-valued optionals skip the isinstance
-            # check by mirroring the pre-existing tolerance for
-            # optional=None per US-001 test
-            # ``test_optional_key_allows_none``). ``bool`` is a
-            # subclass of ``int`` in Python, so a raw
-            # ``isinstance`` check would silently accept
-            # ``{"count": True}``; we guard with the
-            # ``not isinstance(val, bool)`` clause on the int
-            # branch.
+            # ``field_types`` entry present in the user's dict.
+            # Two subtleties:
+            #   1. A present-but-``None`` optional key is rejected
+            #      — ``a.get("count", 1)`` does NOT substitute for
+            #      ``None`` at runtime, so accepting it at load
+            #      time would crash the handler downstream. The
+            #      ``None`` branch produces a friendlier error
+            #      ("must be int, not null …") than the generic
+            #      ``isinstance`` miss would.
+            #   2. ``bool`` is a subclass of ``int`` in Python, so
+            #      a raw ``isinstance`` check would silently
+            #      accept ``{"count": True}``. The int branch
+            #      guards with ``not isinstance(val, bool)``.
             for key, expected in spec.field_types.items():
                 if key not in entry:
                     continue
                 val = entry[key]
                 if val is None:
-                    continue
+                    raise ValueError(
+                        f"EvalSpec(skill_name={skill_name!r}): {ctx} "
+                        f"(type={type_val!r}): key {key!r} must be "
+                        f"{expected.__name__}, not null (omit the "
+                        f"key to use the default)"
+                    )
                 ok = isinstance(val, expected) and not (
                     expected is int and isinstance(val, bool)
                 )

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class AssertionKeySpec:
-    """Per-assertion-type key invariant (DEC-008 of #61).
+    """Per-assertion-type key invariant (DEC-008 of #61, DEC-012 of #67).
 
     Single source of truth for which assertion-dict keys each
     ``type`` value in :data:`ASSERTION_TYPE_REQUIRED_KEYS` accepts.
@@ -21,55 +21,109 @@ class AssertionKeySpec:
     allowed but the handler falls back to a safe default when
     they are omitted. Any key outside the union of ``required``,
     ``optional``, and the metadata set ``{"id", "type", "name"}``
-    is rejected by ``_require_assertion_keys``. Consumed by the
-    loader-side validator (US-002) and the ``propose-eval``
-    prompt builder (US-003); kept in lockstep with the
-    ``_ASSERTION_HANDLERS`` dispatch table in
+    is rejected by ``_require_assertion_keys``. ``field_types``
+    declares the expected native JSON type for each payload key
+    (``str`` or ``int``); the loader validator enforces
+    ``isinstance(val, expected)`` per-key at load time (DEC-012
+    of #67) so string-typed ints like ``{"length": "500"}`` are
+    rejected loudly. Consumed by the loader-side validator and
+    the ``propose-eval`` prompt builder; kept in lockstep with
+    the ``_ASSERTION_HANDLERS`` dispatch table in
     :mod:`clauditor.assertions` via a test-side drift guard.
     """
 
     required: frozenset[str]
     optional: frozenset[str] = frozenset()
+    field_types: dict[str, type] = field(default_factory=dict)
 
 
-# Single source of truth (DEC-008 of #61): every assertion ``type``
-# string accepted by :func:`clauditor.assertions.run_assertions` maps
-# to the set of keys its handler reads from the assertion dict. The
-# split between ``required`` and ``optional`` mirrors handler runtime
-# behavior — if the handler reads ``.get(key, <default>)`` and the
-# default is a sensible value (e.g. ``1`` for a minimum count), the
-# key is optional; if the default is a sentinel that makes the
-# assertion vacuous (e.g. ``""`` for a regex pattern, ``0`` for a
-# length threshold), the key is required. Must stay in lockstep with
-# ``_ASSERTION_HANDLERS`` in :mod:`clauditor.assertions`; the drift
-# guard lives in ``tests/test_schemas.py::TestAssertionKeySpec``
+# Single source of truth (DEC-008 of #61, DEC-001/DEC-012 of #67):
+# every assertion ``type`` string accepted by
+# :func:`clauditor.assertions.run_assertions` maps to the set of keys
+# its handler reads from the assertion dict. The split between
+# ``required`` and ``optional`` mirrors handler runtime behavior — if
+# the handler reads ``.get(key, <default>)`` and the default is a
+# sensible value (e.g. ``1`` for a minimum count), the key is
+# optional; if the default is a sentinel that makes the assertion
+# vacuous (e.g. ``""`` for a regex pattern, ``0`` for a length
+# threshold), the key is required. ``field_types`` declares each
+# payload key's expected native JSON type (``str`` or ``int``).
+# Must stay in lockstep with ``_ASSERTION_HANDLERS`` in
+# :mod:`clauditor.assertions`; the drift guard lives in
+# ``tests/test_schemas.py::TestAssertionKeySpec``
 # (``test_handler_signature_agrees_with_constant``).
 ASSERTION_TYPE_REQUIRED_KEYS: dict[str, AssertionKeySpec] = {
-    "contains": AssertionKeySpec(required=frozenset({"value"})),
-    "not_contains": AssertionKeySpec(required=frozenset({"value"})),
-    "regex": AssertionKeySpec(required=frozenset({"value"})),
-    "min_count": AssertionKeySpec(
-        required=frozenset({"value"}),
-        optional=frozenset({"minimum"}),
+    "contains": AssertionKeySpec(
+        required=frozenset({"needle"}),
+        field_types={"needle": str},
     ),
-    "min_length": AssertionKeySpec(required=frozenset({"value"})),
-    "max_length": AssertionKeySpec(required=frozenset({"value"})),
+    "not_contains": AssertionKeySpec(
+        required=frozenset({"needle"}),
+        field_types={"needle": str},
+    ),
+    "regex": AssertionKeySpec(
+        required=frozenset({"pattern"}),
+        field_types={"pattern": str},
+    ),
+    "min_count": AssertionKeySpec(
+        required=frozenset({"pattern", "count"}),
+        field_types={"pattern": str, "count": int},
+    ),
+    "min_length": AssertionKeySpec(
+        required=frozenset({"length"}),
+        field_types={"length": int},
+    ),
+    "max_length": AssertionKeySpec(
+        required=frozenset({"length"}),
+        field_types={"length": int},
+    ),
     "has_urls": AssertionKeySpec(
         required=frozenset(),
-        optional=frozenset({"value"}),
+        optional=frozenset({"count"}),
+        field_types={"count": int},
     ),
     "has_entries": AssertionKeySpec(
         required=frozenset(),
-        optional=frozenset({"value"}),
+        optional=frozenset({"count"}),
+        field_types={"count": int},
     ),
     "urls_reachable": AssertionKeySpec(
         required=frozenset(),
-        optional=frozenset({"value"}),
+        optional=frozenset({"count"}),
+        field_types={"count": int},
     ),
     "has_format": AssertionKeySpec(
         required=frozenset({"format"}),
-        optional=frozenset({"value"}),
+        optional=frozenset({"count"}),
+        field_types={"format": str, "count": int},
     ),
+}
+
+
+# Per-type drift-hint table (DEC-009 of #67). Sibling to
+# :data:`ASSERTION_TYPE_REQUIRED_KEYS`. For each assertion ``type``,
+# a map of ``common-wrong-key → correct-key-for-this-type``.
+# Consulted by ``_require_assertion_keys`` when flagging an unknown
+# key: emits `" — did you mean {suggestion!r}?"` if the wrong key
+# is hinted for that specific type, else no suffix. Keyed per-type
+# because ``pattern`` is a VALID key for ``regex``/``min_count``
+# but should suggest ``needle`` on ``contains``/``not_contains``.
+_ASSERTION_DRIFT_HINTS: dict[str, dict[str, str]] = {
+    "contains":       {"value": "needle", "pattern": "needle"},
+    "not_contains":   {"value": "needle", "pattern": "needle"},
+    "regex":          {"value": "pattern"},
+    "min_count":      {"value": "pattern", "minimum": "count",
+                       "min_count": "count", "threshold": "count"},
+    "min_length":     {"value": "length", "min": "length"},
+    "max_length":     {"value": "length", "max": "length"},
+    "has_urls":       {"value": "count", "minimum": "count",
+                       "min_count": "count", "threshold": "count"},
+    "has_entries":    {"value": "count", "minimum": "count",
+                       "min_count": "count", "threshold": "count"},
+    "urls_reachable": {"value": "count", "minimum": "count",
+                       "min_count": "count", "threshold": "count"},
+    "has_format":     {"value": "count", "minimum": "count",
+                       "min_count": "count"},
 }
 
 
@@ -345,16 +399,34 @@ class EvalSpec:
         def _require_assertion_keys(entry: dict, ctx: str) -> None:
             """Hard-validate per-assertion required and allowed keys.
 
-            DEC-001 / DEC-002 / DEC-008 of #61: every assertion dict
-            must carry a known ``type`` value and exactly the keys
-            named by :data:`ASSERTION_TYPE_REQUIRED_KEYS` for that
-            type (plus the always-allowed ``id``, ``type``, ``name``
-            metadata keys). Missing required keys and unknown keys
-            both raise ``ValueError`` — strict rejection per
-            ``.claude/rules/pre-llm-contract-hard-validate.md``, with
-            a "did you mean X?" hint for the three known drift
-            aliases so hand-authors get a quick migration nudge.
+            DEC-001 / DEC-002 / DEC-008 of #61 and DEC-001 / DEC-009 /
+            DEC-012 of #67: every assertion dict must carry a known
+            ``type`` value and exactly the keys named by
+            :data:`ASSERTION_TYPE_REQUIRED_KEYS` for that type (plus
+            the always-allowed ``id``, ``type``, ``name`` metadata
+            keys). Each payload key is additionally type-checked
+            against ``spec.field_types`` so string-typed ints
+            (``{"length": "500"}``) reject at load time. Unknown
+            keys, missing required keys, and wrong-typed keys all
+            raise ``ValueError`` — strict rejection per
+            ``.claude/rules/pre-llm-contract-hard-validate.md``.
+            Unknown-key errors consult
+            :data:`_ASSERTION_DRIFT_HINTS` for a per-type
+            ``"did you mean X?"`` hint so hand-authors get a quick
+            migration nudge when renaming legacy aliases
+            (``value``, ``pattern``, ``min``, ``max``, ``threshold``,
+            ``minimum``).
+
+            Error-path order: (a) unknown/missing type →
+            (b) unknown key → (c) missing required → (d) wrong
+            type. Unknown-key fires before missing-required so a
+            user who wrote an old alias (``value`` on ``contains``)
+            gets the actionable ``"did you mean 'needle'?"`` hint
+            instead of the opaque ``"missing required key 'needle'"``
+            that would hide the rename from them. Each branch
+            raises at the first violation; no cascading noise.
             """
+            # (a) Unknown or missing ``type``.
             type_val = entry.get("type")
             if (
                 not isinstance(type_val, str)
@@ -365,12 +437,9 @@ class EvalSpec:
                     f"unknown or missing 'type' (got {type_val!r})"
                 )
             spec = ASSERTION_TYPE_REQUIRED_KEYS[type_val]
-            for key in sorted(spec.required):
-                if key not in entry or entry[key] is None:
-                    raise ValueError(
-                        f"EvalSpec(skill_name={skill_name!r}): {ctx} "
-                        f"(type={type_val!r}): missing required key {key!r}"
-                    )
+            # (b) Unknown keys — fires before missing-required so
+            # legacy-alias migrations surface the drift hint that
+            # names the correct replacement key.
             allowed = (
                 {"id", "type", "name"}
                 | set(spec.required)
@@ -379,16 +448,50 @@ class EvalSpec:
             for key in entry:
                 if key in allowed:
                     continue
-                if key in {"pattern", "min", "max"}:
-                    hint = " — did you mean 'value'?"
-                elif key == "threshold":
-                    hint = " — did you mean 'minimum'?"
-                else:
-                    hint = ""
+                suggestion = _ASSERTION_DRIFT_HINTS.get(type_val, {}).get(key)
+                hint = (
+                    f" — did you mean {suggestion!r}?"
+                    if suggestion is not None
+                    else ""
+                )
                 raise ValueError(
                     f"EvalSpec(skill_name={skill_name!r}): {ctx} "
                     f"(type={type_val!r}): unknown key {key!r}{hint}"
                 )
+            # (c) Missing required keys.
+            for key in sorted(spec.required):
+                if key not in entry or entry[key] is None:
+                    raise ValueError(
+                        f"EvalSpec(skill_name={skill_name!r}): {ctx} "
+                        f"(type={type_val!r}): missing required key {key!r}"
+                    )
+            # (d) Wrong-typed payload keys. Check every declared
+            # ``field_types`` entry that is present in the user's
+            # dict (None-valued optionals skip the isinstance
+            # check by mirroring the pre-existing tolerance for
+            # optional=None per US-001 test
+            # ``test_optional_key_allows_none``). ``bool`` is a
+            # subclass of ``int`` in Python, so a raw
+            # ``isinstance`` check would silently accept
+            # ``{"count": True}``; we guard with the
+            # ``not isinstance(val, bool)`` clause on the int
+            # branch.
+            for key, expected in spec.field_types.items():
+                if key not in entry:
+                    continue
+                val = entry[key]
+                if val is None:
+                    continue
+                ok = isinstance(val, expected) and not (
+                    expected is int and isinstance(val, bool)
+                )
+                if not ok:
+                    raise ValueError(
+                        f"EvalSpec(skill_name={skill_name!r}): {ctx} "
+                        f"(type={type_val!r}): key {key!r} must be "
+                        f"{expected.__name__}, got "
+                        f"{type(val).__name__} {val!r}"
+                    )
 
         raw_assertions = data.get("assertions", [])
         if not isinstance(raw_assertions, list):

--- a/src/clauditor/skills/clauditor/assets/clauditor.eval.json
+++ b/src/clauditor/skills/clauditor/assets/clauditor.eval.json
@@ -7,17 +7,17 @@
     {
       "id": "mentions-assertions",
       "type": "contains",
-      "value": "assertion"
+      "needle": "assertion"
     },
     {
       "id": "no-error-trace",
       "type": "not_contains",
-      "value": "Traceback"
+      "needle": "Traceback"
     },
     {
       "id": "produces-output",
       "type": "min_length",
-      "value": "50"
+      "length": 50
     }
   ],
   "grading_criteria": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,11 +135,11 @@ def sample_eval_data() -> dict:
         "description": "Eval for /find-kid-activities",
         "test_args": '"Cupertino, CA" --dates today --cost Free --depth quick',
         "assertions": [
-            {"type": "contains", "value": "Venues"},
-            {"type": "has_entries", "value": "3"},
-            {"type": "has_urls", "value": "2"},
-            {"type": "not_contains", "value": "ERROR"},
-            {"type": "min_length", "value": "500"},
+            {"type": "contains", "needle": "Venues"},
+            {"type": "has_entries", "count": 3},
+            {"type": "has_urls", "count": 2},
+            {"type": "not_contains", "needle": "ERROR"},
+            {"type": "min_length", "length": 500},
         ],
         "sections": [
             {
@@ -199,7 +199,7 @@ def make_eval_spec():
             "skill_name": "test-skill",
             "description": "A test eval spec",
             "test_args": "--depth quick",
-            "assertions": [{"type": "contains", "value": "test"}],
+            "assertions": [{"type": "contains", "needle": "test"}],
             "sections": [
                 SectionRequirement(
                     name="Results",
@@ -361,7 +361,7 @@ def build_eval_spec(**overrides) -> EvalSpec:
         skill_name="test-skill",
         description="A test skill",
         test_args="--depth quick",
-        assertions=[{"type": "contains", "value": "hello"}],
+        assertions=[{"type": "contains", "needle": "hello"}],
         sections=[],
         grading_criteria=["Is the output relevant?"],
         grading_model="claude-sonnet-4-6",

--- a/tests/test_asserters.py
+++ b/tests/test_asserters.py
@@ -105,7 +105,7 @@ class TestRunAssertions:
     def test_delegates_to_assertions_module(self):
         asserter = SkillAsserter(_result("hello world"))
         assertion_set = asserter.run_assertions(
-            [{"type": "contains", "value": "hello"}]
+            [{"type": "contains", "needle": "hello"}]
         )
         assert assertion_set.passed
 

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -139,12 +139,12 @@ class TestHasEntries:
 class TestRunAssertions:
     def test_all_pass(self):
         assertions = [
-            {"type": "contains", "value": "Venues"},
-            {"type": "contains", "value": "Events"},
-            {"type": "has_urls", "value": "3"},
-            {"type": "has_entries", "value": "3"},
-            {"type": "not_contains", "value": "ERROR"},
-            {"type": "min_length", "value": "500"},
+            {"type": "contains", "needle": "Venues"},
+            {"type": "contains", "needle": "Events"},
+            {"type": "has_urls", "count": 3},
+            {"type": "has_entries", "count": 3},
+            {"type": "not_contains", "needle": "ERROR"},
+            {"type": "min_length", "length": 500},
         ]
         results = run_assertions(SAMPLE_OUTPUT, assertions)
         assert results.passed
@@ -152,8 +152,8 @@ class TestRunAssertions:
 
     def test_mixed_results(self):
         assertions = [
-            {"type": "contains", "value": "Venues"},
-            {"type": "contains", "value": "Nonexistent"},
+            {"type": "contains", "needle": "Venues"},
+            {"type": "contains", "needle": "Nonexistent"},
         ]
         results = run_assertions(SAMPLE_OUTPUT, assertions)
         assert not results.passed
@@ -161,13 +161,13 @@ class TestRunAssertions:
         assert len(results.failed) == 1
 
     def test_unknown_type(self):
-        results = run_assertions(SAMPLE_OUTPUT, [{"type": "bogus", "value": "x"}])
+        results = run_assertions(SAMPLE_OUTPUT, [{"type": "bogus", "needle": "x"}])
         assert not results.passed
 
     def test_summary(self):
         assertions = [
-            {"type": "contains", "value": "Venues"},
-            {"type": "contains", "value": "Missing"},
+            {"type": "contains", "needle": "Venues"},
+            {"type": "contains", "needle": "Missing"},
         ]
         results = run_assertions(SAMPLE_OUTPUT, assertions)
         summary = results.summary()
@@ -385,36 +385,36 @@ class TestRunAssertionsEdgeCases:
         assert len(result.results) == 0
 
     def test_unknown_type_message(self):
-        result = run_assertions("text", [{"type": "bogus", "value": "x"}])
+        result = run_assertions("text", [{"type": "bogus", "needle": "x"}])
         assert not result.passed
         assert len(result.results) == 1
         assert "Unknown assertion type" in result.results[0].message
         assert result.results[0].name == "unknown:bogus"
 
     def test_max_length_via_run(self):
-        result = run_assertions("short", [{"type": "max_length", "value": "100"}])
+        result = run_assertions("short", [{"type": "max_length", "length": 100}])
         assert result.passed
 
     def test_regex_via_run(self):
-        result = run_assertions("hello 123", [{"type": "regex", "value": r"\d+"}])
+        result = run_assertions("hello 123", [{"type": "regex", "pattern": r"\d+"}])
         assert result.passed
 
     def test_min_count_via_run(self):
-        assertion = {"type": "min_count", "value": "a", "minimum": 3}
+        assertion = {"type": "min_count", "pattern": "a", "count": 3}
         result = run_assertions("aaa", [assertion])
         assert result.passed
 
     def test_has_urls_via_run(self):
         result = run_assertions(
             "visit https://example.com",
-            [{"type": "has_urls", "value": "1"}],
+            [{"type": "has_urls", "count": 1}],
         )
         assert result.passed
 
     def test_has_entries_via_run(self):
         result = run_assertions(
             "**1. Item** **2. Item**",
-            [{"type": "has_entries", "value": "2"}],
+            [{"type": "has_entries", "count": 2}],
         )
         assert result.passed
 
@@ -427,14 +427,14 @@ class TestRunAssertionsEdgeCases:
         ):
             result = run_assertions(
                 "visit https://example.com",
-                [{"type": "urls_reachable", "value": "1"}],
+                [{"type": "urls_reachable", "count": 1}],
             )
             assert result.passed
 
     def test_has_format_via_run(self):
         result = run_assertions(
             "contact user@example.com or admin@test.org",
-            [{"type": "has_format", "format": "email", "value": "2"}],
+            [{"type": "has_format", "format": "email", "count": 2}],
         )
         assert result.passed
 
@@ -927,8 +927,8 @@ class TestAssertionSetJson:
         """run_assertions stamps the spec ``id`` onto every result so
         assertions.json is keyed by id, not by list position."""
         assertions = [
-            {"id": "venues", "type": "contains", "value": "Venues"},
-            {"id": "min-len", "type": "min_length", "value": "10"},
+            {"id": "venues", "type": "contains", "needle": "Venues"},
+            {"id": "min-len", "type": "min_length", "length": 10},
         ]
         result_set = run_assertions(SAMPLE_OUTPUT, assertions)
         payload = result_set.to_json()

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -71,7 +71,7 @@ def _make_eval_spec() -> EvalSpec:
         skill_name="test-skill",
         test_args="test args",
         assertions=[
-            {"id": "a1", "type": "contains", "value": "baseline"},
+            {"id": "a1", "type": "contains", "needle": "baseline"},
         ],
         grading_criteria=[
             {"id": "c0", "criterion": "c0"},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -829,8 +829,8 @@ class TestCmdGradeSaveDiff:
 
         eval_spec = _make_eval_spec(
             assertions=[
-                {"id": "has-hello", "type": "contains", "value": "hello"},
-                {"id": "min-len", "type": "min_length", "value": "5"},
+                {"id": "has-hello", "type": "contains", "needle": "hello"},
+                {"id": "min-len", "type": "min_length", "length": 5},
             ]
         )
         spec = _make_spec(eval_spec=eval_spec)
@@ -875,8 +875,8 @@ class TestCmdGradeSaveDiff:
         monkeypatch.chdir(tmp_path)
         eval_spec = _make_eval_spec(
             assertions=[
-                {"id": "has-primary", "type": "contains", "value": "primary"},
-                {"id": "min-len", "type": "min_length", "value": "3"},
+                {"id": "has-primary", "type": "contains", "needle": "primary"},
+                {"id": "min-len", "type": "min_length", "length": 3},
             ]
         )
         spec = _make_spec(eval_spec=eval_spec)
@@ -916,8 +916,8 @@ class TestCmdGradeSaveDiff:
         monkeypatch.chdir(tmp_path)
         eval_spec = _make_eval_spec(
             assertions=[
-                {"id": "has-primary", "type": "contains", "value": "primary"},
-                {"id": "min-len", "type": "min_length", "value": "3"},
+                {"id": "has-primary", "type": "contains", "needle": "primary"},
+                {"id": "min-len", "type": "min_length", "length": 3},
             ]
         )
         spec = _make_spec(eval_spec=eval_spec)
@@ -963,7 +963,7 @@ class TestCmdGradeSaveDiff:
 
         eval_spec = _make_eval_spec(
             assertions=[
-                {"id": "has-text", "type": "contains", "value": "text"},
+                {"id": "has-text", "type": "contains", "needle": "text"},
             ]
         )
         spec = _make_spec(eval_spec=eval_spec)
@@ -1492,7 +1492,7 @@ class TestBaselineFlag:
             assertions=[
                 {
                     "type": "contains",
-                    "value": "hello",
+                    "needle": "hello",
                     "id": "a.hello.v1",
                 }
             ],
@@ -2181,7 +2181,7 @@ class TestCmdCompare:
         after_txt.write_text("hello world")
 
         eval_spec = _make_eval_spec(
-            assertions=[{"type": "contains", "value": "hello"}]
+            assertions=[{"type": "contains", "needle": "hello"}]
         )
         spec = _make_spec(eval_spec=eval_spec)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2874,6 +2874,37 @@ class TestCmdInit:
         assert data["skill_name"] == "bar"
         assert data["description"] == "Eval spec for /bar"
 
+    def test_init_generated_spec_uses_per_type_keys(self, tmp_path):
+        """Regression (DEC-001/DEC-002 of #67): generated eval.json loads
+        via ``EvalSpec.from_file`` (no legacy ``value`` keys) and uses
+        native JSON ints for counts/lengths — the starter scaffold must
+        stay in lockstep with the per-type validator.
+        """
+        from clauditor.schemas import EvalSpec
+
+        skill_path = tmp_path / "my-skill.md"
+        skill_path.write_text("# My Skill")
+
+        rc = main(["init", str(skill_path)])
+        assert rc == 0
+
+        eval_path = tmp_path / "my-skill.eval.json"
+        # Substring check: the generated file must not contain any
+        # legacy ``"value":`` assertion key. Cheap guard against a
+        # future regression that reverts the scaffold.
+        raw = eval_path.read_text(encoding="utf-8")
+        assert '"value":' not in raw, (
+            "generated eval.json must not contain legacy 'value' keys"
+        )
+
+        # Must load cleanly via EvalSpec.from_file — the per-type
+        # required-key + type-check validator from US-001 rejects the
+        # legacy shape at load time.
+        spec = EvalSpec.from_file(eval_path)
+        assert spec.skill_name == "my-skill"
+        # Starter scaffold ships 4 assertions per DEC-001 mapping.
+        assert len(spec.assertions) == 4
+
 
 @pytest.fixture
 def setup_env(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2905,6 +2905,20 @@ class TestCmdInit:
         # Starter scaffold ships 4 assertions per DEC-001 mapping.
         assert len(spec.assertions) == 4
 
+        # Each assertion uses the per-type semantic key (DEC-001)
+        # with native JSON ints for counts/lengths (DEC-002). A
+        # future scaffold edit that swaps a key name (``length`` →
+        # ``len``) or reverts to stringly-typed ints (``500`` →
+        # ``"500"``) must fail this test, not silently pass.
+        by_id = {a["id"]: a for a in spec.assertions}
+        assert by_id["min_length_500"]["length"] == 500
+        assert isinstance(by_id["min_length_500"]["length"], int)
+        assert by_id["has_urls_3"]["count"] == 3
+        assert isinstance(by_id["has_urls_3"]["count"], int)
+        assert by_id["has_entries_3"]["count"] == 3
+        assert isinstance(by_id["has_entries_3"]["count"], int)
+        assert by_id["no_error"]["needle"] == "Error"
+
 
 @pytest.fixture
 def setup_env(tmp_path, monkeypatch):

--- a/tests/test_cli_propose_eval.py
+++ b/tests/test_cli_propose_eval.py
@@ -38,7 +38,7 @@ def _make_report(
                     "id": "greets-user",
                     "type": "contains",
                     "name": "greets the user",
-                    "value": "hello",
+                    "needle": "hello",
                 }
             ],
             "grading_criteria": [

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -173,7 +173,7 @@ class TestGradeVerboseInvocation:
             description="T",
             test_args="--depth quick",
             # Assertion deliberately fails against the mocked output.
-            assertions=[{"type": "contains", "value": "WILL_NOT_MATCH"}],
+            assertions=[{"type": "contains", "needle": "WILL_NOT_MATCH"}],
             sections=[],
             grading_criteria=["Is it relevant?"],
             grading_model="claude-sonnet-4-6",
@@ -293,7 +293,7 @@ class TestGradeVerboseInvocation:
             skill_name="test-skill",
             description="T",
             test_args="--depth quick",
-            assertions=[{"type": "contains", "value": "hello"}],
+            assertions=[{"type": "contains", "needle": "hello"}],
             sections=[],
             grading_criteria=["Is it relevant?"],
             grading_model="claude-sonnet-4-6",
@@ -334,7 +334,7 @@ class TestValidateVerboseInvocation:
         skill_path.write_text("# demo\nhello\n")
         eval_path = tmp_path / "demo.eval.json"
         eval_path.write_text(
-            '{"assertions": [{"id": "a1", "type": "contains", "value": "__nope__"}]}'
+            '{"assertions": [{"id": "a1", "type": "contains", "needle": "__nope__"}]}'
         )
 
         fake_skill_result = MagicMock()

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -62,15 +62,20 @@ def _json_fenced_blocks(text: str) -> list[str]:
     """Extract every ```json ... ``` fenced code block from ``text``.
 
     Returns the block bodies (fence markers stripped) in file order.
-    A fenced block is matched by a line beginning with ```json``` and
-    a subsequent line beginning with ``` on its own (allowing trailing
+    A fenced block is matched by a line beginning with ```json`` and
+    a subsequent line whose entire content is ``` (allowing trailing
     whitespace). Non-JSON fences (```python```, ```text```, …) are
     skipped so rubric / pytest examples do not trigger false positives.
     """
-    # Multiline-dotall: ``.`` matches newline so we can capture block
-    # bodies across lines. Non-greedy ``.*?`` stops at the first
-    # closing fence.
-    pattern = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+    # ``^...$`` anchors (MULTILINE) keep the match scoped to
+    # line-start / line-end so inline backtick sequences inside prose
+    # cannot accidentally open or close a fence. ``.`` with DOTALL
+    # lets the body span lines; non-greedy ``.*?`` stops at the first
+    # bare closing fence.
+    pattern = re.compile(
+        r"^```json\s*\n(.*?)^```\s*$",
+        re.DOTALL | re.MULTILINE,
+    )
     return pattern.findall(text)
 
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,147 @@
+"""Regression test for assertion JSON examples in human-facing docs.
+
+Guards against the specific failure mode that landed the #67 per-type
+semantic-key redesign: a doc file silently keeping the legacy
+``{"type": "...", "value": "..."}`` shape after the loader has stopped
+accepting ``value`` as a valid assertion key. The redesign renamed the
+single overloaded ``value`` field to per-type semantic keys
+(``needle`` / ``pattern`` / ``length`` / ``count`` / ``format``) and
+switched integer fields from stringly-typed to native JSON ints —
+docs that still show the old shape would copy-paste into a broken
+eval spec.
+
+The test is deliberately grep-based (string-level) rather than
+JSON-parsing. The motivating bug is "wrong key name in a code-fence
+example"; a substring scan catches every instance without the
+fragility of extracting and parsing every fenced block (which would
+need to handle triple-backtick-inside-quoted-string, skipped
+```text``` blocks that aren't JSON, etc.). The alternative full-parse
+approach is tracked in US-003 of ``plans/super/67-per-type-assertion-keys.md``
+as a future tightening if a false positive ever slips through.
+
+Files covered (the human-facing doc triangle per
+``.claude/rules/bundled-skill-docs-sync.md``):
+
+* ``README.md``
+* every ``docs/*.md`` file
+* ``src/clauditor/skills/clauditor/SKILL.md``
+
+Explicitly NOT covered:
+
+* ``plans/**/*.md`` — plan files legitimately cite the old shape
+  when discussing the ``#67`` migration and its history. Plans are
+  audit history, not examples users copy-paste.
+* ``CHANGELOG.md`` — may legitimately cite the old shape when
+  describing the ``#67`` rename.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Scope: the human-facing doc triangle. See module docstring for the
+# rationale for excluding plans/ and CHANGELOG.md.
+README = REPO_ROOT / "README.md"
+DOCS_DIR = REPO_ROOT / "docs"
+SKILL_MD = REPO_ROOT / "src" / "clauditor" / "skills" / "clauditor" / "SKILL.md"
+
+
+def _doc_files() -> list[Path]:
+    """Return every in-scope doc file under the repository."""
+    files = [README, SKILL_MD]
+    files.extend(sorted(DOCS_DIR.glob("**/*.md")))
+    return [p for p in files if p.is_file()]
+
+
+def _json_fenced_blocks(text: str) -> list[str]:
+    """Extract every ```json ... ``` fenced code block from ``text``.
+
+    Returns the block bodies (fence markers stripped) in file order.
+    A fenced block is matched by a line beginning with ```json``` and
+    a subsequent line beginning with ``` on its own (allowing trailing
+    whitespace). Non-JSON fences (```python```, ```text```, …) are
+    skipped so rubric / pytest examples do not trigger false positives.
+    """
+    # Multiline-dotall: ``.`` matches newline so we can capture block
+    # bodies across lines. Non-greedy ``.*?`` stops at the first
+    # closing fence.
+    pattern = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+    return pattern.findall(text)
+
+
+class TestAssertionExamplesUsePerTypeKeys:
+    """Every ``"value":`` in a JSON-fenced assertion example is a bug.
+
+    Per DEC-001 of ``plans/super/67-per-type-assertion-keys.md``, the
+    loader rejects ``value`` as an assertion key. If a doc shows a
+    ``{"type": "contains", "value": "..."}`` example the reader's
+    copy-paste will fail validation at load time.
+    """
+
+    @pytest.mark.parametrize(
+        "doc_path",
+        _doc_files(),
+        ids=lambda p: str(p.relative_to(REPO_ROOT)),
+    )
+    def test_no_value_key_in_assertion_json_block(self, doc_path: Path) -> None:
+        """No json-fenced block that mentions an assertion ``"type":`` also
+        carries a ``"value":`` key."""
+        text = doc_path.read_text(encoding="utf-8")
+        offenders: list[tuple[int, str]] = []
+        for idx, block in enumerate(_json_fenced_blocks(text)):
+            if '"type":' not in block:
+                continue
+            if '"value":' in block:
+                offenders.append((idx, block))
+        assert not offenders, (
+            f"{doc_path.relative_to(REPO_ROOT)}: found "
+            f"{len(offenders)} assertion JSON block(s) with legacy "
+            f"'value' key. Migrate to per-type semantic keys per "
+            f"#67: needle / pattern / length / count / format.\n"
+            f"First offender body:\n{offenders[0][1][:400]}"
+        )
+
+
+class TestAssertionExamplesUseNativeIntPayloads:
+    """Integer payload fields (length / count) must be JSON ints.
+
+    Per DEC-002 of ``plans/super/67-per-type-assertion-keys.md``, the
+    loader rejects stringly-typed ints (e.g. ``"length": "500"``) with
+    a wrong-type ``ValueError``. Docs showing the old stringly-typed
+    shape would copy-paste into a broken spec.
+    """
+
+    # Regex: a JSON key listed below, followed by a quoted numeric
+    # string. Matches e.g. ``"length": "500"`` or ``"count":"3"``.
+    _STRINGLY_INT_RE = re.compile(
+        r'"(length|count)":\s*"\d+"'
+    )
+
+    @pytest.mark.parametrize(
+        "doc_path",
+        _doc_files(),
+        ids=lambda p: str(p.relative_to(REPO_ROOT)),
+    )
+    def test_int_fields_are_native_json_ints(self, doc_path: Path) -> None:
+        """No json-fenced block that mentions an assertion ``"type":`` has
+        a stringly-typed ``length`` or ``count`` field."""
+        text = doc_path.read_text(encoding="utf-8")
+        offenders: list[tuple[int, str]] = []
+        for idx, block in enumerate(_json_fenced_blocks(text)):
+            if '"type":' not in block:
+                continue
+            matches = self._STRINGLY_INT_RE.findall(block)
+            if matches:
+                offenders.append((idx, block))
+        assert not offenders, (
+            f"{doc_path.relative_to(REPO_ROOT)}: found "
+            f"{len(offenders)} assertion JSON block(s) with "
+            f"stringly-typed int field(s). Per DEC-002 of #67, "
+            f"length/count are native JSON ints — use 500, not "
+            f'"500".\nFirst offender body:\n{offenders[0][1][:400]}'
+        )

--- a/tests/test_propose_eval.py
+++ b/tests/test_propose_eval.py
@@ -65,7 +65,7 @@ def _good_spec_dict(
                 "id": "greets-user",
                 "type": "contains",
                 "name": "greets the user",
-                "value": "hello",
+                "needle": "hello",
             }
         ]
     if with_criterion:
@@ -442,52 +442,59 @@ class TestBuildProposeEvalPrompt:
         _ = build_propose_eval_prompt(pi)
 
     def test_prompt_contains_per_type_table(self) -> None:
-        """DEC-003 / DEC-008 of #61 — the prompt must enumerate each
-        assertion type's required AND optional keys (rendered from
-        ``ASSERTION_TYPE_REQUIRED_KEYS``) so the model has a literal
-        reference table for key names. Rows without optional keys
-        omit the ``· optional: …`` suffix; rows with no required
-        keys render ``required: (none)``.
+        """DEC-003 / DEC-008 of #61 and DEC-001 of #67 — the prompt
+        enumerates each assertion type's required AND optional keys
+        (rendered from ``ASSERTION_TYPE_REQUIRED_KEYS``) so the model
+        has a literal reference table for key names. Rows without
+        optional keys omit the ``· optional: …`` suffix; rows with
+        no required keys render ``required: (none)``.
         """
         pi = _make_propose_input()
         prompt = build_propose_eval_prompt(pi)
-        # 1-required-key shape, no optional.
-        assert "contains → required: value" in prompt
-        assert "not_contains → required: value" in prompt
-        assert "regex → required: value" in prompt
-        assert "min_length → required: value" in prompt
-        assert "max_length → required: value" in prompt
+        # 1-required-key shape, no optional (post-#67 rename).
+        assert "contains → required: needle" in prompt
+        assert "not_contains → required: needle" in prompt
+        assert "regex → required: pattern" in prompt
+        assert "min_length → required: length" in prompt
+        assert "max_length → required: length" in prompt
         # required + optional shape. Keys sorted alphabetically
         # within each side.
         assert (
-            "min_count → required: value · optional: minimum"
+            "min_count → required: count, pattern"
         ) in prompt
         assert (
-            "has_format → required: format · optional: value"
+            "has_format → required: format · optional: count"
         ) in prompt
         # All-optional shape (no required keys) — ``(none)`` marker.
         assert (
-            "has_urls → required: (none) · optional: value"
+            "has_urls → required: (none) · optional: count"
         ) in prompt
         assert (
-            "has_entries → required: (none) · optional: value"
+            "has_entries → required: (none) · optional: count"
         ) in prompt
         assert (
-            "urls_reachable → required: (none) · optional: value"
+            "urls_reachable → required: (none) · optional: count"
         ) in prompt
 
     def test_prompt_has_no_alias_keys(self) -> None:
-        """The drift-source ellipsis ("pattern", "min", "max" alias
-        key names) must not appear in the new prompt — per DEC-003
-        of #61, these keys are *not* accepted by the validator.
+        """The legacy alias key names (``value``, ``minimum``) must
+        not appear in quoted-key form in the new prompt — per DEC-001
+        of #67, these keys are not accepted by the validator. Note:
+        ``pattern`` is now a VALID key for ``regex`` and ``min_count``
+        so a bare ``pattern`` substring legitimately appears in the
+        rendered per-type table; we only assert the obsolete aliases
+        are gone.
         """
         pi = _make_propose_input()
         prompt = build_propose_eval_prompt(pi)
-        # Alias JSON key-name literals must not appear.
-        assert '"pattern"' not in prompt
-        assert '"min"' not in prompt
-        assert '"max"' not in prompt
-        # The old drift-source line must also be gone verbatim.
+        # Legacy alias JSON key-name literals must not appear in
+        # quoted form (the model would interpret e.g. `"value"` as
+        # a valid key to emit).
+        assert "'value'" not in prompt
+        assert "'minimum'" not in prompt
+        # The old drift-source example line must also be gone
+        # verbatim (it used `"value", "pattern"` to introduce the
+        # old-alias migration nudge).
         assert 'e.g. "value", "pattern"' not in prompt
 
     def test_prompt_table_is_rendered_from_constant(
@@ -610,7 +617,7 @@ class TestValidateProposedSpec:
             "test_args": "",
             "assertions": [
                 # missing id
-                {"type": "contains", "name": "n", "value": "v"}
+                {"type": "contains", "name": "n", "needle": "v"}
             ],
             "grading_criteria": [
                 {"id": "crit-1", "criterion": "ok"}
@@ -628,7 +635,7 @@ class TestValidateProposedSpec:
                     "id": "same-id",
                     "type": "contains",
                     "name": "n",
-                    "value": "v",
+                    "needle": "v",
                 }
             ],
             "grading_criteria": [
@@ -701,7 +708,7 @@ class TestValidateProposedSpec:
                     "id": "a1",
                     "type": "contains",
                     "name": "n",
-                    "value": "v",
+                    "needle": "v",
                 }
             ],
             "grading_criteria": [],
@@ -905,7 +912,7 @@ class TestProposeEval:
             "test_args": "",
             "assertions": [
                 # missing id
-                {"type": "contains", "name": "x", "value": "y"}
+                {"type": "contains", "name": "x", "needle": "y"}
             ],
         }
         result = _mock_anthropic_result(text=json.dumps(bad_spec))
@@ -1202,7 +1209,7 @@ def _bad_response_text_missing_id() -> str:
             "test_args": "",
             "assertions": [
                 # Missing `id` — from_dict rejects via _require_id.
-                {"type": "contains", "name": "n", "value": "v"}
+                {"type": "contains", "name": "n", "needle": "v"}
             ],
         }
     )
@@ -1269,7 +1276,7 @@ class TestProposeEvalRepairRetry:
             "test_args": "",
             "assertions": [
                 # Missing `id` — from_dict rejects.
-                {"type": "contains", "name": "n", "value": "v"}
+                {"type": "contains", "name": "n", "needle": "v"}
             ],
         }
         # Second attempt fails on a DIFFERENT error so we can verify
@@ -1281,7 +1288,7 @@ class TestProposeEvalRepairRetry:
                     "id": "same-id",
                     "type": "contains",
                     "name": "n",
-                    "value": "v",
+                    "needle": "v",
                 }
             ],
             "grading_criteria": [
@@ -1540,7 +1547,7 @@ class TestValidateProposedSpecNonListFields:
                 {
                     "id": "a1",
                     "type": "contains",
-                    "value": "hi",
+                    "needle": "hi",
                 }
             ],
             "grading_criteria": {"not": "a list"},

--- a/tests/test_propose_eval.py
+++ b/tests/test_propose_eval.py
@@ -1099,10 +1099,10 @@ class TestBuildRepairProposeEvalPrompt:
         """<validation_errors> contains every error verbatim, newline-joined."""
         errors = [
             (
-                "assertions[0] (type='regex'): unknown key 'pattern' "
-                "— did you mean 'value'?"
+                "assertions[0] (type='regex'): unknown key 'value' "
+                "— did you mean 'pattern'?"
             ),
-            "assertions[1] (type='min_count'): missing required key 'minimum'",
+            "assertions[1] (type='min_count'): missing required key 'count'",
             "grading_criteria[0]: duplicate id 'greets-user'",
         ]
         repair = build_repair_propose_eval_prompt(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -187,7 +187,7 @@ class TestSkillAsserter:
     def test_run_assertions_delegates(self):
         asserter = self._make("hello world")
         assertion_set = asserter.run_assertions(
-            [{"type": "contains", "value": "hello"}]
+            [{"type": "contains", "needle": "hello"}]
         )
         assert assertion_set.passed
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -11,6 +11,7 @@ import clauditor.schemas as _schemas_mod
 importlib.reload(_schemas_mod)
 
 from clauditor.schemas import (  # noqa: E402
+    _ASSERTION_DRIFT_HINTS,
     ASSERTION_TYPE_REQUIRED_KEYS,
     AssertionKeySpec,
     EvalSpec,
@@ -27,8 +28,8 @@ SAMPLE_EVAL = {
     "description": "Eval for /find-kid-activities",
     "test_args": '"Cupertino, CA" --dates today --cost Free --depth quick',
     "assertions": [
-        {"id": "a_venues", "type": "contains", "value": "Venues"},
-        {"id": "a_entries", "type": "has_entries", "value": "3"},
+        {"id": "a_venues", "type": "contains", "needle": "Venues"},
+        {"id": "a_entries", "type": "has_entries", "count": 3},
     ],
     "sections": [
         {
@@ -367,8 +368,8 @@ FULL_EVAL_DATA = {
     "description": "A fully populated eval spec",
     "test_args": "--location NYC --depth full",
     "assertions": [
-        {"id": "a_contains", "type": "contains", "value": "Results"},
-        {"id": "a_minlen", "type": "min_length", "value": "200"},
+        {"id": "a_contains", "type": "contains", "needle": "Results"},
+        {"id": "a_minlen", "type": "min_length", "length": 200},
     ],
     "sections": [
         {
@@ -501,8 +502,8 @@ class TestFromFile:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "ok", "type": "contains", "value": "a"},
-                {"type": "contains", "value": "b"},  # missing id
+                {"id": "ok", "type": "contains", "needle": "a"},
+                {"type": "contains", "needle": "b"},  # missing id
             ],
         }
         path = _write_json(tmp_path, data)
@@ -514,8 +515,8 @@ class TestFromFile:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "dup", "type": "contains", "value": "a"},
-                {"id": "dup", "type": "contains", "value": "b"},
+                {"id": "dup", "type": "contains", "needle": "a"},
+                {"id": "dup", "type": "contains", "needle": "b"},
             ],
         }
         path = _write_json(tmp_path, data)
@@ -615,7 +616,7 @@ class TestFromFile:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "", "type": "contains", "value": "x"},
+                {"id": "", "type": "contains", "needle": "x"},
             ],
         }
         path = _write_json(tmp_path, data)
@@ -661,8 +662,8 @@ class TestFromFile:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "a1", "type": "contains", "value": "x"},
-                {"id": "a2", "type": "min_length", "value": "10"},
+                {"id": "a1", "type": "contains", "needle": "x"},
+                {"id": "a2", "type": "min_length", "length": 10},
             ],
             "sections": [
                 {
@@ -696,7 +697,7 @@ class TestFromFile:
         uniqueness scope is the whole skill, not per-layer."""
         data = {
             "skill_name": "s",
-            "assertions": [{"id": "shared", "type": "contains", "value": "x"}],
+            "assertions": [{"id": "shared", "type": "contains", "needle": "x"}],
             "sections": [
                 {
                     "name": "S",
@@ -888,7 +889,7 @@ class TestEvalSpecOutputFields:
         old_data = {
             "skill_name": "legacy",
             "description": "An old spec",
-            "assertions": [{"id": "a_hello", "type": "contains", "value": "hello"}],
+            "assertions": [{"id": "a_hello", "type": "contains", "needle": "hello"}],
         }
         path = _write_json(tmp_path, old_data)
         spec = EvalSpec.from_file(path)
@@ -1549,8 +1550,8 @@ class TestEvalSpecFromDict:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "dup", "type": "contains", "value": "a"},
-                {"id": "dup", "type": "contains", "value": "b"},
+                {"id": "dup", "type": "contains", "needle": "a"},
+                {"id": "dup", "type": "contains", "needle": "b"},
             ],
         }
         with pytest.raises(
@@ -1563,7 +1564,7 @@ class TestEvalSpecFromDict:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "shared", "type": "contains", "value": "x"},
+                {"id": "shared", "type": "contains", "needle": "x"},
             ],
             "grading_criteria": [
                 {"id": "shared", "criterion": "Is it good?"},
@@ -1576,8 +1577,8 @@ class TestEvalSpecFromDict:
         data = {
             "skill_name": "s",
             "assertions": [
-                {"id": "ok", "type": "contains", "value": "a"},
-                {"type": "contains", "value": "b"},
+                {"id": "ok", "type": "contains", "needle": "a"},
+                {"type": "contains", "needle": "b"},
             ],
         }
         with pytest.raises(
@@ -1746,7 +1747,7 @@ class TestEvalSpecFromDict:
             "description": "d",
             "user_prompt": "Do the thing",
             "test_args": "--flag",
-            "assertions": [{"id": "a1", "type": "contains", "value": "ok"}],
+            "assertions": [{"id": "a1", "type": "contains", "needle": "ok"}],
             "sections": [
                 {
                     "name": "Items",
@@ -1795,7 +1796,7 @@ class TestEvalSpecFromDict:
             "skill_name": "s",
             "assertions": [
                 # Missing 'id' field triggers _require_id failure.
-                {"type": "contains", "value": "ok"}
+                {"type": "contains", "needle": "ok"}
             ],
         }
         spec_path = tmp_path / "bad.eval.json"
@@ -1811,26 +1812,34 @@ class TestEvalSpecFromDict:
 
 class TestAssertionKeySpec:
     """Tests for ``AssertionKeySpec`` + ``ASSERTION_TYPE_REQUIRED_KEYS``
-    (DEC-008 of #61). The constant is the single source of truth that
-    the loader validator (US-002) and the ``propose-eval`` prompt
-    builder (US-003) both consume.
+    (DEC-008 of #61, DEC-001/DEC-012 of #67). The constant is the
+    single source of truth that the loader validator and the
+    ``propose-eval`` prompt builder both consume.
     """
 
-    # Maps type → (required, optional) sets. Mirrors the split in the
-    # production ``ASSERTION_TYPE_REQUIRED_KEYS`` constant; any drift
-    # between this table and that constant is surfaced by the tests
-    # below.
-    EXPECTED_KEYS: dict[str, tuple[set[str], set[str]]] = {
-        "contains": ({"value"}, set()),
-        "not_contains": ({"value"}, set()),
-        "regex": ({"value"}, set()),
-        "min_count": ({"value"}, {"minimum"}),
-        "min_length": ({"value"}, set()),
-        "max_length": ({"value"}, set()),
-        "has_urls": (set(), {"value"}),
-        "has_entries": (set(), {"value"}),
-        "urls_reachable": (set(), {"value"}),
-        "has_format": ({"format"}, {"value"}),
+    # Maps type → (required, optional, field_types) tuples. Mirrors
+    # the production ``ASSERTION_TYPE_REQUIRED_KEYS`` constant;
+    # drift between this table and that constant is surfaced by the
+    # tests below.
+    EXPECTED_KEYS: dict[
+        str, tuple[set[str], set[str], dict[str, type]]
+    ] = {
+        "contains": ({"needle"}, set(), {"needle": str}),
+        "not_contains": ({"needle"}, set(), {"needle": str}),
+        "regex": ({"pattern"}, set(), {"pattern": str}),
+        "min_count": (
+            {"pattern", "count"}, set(),
+            {"pattern": str, "count": int},
+        ),
+        "min_length": ({"length"}, set(), {"length": int}),
+        "max_length": ({"length"}, set(), {"length": int}),
+        "has_urls": (set(), {"count"}, {"count": int}),
+        "has_entries": (set(), {"count"}, {"count": int}),
+        "urls_reachable": (set(), {"count"}, {"count": int}),
+        "has_format": (
+            {"format"}, {"count"},
+            {"format": str, "count": int},
+        ),
     }
 
     def test_constant_contains_all_ten_assertion_types(self):
@@ -1841,30 +1850,67 @@ class TestAssertionKeySpec:
         assert len(ASSERTION_TYPE_REQUIRED_KEYS) == 10
 
     @pytest.mark.parametrize(
-        "atype,expected_required,expected_optional",
+        "atype,expected_required,expected_optional,expected_field_types",
         sorted(
-            (atype, req, opt)
-            for atype, (req, opt) in EXPECTED_KEYS.items()
+            (atype, req, opt, ft)
+            for atype, (req, opt, ft) in EXPECTED_KEYS.items()
         ),
     )
     def test_contains_expected_keys(
-        self, atype, expected_required, expected_optional
+        self,
+        atype,
+        expected_required,
+        expected_optional,
+        expected_field_types,
     ):
-        """Each type's ``required`` and ``optional`` sets match the
-        canonical spec. The split mirrors handler runtime behavior:
+        """Each type's ``required``, ``optional``, and
+        ``field_types`` declarations match the canonical spec. The
+        required/optional split mirrors handler runtime behavior:
         keys whose ``.get(key, <default>)`` returns a safe default
         (e.g. ``1`` for a minimum count) are optional; keys whose
         default is a vacuous sentinel (``""``, ``0``) are required.
+        ``field_types`` declares the expected native JSON type for
+        each payload key so the loader rejects string-typed ints at
+        load time (DEC-012 of #67).
         """
         spec = ASSERTION_TYPE_REQUIRED_KEYS[atype]
         assert isinstance(spec, AssertionKeySpec)
         assert spec.required == frozenset(expected_required)
         assert spec.optional == frozenset(expected_optional)
+        assert spec.field_types == expected_field_types
         # Both sets are frozensets — load-bearing hashable contract
         # for downstream callers that use them as dict keys or
         # set members.
         assert isinstance(spec.required, frozenset)
         assert isinstance(spec.optional, frozenset)
+        assert isinstance(spec.field_types, dict)
+
+    def test_field_types_match(self):
+        """Every ``required`` ∪ ``optional`` key must have an entry
+        in ``field_types``, and every ``field_types`` key must be in
+        ``required`` ∪ ``optional``. Guards against a future type
+        rename that forgets to extend ``field_types`` — or vice
+        versa, a stale ``field_types`` entry for a removed key.
+        """
+        for atype, spec in ASSERTION_TYPE_REQUIRED_KEYS.items():
+            payload_keys = set(spec.required) | set(spec.optional)
+            field_keys = set(spec.field_types.keys())
+            assert payload_keys == field_keys, (
+                f"type={atype!r}: payload keys "
+                f"(required∪optional)={payload_keys!r} vs "
+                f"field_types keys={field_keys!r} — sets must match"
+            )
+            # Every declared type must be one of the primitive
+            # types the loader's isinstance check supports. The
+            # only legal values today are ``str`` and ``int``; any
+            # future addition (``bool``, ``float``) is an explicit
+            # loader-side change.
+            for key, expected_type in spec.field_types.items():
+                assert expected_type in (str, int), (
+                    f"type={atype!r} key={key!r}: unexpected "
+                    f"field_type {expected_type!r} — loader only "
+                    f"supports str/int"
+                )
 
     def test_required_and_optional_are_disjoint(self):
         """A key is either required or optional for a given type, not
@@ -1921,15 +1967,16 @@ def _minimal_assertion_entry(atype: str, aid: str = "a1") -> dict:
     """Build a minimal valid assertion dict for ``atype``.
 
     Drives off :data:`ASSERTION_TYPE_REQUIRED_KEYS` so the shape
-    stays in lockstep with the production constant. Every required
-    key gets a non-None string sentinel — ``_require_assertion_keys``
-    only checks presence/non-None-ness, so the string sentinel is
-    valid regardless of whether the downstream handler expects a
-    string or numeric value.
+    stays in lockstep with the production constant. Per DEC-012 of
+    #67 the loader also type-checks each required key against
+    ``spec.field_types``, so this helper emits a value of the
+    declared native type (``"1"`` for ``str``, ``1`` for ``int``).
     """
+    spec = ASSERTION_TYPE_REQUIRED_KEYS[atype]
     entry: dict = {"id": aid, "type": atype}
-    for key in ASSERTION_TYPE_REQUIRED_KEYS[atype].required:
-        entry[key] = "1"
+    for key in spec.required:
+        expected = spec.field_types.get(key, str)
+        entry[key] = 1 if expected is int else "1"
     return entry
 
 
@@ -2012,19 +2059,31 @@ class TestRequireAssertionKeys:
             EvalSpec.from_dict(data, spec_dir=tmp_path)
 
     @pytest.mark.parametrize(
-        "bad_key,hint_fragment",
-        [
-            ("pattern", "did you mean 'value'?"),
-            ("min", "did you mean 'value'?"),
-            ("max", "did you mean 'value'?"),
-            ("threshold", "did you mean 'minimum'?"),
-            ("foo_bar", None),  # generic case — no hint suffix.
+        "atype,bad_key,hint_fragment",
+        sorted(
+            (atype, bad_key, f"did you mean {correct!r}?")
+            for atype, hints in _ASSERTION_DRIFT_HINTS.items()
+            for bad_key, correct in hints.items()
+        )
+        + [
+            # Generic case — no hint suffix when the key is not in
+            # any type's drift-hint table.
+            ("contains", "foo_bar", None),
         ],
     )
-    def test_unknown_key_rejected(self, tmp_path, bad_key, hint_fragment):
-        """Unknown keys raise ``ValueError`` with the right hint (or
-        no hint for keys outside the known drift alias set)."""
-        entry = _minimal_assertion_entry("contains")
+    def test_unknown_key_rejected(
+        self, tmp_path, atype, bad_key, hint_fragment
+    ):
+        """Unknown keys raise ``ValueError`` with the right per-type
+        hint (or no hint for keys outside the drift alias table).
+
+        Drives the parametrize table off
+        :data:`_ASSERTION_DRIFT_HINTS` so every (type, wrong-key)
+        pair in the production table is exercised exactly once.
+        """
+        entry = _minimal_assertion_entry(atype)
+        # Pick a value whose native type is a string; we just need
+        # something non-None so the unknown-key branch sees the key.
         entry[bad_key] = "whatever"
         data = {
             "skill_name": "s",
@@ -2035,7 +2094,7 @@ class TestRequireAssertionKeys:
         msg = str(ei.value)
         assert f"unknown key {bad_key!r}" in msg
         assert "assertions[0]" in msg
-        assert "(type='contains')" in msg
+        assert f"(type={atype!r})" in msg
         if hint_fragment is None:
             # Generic unknown key — must NOT carry a "did you mean"
             # hint so we don't teach the user a wrong alias.
@@ -2102,19 +2161,23 @@ class TestRequireAssertionKeys:
     def test_optional_key_is_allowed_when_present(
         self, tmp_path, atype, opt_key
     ):
-        """Specifying an optional key (e.g. ``minimum`` on ``min_count``
-        or ``value`` on ``has_urls``) is accepted; the validator does
-        not reject it as unknown.
+        """Specifying an optional key (e.g. ``count`` on ``has_urls``
+        or ``has_format``) is accepted; the validator does not reject
+        it as unknown. The value respects ``spec.field_types[opt_key]``
+        so ``count`` lands as a native int per DEC-012 of #67.
         """
+        spec_entry = ASSERTION_TYPE_REQUIRED_KEYS[atype]
         entry = _minimal_assertion_entry(atype)
-        entry[opt_key] = "1"
+        expected = spec_entry.field_types.get(opt_key, str)
+        value: object = 1 if expected is int else "1"
+        entry[opt_key] = value
         data = {
             "skill_name": "s",
             "test_args": "y",
             "assertions": [entry],
         }
         spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
-        assert spec.assertions[0][opt_key] == "1"
+        assert spec.assertions[0][opt_key] == value
 
     @pytest.mark.parametrize(
         "atype",
@@ -2138,35 +2201,91 @@ class TestRequireAssertionKeys:
         spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
         assert spec.assertions == [entry]
 
-    def test_min_count_without_minimum_is_allowed(self, tmp_path):
-        """``min_count`` requires ``value`` (pattern) but ``minimum``
-        is optional — the handler defaults the count to 1 when
-        omitted. This mirrors the pre-#61 runtime behavior that
-        hand-authored specs relied on.
-        """
-        entry = {"id": "a1", "type": "min_count", "value": r"\d+"}
-        data = {
-            "skill_name": "s",
-            "test_args": "y",
-            "assertions": [entry],
-        }
-        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
-        assert spec.assertions == [entry]
-
     def test_optional_key_allows_none(self, tmp_path):
         """An optional key with a ``None`` value is accepted — we
         allow it but don't special-case None the way we do for
         required keys. This documents the boundary: None is only
         rejected when the key is REQUIRED.
         """
-        entry = {"id": "a1", "type": "has_urls", "value": None}
+        entry = {"id": "a1", "type": "has_urls", "count": None}
         data = {
             "skill_name": "s",
             "test_args": "y",
             "assertions": [entry],
         }
-        # Optional + None currently passes validation (the
-        # downstream handler does its own None-tolerant coercion
-        # via `.get("value", "") if a.get("value", "") else 1`).
+        # Optional + None passes validation; the downstream handler
+        # reads ``a.get("count", 1)`` and a None-valued key short-
+        # circuits to the default at runtime.
         spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
         assert spec.assertions == [entry]
+
+    @pytest.mark.parametrize(
+        "atype,key,bad_value,expected_fragment",
+        [
+            (
+                "min_length",
+                "length",
+                "500",
+                "key 'length' must be int, got str '500'",
+            ),
+            (
+                "contains",
+                "needle",
+                123,
+                "key 'needle' must be str, got int 123",
+            ),
+            (
+                "min_count",
+                "count",
+                "3",
+                "key 'count' must be int, got str '3'",
+            ),
+            (
+                "has_format",
+                "format",
+                42,
+                "key 'format' must be str, got int 42",
+            ),
+        ],
+    )
+    def test_wrong_type_rejected(
+        self, tmp_path, atype, key, bad_value, expected_fragment
+    ):
+        """DEC-012 of #67 — every payload key's value must match
+        the native type declared in ``spec.field_types``. String-
+        typed ints (``{"length": "500"}``) and int-typed strings
+        (``{"needle": 123}``) reject at load time with a message
+        naming the key, expected type, actual type, and the
+        offending value.
+        """
+        entry = _minimal_assertion_entry(atype)
+        entry[key] = bad_value
+        data = {
+            "skill_name": "s",
+            "test_args": "y",
+            "assertions": [entry],
+        }
+        with pytest.raises(ValueError) as ei:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(ei.value)
+        assert expected_fragment in msg
+        assert "assertions[0]" in msg
+        assert f"(type={atype!r})" in msg
+
+    def test_wrong_type_rejects_bool_where_int_expected(self, tmp_path):
+        """``bool`` is a subclass of ``int`` in Python, so a naive
+        ``isinstance`` check would silently accept
+        ``{"count": True}``. DEC-012 of #67 guards against this by
+        excluding ``bool`` from the int branch; the loader must
+        raise.
+        """
+        entry = {"id": "a1", "type": "has_urls", "count": True}
+        data = {
+            "skill_name": "s",
+            "assertions": [entry],
+        }
+        with pytest.raises(ValueError) as ei:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(ei.value)
+        assert "key 'count' must be int" in msg
+        assert "bool" in msg

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1924,6 +1924,21 @@ class TestAssertionKeySpec:
                 "optional — each key must be in exactly one set"
             )
 
+    def test_drift_hints_cover_every_type(self):
+        """Every type in ``ASSERTION_TYPE_REQUIRED_KEYS`` must have a
+        matching entry in ``_ASSERTION_DRIFT_HINTS`` (may be empty).
+        Guards against a future type addition that forgets the
+        hints table — the validator would still work (emit no
+        hint) but DEC-009's per-type coverage invariant would
+        silently drift.
+        """
+        assert set(ASSERTION_TYPE_REQUIRED_KEYS) == set(
+            _ASSERTION_DRIFT_HINTS
+        ), (
+            "ASSERTION_TYPE_REQUIRED_KEYS and _ASSERTION_DRIFT_HINTS "
+            "must cover the same set of types"
+        )
+
     def test_handler_signature_agrees_with_constant(self):
         """Drift guard: every required AND optional key appears in
         the handler's lambda source as a quoted key name.
@@ -2201,11 +2216,13 @@ class TestRequireAssertionKeys:
         spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
         assert spec.assertions == [entry]
 
-    def test_optional_key_allows_none(self, tmp_path):
-        """An optional key with a ``None`` value is accepted — we
-        allow it but don't special-case None the way we do for
-        required keys. This documents the boundary: None is only
-        rejected when the key is REQUIRED.
+    def test_optional_key_with_none_rejected(self, tmp_path):
+        """An optional key with a ``None`` value is REJECTED — if
+        accepted at load time, the downstream handler
+        (``a.get("count", 1)``) would read ``None`` (not the
+        default) and crash with ``TypeError`` on the comparison.
+        The loader treats a present-but-None optional the same
+        as a wrong-type value and raises at load time.
         """
         entry = {"id": "a1", "type": "has_urls", "count": None}
         data = {
@@ -2213,11 +2230,10 @@ class TestRequireAssertionKeys:
             "test_args": "y",
             "assertions": [entry],
         }
-        # Optional + None passes validation; the downstream handler
-        # reads ``a.get("count", 1)`` and a None-valued key short-
-        # circuits to the default at runtime.
-        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
-        assert spec.assertions == [entry]
+        with pytest.raises(
+            ValueError, match=r"must be int, not null \(omit the key"
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
 
     @pytest.mark.parametrize(
         "atype,key,bad_value,expected_fragment",

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -492,9 +492,11 @@ class TestExampleEvalSpec:
         # Must not raise.
         spec = EvalSpec.from_file(EXAMPLE_EVAL_JSON)
         assert spec.skill_name == "find-kid-activities"
-        # Sanity check on the migrated shape: the 8 assertions survived
-        # the migration (no entries silently dropped).
-        assert len(spec.assertions) == 8
+        # The load-bearing invariant is "loads without error" — avoid
+        # hard-coding the exact count, which would flip red on any
+        # legitimate addition/removal to the example spec for the
+        # wrong reason.
+        assert len(spec.assertions) >= 1
 
     def test_example_eval_spec_has_no_legacy_value_keys(self):
         # Substring guard: the migrated file must not contain any

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -461,3 +461,48 @@ class TestFailedRunResult:
         assert "my-skill" in r.message
         assert "timeout" in r.message
         assert r.name == "skill_execution"
+
+
+# Path to the checked-in example eval spec used by
+# ``TestExampleEvalSpec`` below. Defined once at module scope so both
+# the class and any future regression tests can reference it.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_EVAL_JSON = (
+    _REPO_ROOT / "examples" / ".claude" / "commands" / "example-skill.eval.json"
+)
+
+
+class TestExampleEvalSpec:
+    """Regression: the checked-in example spec loads via ``EvalSpec.from_file``.
+
+    Traces to DEC-001 / DEC-002 of
+    ``plans/super/67-per-type-assertion-keys.md``: every assertion
+    entry uses the per-type semantic key (``needle`` / ``pattern`` /
+    ``length`` / ``count``) and counts/lengths are native JSON ints.
+    A future migration that misses this file will surface here as a
+    load-time ``ValueError`` from ``_require_assertion_keys``.
+    """
+
+    def test_example_eval_spec_loads(self):
+        # Import via the normal schemas path; ``EvalSpec.from_file``
+        # delegates to ``from_dict`` which runs the per-type
+        # required-key + type-check validator from US-001.
+        from clauditor.schemas import EvalSpec
+
+        # Must not raise.
+        spec = EvalSpec.from_file(EXAMPLE_EVAL_JSON)
+        assert spec.skill_name == "find-kid-activities"
+        # Sanity check on the migrated shape: the 8 assertions survived
+        # the migration (no entries silently dropped).
+        assert len(spec.assertions) == 8
+
+    def test_example_eval_spec_has_no_legacy_value_keys(self):
+        # Substring guard: the migrated file must not contain any
+        # ``"value":`` keys in assertion dicts. Checking the raw JSON
+        # text is cheap and catches regressions that re-introduce the
+        # legacy shape via copy-paste.
+        raw = EXAMPLE_EVAL_JSON.read_text(encoding="utf-8")
+        assert '"value":' not in raw, (
+            "example eval spec must not contain legacy 'value' keys; "
+            "use per-type semantic keys (needle/pattern/length/count)"
+        )

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -21,7 +21,7 @@ MINIMAL_EVAL = {
     "skill_name": "test-skill",
     "description": "test eval",
     "test_args": "--depth quick",
-    "assertions": [{"id": "a_hello", "type": "contains", "value": "hello"}],
+    "assertions": [{"id": "a_hello", "type": "contains", "needle": "hello"}],
 }
 
 
@@ -192,7 +192,7 @@ class TestEvaluate:
     def test_happy_path_with_explicit_output(self, tmp_skill_file, mock_runner):
         eval_data = {
             "skill_name": "eval-skill",
-            "assertions": [{"id": "a_hello", "type": "contains", "value": "hello"}],
+            "assertions": [{"id": "a_hello", "type": "contains", "needle": "hello"}],
         }
         skill_path, _ = tmp_skill_file("eval-skill", eval_data=eval_data)
         runner = mock_runner()
@@ -205,7 +205,7 @@ class TestEvaluate:
     def test_evaluate_runs_skill_when_no_output(self, tmp_skill_file, mock_runner):
         eval_data = {
             "skill_name": "auto-skill",
-            "assertions": [{"id": "a_mock", "type": "contains", "value": "mock"}],
+            "assertions": [{"id": "a_mock", "type": "contains", "needle": "mock"}],
         }
         skill_path, _ = tmp_skill_file("auto-skill", eval_data=eval_data)
         runner = mock_runner(output="mock output")
@@ -217,7 +217,7 @@ class TestEvaluate:
     def test_evaluate_returns_error_on_failed_run(self, tmp_skill_file, mock_runner):
         eval_data = {
             "skill_name": "fail-skill",
-            "assertions": [{"id": "a_any", "type": "contains", "value": "anything"}],
+            "assertions": [{"id": "a_any", "type": "contains", "needle": "anything"}],
         }
         skill_path, _ = tmp_skill_file("fail-skill", eval_data=eval_data)
         runner = mock_runner(output="", exit_code=1, error="boom")


### PR DESCRIPTION
## Summary

Super plan for #67 — redesign `EvalSpec` assertion schema, replacing the overloaded `value` slot with per-type semantic keys (`needle`, `pattern`, `length`, `count`, `format`).

**Phase:** detailing (awaiting approval)
**Decisions:** 12 (DEC-001..DEC-012)
**Stories:** 4 implementation + Quality Gate + Patterns & Memory
**Net shape:** one constant rewrite (`ASSERTION_TYPE_REQUIRED_KEYS`), one handler-dict update (`_ASSERTION_HANDLERS`), new per-type `_ASSERTION_DRIFT_HINTS` table, hand-migration of 2 in-repo `.eval.json` files + ~100 test fixtures + docs — all atomic.

## Scope trim (no external users)

- No `schema_version` introduction on EvalSpec — the per-type validator's "unknown key `value`" error is sufficient (DEC-003).
- No migration CLI subcommand — hand-edit the two in-repo specs (DEC-004).

## Key design point

Per-type drift-hints (DEC-009): after the rename, `pattern` is a valid key for `regex` and `min_count`-type, so the current global `pattern → value` hint becomes incorrect. New `_ASSERTION_DRIFT_HINTS: dict[str, dict[str, str]]` table maps (type, wrong-key) → right-key-for-that-type. Single meaningful design task in the ticket.

## Native int typing (DEC-002 / DEC-012)

Counts and lengths today are stringly-typed on disk (`"value": "500"`). DEC-002 switches to native JSON ints; DEC-012 extends `AssertionKeySpec` with `field_types: dict[str, type]` so the loader hard-rejects wrong types at load time.

## Plan document

See [`plans/super/67-per-type-assertion-keys.md`](../blob/feature/67-per-type-assertion-keys/plans/super/67-per-type-assertion-keys.md) for the full plan: Discovery, Architecture Review, all 12 decisions with rationale, and the 6-story breakdown with TDD notes + rule traces.

## Next steps

- Review the plan in this PR.
- Approve in Claude Code to proceed to devolve (beads creation).