### PR TITLE
#64: Runner auth-source control + configurable timeout

### DIFF
--- a/.claude/rules/spec-cli-precedence.md
+++ b/.claude/rules/spec-cli-precedence.md
@@ -279,7 +279,7 @@ the CLI layer is an extend, not a redesign.
 
 - **CLI**: `--no-api-key` flag on `validate`, `grade`, `capture`,
   `run`. When set, constructs the env dict via
-  `_env_without_api_key()` in `runner.py`; passes as
+  `env_without_api_key()` in `runner.py`; passes as
   `spec.run(env_override=env)`.
 - **Spec field**: NONE. Auth source is environmental, not
   skill-intrinsic (DEC-004 of

--- a/.claude/rules/spec-cli-precedence.md
+++ b/.claude/rules/spec-cli-precedence.md
@@ -1,0 +1,348 @@
+# Rule: CLI > spec > default precedence for per-invocation runner config
+
+When a runner-adjacent knob (timeout, interactive-hang heuristic, a
+future retry cap, rate-limit budget, …) needs to be settable at
+*three* different layers — a CLI flag for the operator running one
+command, a spec field for the skill author expressing a per-skill
+preference, and a hardcoded default for everyone else — resolve the
+effective value **inside `SkillSpec.run`** and thread it to
+`SkillRunner.run` as a keyword-only kwarg. The CLI wins when
+explicitly passed; otherwise the `EvalSpec` field wins when set;
+otherwise `None` falls through to the runner's own `__init__`
+default.
+
+The shape is small, but the precedence direction is the load-bearing
+piece: **operator override > author preference > library default**.
+Flipping that order — e.g., letting the spec field win over the CLI
+— silently defeats the operator's explicit flag on the spot where it
+is most needed (e.g. a CI pipeline forcing `--timeout 30` to fail
+fast is silently overruled by `eval.json` declaring `"timeout":
+600`). Getting the direction right once is cheap; getting it wrong
+and auditing every call site is expensive.
+
+## The pattern
+
+### Layer 1 — spec field (EvalSpec)
+
+Carries the author's per-skill preference. Optional, `None` default,
+load-time validated:
+
+```python
+# schemas.py
+@dataclass
+class EvalSpec:
+    # ... other fields ...
+    timeout: int | None = None  # None means "unset"
+
+# from_dict validation block:
+if "timeout" in data and data["timeout"] is not None:
+    raw = data["timeout"]
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        raise ValueError(
+            f"EvalSpec(skill_name={skill_name!r}): "
+            f"'timeout' must be an int, got {type(raw).__name__} {raw!r}"
+        )
+    if raw <= 0:
+        raise ValueError(
+            f"EvalSpec(skill_name={skill_name!r}): "
+            f"'timeout' must be > 0, got {raw}"
+        )
+    timeout = raw
+```
+
+### Layer 2 — `SkillSpec.run` resolution + thread
+
+Keyword-only `<field>_override` kwarg; `None` default. Resolve
+inside `run` just before calling `self.runner.run`:
+
+```python
+# spec.py
+def run(
+    self,
+    args: str | None = None,
+    *,
+    run_dir: Path | None = None,
+    timeout_override: int | None = None,
+    env_override: dict[str, str] | None = None,
+) -> SkillResult:
+    # ... args / run_dir resolution above ...
+
+    # DEC-002: timeout precedence is CLI > spec > default. ``None``
+    # falls through to ``SkillRunner.run``, which then uses its own
+    # ``self.timeout`` default.
+    effective_timeout = (
+        timeout_override
+        if timeout_override is not None
+        else (
+            self.eval_spec.timeout
+            if self.eval_spec is not None
+            else None
+        )
+    )
+    result = self.runner.run(
+        self.skill_name,
+        run_args,
+        cwd=effective_cwd,
+        allow_hang_heuristic=allow_hang_heuristic,
+        timeout=effective_timeout,
+        env=env_override,
+    )
+```
+
+### Layer 3 — `SkillRunner.run` fallback
+
+Keyword-only, `None` default that falls back to the constructor's
+`self.<field>`. Matches `.claude/rules/subprocess-cwd.md` (the
+sibling pattern for the per-invocation `cwd` kwarg):
+
+```python
+# runner.py
+class SkillRunner:
+    def __init__(self, ..., timeout: int = 180, ...):
+        self.timeout = timeout
+
+    def run(
+        self,
+        skill_name: str,
+        args: str = "",
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
+        ...,
+    ) -> SkillResult:
+        effective_timeout = timeout if timeout is not None else self.timeout
+        # ... pass effective_timeout into the watchdog / Popen ...
+```
+
+### Layer 4 — CLI flag
+
+`argparse` type callable for input validation; default `None` (so
+the sentinel path through `SkillSpec.run` kicks in); pass explicitly
+to `spec.run(..._override=args.<field>)`:
+
+```python
+# cli/validate.py (same shape on grade/capture/run)
+p_validate.add_argument(
+    "--timeout",
+    type=_positive_int,    # exit 2 on <= 0 / non-int
+    default=None,          # None = "not set"
+    metavar="SECONDS",
+    help="Override the runner timeout; defaults to EvalSpec.timeout or 180s.",
+)
+
+# cmd_validate:
+skill_result = spec.run(
+    run_dir=workspace.tmp_path / "run-0",
+    timeout_override=getattr(args, "timeout", None),
+    env_override=env_override,
+)
+```
+
+## Why this shape
+
+- **Operator intent wins over author intent wins over library
+  default.** The CI operator who typed `--timeout 30` knows
+  something the spec author did not — that this run, in this
+  pipeline, at this moment, should fail fast. A reverse
+  precedence (spec > CLI) silently ignores their flag; an
+  all-equal precedence (whoever was evaluated last) is
+  order-dependent and fragile. This direction is the one
+  direction that maps to user expectations at every layer.
+- **Resolution at `SkillSpec.run`, not at the CLI layer.** The
+  CLI can't see `eval_spec.timeout` without loading the spec,
+  and the runner can't see the CLI flag without plumbing it.
+  `SkillSpec` is the one layer that already holds both the
+  `eval_spec` (for the author's preference) and is called from
+  the CLI (which passes the operator's override) — it is the
+  natural aggregation seam. Centralizing the resolution there
+  means every future caller (pytest plugin fixture, baseline
+  phase, variance reps) inherits the same precedence with no
+  per-caller drift.
+- **`None` as "unset" sentinel, no magic numbers.** Every layer
+  defaults to `None` to mean "I have no preference, fall
+  through." This is how a CLI flag without `--timeout` (default
+  `None`), a spec without `"timeout"` (field default `None`),
+  and a direct constructor call (runner's own `self.timeout`
+  fallback) all compose cleanly. A default-to-180 at the CLI
+  layer would silently shadow the spec field; a default-to-180
+  on the spec field would silently shadow the library's choice
+  of default.
+- **Keyword-only overrides at every boundary.** `SkillSpec.run(*,
+  timeout_override=...)` and `SkillRunner.run(*, timeout=...)`
+  both use `*,` to force call sites to be explicit. This is
+  directly inherited from `.claude/rules/subprocess-cwd.md` —
+  per-invocation config must be keyword-only so a future
+  positional-arg addition doesn't silently shadow it.
+- **Load-time validation on the spec field is mandatory.** The
+  `EvalSpec` dataclass validator rejects non-int, bool (which is
+  an `int` subclass in Python, per
+  `.claude/rules/constant-with-type-info.md`), zero, and
+  negative values at load time. If the spec field is garbage,
+  the precedence chain never runs — exit 2 at load surfaces the
+  error where the author can fix it, rather than passing it
+  down to a confused watchdog.
+- **CLI-side validation via an argparse `type=` callable.** A
+  shared `_positive_int` helper in `clauditor.cli.__init__`
+  rejects `--timeout 0 | -5 | foo` with an
+  `argparse.ArgumentTypeError`, which argparse surfaces as exit
+  2 per `.claude/rules/llm-cli-exit-code-taxonomy.md`. The
+  `EvalSpec` validator and the argparse helper enforce the
+  *same* invariant (`> 0`, int, not bool) — two validators, one
+  contract.
+- **Pass-through for knobs that are CLI-only** (no spec field).
+  The `env_override` kwarg in #64 demonstrates the shape:
+  `SkillSpec.run` threads `env_override` to
+  `SkillRunner.run(env=env_override)` unchanged, with no
+  resolution or merge. A 1-level pass-through shares the
+  `*_override` keyword-only contract but skips the
+  `if ... is not None else eval_spec.<field>` resolution block.
+  This keeps the surface uniform for future callers even when a
+  particular knob has no spec-field counterpart yet. (Auth
+  source is environmental, not skill-intrinsic — DEC-004 of
+  `plans/super/64-runner-auth-timeout.md`.)
+
+## What NOT to do
+
+- Do NOT flip the precedence to "spec wins over CLI." That
+  silently defeats operator intent.
+- Do NOT default the CLI flag to the library default value
+  (e.g. `--timeout` defaulting to `180`). That makes the flag
+  indistinguishable from "not passed," so the `SkillSpec.run`
+  resolution sees `180` always and the spec field can never
+  win. The CLI default MUST be `None`.
+- Do NOT resolve precedence inside the CLI command function
+  (`cmd_validate`, `cmd_grade`, …). Every CLI entry point
+  would then need to duplicate the resolution, and a future
+  caller (pytest fixture, baseline phase) would silently miss
+  it. The resolution belongs on `SkillSpec.run`.
+- Do NOT forget the `bool` guard on any int-typed spec field.
+  `isinstance(True, int)` is `True` in Python; without
+  `and not isinstance(val, bool)`, a spec with `"timeout":
+  true` loads as `timeout=1`. See
+  `.claude/rules/constant-with-type-info.md` for the
+  canonical shape.
+- Do NOT thread the CLI value directly to `SkillRunner.run`
+  (bypassing `SkillSpec`). The spec-field layer would be
+  skipped, and a CLI-less caller (the pytest plugin factory
+  fixture, a future batch runner) would have no way to pick
+  up the author's preference.
+
+## Canonical implementations
+
+### Three-level precedence (this rule's anchor)
+
+`timeout`, introduced in #64:
+
+- **Spec field**: `src/clauditor/schemas.py::EvalSpec.timeout` (last
+  field) + the `from_dict` validator block. Rejects non-int,
+  `bool`, and `<= 0` at load time per
+  `.claude/rules/constant-with-type-info.md`.
+- **Resolution**: `src/clauditor/spec.py::SkillSpec.run` — the
+  `effective_timeout = timeout_override if ... else (eval_spec.timeout ...)`
+  block (~lines 147-159). Threaded to
+  `SkillRunner.run(timeout=effective_timeout)`.
+- **Runner fallback**: `src/clauditor/runner.py::SkillRunner.run`
+  — the `effective_timeout = timeout if timeout is not None else
+  self.timeout` block (top of `_invoke`). The 180s default lives
+  on `__init__`.
+- **CLI flag**: `src/clauditor/cli/validate.py`, `cli/grade.py`,
+  `cli/capture.py`, `cli/run.py` — each adds `--timeout
+  SECONDS` with `type=_positive_int`, `default=None`. The shared
+  `_positive_int` helper lives at
+  `src/clauditor/cli/__init__.py::_positive_int`. Each CLI command
+  calls `spec.run(..., timeout_override=args.timeout)`.
+- **Pytest plugin**: `src/clauditor/pytest_plugin.py::clauditor_spec`
+  — the factory wraps `SkillSpec.run` so callers can pass
+  `timeout_override=` and `env_override=` to the fixture too.
+
+### Two-level (spec > default; no CLI yet)
+
+`allow_hang_heuristic`, introduced in #63:
+
+- **Spec field**: `src/clauditor/schemas.py::EvalSpec.allow_hang_heuristic`
+  + `from_dict` validator (bool, default `True`).
+- **Resolution**: `src/clauditor/spec.py::SkillSpec.run` —
+  `allow_hang_heuristic = self.eval_spec.allow_hang_heuristic if
+  self.eval_spec else True` (~lines 142-146). Threaded to
+  `SkillRunner.run(allow_hang_heuristic=allow_hang_heuristic)`.
+- **Runner**: `src/clauditor/runner.py::SkillRunner.run(*,
+  allow_hang_heuristic=True, ...)` — keyword-only.
+
+No CLI flag today. If a future ticket adds `--hang-heuristic /
+--no-hang-heuristic`, follow the three-level shape above — adding
+the CLI layer is an extend, not a redesign.
+
+### One-level pass-through (CLI-only; no spec field)
+
+`env_override`, introduced in #64:
+
+- **CLI**: `--no-api-key` flag on `validate`, `grade`, `capture`,
+  `run`. When set, constructs the env dict via
+  `_env_without_api_key()` in `runner.py`; passes as
+  `spec.run(env_override=env)`.
+- **Spec field**: NONE. Auth source is environmental, not
+  skill-intrinsic (DEC-004 of
+  `plans/super/64-runner-auth-timeout.md`).
+- **Resolution**: `src/clauditor/spec.py::SkillSpec.run` —
+  pass-through, no merge, no fallback (~line 166). Threaded as
+  `self.runner.run(env=env_override)`.
+- **Runner**: `src/clauditor/runner.py::SkillRunner.run(*, env=None,
+  ...)` — forwarded verbatim to `subprocess.Popen(env=...)`. The
+  `None` default preserves today's inherit-os-environ behavior.
+
+Traces to DEC-002, DEC-004, DEC-010, DEC-013, DEC-014 of
+`plans/super/64-runner-auth-timeout.md`. Companion rules:
+`.claude/rules/subprocess-cwd.md` (per-invocation `cwd` kwarg
+shape, the original anchor for keyword-only runner config),
+`.claude/rules/constant-with-type-info.md` (load-time int /
+bool-guard validation for the spec field),
+`.claude/rules/llm-cli-exit-code-taxonomy.md` (CLI input-error
+exit-code routing for the argparse-type validator).
+
+## When this rule applies
+
+Any future runner-adjacent knob that an operator may want to
+override on the CLI AND a skill author may want to declare on a
+per-skill basis AND a library default exists. Plausible future
+callers:
+
+- **Per-spec retry cap** (`EvalSpec.max_retries`) — operator
+  forces `--retries 0` for a dry-run CI check; spec author
+  declares `"max_retries": 3` for a flaky skill; library
+  default is `1`.
+- **Per-spec stdout line budget** (`EvalSpec.max_stdout_bytes`)
+  — operator caps to 1 MB on a constrained runner; spec author
+  allows 100 MB for a research skill; library default is 10 MB.
+- **Per-spec concurrency** (`EvalSpec.max_parallel`) for
+  variance or trigger-test runs.
+- Any other "operator has final say, author has strong
+  preference, library ships sane default" knob.
+
+The rule also applies retroactively: an existing knob that is
+currently resolved inside a CLI command function (rather than
+`SkillSpec.run`) is a latent drift site — migrate the
+resolution up to `SkillSpec.run` the next time the knob is
+touched.
+
+## When this rule does NOT apply
+
+- Knobs that are *exclusively* environmental and have no
+  skill-intrinsic meaning (auth source, proxy URL, working
+  directory). Those are CLI-only pass-through — the one-level
+  shape above. Do not invent a spec field just to satisfy the
+  three-level pattern.
+- Knobs that are *exclusively* library-internal (e.g. retry
+  back-off curves, stream buffering sizes). Those have no
+  operator or author use case and should stay on the
+  constructor or as module-level constants.
+- Construction-time config that does not vary per-invocation
+  (e.g. `claude_bin`, `project_dir`). Those live on the
+  runner's `__init__` signature, not on `run()`. See
+  `.claude/rules/subprocess-cwd.md` for the per-invocation vs
+  per-construction distinction.
+- One-shot diagnostic scripts in `scripts/` that hit the
+  runner directly with inline kwargs. They can skip the
+  precedence chain — but production paths (CLI, pytest plugin,
+  any `import clauditor.*` caller) must go through
+  `SkillSpec.run`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Runner auth-source control + configurable timeout (#64).** Four
+  skill-invoking CLI commands (`validate`, `grade`, `capture`, `run`)
+  and the pytest plugin gained two knobs that together unblock Pro/Max
+  subscribers iterating on research-heavy skills:
+  - `--no-api-key` / `--clauditor-no-api-key` (pytest) strip both
+    `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the `claude -p`
+    subprocess environment so the child falls back to whatever auth is
+    cached in `~/.claude/` (typically a Pro/Max subscription with a
+    much higher throughput ceiling than the API-key tier). Non-auth
+    Anthropic env vars such as `ANTHROPIC_BASE_URL` are preserved.
+  - `--timeout SECONDS` overrides the runner's 180-second watchdog on
+    a per-invocation basis. Must be a positive integer; argparse
+    rejects `<= 0` / non-int with exit 2. Precedence is
+    **CLI > spec > default**: the flag wins when passed explicitly,
+    otherwise a new `EvalSpec.timeout` field wins when set, otherwise
+    the built-in 180s default applies. `EvalSpec.timeout` is
+    load-time validated (positive int only; `bool` is explicitly
+    rejected because it is an `int` subclass in Python).
+  - `SkillResult.api_key_source` carries the `apiKeySource` value
+    parsed from the stream-json `system/init` event (when present);
+    the runner prints one stderr info line of the form
+    `clauditor.runner: apiKeySource=<value>` per run. Values are
+    labels (`"ANTHROPIC_API_KEY"`, `"claude.ai"`, `"none"`), not
+    secrets. Older `claude` builds that omit the field leave
+    `api_key_source` at `None` and suppress the stderr line. See
+    [`docs/cli-reference.md#shared-runner-flags-validate-grade-capture-run`](docs/cli-reference.md#shared-runner-flags-validate-grade-capture-run),
+    [`docs/eval-spec-reference.md#optional-top-level-fields`](docs/eval-spec-reference.md#optional-top-level-fields),
+    and [`docs/stream-json-schema.md`](docs/stream-json-schema.md).
+    Precedence shape codified in
+    [`.claude/rules/spec-cli-precedence.md`](.claude/rules/spec-cli-precedence.md).
 - **Runner error surfacing (#63).** `SkillResult` gained an
   `error_category` field —
   `"rate_limit" | "auth" | "api" | "interactive" | "subprocess" |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,6 +103,27 @@ Captured skill output is scrubbed through `clauditor.transcripts.redact` before 
 - `clauditor propose-eval` fills in an `eval.json` for a skill whose **SKILL.md already exists**. It does not write a skill stub and does not regenerate SKILL.md.
 - `clauditor capture <skill> -- "args"` produces the captured run that `propose-eval` reads as grounding context. Capturing before `propose-eval` typically lifts the quality of the generated spec (the proposer sees what real output looks like).
 
+## Shared runner flags (`validate`, `grade`, `capture`, `run`)
+
+Four skill-invoking commands share two flags that control the `claude -p` subprocess the runner spawns. Both default to "not set" so today's behavior is unchanged when neither flag is passed.
+
+| Flag | Purpose |
+| ---- | ------- |
+| `--no-api-key` | Strip both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the subprocess environment before invoking `claude -p`. The child then falls back to whatever auth is cached in `~/.claude/` — typically a Pro/Max subscription, which carries a much higher throughput ceiling than the API-key tier. Useful for research-heavy skills (multi-agent, deep-research) that exhaust the free API tier in a single run. Non-auth Anthropic env vars such as `ANTHROPIC_BASE_URL` are preserved. |
+| `--timeout SECONDS` | Override the runner's 180-second watchdog for a single invocation. Must be a positive integer; `--timeout 0`, `--timeout -5`, and `--timeout foo` exit `2` at argparse time. Precedence: the CLI flag wins when passed explicitly; otherwise the `EvalSpec.timeout` field wins when set; otherwise the built-in 180s default applies. See [`docs/eval-spec-reference.md#optional-top-level-fields`](eval-spec-reference.md#optional-top-level-fields) for the spec-field side of the contract. |
+
+When `claude -p` emits an `apiKeySource` value on its stream-json `init` event, the runner captures it on `SkillResult.api_key_source` and prints one stderr info line of the form `clauditor.runner: apiKeySource=<value>`. Values are labels (`"ANTHROPIC_API_KEY"`, `"claude.ai"`, `"none"`), not secrets. Older `claude` builds that omit the field leave `api_key_source` at `None` and suppress the stderr line — absence is the signal. See [`docs/stream-json-schema.md`](stream-json-schema.md#type-system) for the parser contract.
+
+```bash
+# Force subscription auth, raise the watchdog to five minutes.
+clauditor grade .claude/commands/deep-research.md --no-api-key --timeout 300
+
+# Pro/Max operator running a fast-failing CI check — CLI wins over spec.
+clauditor validate .claude/commands/my-skill.md --no-api-key --timeout 30
+```
+
+Pytest integration: `--clauditor-no-api-key` is the plugin-option counterpart to `--no-api-key` on the CLI. It threads the same env scrub through the `clauditor_spec` fixture's `env_override`. The existing `--clauditor-timeout` pytest option continues to control the per-runner default (constructor `timeout=...`); per-invocation overrides flow through the fixture factory just like the CLI path. See [`docs/pytest-plugin.md`](pytest-plugin.md).
+
 ## Persistent metric history
 
 Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.clauditor/history.jsonl`. Each record carries a `command` discriminator, a nested `metrics` dict, and (for `grade`) the `iteration` slot and on-disk `workspace_path`.

--- a/docs/eval-spec-reference.md
+++ b/docs/eval-spec-reference.md
@@ -239,6 +239,14 @@ A few `EvalSpec` fields tune specific code paths and are safe to omit:
 - **`trigger_tests`** (object, default `null`) — `{"should_trigger":
   [str, ...], "should_not_trigger": [str, ...]}` for `clauditor
   triggers`. Required by that command; other commands ignore it.
+- **`timeout`** (int, default `null`) — per-skill runner timeout in
+  seconds. Overrides the built-in 180-second watchdog for skills that
+  legitimately need longer (e.g. multi-agent research skills).
+  Precedence: `--timeout <seconds>` on the CLI wins when passed
+  explicitly; otherwise `EvalSpec.timeout` wins when set; otherwise
+  the runner falls back to its 180-second default. Load-time
+  validation rejects non-int values (including `true`/`false`) and
+  values `<= 0`.
 
 ## Schema history
 

--- a/docs/stream-json-schema.md
+++ b/docs/stream-json-schema.md
@@ -34,12 +34,35 @@ but otherwise ignored.
 Init / hook / misc events from the CLI.
 
 ```json
-{"type":"system","subtype":"init","session_id":"abc123","cwd":"/tmp/work"}
+{"type":"system","subtype":"init","session_id":"abc123","cwd":"/tmp/work","apiKeySource":"ANTHROPIC_API_KEY"}
 ```
 
-**Read by clauditor:** nothing beyond `type` — the message is appended to
-`raw_messages` and `stream_events`, but no fields are extracted. System
-events are forwarded to transcripts but do not affect `SkillResult.output`
+**Read by clauditor:** the `type: "system"` / `subtype: "init"` message
+is parsed for its `apiKeySource` field (when present).
+
+- `subtype` (string) — tolerated-if-missing. Only `"init"` messages
+  trigger `apiKeySource` extraction; other subtypes (e.g. `"hook"`)
+  are appended to `raw_messages` / `stream_events` but otherwise
+  ignored.
+- `apiKeySource` (string) — tolerated-if-missing / non-string
+  (`SkillResult.api_key_source` stays `None` in that case). When a
+  string is present on the FIRST `system/init` message, clauditor
+  stores the value on `SkillResult.api_key_source` and emits one
+  stderr info line of the form
+  `clauditor.runner: apiKeySource=<value>`. Example values the
+  Claude CLI emits today: `"ANTHROPIC_API_KEY"`, `"claude.ai"`,
+  `"none"`. **The value is a label (identifying which auth path
+  was used), not a secret** — it does not contain the API key
+  itself, so printing it to stderr and persisting it on
+  `SkillResult` is safe. Older CLI builds may omit this field; in
+  that case `api_key_source` stays `None` and no stderr line is
+  emitted (absence is the signal, per DEC-012 of
+  `plans/super/64-runner-auth-timeout.md`). Subsequent `system/init`
+  messages are ignored — first init wins, per DEC-015.
+
+All `system/*` messages (every subtype) are appended to
+`raw_messages` and `stream_events` for downstream tooling
+(transcripts, debug dumps) but do not affect `SkillResult.output`
 or token counts.
 
 ### `type: "assistant"`
@@ -141,6 +164,8 @@ surfaces this through `SkillResult.error` + `SkillResult.error_category
 | `result` message with `is_error` absent | Treat as success (back-compat with older CLI versions) |
 | `result` message with non-bool `is_error` (e.g. `"true"`, `1`) | Treat as absent — strict `is True` check only |
 | `result` message with `is_error: true` and no `result` string | `SkillResult.error = "API error (no detail)"`, `error_category = "api"` |
+| `system/init` message with non-string `apiKeySource` | Field ignored; `SkillResult.api_key_source` stays `None`; no stderr line emitted |
+| Multiple `system/init` messages with `apiKeySource` | First wins; later init messages are ignored (DEC-015) |
 | `result` message with `is_error: true` and `result` > 4 KB | Truncate at 4 KB with `" ... (truncated)"` suffix on `SkillResult.error`; classify from the prefix; full string retained in `stream_events` |
 | No `result` message before EOF | Warn to stderr, return `SkillResult` with zero tokens |
 | Subprocess times out | Kill child, return `SkillResult(exit_code=-1, error="timeout")` with whatever text was captured so far |

--- a/plans/super/64-runner-auth-timeout.md
+++ b/plans/super/64-runner-auth-timeout.md
@@ -637,9 +637,12 @@ the line when the field is absent. Document the new field in
 - Parser in `_invoke` reads `apiKeySource` defensively from
   the first `type=="system"`/`subtype=="init"` message; later
   init messages are ignored.
-- Stderr line format: `clauditor.runner: apiKeySource=<value>
-  model=<value>` printed exactly once per run when
-  `api_key_source is not None`.
+- Stderr line format: `clauditor.runner: apiKeySource=<value>`
+  printed exactly once per run when `api_key_source is not None`.
+  (Implementation simplified from the original draft which also
+  included `model=<value>`: `model` isn't currently parsed from the
+  init message, and CodeRabbit flagged the drift between the draft
+  format and the actual implementation.)
 - No stderr line when `api_key_source is None` (older CLI
   builds missing the field).
 - `tests/conftest.py::make_fake_skill_stream` accepts an
@@ -765,7 +768,14 @@ already has `--timeout`; align its shape and add `--no-api-key`.
   already uses `type=int` with `default=180`, align the
   semantics with the new precedence pattern: the CLI default
   should become `None`, not `180`, so the spec/runner defaults
-  can kick in).
+  can kick in). This is behaviorally identical to the prior
+  default-180 shape because `SkillRunner.__init__(timeout=180)`
+  is unchanged — `runner.run(timeout=None)` falls back to
+  `self.timeout=180` — so no user invocation of `clauditor run`
+  changes wall-clock behavior. (CodeRabbit review flagged this
+  as a potential breaking change; verified false positive —
+  `cli/run.py` has no `EvalSpec` in its flow so the precedence
+  chain has only one producer.)
 - Shared validation gate passes.
 
 **Done when:** Seven new tests pass in `tests/test_cli.py`

--- a/plans/super/64-runner-auth-timeout.md
+++ b/plans/super/64-runner-auth-timeout.md
@@ -4,8 +4,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/64
 - **Branch:** `feature/64-runner-auth-timeout`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/64-runner-auth-timeout`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/70
+- **Epic:** `clauditor-r53`
 - **Sessions:** 1
 - **Last session:** 2026-04-20
 
@@ -916,7 +917,33 @@ document `EvalSpec.timeout`.
 
 ## Beads Manifest
 
-_(pending)_
+- **Epic:** `clauditor-r53` — #64: Runner auth-source control +
+  configurable timeout.
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/64-runner-auth-timeout`
+- **Branch:** `feature/64-runner-auth-timeout`
+- **PR:** https://github.com/wjduenow/clauditor/pull/70 (plan only)
+
+### Tasks
+
+| Bead ID | Story | Depends on |
+|---------|-------|------------|
+| clauditor-r53.1 | US-001 — EvalSpec.timeout field + load validation | — |
+| clauditor-r53.2 | US-002 — `_env_without_api_key()` pure helper | — |
+| clauditor-r53.3 | US-003 — `SkillRunner.run(env=, timeout=)` kwargs | r53.2 |
+| clauditor-r53.4 | US-004 — `apiKeySource` parser + `SkillResult.api_key_source` + stderr + docs | — |
+| clauditor-r53.5 | US-005 — `SkillSpec.run` precedence (CLI > spec > default) | r53.1, r53.3 |
+| clauditor-r53.6 | US-006 — CLI flags on validate/grade/capture/run | r53.2, r53.5 |
+| clauditor-r53.7 | US-007 — `--clauditor-no-api-key` pytest option | r53.2, r53.5 |
+| clauditor-r53.8 | US-008 — Quality Gate (code-reviewer ×4 + CodeRabbit) | r53.1…r53.7 |
+| clauditor-r53.9 | US-009 — Patterns & Memory (rules + docs) | r53.8 |
+
+### Ready work (no blockers)
+
+- `clauditor-r53.1` (US-001)
+- `clauditor-r53.2` (US-002)
+- `clauditor-r53.4` (US-004)
+
+Confirmed via `bd ready` from the worktree.
 
 ---
 
@@ -956,3 +983,8 @@ user-facing surfaces (CLI flags, pytest plugin option).
 (https://github.com/wjduenow/clauditor/pull/70). Awaiting
 GitHub review; next command: "devolve" / "ready for Ralph" to
 create beads.
+
+**2026-04-20 (7)** — Devolved to beads. Epic `clauditor-r53`
+with 9 tasks (r53.1…r53.9) and 15 dependencies wired. `bd
+ready` confirms US-001, US-002, US-004 have no blockers. Ready
+for `/ralph-run`.

--- a/plans/super/64-runner-auth-timeout.md
+++ b/plans/super/64-runner-auth-timeout.md
@@ -4,7 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/64
 - **Branch:** `feature/64-runner-auth-timeout`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/64-runner-auth-timeout`
-- **Phase:** `detailing`
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/70
 - **Sessions:** 1
 - **Last session:** 2026-04-20
 
@@ -950,3 +951,8 @@ Memory (US-009). Ordering: foundational layers first
 (EvalSpec field, pure env helper, runner kwargs, stream-json
 parser) → runtime plumbing (SkillSpec precedence) →
 user-facing surfaces (CLI flags, pytest plugin option).
+
+**2026-04-20 (6)** — Plan approved. Published as draft PR #70
+(https://github.com/wjduenow/clauditor/pull/70). Awaiting
+GitHub review; next command: "devolve" / "ready for Ralph" to
+create beads.

--- a/plans/super/64-runner-auth-timeout.md
+++ b/plans/super/64-runner-auth-timeout.md
@@ -1,0 +1,952 @@
+# Super Plan: #64 — Runner auth-source control + configurable timeout
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/64
+- **Branch:** `feature/64-runner-auth-timeout`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/64-runner-auth-timeout`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-20
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Two runner defects plus one observability miss, all
+rooted in `src/clauditor/runner.py`:
+
+1. **Auth source is uncontrollable.** `SkillRunner._invoke` spawns
+   `subprocess.Popen` with no `env=` argument (runner.py:367–380).
+   The child inherits the full parent environment, which means a
+   dev shell that has `ANTHROPIC_API_KEY` set (most of them, for
+   unrelated tools) forces `claude -p` onto the lowest API tier
+   (30k input tokens/min). There is no flag to opt into
+   subscription (Pro/Max) auth, which has much higher throughput.
+2. **Timeout is hardcoded.** `SkillRunner.__init__` defaults
+   `timeout=180` (runner.py:255). No CLI flag, no per-spec
+   override. Research-heavy skills (multi-agent, deep-research)
+   legitimately need 5–15 minutes and get killed at 180.05s by the
+   watchdog.
+3. **`apiKeySource` observability gap.** The stream-json `init`
+   event already reports which auth source the CLI ran against
+   (`"ANTHROPIC_API_KEY"` / `"claude.ai"` / `"none"`). Clauditor
+   currently ignores it. Surfacing it tells users which tier just
+   validated their assertions.
+
+**Why:** Anyone testing a non-trivial skill on a Pro/Max plan is
+blocked: the env-var path forces API-tier rate limits, and even
+after stripping `ANTHROPIC_API_KEY` manually the 180s wall kills
+the legitimate run. This is a specific class of user (Pro/Max
+subscribers iterating on research skills) who currently cannot use
+clauditor at all without editing the source.
+
+**Done when:**
+- A CLI flag exists on `validate` / `grade` / `capture` / `run`
+  that, when set, strips `ANTHROPIC_API_KEY` from the subprocess
+  environment so `claude -p` uses whatever auth is cached in
+  `~/.claude/` (typically subscription).
+- A CLI flag exists on the same commands to override the runner
+  timeout; a spec-level field overrides the default for a
+  specific skill.
+- The stream-json `init` event's `apiKeySource` is surfaced — at
+  minimum as a stderr info line, ideally as a `SkillResult` field
+  accessible to tests.
+- Coverage stays ≥80%; ruff passes.
+
+### Key findings — codebase scout
+
+#### Bug site 1: `src/clauditor/runner.py::_invoke` (lines 367–380)
+
+```python
+proc = subprocess.Popen(
+    [
+        self.claude_bin,
+        "-p",
+        prompt,
+        "--output-format",
+        "stream-json",
+        "--verbose",
+    ],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    cwd=str(cwd) if cwd is not None else str(self.project_dir),
+)
+```
+
+No `env=` argument — child inherits full parent environment.
+
+#### Bug site 2: `src/clauditor/runner.py::SkillRunner.__init__` (252–260)
+
+```python
+def __init__(
+    self,
+    project_dir: str | Path | None = None,
+    timeout: int = 180,
+    claude_bin: str = "claude",
+):
+    self.project_dir = Path(project_dir) if project_dir else Path.cwd()
+    self.timeout = timeout
+    self.claude_bin = claude_bin
+```
+
+Hardcoded `timeout=180`. Watchdog enforcement lives at
+`runner.py:446–448` (a `threading.Timer(self.timeout, _on_timeout)`
+that calls `proc.kill()` on expiry).
+
+#### Observability miss: stream-json `init` parsing (runner.py:~452–480)
+
+The for-loop reads `mtype = msg.get("type")` and handles only
+`"assistant"` and `"result"`. The `"init"` message type — which
+carries `apiKeySource`, `model`, and other init metadata — is
+appended to `raw_messages` / `stream_events` unchanged but never
+inspected. `SkillResult` has no `api_key_source` field.
+
+#### Call sites of `SkillRunner(...)` (six total)
+
+1. `src/clauditor/cli/capture.py:69` — bare constructor.
+2. `src/clauditor/cli/run.py:28–31` — `project_dir`, `timeout`
+   (already parses `--timeout` CLI arg).
+3. `src/clauditor/pytest_plugin.py:90–93` — fixture, threads
+   `timeout` from the `--clauditor-timeout` pytest option.
+4. `src/clauditor/pytest_plugin.py:130–133` — factory fixture,
+   threads `timeout` from the same option.
+5. `src/clauditor/spec.py:61` — conditional:
+   `runner or SkillRunner(project_dir=...)`.
+6. `tests/test_runner.py` — ~30 direct test instantiations.
+
+#### EvalSpec today (`src/clauditor/schemas.py:236–269`)
+
+```python
+@dataclass
+class EvalSpec:
+    skill_name: str
+    description: str = ""
+    test_args: str = ""
+    user_prompt: str | None = None
+    input_files: list[str] = field(default_factory=list)
+    assertions: list[dict] = field(default_factory=list)
+    sections: list[SectionRequirement] = field(default_factory=list)
+    grading_criteria: list = field(default_factory=list)
+    grading_model: str = "claude-sonnet-4-6"
+    output_file: str | None = None
+    output_files: list[str] = field(default_factory=list)
+    trigger_tests: TriggerTests | None = None
+    variance: VarianceConfig | None = None
+    grade_thresholds: GradeThresholds | None = None
+    allow_hang_heuristic: bool = True
+```
+
+No `timeout` field. `allow_hang_heuristic` (#63's precedent) is
+the last field added — it's threaded from spec → `SkillSpec.run`
+→ `SkillRunner.run(..., allow_hang_heuristic=...)` in
+`src/clauditor/spec.py:140–150`. That is the parallel shape a
+spec-level `timeout` would follow.
+
+### Key findings — convention checker
+
+**Directly load-bearing rules:**
+
+- **`.claude/rules/subprocess-cwd.md`** — the `env=` kwarg on
+  `SkillRunner.run` (and inside `_invoke`'s `Popen` call) must
+  follow the same keyword-only, `None`-default, resolve-at-call-
+  time pattern as `cwd`. This is the canonical shape for threading
+  optional subprocess params without disturbing existing call
+  sites.
+- **`.claude/rules/stream-json-schema.md`** — reading `apiKeySource`
+  from the `init` message must be defensive: `.get()` with falsy-
+  safe defaults, `isinstance` guards, skip-and-warn on malformed
+  lines. Never abort on a missing field. The rule also mandates
+  documenting any newly-read field in `docs/stream-json-schema.md`
+  as a companion update.
+- **`.claude/rules/pre-llm-contract-hard-validate.md`** — CLI flag
+  values (`--timeout`) and spec-level `timeout` must hard-validate
+  at parse/load time with a clear error. Negative or zero timeouts
+  reject before any runner spins up.
+- **`.claude/rules/llm-cli-exit-code-taxonomy.md`** — a malformed
+  `--timeout` routes to exit 2 (input-validation); this is a pre-
+  call input check regardless of whether the command wraps an LLM.
+
+**Tangential rules:**
+
+- **`.claude/rules/json-schema-version.md`** — only fires if we
+  persist `api_key_source` into an already-versioned sidecar.
+  Adding `timeout` to in-memory `EvalSpec` does not require a
+  version bump by itself.
+- **`.claude/rules/eval-spec-stable-ids.md`** — no new per-entry
+  id fields. N/A.
+- **`.claude/rules/pure-compute-vs-io-split.md`** — small helper
+  for "resolve effective env dict from auth-source choice + os
+  environ" could be a pure function worth factoring out.
+
+**Project-wide conventions:**
+
+- CLI flags are kebab-case. Binary flags use `--no-foo` style
+  (`--no-transcript`, `--no-verify`). Int-valued flags use
+  positional int with a metavar (`--iteration N`, `--timeout
+  SECONDS`).
+- Existing pytest plugin already carries `--clauditor-timeout`
+  (no auth-source equivalent yet).
+- No `.claude/workflow-project.md` file — no project-specific
+  scoping questions or review areas.
+
+### Precedent plans
+
+- **#63 runner-error-surfacing (shipped)** — added
+  `error_category` to `SkillResult`, introduced
+  `_classify_result_message` pure helper, threaded
+  `allow_hang_heuristic` from EvalSpec → runner. This is the
+  closest-shape precedent: same file (`runner.py`), same
+  cross-layer threading (spec → runner kwarg), same
+  `docs/stream-json-schema.md` companion update contract.
+- **#22 iteration-workspace** — atomic publication pattern;
+  tangential.
+- **#26 execution-transcripts** — stream-json persistence;
+  tangential.
+
+### Proposed scope
+
+Three concurrent tracks that share `runner.py` but are
+architecturally independent:
+
+1. **Auth source control.** Add a keyword-only `env` override to
+   `SkillRunner.run` (defaulting to `None` → `os.environ.copy()`),
+   threaded from a new `--no-api-key` CLI flag that, when set,
+   constructs the env dict with `ANTHROPIC_API_KEY` stripped.
+2. **Timeout configurability.** Add `--timeout <seconds>` to CLI
+   commands that lack it, and a top-level `timeout` field on
+   `EvalSpec`. Precedence: CLI flag > spec field > default
+   (180 preserved).
+3. **`apiKeySource` observability.** Extend the stream-json parser
+   to capture `apiKeySource` from the `init` event; add
+   `api_key_source: str | None = None` to `SkillResult`; surface
+   it in stderr / CLI summary. Document the field in
+   `docs/stream-json-schema.md`.
+
+### Scoping decisions
+
+- **Q1 — Auth-source flag shape.** `--no-api-key` (boolean).
+  Smallest surface, mirrors `--no-transcript`.
+- **Q2 — Timeout placement.** Both CLI flag and `EvalSpec.timeout`
+  field. Precedence: CLI flag > spec field > default.
+- **Q3 — Default timeout value.** Keep 180s. Additive change;
+  authors opt in.
+- **Q4 — Auth source in EvalSpec.** No — CLI-only. Auth source is
+  environmental, not skill-intrinsic.
+- **Q5 — `apiKeySource` surfacing.** Stderr info line **plus**
+  `SkillResult.api_key_source` field (`str | None`, defensive).
+- **Q6 — Commands.** `validate`, `grade`, `capture`, `run`, plus
+  pytest plugin option (`--clauditor-no-api-key` alongside the
+  existing `--clauditor-timeout`).
+
+---
+
+## Architecture Review
+
+Six baseline review areas run in parallel. Ratings:
+
+| Area | Rating | Summary |
+|------|--------|---------|
+| Security | **blocker** | `ANTHROPIC_AUTH_TOKEN` is a second Anthropic env-auth path the plan does not account for. |
+| Performance | **pass** | Trivial: one env copy / one parse branch / one dataclass field per run. |
+| Data Model | **concern** | Bool-guard needed on `EvalSpec.timeout`; `docs/stream-json-schema.md` companion update is mandatory. |
+| API Design | **concern** | Move `timeout` to keyword-only `run()` kwarg; extract pure `_env_without_api_key()` helper. |
+| Observability | **concern** | Suppress stderr line when `api_key_source is None` (don't print "unavailable"). |
+| Testing Strategy | **pass** | ~25–30 new tests across six files; no new test files needed. |
+
+### Blockers
+
+**BL-1 — `ANTHROPIC_AUTH_TOKEN` second env-auth path.**
+The Anthropic SDK recognizes both `ANTHROPIC_API_KEY` and
+`ANTHROPIC_AUTH_TOKEN` as env-based auth paths. A user who has
+`ANTHROPIC_AUTH_TOKEN` set and expects `--no-api-key` to force
+subscription auth will silently still use token-based API auth.
+Two options:
+
+- **BL-1a. `--no-api-key` strips both `ANTHROPIC_API_KEY` and
+  `ANTHROPIC_AUTH_TOKEN`.** Flag name means "no env-based API
+  auth." Simple and matches the user intent.
+- **BL-1b. Rename the flag to something precise.** E.g.
+  `--strip-api-auth` or `--use-subscription`. The flag then
+  unambiguously strips all env-based auth paths.
+
+### Concerns
+
+**C-1 — Interactive hang on missing subscription auth
+(security).** If a user sets `--no-api-key` but has no cached
+`~/.claude/` subscription auth, `claude -p` will block on stdin
+waiting for interactive login. The existing interactive-hang
+heuristic from #63 fires on `num_turns==1 + trailing "?"`
+patterns, not on pre-stream-json stdin blocking. Failure mode:
+watchdog timeout → ambiguous "timeout" error. Acceptable cost
+for v1: the user sees a timeout and a stderr line telling them
+`apiKeySource=` is absent, which is a strong signal. Not a
+blocker.
+
+**C-2 — `EvalSpec.timeout` validation must exclude `bool`
+(data model).** Python `isinstance(True, int)` returns `True`
+because `bool` is an `int` subclass. The validator must do
+`isinstance(val, int) and not isinstance(val, bool)` per the
+precedent in `.claude/rules/constant-with-type-info.md`.
+
+**C-3 — `docs/stream-json-schema.md` companion update (data
+model).** Per `.claude/rules/stream-json-schema.md`, every new
+parser field requires a doc update in the same PR. Add a row
+for `apiKeySource` under the `type: "system"` / `subtype:
+"init"` section. Note the label-not-secret observation from
+Observability review.
+
+**C-4 — Move `timeout` from `__init__` to keyword-only
+`run()` kwarg (API design).** Today
+`SkillRunner(timeout=180).__init__` stores `self.timeout`. Per
+`.claude/rules/subprocess-cwd.md`, per-invocation config
+belongs on `run()` kwargs, defaulting to `self.timeout` for
+back-compat with the 6 existing constructor call sites. Add
+keyword-only `timeout: int | None = None` on `run()`; resolve
+as `effective_timeout = timeout if timeout is not None else
+self.timeout`. No caller changes required.
+
+**C-5 — Extract `_env_without_api_key()` pure helper (API
+design).** Per `.claude/rules/pure-compute-vs-io-split.md`,
+lift the "copy env and strip the two auth vars" logic into a
+pure helper in `runner.py`. Call sites (CLI commands, pytest
+plugin) then call one function instead of re-rolling the
+comprehension. Testable without subprocess mocks.
+
+**C-6 — Suppress stderr info line when `api_key_source is
+None` (observability).** When the `init` message doesn't
+carry `apiKeySource` (older `claude` CLI builds), emit
+nothing — don't print `apiKeySource=unavailable`. The absence
+is already the signal.
+
+### Accepted as-is
+
+- Performance: one env copy per run is trivial; one extra
+  branch in the stream-json parser is constant-time.
+- Testing: the proposed test plan (~25–30 new methods across
+  existing files) is comprehensive. No new test files needed.
+  Coverage gate (80%) stays green by construction.
+- Secret redaction: `apiKeySource` values are labels
+  (`"ANTHROPIC_API_KEY"`, `"claude.ai"`, `"none"`), not
+  secrets. Existing `transcripts.py::redact` handles any
+  unexpected shape regressions.
+- CLI arg validation: `argparse type=int` syntax check is
+  fine; range check (`> 0`) lives in the `EvalSpec` validator
+  per C-2 and the CLI-side reject-early pattern per
+  `.claude/rules/llm-cli-exit-code-taxonomy.md`.
+
+---
+
+## Refinement Log
+
+### Decisions
+
+**DEC-001 — Auth flag shape: `--no-api-key` (boolean).** One
+binary flag matches the project's `--no-<feature>` style
+(`--no-transcript`). (Q1 answer A.)
+
+**DEC-002 — Timeout precedence: CLI > spec > default.** The CLI
+flag wins when passed explicitly; otherwise the `EvalSpec.timeout`
+field wins; otherwise the hardcoded default (180s). Resolution
+happens in `SkillSpec.run` per the `allow_hang_heuristic`
+precedent from #63. (Q2 answer A.)
+
+**DEC-003 — Default timeout stays at 180s.** Additive change;
+authors opt in to higher timeouts. Changing the default would
+silently alter behavior for every existing spec. (Q3 answer A.)
+
+**DEC-004 — Auth source is CLI-only; not an `EvalSpec` field.**
+Auth source is environmental, not skill-intrinsic. A spec author
+should not embed "I expect subscription auth" in the spec — that
+is a quota / tier preference of the operator running the eval.
+(Q4 answer A.)
+
+**DEC-005 — `apiKeySource` surfaces as both stderr info line AND
+`SkillResult.api_key_source` field.** Humans see the stderr line;
+tests and downstream consumers read the field. Field type is
+`str | None`. (Q5 answer B.)
+
+**DEC-006 — Flags land on `validate`, `grade`, `capture`, `run`;
+pytest plugin gets `--clauditor-no-api-key`.** All four
+skill-invoking CLI commands plus the pytest fixture factory
+config. (Q6 answer A + B.)
+
+**DEC-007 — `--no-api-key` strips BOTH `ANTHROPIC_API_KEY` and
+`ANTHROPIC_AUTH_TOKEN`.** Both are documented Anthropic SDK
+env-auth paths. Stripping only one leaves the flag name
+misleading. Flag-name interpretation: "no env-based API auth
+credential." (BL-1 resolved as BL-1a.)
+
+**DEC-008 — `EvalSpec.timeout` validator excludes `bool`.**
+`isinstance(True, int)` returns `True` because `bool` is an `int`
+subclass. Validator is
+`isinstance(val, int) and not isinstance(val, bool)` per the
+canonical pattern in `.claude/rules/constant-with-type-info.md`.
+Error message follows the existing style
+(`"EvalSpec(skill_name=…): 'timeout' must be an int, got …"`).
+(C-2.)
+
+**DEC-009 — `docs/stream-json-schema.md` companion update in the
+same PR.** Add a row for `apiKeySource` under the
+`type: "system"` / `subtype: "init"` section with values
+(`"ANTHROPIC_API_KEY"`, `"claude.ai"`, `"none"`) and a
+"label, not secret" note to preempt future redaction questions.
+Two-step recipe per `.claude/rules/stream-json-schema.md`. (C-3.)
+
+**DEC-010 — Move `timeout` from `SkillRunner.__init__` to a
+keyword-only `run()` kwarg; keep `self.timeout` as fallback.**
+Per `.claude/rules/subprocess-cwd.md`, per-invocation config
+belongs on `run()`. `__init__` keeps `timeout: int = 180` for
+back-compat with the 6 existing constructor call sites (no
+changes needed to any caller). `run()` adds
+`timeout: int | None = None`; `_invoke` uses
+`effective_timeout = timeout if timeout is not None else self.timeout`.
+(C-4.)
+
+**DEC-011 — Pure helper `_env_without_api_key(base_env=None) ->
+dict[str, str]` in `runner.py`.** Returns a new dict, always
+non-mutating (per `.claude/rules/non-mutating-scrub.md`).
+Stripped keys: `{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"}`.
+Reused by CLI entrypoints, pytest plugin, and any future caller
+that needs the same transformation. Testable without subprocess
+mocks. (C-5.)
+
+**DEC-012 — When the `init` message omits `apiKeySource`,
+`SkillResult.api_key_source` stays `None` and the stderr info
+line is suppressed.** Absence is the signal; don't print
+"apiKeySource=unavailable". (C-6.)
+
+**DEC-013 — `SkillRunner.run(env=dict | None)` kwarg shape;
+mirrors `cwd`.** `None` default → `subprocess.Popen(env=None)`
+inherits `os.environ` (today's behavior). A dict → `Popen`
+receives it unchanged. CLI/plugin callers compute the dict via
+`_env_without_api_key()` when `--no-api-key` is set. Flexibility
+doubles as "tests can inject arbitrary env without monkeypatching
+`os.environ`."
+
+**DEC-014 — CLI `--timeout SECONDS` validates at argparse AND at
+load time.** argparse uses `type=int` for syntax. A small custom
+type function (`_positive_int`) rejects `<= 0` with a clear
+message; argparse surfaces it as exit 2 (per
+`.claude/rules/llm-cli-exit-code-taxonomy.md`). `EvalSpec.timeout`
+reuses the same `> 0` check at load time per DEC-008.
+
+**DEC-015 — First `init` message wins; subsequent `init` events
+are ignored.** Stream-json spec allows at most one init per run;
+defensive-parse pattern means we tolerate duplicates by taking
+the first and skipping others. Per
+`.claude/rules/stream-json-schema.md`.
+
+**DEC-016 — `_env_without_api_key` preserves non-auth Anthropic
+env vars (`ANTHROPIC_BASE_URL` etc.).** Only the two credential
+vars are stripped. A user who sets `ANTHROPIC_BASE_URL` to point
+at a proxy still gets their proxy; they just lose the API key.
+
+**DEC-017 — Parser match on `type == "system"` AND `subtype ==
+"init"` for `apiKeySource` extraction.** Today the parser only
+handles `type == "assistant"` and `type == "result"`. Add a third
+branch that matches the compound shape and reads `apiKeySource`
+with `.get(...)`. Defensive per
+`.claude/rules/stream-json-schema.md`.
+
+### Open questions
+
+None. Architecture concerns resolved; decisions trace every
+acceptance criterion in Discovery "Done when."
+
+---
+
+## Detailed Breakdown
+
+Seven implementation stories + Quality Gate + Patterns & Memory.
+Ordering is bottom-up: foundational pure layers first
+(`EvalSpec.timeout`, `_env_without_api_key`, stream-json parser),
+runtime plumbing next (`SkillRunner.run` kwargs, `SkillSpec.run`
+precedence), user-facing surfaces last (CLI flags, pytest plugin
+option). Each story targets ≤~150 lines of diff so a single Ralph
+context window can complete it. Every story's acceptance
+includes the shared validation gate: **`uv run ruff check src/
+tests/` passes AND `uv run pytest --cov=clauditor
+--cov-fail-under=80` passes**.
+
+---
+
+### US-001 — Add `EvalSpec.timeout` field with load-time validation
+
+**Description:** Add an optional `timeout: int | None = None`
+field on `EvalSpec`. Validate at `from_dict` load time — reject
+non-int (including `bool`), reject `<= 0`, accept `None` /
+missing as "unset."
+
+**Traces to:** DEC-002, DEC-003, DEC-008, DEC-014.
+
+**Acceptance Criteria:**
+- `EvalSpec` carries `timeout: int | None = None` as the last
+  field (after `allow_hang_heuristic`).
+- `{"timeout": 300}` loads → `spec.timeout == 300`.
+- `{"timeout": 0}` or `{"timeout": -5}` raises `ValueError` with
+  message matching `"EvalSpec(skill_name=…): 'timeout' must be >
+  0, got …"`.
+- `{"timeout": "300"}` raises `ValueError` with message matching
+  `"'timeout' must be an int, got str '300'"`.
+- `{"timeout": True}` (bool guard) raises `ValueError` —
+  `isinstance(True, int)` is True in Python but `bool`
+  rejection is explicit.
+- `{"timeout": None}` loads → `spec.timeout is None`.
+- Missing `timeout` key → `spec.timeout is None`.
+- Shared validation gate passes.
+
+**Done when:** Six new test methods pass in
+`tests/test_schemas.py::TestFromDict`; coverage ≥ 80%; ruff
+clean.
+
+**Files:**
+- `src/clauditor/schemas.py` — add the field on `EvalSpec` and
+  the validation block inside `from_dict` (pattern matches the
+  existing `allow_hang_heuristic` validation).
+- `tests/test_schemas.py` — six new tests in `TestFromDict`.
+
+**Depends on:** none.
+
+**TDD:**
+- `test_timeout_int_300` — positive int loads.
+- `test_timeout_zero_raises` — `<= 0` rejection.
+- `test_timeout_negative_raises` — `<= 0` rejection.
+- `test_timeout_string_raises` — non-int rejection.
+- `test_timeout_bool_raises` — bool guard.
+- `test_timeout_null_is_none` — null maps to None.
+- `test_timeout_missing_is_none` — absence maps to None.
+
+---
+
+### US-002 — Add `_env_without_api_key()` pure helper in runner.py
+
+**Description:** Add a pure, non-mutating helper that returns a
+new env dict with both `ANTHROPIC_API_KEY` and
+`ANTHROPIC_AUTH_TOKEN` removed. Preserves all other env vars
+(including `ANTHROPIC_BASE_URL`).
+
+**Traces to:** DEC-007, DEC-011, DEC-016.
+
+**Acceptance Criteria:**
+- `_env_without_api_key(base_env: dict[str, str] | None = None)
+  -> dict[str, str]` lives in `src/clauditor/runner.py`.
+- When `base_env is None`, uses `os.environ` as the source.
+- Always returns a **new** dict (never mutates the input).
+- Strips both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`.
+- Preserves every other key (including `ANTHROPIC_BASE_URL`,
+  `PATH`, etc.).
+- Is a no-op (but still returns a new dict) when neither
+  auth key is present.
+- Unit tests require no subprocess mocks (the helper is pure).
+- Shared validation gate passes.
+
+**Done when:** Four new tests pass in
+`tests/test_runner.py::TestEnvWithoutApiKey`; coverage ≥ 80%;
+ruff clean.
+
+**Files:**
+- `src/clauditor/runner.py` — new module-level function near
+  the top of the file, above `SkillRunner`.
+- `tests/test_runner.py` — new `TestEnvWithoutApiKey` class.
+
+**Depends on:** none.
+
+**TDD:**
+- `test_strips_both_auth_vars` — input has both; output has
+  neither.
+- `test_preserves_other_vars` — `ANTHROPIC_BASE_URL`, `PATH`,
+  unrelated key preserved.
+- `test_default_reads_os_environ` — `base_env=None` path.
+- `test_is_non_mutating` — input dict unchanged after call.
+- `test_no_auth_vars_present` — no-op returns a new dict equal
+  in content to the source.
+
+---
+
+### US-003 — Add keyword-only `env=` and `timeout=` kwargs on `SkillRunner.run`
+
+**Description:** Thread the `env` dict and the per-invocation
+`timeout` override through `SkillRunner.run` → `_invoke` to
+`subprocess.Popen`. Defaults preserve back-compat: `env=None` →
+`Popen(env=None)` inherits `os.environ` (today's behavior);
+`timeout=None` → falls back to `self.timeout`.
+
+**Traces to:** DEC-010, DEC-013.
+
+**Acceptance Criteria:**
+- `SkillRunner.run(..., *, env: dict[str, str] | None = None,
+  timeout: int | None = None, ...)` — new keyword-only kwargs.
+- `_invoke` receives and uses both. `subprocess.Popen` is
+  invoked with `env=env` (which may be `None`, unchanged
+  behavior, or a dict).
+- The watchdog (`threading.Timer`) uses
+  `effective_timeout = timeout if timeout is not None else
+  self.timeout`.
+- `SkillRunner.__init__(timeout=180, ...)` signature unchanged;
+  existing six constructor call sites continue to work without
+  modification.
+- Shared validation gate passes.
+
+**Done when:** Six new tests pass in
+`tests/test_runner.py`; all existing runner tests still pass;
+coverage ≥ 80%; ruff clean.
+
+**Files:**
+- `src/clauditor/runner.py` — `SkillRunner.run` signature,
+  `_invoke` `env` parameter, Popen call site (lines 367–380),
+  watchdog timer (lines 446–448).
+- `tests/test_runner.py` — new test class covering both kwargs.
+
+**Depends on:** US-002 (the helper is the canonical env-dict
+producer, though `run()` itself doesn't import it).
+
+**TDD:**
+- `test_run_env_none_popen_receives_none` — default path.
+- `test_run_env_dict_popen_receives_dict` — threading.
+- `test_run_timeout_override_used_in_watchdog` — override
+  wins.
+- `test_run_timeout_none_falls_back_to_self_timeout` — back-
+  compat.
+- `test_init_timeout_default_180_unchanged` — constructor
+  default preserved.
+- `test_existing_call_sites_unaffected` — a representative
+  call with neither new kwarg still works.
+
+---
+
+### US-004 — Parse `apiKeySource` from stream-json init; add `SkillResult.api_key_source`; stderr line; docs update
+
+**Description:** Extend the stream-json parser to match on
+`type == "system" AND subtype == "init"`, read `apiKeySource`
+defensively via `.get()`, and populate a new
+`SkillResult.api_key_source: str | None = None` field. Emit one
+stderr info line per run when the field is present. Suppress
+the line when the field is absent. Document the new field in
+`docs/stream-json-schema.md`.
+
+**Traces to:** DEC-005, DEC-009, DEC-012, DEC-015, DEC-017.
+
+**Acceptance Criteria:**
+- `SkillResult.api_key_source: str | None = None` is the last
+  field on the dataclass.
+- Parser in `_invoke` reads `apiKeySource` defensively from
+  the first `type=="system"`/`subtype=="init"` message; later
+  init messages are ignored.
+- Stderr line format: `clauditor.runner: apiKeySource=<value>
+  model=<value>` printed exactly once per run when
+  `api_key_source is not None`.
+- No stderr line when `api_key_source is None` (older CLI
+  builds missing the field).
+- `tests/conftest.py::make_fake_skill_stream` accepts an
+  optional `init_message` kwarg that injects a `system/init`
+  event at the head of the stream.
+- `docs/stream-json-schema.md` has a new row documenting
+  `apiKeySource` under the `type: "system"` / `subtype:
+  "init"` section, including example values and a "label,
+  not secret" note.
+- Shared validation gate passes.
+
+**Done when:** Five new parser tests + stderr-line test pass
+in `tests/test_runner.py`; docs file updated; coverage ≥ 80%;
+ruff clean.
+
+**Files:**
+- `src/clauditor/runner.py` — `SkillResult` dataclass (lines
+  25–53); parser loop `init`-branch (add alongside `assistant`
+  / `result` branches, ~line 481+); stderr print (near parser,
+  after init is captured).
+- `tests/conftest.py` — extend `make_fake_skill_stream`
+  signature.
+- `tests/test_runner.py` — new `TestApiKeySourceParsing` class.
+- `docs/stream-json-schema.md` — new row under `type:
+  "system"` section.
+
+**Depends on:** none (parser change is independent of
+env/timeout work; could run in parallel with US-003 but is
+sequenced after for simplicity).
+
+**TDD:**
+- `test_init_apikeysource_none` — `"none"` value captured.
+- `test_init_apikeysource_env_var` —
+  `"ANTHROPIC_API_KEY"` value captured.
+- `test_init_apikeysource_missing` — no field → None.
+- `test_no_init_message` — malformed stream → None, no crash.
+- `test_first_init_wins` — duplicate init events → first
+  wins.
+- `test_stderr_line_emitted` — stderr contains the info line
+  when source is present.
+- `test_stderr_line_suppressed_on_none` — no line when field
+  absent.
+
+---
+
+### US-005 — Implement `SkillSpec.run` precedence resolution (CLI > spec > default)
+
+**Description:** In `SkillSpec.run`, resolve the effective
+`timeout` from the CLI override param, the `EvalSpec.timeout`
+field, and the default (None → fall through to
+`SkillRunner.run`'s own default which uses `self.timeout`).
+Thread the result to `SkillRunner.run(timeout=…)`. Mirror the
+`env` pass-through for `--no-api-key`.
+
+**Traces to:** DEC-002, DEC-013.
+
+**Acceptance Criteria:**
+- `SkillSpec.run(..., *, timeout_override: int | None = None,
+  env_override: dict[str, str] | None = None, ...)` — new
+  keyword-only kwargs.
+- Precedence: `timeout_override` wins when not None; else
+  `spec.eval_spec.timeout` (if set); else `None` (let runner
+  fall back to `self.timeout`).
+- `env_override` (when not None) forwarded as
+  `SkillRunner.run(env=env_override)`. No precedence merge —
+  CLI is the only producer.
+- Mirror shape of the existing `allow_hang_heuristic`
+  threading (spec.py:142–150).
+- Shared validation gate passes.
+
+**Done when:** Three new precedence tests + one env-threading
+test pass in `tests/test_spec.py::TestTimeoutPrecedence` (new
+class); coverage ≥ 80%; ruff clean.
+
+**Files:**
+- `src/clauditor/spec.py` — `SkillSpec.run` signature +
+  resolution block before the `self.runner.run(...)` call.
+- `tests/test_spec.py` — new `TestTimeoutPrecedence` class.
+
+**Depends on:** US-001 (`EvalSpec.timeout`), US-003
+(`SkillRunner.run(timeout=, env=)` kwargs).
+
+**TDD:**
+- `test_cli_override_wins` — `timeout_override=60` with
+  `spec.timeout=300` → runner gets 60.
+- `test_spec_wins_when_no_cli_override` —
+  `timeout_override=None`, `spec.timeout=300` → runner gets
+  300.
+- `test_default_when_neither_set` — both None → runner gets
+  None (i.e. its own `self.timeout`).
+- `test_env_override_threaded_through` — `env_override=dict`
+  → runner gets `env=dict`.
+
+---
+
+### US-006 — Add `--no-api-key` and `--timeout` CLI flags on validate, grade, capture, run
+
+**Description:** Add the two new flags on four CLI entry
+points. `--no-api-key` computes
+`env = _env_without_api_key() if args.no_api_key else None`
+and passes to `SkillSpec.run(env_override=env)`. `--timeout`
+uses a custom argparse type (`_positive_int`) that rejects
+`<= 0` at parse time with exit 2; result threads to
+`SkillSpec.run(timeout_override=args.timeout)`. `run.py`
+already has `--timeout`; align its shape and add `--no-api-key`.
+
+**Traces to:** DEC-001, DEC-006, DEC-014.
+
+**Acceptance Criteria:**
+- `validate`, `grade`, `capture`, `run` each expose
+  `--no-api-key` (bool, default False) and `--timeout
+  SECONDS` (int, default None → means "not set").
+- `_positive_int` argparse type is defined once (in a shared
+  util, or per-CLI as a small module-level helper — pick one
+  and do it consistently).
+- `--timeout 0` / `--timeout -5` / `--timeout foo` exits with
+  code 2 and a clear stderr message.
+- Valid `--timeout 300` reaches the runner via
+  `SkillSpec.run(timeout_override=300)`.
+- `--no-api-key` on any of the four commands results in
+  `SkillSpec.run(env_override=<dict without both auth vars>)`.
+- `run.py`'s existing `--timeout` stays functional (if it
+  already uses `type=int` with `default=180`, align the
+  semantics with the new precedence pattern: the CLI default
+  should become `None`, not `180`, so the spec/runner defaults
+  can kick in).
+- Shared validation gate passes.
+
+**Done when:** Seven new tests pass in `tests/test_cli.py`
+(one per flag per command + one argparse-reject case);
+coverage ≥ 80%; ruff clean.
+
+**Files:**
+- `src/clauditor/cli/validate.py`, `cli/grade.py`,
+  `cli/capture.py`, `cli/run.py` — argparse additions, kwarg
+  pass-through to `SkillSpec.run`.
+- `tests/test_cli.py` — new `TestNoApiKeyFlag` and
+  `TestTimeoutFlag` classes (or extend existing per-command
+  test classes).
+
+**Depends on:** US-002 (`_env_without_api_key`), US-005
+(`SkillSpec.run(timeout_override=, env_override=)`).
+
+**TDD:**
+- `test_validate_no_api_key_strips_both_vars`
+- `test_grade_no_api_key_strips_both_vars`
+- `test_capture_no_api_key_strips_both_vars`
+- `test_run_no_api_key_strips_both_vars`
+- `test_validate_timeout_300_reaches_runner`
+- `test_validate_timeout_zero_exits_2`
+- `test_validate_timeout_non_int_exits_2`
+
+---
+
+### US-007 — Add `--clauditor-no-api-key` pytest plugin option
+
+**Description:** Add a pytest plugin option parallel to the
+existing `--clauditor-timeout`. The option controls the
+`env_override` threaded through the `clauditor_runner` /
+`clauditor_spec` fixtures to `SkillSpec.run(env_override=…)` at
+skill-invocation time (not at runner-construction time; the
+runner stays constructed with a default env).
+
+**Traces to:** DEC-006.
+
+**Acceptance Criteria:**
+- `--clauditor-no-api-key` pytest option registered in
+  `pytest_addoption`.
+- The `clauditor_spec` fixture (or whatever layer calls
+  `SkillSpec.run`) reads the option and threads
+  `env_override=_env_without_api_key() if option else None`.
+- `--clauditor-timeout` stays functional; the new option does
+  not disrupt its wiring.
+- Shared validation gate passes.
+
+**Done when:** Two new tests pass in
+`tests/test_pytest_plugin.py`; coverage ≥ 80%; ruff clean.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py` — `pytest_addoption` and
+  the fixture wrapping skill invocation.
+- `tests/test_pytest_plugin.py` — new tests following the
+  existing `--clauditor-timeout` test pattern.
+
+**Depends on:** US-002 (`_env_without_api_key`), US-005
+(`SkillSpec.run(env_override=)`).
+
+**TDD:**
+- `test_no_api_key_option_reaches_spec_run` — fixture
+  threads `env_override` to the spec.
+- `test_timeout_option_still_works` — regression guard on
+  existing option.
+
+---
+
+### US-008 — Quality Gate
+
+**Description:** Run `code-reviewer` Task 4x on the full
+changeset, fixing every real bug found each pass. Run
+CodeRabbit review on the PR. Resolve all findings (no
+deferrals) and re-run the shared validation gate.
+
+**Traces to:** project quality standard; no specific DEC-###.
+
+**Acceptance Criteria:**
+- `code-reviewer` Task agent has run four separate passes on
+  `git diff dev..HEAD`. Every real finding is fixed; false
+  positives are documented in a brief note.
+- CodeRabbit review on the PR has zero unresolved comments
+  (fix or reply-with-justification on each).
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-fail-under=80`
+  passes.
+
+**Done when:** four review passes complete, all findings
+addressed, validation gate green.
+
+**Files:** all of the above, as needed.
+
+**Depends on:** US-001, US-002, US-003, US-004, US-005,
+US-006, US-007 (all implementation stories complete).
+
+---
+
+### US-009 — Patterns & Memory
+
+**Description:** Review this epic's changes for new patterns
+worth codifying in `.claude/rules/` or `docs/`. Candidate
+patterns:
+
+- **Auth-env stripping helper** — if `_env_without_api_key`
+  becomes a reusable pattern (e.g. future `_env_without_aws_auth`
+  for a Bedrock path), codify the "pure env-scrub helper in
+  runner.py" shape as a rule.
+- **CLI > spec > default precedence** — the pattern is now
+  used twice (`allow_hang_heuristic`, `timeout`). A new rule
+  `.claude/rules/spec-cli-precedence.md` documenting the
+  "resolve in `SkillSpec.run`, thread as keyword-only kwarg"
+  shape is warranted.
+- **Positive-int argparse type** — if `_positive_int` is
+  reused, codify as a small rule anchor; otherwise leave as
+  an inline helper.
+
+Update `docs/cli-reference.md` to document the new flags.
+Update `README.md` and/or `docs/eval-spec-reference.md` to
+document `EvalSpec.timeout`.
+
+**Traces to:** broader project convention maintenance.
+
+**Acceptance Criteria:**
+- Any new pattern identified is codified as a
+  `.claude/rules/<name>.md` file with canonical-implementation
+  pointers (or explicitly declared "not yet; wait for third
+  occurrence").
+- `docs/cli-reference.md` documents `--no-api-key` and
+  `--timeout` on validate / grade / capture / run.
+- `docs/eval-spec-reference.md` (or equivalent) documents the
+  new `EvalSpec.timeout` field with validation rules.
+- README changes, if any, follow
+  `.claude/rules/readme-promotion-recipe.md`.
+
+**Done when:** rules / docs updated and committed.
+
+**Files:**
+- `.claude/rules/<new-rule>.md` (zero or more).
+- `docs/cli-reference.md`.
+- `docs/eval-spec-reference.md` (or whichever file documents
+  `EvalSpec` fields).
+- `README.md` (only if a teaser section changed shape per the
+  promotion recipe).
+
+**Depends on:** US-008 (Quality Gate).
+
+---
+
+## Beads Manifest
+
+_(pending)_
+
+---
+
+## Session Notes
+
+**2026-04-20** — Discovery opened. Fetched ticket, spawned parallel
+codebase-scout and convention-checker subagents, assembled findings.
+Worktree created at
+`/home/wesd/dev/worktrees/clauditor/64-runner-auth-timeout` on branch
+`feature/64-runner-auth-timeout`. Six scoping questions presented.
+
+**2026-04-20 (2)** — Scoping answers locked: A/A/A/A/B/A+B. Moving
+to architecture review: six baseline areas (security, performance,
+data model, API design, observability, testing strategy) spawned
+in parallel.
+
+**2026-04-20 (3)** — Architecture review complete. 1 blocker
+(`ANTHROPIC_AUTH_TOKEN` second env-auth path), 5 concerns (hang
+heuristic gap, bool-guard on `EvalSpec.timeout`, docs companion
+update, `timeout` kwarg placement, pure `_env_without_api_key`
+helper, suppress-stderr-when-None). Performance and Testing
+reviews pass cleanly.
+
+**2026-04-20 (4)** — Refinement locked. BL-1a (strip both env
+vars, keep `--no-api-key` name) and C-1…C-6 all accepted.
+17 decisions recorded. No open questions. Ready to generate
+stories.
+
+**2026-04-20 (5)** — Detailing complete. Seven implementation
+stories (US-001…007) + Quality Gate (US-008) + Patterns &
+Memory (US-009). Ordering: foundational layers first
+(EvalSpec field, pure env helper, runner kwargs, stream-json
+parser) → runtime plumbing (SkillSpec precedence) →
+user-facing surfaces (CLI flags, pytest plugin option).

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -286,7 +286,7 @@ def _render_skill_error(
        ignored.
     3. **Warnings trailer** (DEC-002) — when ``result.warnings`` is
        non-empty, the first non-empty line of the first warning is
-       appended as ``"\\n(stderr: <first-line>)"``. Only the first
+       appended as ``"\\n(warning: <first-line>)"``. Only the first
        warning is rendered; the full list stays in
        ``result.warnings`` for forensics. Warnings whose lines are
        all whitespace-only are skipped entirely.

--- a/src/clauditor/cli/capture.py
+++ b/src/clauditor/cli/capture.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from clauditor.runner import SkillRunner, _env_without_api_key
+from clauditor.runner import SkillRunner, env_without_api_key
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -92,7 +92,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
     # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
     # to the runner. Defaults are both None (today's behavior).
     env_override = (
-        _env_without_api_key()
+        env_without_api_key()
         if getattr(args, "no_api_key", False)
         else None
     )

--- a/src/clauditor/cli/capture.py
+++ b/src/clauditor/cli/capture.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from clauditor.runner import SkillRunner
+from clauditor.runner import SkillRunner, _env_without_api_key
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -75,7 +75,6 @@ def cmd_capture(args: argparse.Namespace) -> int:
     # Shared helper lives in ``clauditor.cli`` (package __init__). Import
     # lazily to avoid a circular import at module load.
     from clauditor.cli import _render_skill_error
-    from clauditor.runner import _env_without_api_key
 
     skill_name = args.skill.lstrip("/")
     skill_args = " ".join(args.skill_args) if args.skill_args else ""

--- a/src/clauditor/cli/capture.py
+++ b/src/clauditor/cli/capture.py
@@ -11,6 +11,10 @@ from clauditor.runner import SkillRunner
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``capture`` subparser."""
+    # Shared argparse type helpers live in the package __init__; import
+    # lazily to avoid a circular import at module load time.
+    from clauditor.cli import _positive_int
+
     p_capture = subparsers.add_parser(
         "capture",
         help="Run a skill via `claude -p` and save stdout to a captured file",
@@ -35,6 +39,24 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Path to the `claude` CLI (default: `claude` on PATH)",
     )
     p_capture.add_argument(
+        "--no-api-key",
+        action="store_true",
+        help=(
+            "Strip ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN from the "
+            "subprocess environment to force subscription auth."
+        ),
+    )
+    p_capture.add_argument(
+        "--timeout",
+        type=_positive_int,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Override the runner timeout (seconds); must be > 0. "
+            "Defaults to SkillRunner's 180s default."
+        ),
+    )
+    p_capture.add_argument(
         "skill_args",
         nargs="*",
         help="Arguments to pass to the skill (put after `--`)",
@@ -53,6 +75,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
     # Shared helper lives in ``clauditor.cli`` (package __init__). Import
     # lazily to avoid a circular import at module load.
     from clauditor.cli import _render_skill_error
+    from clauditor.runner import _env_without_api_key
 
     skill_name = args.skill.lstrip("/")
     skill_args = " ".join(args.skill_args) if args.skill_args else ""
@@ -67,8 +90,20 @@ def cmd_capture(args: argparse.Namespace) -> int:
         )
 
     runner = SkillRunner(claude_bin=args.claude_bin or "claude")
+    # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
+    # to the runner. Defaults are both None (today's behavior).
+    env_override = (
+        _env_without_api_key()
+        if getattr(args, "no_api_key", False)
+        else None
+    )
     print(f"Running /{skill_name} {skill_args}...", file=sys.stderr)
-    result = runner.run(skill_name, skill_args)
+    result = runner.run(
+        skill_name,
+        skill_args,
+        env=env_override,
+        timeout=getattr(args, "timeout", None),
+    )
 
     if not result.succeeded_cleanly:
         print(

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -12,7 +12,7 @@ from clauditor import history
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.benchmark import Benchmark, compute_benchmark
 from clauditor.paths import resolve_clauditor_dir
-from clauditor.runner import SkillResult
+from clauditor.runner import SkillResult, _env_without_api_key
 from clauditor.spec import SkillSpec
 from clauditor.workspace import (
     InvalidSkillNameError,
@@ -358,7 +358,6 @@ def _run_skill_variants(
     # Shared helper lives in ``clauditor.cli`` (package __init__). Import
     # lazily to avoid a circular import at module load.
     from clauditor.cli import _render_skill_error
-    from clauditor.runner import _env_without_api_key
 
     # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
     # to every ``spec.run`` invocation (primary + variance). Defaults
@@ -553,8 +552,6 @@ def _write_workspace_sidecars(
     if getattr(args, "baseline", False):
         # Mirror the primary arm's env/timeout wiring so --no-api-key
         # and --timeout apply to both halves of the baseline delta.
-        from clauditor.runner import _env_without_api_key
-
         no_api_key = bool(getattr(args, "no_api_key", False))
         env_override = _env_without_api_key() if no_api_key else None
         timeout_override = getattr(args, "timeout", None)

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -12,7 +12,7 @@ from clauditor import history
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.benchmark import Benchmark, compute_benchmark
 from clauditor.paths import resolve_clauditor_dir
-from clauditor.runner import SkillResult, _env_without_api_key
+from clauditor.runner import SkillResult, env_without_api_key
 from clauditor.spec import SkillSpec
 from clauditor.workspace import (
     InvalidSkillNameError,
@@ -363,7 +363,7 @@ def _run_skill_variants(
     # to every ``spec.run`` invocation (primary + variance). Defaults
     # are both None (today's behavior).
     env_override = (
-        _env_without_api_key()
+        env_without_api_key()
         if getattr(args, "no_api_key", False)
         else None
     )
@@ -553,7 +553,7 @@ def _write_workspace_sidecars(
         # Mirror the primary arm's env/timeout wiring so --no-api-key
         # and --timeout apply to both halves of the baseline delta.
         no_api_key = bool(getattr(args, "no_api_key", False))
-        env_override = _env_without_api_key() if no_api_key else None
+        env_override = env_without_api_key() if no_api_key else None
         timeout_override = getattr(args, "timeout", None)
         return _write_baseline_and_benchmark(
             spec=spec,

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -551,6 +551,13 @@ def _write_workspace_sidecars(
         _write_extraction_sidecar(skill_dir, primary_text, spec)
 
     if getattr(args, "baseline", False):
+        # Mirror the primary arm's env/timeout wiring so --no-api-key
+        # and --timeout apply to both halves of the baseline delta.
+        from clauditor.runner import _env_without_api_key
+
+        no_api_key = bool(getattr(args, "no_api_key", False))
+        env_override = _env_without_api_key() if no_api_key else None
+        timeout_override = getattr(args, "timeout", None)
         return _write_baseline_and_benchmark(
             spec=spec,
             skill_dir=skill_dir,
@@ -558,6 +565,8 @@ def _write_workspace_sidecars(
             skill_results=skill_results,
             reports=reports,
             model=model,
+            env_override=env_override,
+            timeout_override=timeout_override,
         )
 
     return None
@@ -687,18 +696,27 @@ def _write_baseline_and_benchmark(
     skill_results: list[SkillResult | None],
     reports: list[GradingReport],
     model: str,
+    env_override: dict[str, str] | None = None,
+    timeout_override: int | None = None,
 ) -> Benchmark | None:
     """Run the baseline phase and compute+persist the benchmark delta.
 
     Returns the computed :class:`Benchmark` when every primary run has
     a real :class:`SkillResult` (i.e. not ``--output`` mode); otherwise
     returns ``None`` (the baseline sidecars still land on disk).
+
+    ``env_override`` and ``timeout_override`` thread the CLI's
+    ``--no-api-key`` / ``--timeout`` flags through to the baseline
+    subprocess so both arms of a ``--baseline`` run share the same
+    auth/deadline — otherwise the baseline bypasses those flags.
     """
     baseline_grading, baseline_skill_result = _run_baseline_phase(
         spec=spec,
         skill_dir=skill_dir,
         iteration=workspace.iteration,
         model=model,
+        env_override=env_override,
+        timeout_override=timeout_override,
     )
 
     # #28 US-002: compute the pair-run benchmark delta and persist
@@ -753,12 +771,19 @@ def _run_baseline_phase(
     skill_dir: Path,
     iteration: int,
     model: str,
+    env_override: dict[str, str] | None = None,
+    timeout_override: int | None = None,
 ) -> tuple[GradingReport, SkillResult]:
     """Run the baseline (no skill prefix) and persist sidecars.
 
     Thin I/O wrapper around :func:`clauditor.baseline.compute_baseline`:
     handles subprocess invocation, input-file staging, stderr progress,
     and sidecar writes into ``skill_dir`` (the staging iteration dir).
+
+    ``env_override`` and ``timeout_override`` mirror the primary arm's
+    wiring so ``--no-api-key`` / ``--timeout`` apply to both arms of a
+    ``--baseline`` run (otherwise the baseline subprocess would bypass
+    the flags, defeating their intent).
 
     Returns ``(GradingReport, SkillResult)`` so the caller can feed
     them to :func:`clauditor.benchmark.compute_benchmark`.
@@ -776,7 +801,12 @@ def _run_baseline_phase(
         stage_inputs(baseline_run_dir, sources)
         effective_cwd = baseline_run_dir / "inputs"
     print(f"Running baseline (no skill prefix) {test_args}...")
-    baseline_result = spec.runner.run_raw(test_args, cwd=effective_cwd)
+    baseline_result = spec.runner.run_raw(
+        test_args,
+        cwd=effective_cwd,
+        env=env_override,
+        timeout=timeout_override,
+    )
 
     reports = compute_baseline(
         skill_result=baseline_result,

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -127,6 +127,24 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
             " (case-insensitive, repeatable)"
         ),
     )
+    p_grade.add_argument(
+        "--no-api-key",
+        action="store_true",
+        help=(
+            "Strip ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN from the "
+            "subprocess environment to force subscription auth."
+        ),
+    )
+    p_grade.add_argument(
+        "--timeout",
+        type=_positive_int,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Override the runner timeout (seconds); must be > 0. "
+            "Defaults to EvalSpec.timeout or 180s."
+        ),
+    )
 
 
 def _load_and_validate_grade_args(
@@ -340,6 +358,17 @@ def _run_skill_variants(
     # Shared helper lives in ``clauditor.cli`` (package __init__). Import
     # lazily to avoid a circular import at module load.
     from clauditor.cli import _render_skill_error
+    from clauditor.runner import _env_without_api_key
+
+    # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
+    # to every ``spec.run`` invocation (primary + variance). Defaults
+    # are both None (today's behavior).
+    env_override = (
+        _env_without_api_key()
+        if getattr(args, "no_api_key", False)
+        else None
+    )
+    timeout_override = getattr(args, "timeout", None)
 
     run_outputs: list[tuple[str, list[dict]]] = []
     # Parallel list of SkillResult objects — None entries correspond to
@@ -367,6 +396,8 @@ def _run_skill_variants(
         )
         primary_skill_result = spec.run(
             run_dir=workspace.tmp_path / "run-0",
+            timeout_override=timeout_override,
+            env_override=env_override,
         )
         if not primary_skill_result.succeeded_cleanly:
             print(
@@ -394,7 +425,11 @@ def _run_skill_variants(
             if args.output
             else workspace.tmp_path / f"run-{variance_idx + 1}"
         )
-        variance_result = spec.run(run_dir=variance_run_dir)
+        variance_result = spec.run(
+            run_dir=variance_run_dir,
+            timeout_override=timeout_override,
+            env_override=env_override,
+        )
         if not variance_result.succeeded_cleanly:
             print(
                 f"ERROR: Variance skill run failed: "

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from clauditor.runner import SkillRunner, _env_without_api_key
+from clauditor.runner import SkillRunner, env_without_api_key
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -56,7 +56,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     # to the runner. Defaults are both None (today's behavior; runner
     # falls back to its own ``self.timeout`` default of 180s).
     env_override = (
-        _env_without_api_key()
+        env_without_api_key()
         if getattr(args, "no_api_key", False)
         else None
     )

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -11,11 +11,35 @@ from clauditor.runner import SkillRunner
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``run`` subparser."""
+    # Shared argparse type helpers live in the package __init__; import
+    # lazily to avoid a circular import at module load time.
+    from clauditor.cli import _positive_int
+
     p_run = subparsers.add_parser("run", help="Run a skill and print output")
     p_run.add_argument("skill", help="Skill name (e.g., find-kid-activities)")
     p_run.add_argument("--args", help="Arguments to pass to the skill")
     p_run.add_argument("--project-dir", help="Project directory (default: cwd)")
-    p_run.add_argument("--timeout", type=int, default=180, help="Timeout in seconds")
+    # DEC-014: default shifts from 180 to None so the precedence chain
+    # (CLI > spec > runner's 180s default) can kick in. ``_positive_int``
+    # rejects <= 0 at parse time with exit 2.
+    p_run.add_argument(
+        "--timeout",
+        type=_positive_int,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Timeout in seconds; must be > 0. Defaults to SkillRunner's "
+            "180s default."
+        ),
+    )
+    p_run.add_argument(
+        "--no-api-key",
+        action="store_true",
+        help=(
+            "Strip ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN from the "
+            "subprocess environment to force subscription auth."
+        ),
+    )
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -24,12 +48,25 @@ def cmd_run(args: argparse.Namespace) -> int:
     # lazily to avoid a circular import at module load: ``clauditor.cli``
     # imports this module to register the subparser.
     from clauditor.cli import _render_skill_error
+    from clauditor.runner import _env_without_api_key
 
     runner = SkillRunner(
         project_dir=Path(args.project_dir) if args.project_dir else Path.cwd(),
-        timeout=args.timeout,
     )
-    result = runner.run(args.skill, args.args or "")
+    # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
+    # to the runner. Defaults are both None (today's behavior; runner
+    # falls back to its own ``self.timeout`` default of 180s).
+    env_override = (
+        _env_without_api_key()
+        if getattr(args, "no_api_key", False)
+        else None
+    )
+    result = runner.run(
+        args.skill,
+        args.args or "",
+        env=env_override,
+        timeout=getattr(args, "timeout", None),
+    )
 
     # Render error whenever the run was not clean — this includes explicit
     # error text (rate_limit / auth / api / timeout / subprocess) AND the

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from clauditor.runner import SkillRunner
+from clauditor.runner import SkillRunner, _env_without_api_key
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -48,7 +48,6 @@ def cmd_run(args: argparse.Namespace) -> int:
     # lazily to avoid a circular import at module load: ``clauditor.cli``
     # imports this module to register the subparser.
     from clauditor.cli import _render_skill_error
-    from clauditor.runner import _env_without_api_key
 
     runner = SkillRunner(
         project_dir=Path(args.project_dir) if args.project_dir else Path.cwd(),

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from clauditor.assertions import run_assertions
 from clauditor.paths import resolve_clauditor_dir
-from clauditor.runner import SkillResult, _env_without_api_key
+from clauditor.runner import SkillResult, env_without_api_key
 from clauditor.workspace import (
     InvalidSkillNameError,
     IterationWorkspace,
@@ -148,11 +148,11 @@ def cmd_validate(args: argparse.Namespace) -> int:
             print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
             # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags
             # through to the spec. ``--no-api-key`` strips both auth env
-            # vars via ``_env_without_api_key``; ``--timeout`` wins over
+            # vars via ``env_without_api_key``; ``--timeout`` wins over
             # spec/default per DEC-002. Both default to None (today's
             # behavior).
             env_override = (
-                _env_without_api_key()
+                env_without_api_key()
                 if getattr(args, "no_api_key", False)
                 else None
             )

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from clauditor.assertions import run_assertions
 from clauditor.paths import resolve_clauditor_dir
-from clauditor.runner import SkillResult
+from clauditor.runner import SkillResult, _env_without_api_key
 from clauditor.workspace import (
     InvalidSkillNameError,
     IterationWorkspace,
@@ -151,8 +151,6 @@ def cmd_validate(args: argparse.Namespace) -> int:
             # vars via ``_env_without_api_key``; ``--timeout`` wins over
             # spec/default per DEC-002. Both default to None (today's
             # behavior).
-            from clauditor.runner import _env_without_api_key
-
             env_override = (
                 _env_without_api_key()
                 if getattr(args, "no_api_key", False)

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -19,6 +19,10 @@ from clauditor.workspace import (
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``validate`` subparser."""
+    # Shared argparse type helpers live in the package __init__; import
+    # lazily to avoid a circular import at module load time.
+    from clauditor.cli import _positive_int
+
     p_validate = subparsers.add_parser(
         "validate", help="Run Layer 1 assertions against a skill's output"
     )
@@ -36,6 +40,24 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         "--no-transcript",
         action="store_true",
         help="Skip writing per-run stream-json transcripts",
+    )
+    p_validate.add_argument(
+        "--no-api-key",
+        action="store_true",
+        help=(
+            "Strip ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN from the "
+            "subprocess environment to force subscription auth."
+        ),
+    )
+    p_validate.add_argument(
+        "--timeout",
+        type=_positive_int,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Override the runner timeout (seconds); must be > 0. "
+            "Defaults to EvalSpec.timeout or 180s."
+        ),
     )
     p_validate.add_argument(
         "-v",
@@ -124,7 +146,23 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
         try:
             print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
-            skill_result = spec.run(run_dir=workspace.tmp_path / "run-0")
+            # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags
+            # through to the spec. ``--no-api-key`` strips both auth env
+            # vars via ``_env_without_api_key``; ``--timeout`` wins over
+            # spec/default per DEC-002. Both default to None (today's
+            # behavior).
+            from clauditor.runner import _env_without_api_key
+
+            env_override = (
+                _env_without_api_key()
+                if getattr(args, "no_api_key", False)
+                else None
+            )
+            skill_result = spec.run(
+                run_dir=workspace.tmp_path / "run-0",
+                timeout_override=getattr(args, "timeout", None),
+                env_override=env_override,
+            )
             if not skill_result.succeeded_cleanly:
                 print(
                     f"ERROR: Skill failed to run: "

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 
 from clauditor.asserters import SkillAsserter
-from clauditor.runner import SkillResult, SkillRunner
+from clauditor.runner import SkillResult, SkillRunner, _env_without_api_key
 from clauditor.spec import SkillSpec
 
 
@@ -39,6 +39,16 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=int,
         default=180,
         help="Timeout for skill execution in seconds (default: 180)",
+    )
+    group.addoption(
+        "--clauditor-no-api-key",
+        action="store_true",
+        default=False,
+        help=(
+            "Strip ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN from the "
+            "subprocess environment so `claude -p` uses cached "
+            "subscription auth (~/.claude/) instead of env-based API auth"
+        ),
     )
     group.addoption(
         "--clauditor-claude-bin",
@@ -132,24 +142,45 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
         timeout=request.config.getoption("--clauditor-timeout"),
         claude_bin=request.config.getoption("--clauditor-claude-bin"),
     )
+    # DEC-006 (US-007): when ``--clauditor-no-api-key`` is set, compute
+    # the env dict once per fixture call and thread it as
+    # ``env_override`` through ``SkillSpec.run``. ``None`` otherwise —
+    # the spec's ``env_override`` kwarg default preserves today's
+    # behavior.
+    no_api_key = request.config.getoption("--clauditor-no-api-key")
+    env_override = _env_without_api_key() if no_api_key else None
 
     def _factory(skill_path: str | Path, eval_path: str | Path | None = None):
         spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
-        if spec.eval_spec is not None and spec.eval_spec.input_files:
+        has_input_files = (
+            spec.eval_spec is not None and bool(spec.eval_spec.input_files)
+        )
+        if has_input_files or env_override is not None:
             original_run = spec.run
             default_run_dir = tmp_path / f"clauditor_run_{id(spec)}"
 
-            def _run_with_default_run_dir(
+            def _run_with_overrides(
                 args: str | None = None,
                 *,
                 run_dir: Path | None = None,
             ):
-                if run_dir is None:
+                effective_run_dir = run_dir
+                if has_input_files and effective_run_dir is None:
                     default_run_dir.mkdir(parents=True, exist_ok=True)
-                    run_dir = default_run_dir
-                return original_run(args, run_dir=run_dir)
+                    effective_run_dir = default_run_dir
+                # Only pass ``env_override`` through when the option is
+                # set; otherwise call ``original_run`` with exactly the
+                # pre-US-007 kwargs so existing callers (and tests that
+                # assert on the call shape) remain unaffected.
+                if env_override is not None:
+                    return original_run(
+                        args,
+                        run_dir=effective_run_dir,
+                        env_override=env_override,
+                    )
+                return original_run(args, run_dir=effective_run_dir)
 
-            spec.run = _run_with_default_run_dir  # type: ignore[method-assign]
+            spec.run = _run_with_overrides  # type: ignore[method-assign]
         return spec
 
     return _factory

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 
 from clauditor.asserters import SkillAsserter
-from clauditor.runner import SkillResult, SkillRunner, _env_without_api_key
+from clauditor.runner import SkillResult, SkillRunner, env_without_api_key
 from clauditor.spec import SkillSpec
 
 
@@ -148,7 +148,7 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
     # the spec's ``env_override`` kwarg default preserves today's
     # behavior.
     no_api_key = request.config.getoption("--clauditor-no-api-key")
-    fixture_env_override = _env_without_api_key() if no_api_key else None
+    fixture_env_override = env_without_api_key() if no_api_key else None
 
     def _factory(skill_path: str | Path, eval_path: str | Path | None = None):
         spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -148,14 +148,14 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
     # the spec's ``env_override`` kwarg default preserves today's
     # behavior.
     no_api_key = request.config.getoption("--clauditor-no-api-key")
-    env_override = _env_without_api_key() if no_api_key else None
+    fixture_env_override = _env_without_api_key() if no_api_key else None
 
     def _factory(skill_path: str | Path, eval_path: str | Path | None = None):
         spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
         has_input_files = (
             spec.eval_spec is not None and bool(spec.eval_spec.input_files)
         )
-        if has_input_files or env_override is not None:
+        if has_input_files or fixture_env_override is not None:
             original_run = spec.run
             default_run_dir = tmp_path / f"clauditor_run_{id(spec)}"
 
@@ -163,20 +163,30 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                 args: str | None = None,
                 *,
                 run_dir: Path | None = None,
+                env_override: dict[str, str] | None = None,
+                timeout_override: int | None = None,
             ):
                 effective_run_dir = run_dir
                 if has_input_files and effective_run_dir is None:
                     default_run_dir.mkdir(parents=True, exist_ok=True)
                     effective_run_dir = default_run_dir
-                # Only pass ``env_override`` through when the option is
-                # set; otherwise call ``original_run`` with exactly the
-                # pre-US-007 kwargs so existing callers (and tests that
-                # assert on the call shape) remain unaffected.
-                if env_override is not None:
+                # Caller-provided overrides win over the fixture-level
+                # default computed from ``--clauditor-no-api-key``;
+                # otherwise the fixture value is used. Keeping the
+                # pre-US-007 call shape means existing tests that don't
+                # pass either override see ``original_run(args,
+                # run_dir=effective_run_dir)`` verbatim.
+                effective_env = (
+                    env_override
+                    if env_override is not None
+                    else fixture_env_override
+                )
+                if effective_env is not None or timeout_override is not None:
                     return original_run(
                         args,
                         run_dir=effective_run_dir,
-                        env_override=env_override,
+                        env_override=effective_env,
+                        timeout_override=timeout_override,
                     )
                 return original_run(args, run_dir=effective_run_dir)
 

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -289,6 +289,8 @@ class SkillRunner:
         args: str = "",
         *,
         cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
         allow_hang_heuristic: bool = True,
     ) -> SkillResult:
         """Run a skill and capture its output.
@@ -298,6 +300,14 @@ class SkillRunner:
             args: Pre-filled arguments to skip interactive prompts
             cwd: Optional override for the subprocess working directory.
                 When ``None``, falls back to ``self.project_dir``.
+            env: Optional env dict forwarded to ``subprocess.Popen``.
+                When ``None`` (default), ``Popen`` inherits ``os.environ``
+                — today's behavior. When a dict, it replaces the child's
+                environment entirely (DEC-013; mirrors ``cwd`` shape per
+                ``.claude/rules/subprocess-cwd.md``).
+            timeout: Optional per-invocation watchdog timeout in seconds.
+                When ``None`` (default), falls back to ``self.timeout``
+                (DEC-010).
             allow_hang_heuristic: When False, skip the interactive-hang
                 heuristic (DEC-005). Threaded here from
                 ``EvalSpec.allow_hang_heuristic`` so authors can opt out
@@ -314,6 +324,8 @@ class SkillRunner:
             skill_name=skill_name,
             args=args,
             cwd=cwd,
+            env=env,
+            timeout=timeout,
             allow_hang_heuristic=allow_hang_heuristic,
         )
 
@@ -356,13 +368,21 @@ class SkillRunner:
         skill_name: str,
         args: str,
         cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
         allow_hang_heuristic: bool = True,
     ) -> SkillResult:
         """Run ``claude`` with stream-json output and parse the NDJSON stream.
 
         Uses ``try/finally`` so ``duration_seconds`` is populated on every
         exit path (success, timeout, CalledProcessError, FileNotFoundError).
+
+        ``env`` is forwarded to ``subprocess.Popen`` verbatim: ``None``
+        means "inherit ``os.environ``" (Popen's default); a dict replaces
+        the child's environment entirely. ``timeout`` overrides
+        ``self.timeout`` for the watchdog when not ``None`` (DEC-010).
         """
+        effective_timeout = timeout if timeout is not None else self.timeout
         start = time.monotonic()
         raw_messages: list[dict] = []
         stream_events: list[dict] = []
@@ -401,6 +421,7 @@ class SkillRunner:
                     stderr=subprocess.PIPE,
                     text=True,
                     cwd=str(cwd) if cwd is not None else str(self.project_dir),
+                    env=env,
                 )
             except FileNotFoundError:
                 result = SkillResult(
@@ -467,7 +488,7 @@ class SkillRunner:
                             f"{type(exc).__name__}: {exc}"
                         )
 
-            watchdog = threading.Timer(self.timeout, _on_timeout)
+            watchdog = threading.Timer(effective_timeout, _on_timeout)
             watchdog.daemon = True
             watchdog.start()
 

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-# Env vars stripped by :func:`_env_without_api_key`. Both are
+# Env vars stripped by :func:`env_without_api_key`. Both are
 # documented Anthropic SDK env-auth paths (DEC-007 of
 # ``plans/super/64-runner-auth-timeout.md``). Non-auth Anthropic env
 # vars such as ``ANTHROPIC_BASE_URL`` are intentionally preserved
@@ -30,7 +30,7 @@ from typing import Literal
 _API_KEY_ENV_VARS = frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"})
 
 
-def _env_without_api_key(
+def env_without_api_key(
     base_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Return a new env dict with both auth env vars removed.
@@ -356,7 +356,7 @@ class SkillRunner:
                 inherits ``os.environ``; when a dict, replaces verbatim.
                 Mirrors the ``env`` kwarg on :meth:`run`; callers that
                 want to strip credentials use
-                :func:`_env_without_api_key`.
+                :func:`env_without_api_key`.
             timeout: Optional per-invocation timeout (seconds). When
                 ``None``, falls back to ``self.timeout``.
             allow_hang_heuristic: When False, skip the interactive-hang

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -75,6 +75,13 @@ class SkillResult:
     raw_messages: list[dict] = field(default_factory=list)
     stream_events: list[dict] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    # US-004 / DEC-005: populated from the first stream-json
+    # ``type=="system" AND subtype=="init"`` message when the CLI
+    # emits an ``apiKeySource`` field. ``None`` when absent (older CLI
+    # builds or a malformed stream — per DEC-012 / DEC-015). The value
+    # is a label (``"ANTHROPIC_API_KEY"``, ``"claude.ai"``, ``"none"``),
+    # not a secret. See ``docs/stream-json-schema.md``.
+    api_key_source: str | None = None
 
     @property
     def succeeded(self) -> bool:
@@ -396,6 +403,13 @@ class SkillRunner:
         # over stderr per DEC-001.
         stream_json_error_text: str | None = None
         stream_json_error_category: str | None = None
+        # US-004 / DEC-005 / DEC-015 / DEC-017: capture the first
+        # ``type=="system" AND subtype=="init"`` message's
+        # ``apiKeySource`` value. First init wins; subsequent inits
+        # ignored. ``None`` when absent (older CLI builds / malformed
+        # stream) — per DEC-012, suppresses the stderr info line.
+        api_key_source: str | None = None
+        init_captured = False
         result: SkillResult | None = None
         proc: subprocess.Popen | None = None
         stderr_thread: threading.Thread | None = None
@@ -524,6 +538,20 @@ class SkillRunner:
                         if "type" in msg:
                             stream_events.append(msg)
                         mtype = msg.get("type")
+                        # US-004 / DEC-017: capture ``apiKeySource`` from
+                        # the FIRST ``system/init`` message. DEC-015: later
+                        # init messages are ignored. DEC-012: absence
+                        # stays ``None`` (no stderr line here — emitted
+                        # once after the loop).
+                        if (
+                            not init_captured
+                            and mtype == "system"
+                            and msg.get("subtype") == "init"
+                        ):
+                            init_captured = True
+                            val = msg.get("apiKeySource")
+                            if isinstance(val, str):
+                                api_key_source = val
                         if mtype == "assistant":
                             message = msg.get("message") or {}
                             content = message.get("content") or []
@@ -597,6 +625,7 @@ class SkillRunner:
                     raw_messages=raw_messages,
                     stream_events=stream_events,
                     warnings=list(warnings),
+                    api_key_source=api_key_source,
                 )
                 # Early return is load-bearing: a post-timeout stream-json
                 # is_error:true must not clobber the "timeout" error. Keep
@@ -613,6 +642,18 @@ class SkillRunner:
                 warnings.append(
                     "stream-json ended without a 'result' message; "
                     "token usage unavailable"
+                )
+
+            # US-004 / DEC-005: emit one stderr info line per run when
+            # ``apiKeySource`` was captured. DEC-012: suppress entirely
+            # when the field is absent (no "apiKeySource=unavailable"
+            # line) — absence is the signal. Values are labels
+            # (``ANTHROPIC_API_KEY``, ``claude.ai``, ``none``), not
+            # secrets, so printing them is safe.
+            if api_key_source is not None:
+                print(
+                    f"clauditor.runner: apiKeySource={api_key_source}",
+                    file=sys.stderr,
                 )
 
             # DEC-005 / DEC-010: interactive-hang heuristic. Only run the
@@ -668,6 +709,7 @@ class SkillRunner:
                 raw_messages=raw_messages,
                 stream_events=stream_events,
                 warnings=list(warnings),
+                api_key_source=api_key_source,
             )
             return result
         finally:

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -341,6 +341,8 @@ class SkillRunner:
         prompt: str,
         *,
         cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
         allow_hang_heuristic: bool = True,
     ) -> SkillResult:
         """Run a raw prompt without skill prefix for baseline comparison.
@@ -350,6 +352,13 @@ class SkillRunner:
             cwd: Optional override for the subprocess working directory.
                 When ``None``, falls back to ``self.project_dir`` — see
                 ``.claude/rules/subprocess-cwd.md`` for the rationale.
+            env: Optional subprocess env dict. When ``None``, Popen
+                inherits ``os.environ``; when a dict, replaces verbatim.
+                Mirrors the ``env`` kwarg on :meth:`run`; callers that
+                want to strip credentials use
+                :func:`_env_without_api_key`.
+            timeout: Optional per-invocation timeout (seconds). When
+                ``None``, falls back to ``self.timeout``.
             allow_hang_heuristic: When False, skip the interactive-hang
                 heuristic (DEC-005).
 
@@ -361,6 +370,8 @@ class SkillRunner:
             skill_name="__baseline__",
             args=prompt,
             cwd=cwd,
+            env=env,
+            timeout=timeout,
             allow_hang_heuristic=allow_hang_heuristic,
         )
 

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -13,6 +13,7 @@ rule: pattern, rationale, canonical implementation pointer).
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import threading
@@ -20,6 +21,29 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
+
+# Env vars stripped by :func:`_env_without_api_key`. Both are
+# documented Anthropic SDK env-auth paths (DEC-007 of
+# ``plans/super/64-runner-auth-timeout.md``). Non-auth Anthropic env
+# vars such as ``ANTHROPIC_BASE_URL`` are intentionally preserved
+# (DEC-016).
+_API_KEY_ENV_VARS = frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"})
+
+
+def _env_without_api_key(
+    base_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a new env dict with both auth env vars removed.
+
+    Pure, non-mutating helper per
+    ``.claude/rules/non-mutating-scrub.md``. When ``base_env`` is
+    ``None``, reads from ``os.environ``. Always returns a new dict
+    (never mutates the input). Strips ``ANTHROPIC_API_KEY`` and
+    ``ANTHROPIC_AUTH_TOKEN``; preserves every other key (including
+    ``ANTHROPIC_BASE_URL``).
+    """
+    source = base_env if base_env is not None else os.environ
+    return {k: v for k, v in source.items() if k not in _API_KEY_ENV_VARS}
 
 
 @dataclass

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -267,6 +267,13 @@ class EvalSpec:
     # Set to ``False`` in an eval spec to opt a specific skill out when
     # the heuristic consistently mis-classifies its output.
     allow_hang_heuristic: bool = True
+    # DEC-002 / DEC-003 / DEC-008 / DEC-014 of #64: optional per-spec
+    # runner timeout (seconds). ``None`` means "unset" — the runner
+    # falls back to the CLI override if present, else to its own
+    # ``self.timeout`` default (180s). Positive int only; bool is
+    # explicitly rejected at load time per
+    # ``.claude/rules/constant-with-type-info.md``.
+    timeout: int | None = None
 
     @classmethod
     def from_file(cls, path: str | Path) -> EvalSpec:
@@ -604,6 +611,30 @@ class EvalSpec:
                 )
             allow_hang_heuristic = raw_flag
 
+        # DEC-002 / DEC-003 / DEC-008 / DEC-014 of #64: optional
+        # per-spec runner timeout override. ``None`` / missing →
+        # "unset" (runner falls back). Must be a positive int;
+        # ``bool`` is an ``int`` subclass in Python, so the check
+        # is ``isinstance(val, int) and not isinstance(val, bool)``
+        # per ``.claude/rules/constant-with-type-info.md``.
+        timeout: int | None = None
+        if "timeout" in data and data["timeout"] is not None:
+            raw_timeout = data["timeout"]
+            if not isinstance(raw_timeout, int) or isinstance(
+                raw_timeout, bool
+            ):
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"'timeout' must be an int, got "
+                    f"{type(raw_timeout).__name__} {raw_timeout!r}"
+                )
+            if raw_timeout <= 0:
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"'timeout' must be > 0, got {raw_timeout}"
+                )
+            timeout = raw_timeout
+
         trigger_tests = None
         if "trigger_tests" in data:
             tt = data["trigger_tests"]
@@ -644,6 +675,7 @@ class EvalSpec:
             variance=variance,
             grade_thresholds=grade_thresholds,
             allow_hang_heuristic=allow_hang_heuristic,
+            timeout=timeout,
         )
 
     def to_dict(self) -> dict:

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -111,6 +111,8 @@ class SkillSpec:
         args: str | None = None,
         *,
         run_dir: Path | None = None,
+        timeout_override: int | None = None,
+        env_override: dict[str, str] | None = None,
     ) -> SkillResult:
         """Run the skill and return captured output.
 
@@ -142,11 +144,26 @@ class SkillSpec:
         allow_hang_heuristic = (
             self.eval_spec.allow_hang_heuristic if self.eval_spec else True
         )
+        # DEC-002: timeout precedence is CLI > spec > default. ``None``
+        # falls through to ``SkillRunner.run``, which then uses its own
+        # ``self.timeout`` default (180s). DEC-013: ``env_override`` has
+        # no merge — passed through to ``runner.run(env=...)`` unchanged.
+        effective_timeout = (
+            timeout_override
+            if timeout_override is not None
+            else (
+                self.eval_spec.timeout
+                if self.eval_spec is not None
+                else None
+            )
+        )
         result = self.runner.run(
             self.skill_name,
             run_args,
             cwd=effective_cwd,
             allow_hang_heuristic=allow_hang_heuristic,
+            timeout=effective_timeout,
+            env=env_override,
         )
 
         # Read output from files if eval spec specifies file-based output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,13 +80,19 @@ def make_fake_skill_stream(
     output_tokens: int = 50,
     extra_messages: list[dict] | None = None,
     error_text: str | None = None,
+    init_message: dict | None = None,
 ) -> _FakePopen:
     """Build a ``_FakePopen`` emitting a realistic stream-json sequence.
 
     Produces:
-      1. one assistant message with a single ``text`` block containing ``text``
-      2. any ``extra_messages`` verbatim, in order
-      3. a final ``result`` message carrying token usage
+      1. optional ``init_message`` verbatim as the FIRST message
+         (typically a ``{"type": "system", "subtype": "init", ...}``
+         event — see US-004 of
+         ``plans/super/64-runner-auth-timeout.md``)
+      2. one assistant message with a single ``text`` block containing
+         ``text``
+      3. any ``extra_messages`` verbatim, in order
+      4. a final ``result`` message carrying token usage
 
     When ``error_text`` is not ``None``, the final ``result`` message
     carries ``is_error: True`` and ``result: <error_text>`` (per DEC-014
@@ -94,7 +100,10 @@ def make_fake_skill_stream(
     (``error_text=None``) preserves today's ``is_error: False`` output
     byte-for-byte so every pre-existing test keeps working.
     """
-    messages: list[dict] = [
+    messages: list[dict] = []
+    if init_message is not None:
+        messages.append(init_message)
+    messages.append(
         {
             "type": "assistant",
             "message": {
@@ -102,7 +111,7 @@ def make_fake_skill_stream(
                 "content": [{"type": "text", "text": text}],
             },
         }
-    ]
+    )
     if extra_messages:
         messages.extend(extra_messages)
     result_msg: dict = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3805,6 +3805,54 @@ class TestNoApiKeyFlag:
         assert rc == 0
         assert spec.run.call_args.kwargs.get("env_override") is None
 
+    def test_grade_baseline_threads_env_and_timeout_to_run_raw(
+        self, tmp_path, monkeypatch
+    ):
+        """#64 QG: grade --baseline --no-api-key --timeout X threads env
+        AND timeout to the baseline's run_raw call, not just the primary
+        arm's spec.run. End-to-end guard for the pass-2 baseline-plumbing
+        fix (argparse → _write_workspace_sidecars →
+        _write_baseline_and_benchmark → _run_baseline_phase → run_raw)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = make_skill_result(
+            output="primary output",
+            duration_seconds=0.5,
+            input_tokens=10,
+            output_tokens=5,
+        )
+        spec.runner = MagicMock()
+        spec.runner.run_raw.return_value = make_skill_result(
+            output="baseline output",
+            duration_seconds=0.3,
+            input_tokens=8,
+            output_tokens=4,
+            skill_name="__baseline__",
+        )
+        report = make_grading_report(passed=True)
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade", "skill.md",
+                    "--baseline", "--no-api-key", "--timeout", "60",
+                ]
+            )
+        assert rc == 0
+        spec.runner.run_raw.assert_called_once()
+        kwargs = spec.runner.run_raw.call_args.kwargs
+        self._assert_env_stripped(kwargs.get("env"))
+        assert kwargs.get("timeout") == 60
+
 
 class TestTimeoutFlag:
     """US-006: --timeout SECONDS threads to the runner, rejects <= 0 at parse time.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1942,6 +1942,71 @@ class TestBaselineFlag:
             skill_dir / "baseline-run" / "inputs" / "fixture.txt"
         ).is_file()
 
+    def test_run_baseline_phase_threads_env_and_timeout_overrides(
+        self, tmp_path, monkeypatch
+    ):
+        """#64 QG: _run_baseline_phase must forward env_override and
+        timeout_override to run_raw so --no-api-key and --timeout
+        apply to both arms of a --baseline run."""
+        from clauditor.cli import _run_baseline_phase
+
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec(sections=[])
+        spec = self._prepare_spec(eval_spec)
+        grading_report = self._make_grading_report()
+        skill_dir = tmp_path / "skill-dir"
+        skill_dir.mkdir()
+
+        sentinel_env = {"PATH": "/fake"}
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new_callable=AsyncMock,
+            return_value=grading_report,
+        ):
+            _run_baseline_phase(
+                spec=spec,
+                skill_dir=skill_dir,
+                iteration=1,
+                model="claude-sonnet-4-6",
+                env_override=sentinel_env,
+                timeout_override=77,
+            )
+
+        kwargs = spec.runner.run_raw.call_args.kwargs
+        assert kwargs["env"] is sentinel_env
+        assert kwargs["timeout"] == 77
+
+    def test_run_baseline_phase_defaults_env_and_timeout_to_none(
+        self, tmp_path, monkeypatch
+    ):
+        """Back-compat: _run_baseline_phase without overrides passes
+        env=None and timeout=None (today's Popen-inherit-os.environ
+        behavior)."""
+        from clauditor.cli import _run_baseline_phase
+
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec(sections=[])
+        spec = self._prepare_spec(eval_spec)
+        grading_report = self._make_grading_report()
+        skill_dir = tmp_path / "skill-dir"
+        skill_dir.mkdir()
+
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new_callable=AsyncMock,
+            return_value=grading_report,
+        ):
+            _run_baseline_phase(
+                spec=spec,
+                skill_dir=skill_dir,
+                iteration=1,
+                model="claude-sonnet-4-6",
+            )
+
+        kwargs = spec.runner.run_raw.call_args.kwargs
+        assert kwargs["env"] is None
+        assert kwargs["timeout"] is None
+
     # ---- #28 US-004: --min-baseline-delta gate ----
 
     def _make_report_with_pass_rate(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,7 +298,10 @@ class TestCmdGradeInputFilesStaging:
         spec = _make_spec(eval_spec=eval_spec)
         outputs_iter = iter(outputs)
 
-        def _run(args=None, *, run_dir=None):
+        def _run(args=None, *, run_dir=None, **kwargs):
+            # kwargs absorbs US-006 ``timeout_override`` / ``env_override``
+            # plumbing without coupling this staging fixture to their
+            # presence.
             if run_dir is not None and eval_spec.input_files:
                 stage_inputs(
                     run_dir, [_Path(p) for p in eval_spec.input_files]
@@ -3549,7 +3552,9 @@ class TestCmdCapture:
         out_path = tmp_path / "tests/eval/captured/find-restaurants.txt"
         assert out_path.exists()
         assert out_path.read_text() == "captured stdout"
-        mock_runner.run.assert_called_once_with("find-restaurants", "")
+        mock_runner.run.assert_called_once_with(
+            "find-restaurants", "", env=None, timeout=None,
+        )
 
     def test_capture_custom_out(self, tmp_path):
         mock_runner = MagicMock()
@@ -3596,7 +3601,9 @@ class TestCmdCapture:
         with patch("clauditor.cli.capture.SkillRunner", return_value=mock_runner):
             rc = main(["capture", "/find-restaurants"])
         assert rc == 0
-        mock_runner.run.assert_called_once_with("find-restaurants", "")
+        mock_runner.run.assert_called_once_with(
+            "find-restaurants", "", env=None, timeout=None,
+        )
         assert (tmp_path / "tests/eval/captured/find-restaurants.txt").exists()
 
     def test_capture_passes_trailing_args(self, tmp_path, monkeypatch):
@@ -3606,7 +3613,9 @@ class TestCmdCapture:
         with patch("clauditor.cli.capture.SkillRunner", return_value=mock_runner):
             rc = main(["capture", "find-restaurants", "--", "near", "San Jose"])
         assert rc == 0
-        mock_runner.run.assert_called_once_with("find-restaurants", "near San Jose")
+        mock_runner.run.assert_called_once_with(
+            "find-restaurants", "near San Jose", env=None, timeout=None,
+        )
 
     def test_capture_runner_failure_returns_nonzero(
         self, tmp_path, monkeypatch, capsys
@@ -3621,6 +3630,201 @@ class TestCmdCapture:
             rc = main(["capture", "find-restaurants"])
         assert rc == 1
         assert "boom" in capsys.readouterr().err
+
+
+class TestNoApiKeyFlag:
+    """US-006: --no-api-key strips both auth env vars on every skill-invoking CLI.
+
+    Each test threads the new ``env_override`` / ``env`` kwarg through
+    and asserts the resulting dict does NOT contain ``ANTHROPIC_API_KEY``
+    or ``ANTHROPIC_AUTH_TOKEN`` (DEC-001, DEC-006, DEC-007).
+    """
+
+    def _assert_env_stripped(self, env: dict | None) -> None:
+        assert env is not None, "env_override must be a dict, got None"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+    def test_validate_no_api_key_threads_env_override(
+        self, tmp_path, monkeypatch
+    ):
+        """validate --no-api-key → SkillSpec.run(env_override=<stripped>)."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="hello world output", duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--no-api-key"])
+        assert rc == 0
+        spec.run.assert_called_once()
+        env = spec.run.call_args.kwargs.get("env_override")
+        self._assert_env_stripped(env)
+
+    def test_grade_no_api_key_threads_env_override(
+        self, tmp_path, monkeypatch
+    ):
+        """grade --no-api-key → SkillSpec.run(env_override=<stripped>)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        spec.run.return_value = make_skill_result(
+            output="primary output", duration_seconds=0.5,
+            input_tokens=10, output_tokens=5,
+        )
+        report = make_grading_report(passed=True)
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--no-api-key"])
+        assert rc == 0
+        spec.run.assert_called()
+        env = spec.run.call_args.kwargs.get("env_override")
+        self._assert_env_stripped(env)
+
+    def test_capture_no_api_key_threads_env(self, tmp_path, monkeypatch):
+        """capture --no-api-key → SkillRunner.run(env=<stripped>)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="captured stdout", skill_name="find-restaurants",
+            duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.capture.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants", "--no-api-key"])
+        assert rc == 0
+        mock_runner.run.assert_called_once()
+        env = mock_runner.run.call_args.kwargs.get("env")
+        self._assert_env_stripped(env)
+
+    def test_run_no_api_key_threads_env(self, monkeypatch):
+        """run --no-api-key → SkillRunner.run(env=<stripped>)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token")
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="skill output", skill_name="my-skill",
+            duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill", "--no-api-key"])
+        assert rc == 0
+        mock_runner.run.assert_called_once()
+        env = mock_runner.run.call_args.kwargs.get("env")
+        self._assert_env_stripped(env)
+
+    def test_validate_without_no_api_key_passes_env_none(
+        self, tmp_path, monkeypatch
+    ):
+        """Without --no-api-key, env_override stays None (today's behavior)."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="hello world output", duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+        assert rc == 0
+        assert spec.run.call_args.kwargs.get("env_override") is None
+
+
+class TestTimeoutFlag:
+    """US-006: --timeout SECONDS threads to the runner, rejects <= 0 at parse time.
+
+    Covers argparse-level validation (exit 2 on 0, negative, non-int) and
+    the happy path (positive int → ``timeout_override`` / ``timeout``
+    kwarg on the underlying run call). Defaults to None (DEC-014).
+    """
+
+    def test_validate_timeout_300_threads_override(
+        self, tmp_path, monkeypatch
+    ):
+        """validate --timeout 300 → SkillSpec.run(timeout_override=300)."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="hello world output", duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--timeout", "300"])
+        assert rc == 0
+        assert spec.run.call_args.kwargs.get("timeout_override") == 300
+
+    def test_validate_timeout_zero_exits_2(self, capsys):
+        """--timeout 0 → argparse rejects with exit 2."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "skill.md", "--timeout", "0"])
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "must be >= 1" in err or "must be > 0" in err
+
+    def test_validate_timeout_negative_exits_2(self, capsys):
+        """--timeout -5 → argparse rejects with exit 2."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "skill.md", "--timeout", "-5"])
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "must be >= 1" in err or "must be > 0" in err
+
+    def test_validate_timeout_non_int_exits_2(self, capsys):
+        """--timeout foo → argparse rejects with exit 2."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["validate", "skill.md", "--timeout", "foo"])
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "not an integer" in err or "invalid" in err.lower()
+
+    def test_run_timeout_default_none_preserves_fallback(self):
+        """run (no --timeout) → SkillRunner.run(timeout=None), so the runner's
+        self.timeout default of 180s kicks in."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="skill output", skill_name="my-skill",
+            duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill"])
+        assert rc == 0
+        assert mock_runner.run.call_args.kwargs.get("timeout") is None
+
+    def test_run_timeout_300_threads_to_runner(self):
+        """run --timeout 300 → SkillRunner.run(timeout=300)."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="skill output", skill_name="my-skill",
+            duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill", "--timeout", "300"])
+        assert rc == 0
+        assert mock_runner.run.call_args.kwargs.get("timeout") == 300
+
+    def test_capture_timeout_300_threads_to_runner(self, tmp_path, monkeypatch):
+        """capture --timeout 300 → SkillRunner.run(timeout=300)."""
+        monkeypatch.chdir(tmp_path)
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="captured stdout", skill_name="find-restaurants",
+            duration_seconds=0.5,
+        )
+        with patch("clauditor.cli.capture.SkillRunner", return_value=mock_runner):
+            rc = main(["capture", "find-restaurants", "--timeout", "300"])
+        assert rc == 0
+        assert mock_runner.run.call_args.kwargs.get("timeout") == 300
 
 
 class TestCmdDoctor:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -99,7 +99,7 @@ class TestPluginFunctionsDirect:
         parser.getgroup.assert_called_once_with(
             "clauditor", "Claude Code skill testing"
         )
-        assert group.addoption.call_count == 5
+        assert group.addoption.call_count == 6
         # Verify option names
         option_names = [call.args[0] for call in group.addoption.call_args_list]
         assert "--clauditor-project-dir" in option_names
@@ -107,6 +107,7 @@ class TestPluginFunctionsDirect:
         assert "--clauditor-claude-bin" in option_names
         assert "--clauditor-grade" in option_names
         assert "--clauditor-model" in option_names
+        assert "--clauditor-no-api-key" in option_names
 
     def test_pytest_configure_adds_marker(self):
         """pytest_configure registers the clauditor_grade, network, and slow markers."""
@@ -179,6 +180,7 @@ class TestPluginFunctionsDirect:
                 "--clauditor-project-dir": None,
                 "--clauditor-timeout": 180,
                 "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
             }[opt]
         )
         factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -238,6 +240,7 @@ class TestPluginFunctionsDirect:
                 "--clauditor-project-dir": None,
                 "--clauditor-timeout": 180,
                 "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
             }[opt]
         )
         factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -267,6 +270,7 @@ class TestClauditorSpecInputFiles:
                 "--clauditor-project-dir": None,
                 "--clauditor-timeout": 180,
                 "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
             }[opt]
         )
         factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -300,6 +304,7 @@ class TestClauditorSpecInputFiles:
                 "--clauditor-project-dir": None,
                 "--clauditor-timeout": 180,
                 "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
             }[opt]
         )
         factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -420,6 +425,7 @@ def _blind_compare_factory(tmp_path: Path, *, cli_model: str | None = None):
             "--clauditor-timeout": 180,
             "--clauditor-claude-bin": "claude",
             "--clauditor-model": cli_model,
+            "--clauditor-no-api-key": False,
         }[opt]
     )
     spec_factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -716,3 +722,101 @@ class TestClauditorTriggersFactory:
         factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
         with pytest.raises(ValueError, match="No eval spec found"):
             factory(tmp_path / "skill.md")
+
+
+class TestClauditorNoApiKeyOption:
+    """US-007: ``--clauditor-no-api-key`` pytest option parity.
+
+    DEC-006: when set, the ``clauditor_spec`` fixture threads
+    ``env_override=_env_without_api_key()`` through ``SkillSpec.run``;
+    otherwise ``env_override`` stays unset and the existing call shape
+    is preserved for back-compat with the ``--clauditor-timeout``
+    wiring tests.
+    """
+
+    def _request(self, *, no_api_key: bool):
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 180,
+                "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": no_api_key,
+            }[opt]
+        )
+        return request
+
+    def test_no_api_key_option_reaches_spec_run(self, tmp_path):
+        """Setting ``--clauditor-no-api-key`` threads ``env_override`` to spec.run.
+
+        The fixture must call ``original_run(..., env_override=<dict>)``
+        where the dict has both auth env vars stripped.
+        """
+        from clauditor.spec import SkillSpec
+
+        request = self._request(no_api_key=True)
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+        original_run.return_value = "RESULT"
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # Wrapping happened because the option is set (even with no input_files).
+        assert result.run is not original_run
+
+        ret = result.run()
+        assert ret == "RESULT"
+        original_run.assert_called_once()
+        call_kwargs = original_run.call_args.kwargs
+        assert "env_override" in call_kwargs
+        env = call_kwargs["env_override"]
+        assert isinstance(env, dict)
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+    def test_timeout_option_still_works(self, tmp_path):
+        """Regression guard: ``--clauditor-timeout`` still reaches SkillRunner.
+
+        Adding ``--clauditor-no-api-key`` must not disturb the existing
+        timeout wiring from ``--clauditor-timeout`` → ``SkillRunner.timeout``.
+        """
+        request = self._request(no_api_key=False)
+        # Override the timeout to a distinct non-default value so a
+        # regression that reverts to the default 180 would be visible.
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 99,
+                "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
+            }[opt]
+        )
+        runner = clauditor_runner.__wrapped__(request)
+        assert runner.timeout == 99
+        # And clauditor_spec must not wrap spec.run when the option is
+        # off AND input_files is empty (pre-US-007 behavior preserved).
+        from clauditor.spec import SkillSpec
+
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        assert result.run is original_run

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -820,3 +820,58 @@ class TestClauditorNoApiKeyOption:
             result = factory("some/skill.md")
 
         assert result.run is original_run
+
+    def test_wrapper_accepts_timeout_override_kwarg(self, tmp_path):
+        """#64 QG: the fixture wrapper must accept ``timeout_override``.
+
+        Before the fix, ``_run_with_overrides`` only accepted
+        ``args`` + ``run_dir``, so a caller doing
+        ``spec.run(timeout_override=60)`` hit ``TypeError``. The
+        wrapper must now forward timeout_override to original_run.
+        """
+        from clauditor.spec import SkillSpec
+
+        request = self._request(no_api_key=True)
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+        original_run.return_value = "RESULT"
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        ret = result.run(timeout_override=60)
+        assert ret == "RESULT"
+        assert original_run.call_args.kwargs["timeout_override"] == 60
+
+    def test_caller_env_override_wins_over_fixture(self, tmp_path):
+        """#64 QG: when the caller passes env_override, it should win
+        over the fixture-level default (principle of least surprise)."""
+        from clauditor.spec import SkillSpec
+
+        request = self._request(no_api_key=True)
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+        original_run.return_value = "RESULT"
+
+        caller_env = {"CUSTOM": "value"}
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+        result.run(env_override=caller_env)
+
+        assert original_run.call_args.kwargs["env_override"] is caller_env

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -728,7 +728,7 @@ class TestClauditorNoApiKeyOption:
     """US-007: ``--clauditor-no-api-key`` pytest option parity.
 
     DEC-006: when set, the ``clauditor_spec`` fixture threads
-    ``env_override=_env_without_api_key()`` through ``SkillSpec.run``;
+    ``env_override=env_without_api_key()`` through ``SkillSpec.run``;
     otherwise ``env_override`` stays unset and the existing call shape
     is preserved for back-compat with the ``--clauditor-timeout``
     wiring tests.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -19,7 +19,7 @@ from clauditor.runner import (  # noqa: E402
     SkillRunner,
     _classify_result_message,
     _detect_interactive_hang,
-    _env_without_api_key,
+    env_without_api_key,
 )
 from tests.conftest import (  # noqa: E402
     _FakePopen,
@@ -2519,7 +2519,7 @@ class TestApiKeySourceParsing:
 
 
 class TestEnvWithoutApiKey:
-    """Pure-unit tests for :func:`clauditor.runner._env_without_api_key`.
+    """Pure-unit tests for :func:`clauditor.runner.env_without_api_key`.
 
     Covers DEC-007 (strip both auth vars), DEC-011 (non-mutating pure
     helper), and DEC-016 (preserve non-auth Anthropic env vars). No
@@ -2532,7 +2532,7 @@ class TestEnvWithoutApiKey:
             "ANTHROPIC_AUTH_TOKEN": "tok-abc",
             "PATH": "/usr/bin",
         }
-        result = _env_without_api_key(base)
+        result = env_without_api_key(base)
         assert "ANTHROPIC_API_KEY" not in result
         assert "ANTHROPIC_AUTH_TOKEN" not in result
         assert result["PATH"] == "/usr/bin"
@@ -2544,7 +2544,7 @@ class TestEnvWithoutApiKey:
             "PATH": "/usr/bin",
             "UNRELATED": "value",
         }
-        result = _env_without_api_key(base)
+        result = env_without_api_key(base)
         assert result == {
             "ANTHROPIC_BASE_URL": "https://proxy.example.com",
             "PATH": "/usr/bin",
@@ -2558,7 +2558,7 @@ class TestEnvWithoutApiKey:
             "MARKER": "present",
         }
         with patch.dict("os.environ", fake_env, clear=True):
-            result = _env_without_api_key()
+            result = env_without_api_key()
         assert "ANTHROPIC_API_KEY" not in result
         assert result["PATH"] == "/usr/bin"
         assert result["MARKER"] == "present"
@@ -2570,12 +2570,12 @@ class TestEnvWithoutApiKey:
             "PATH": "/usr/bin",
         }
         original = dict(base)
-        result = _env_without_api_key(base)
+        result = env_without_api_key(base)
         assert base == original
         assert result is not base
 
     def test_no_auth_vars_present(self):
         base = {"PATH": "/usr/bin", "HOME": "/home/user"}
-        result = _env_without_api_key(base)
+        result = env_without_api_key(base)
         assert result == base
         assert result is not base

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2365,6 +2365,159 @@ class TestInteractiveHangDetection:
         )
 
 
+class TestApiKeySourceParsing:
+    """Parse ``apiKeySource`` from the stream-json ``system/init`` message.
+
+    Covers DEC-005 (stderr line + field), DEC-012 (suppress line when
+    None), DEC-015 (first init wins), and DEC-017 (match on compound
+    ``type=="system" AND subtype=="init"``). Traces to US-004 of
+    ``plans/super/64-runner-auth-timeout.md``.
+    """
+
+    def _run_with_stream(self, fake: _FakePopen) -> SkillResult:
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            return runner.run("skill")
+
+    def test_init_apikeysource_none(self):
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "session_id": "abc",
+                "apiKeySource": "none",
+            },
+        )
+        result = self._run_with_stream(fake)
+        assert result.api_key_source == "none"
+
+    def test_init_apikeysource_env_var(self):
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "session_id": "abc",
+                "apiKeySource": "ANTHROPIC_API_KEY",
+            },
+        )
+        result = self._run_with_stream(fake)
+        assert result.api_key_source == "ANTHROPIC_API_KEY"
+
+    def test_init_apikeysource_missing(self):
+        # init present but no apiKeySource field → api_key_source is None,
+        # no crash.
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "session_id": "abc",
+            },
+        )
+        result = self._run_with_stream(fake)
+        assert result.api_key_source is None
+
+    def test_no_init_message(self):
+        # Stream has no system/init message at all. Field stays None and
+        # no crash occurs.
+        fake = make_fake_skill_stream("hello")
+        result = self._run_with_stream(fake)
+        assert result.api_key_source is None
+
+    def test_first_init_wins(self):
+        # Two init messages; the first value is kept, the second ignored
+        # (DEC-015).
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "first-value",
+            },
+            extra_messages=[
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "apiKeySource": "second-value",
+                }
+            ],
+        )
+        result = self._run_with_stream(fake)
+        assert result.api_key_source == "first-value"
+
+    def test_stderr_emits_info_line_when_present(self, capsys):
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "ANTHROPIC_API_KEY",
+            },
+        )
+        self._run_with_stream(fake)
+        captured = capsys.readouterr()
+        # Exactly one matching line per run.
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        assert len(matching) == 1, captured.err
+        assert "clauditor.runner:" in matching[0]
+        assert "apiKeySource=ANTHROPIC_API_KEY" in matching[0]
+
+    def test_stderr_line_suppressed_when_none(self, capsys):
+        # No init message → no apiKeySource= line on stderr (DEC-012).
+        fake = make_fake_skill_stream("hello")
+        self._run_with_stream(fake)
+        captured = capsys.readouterr()
+        assert "apiKeySource=" not in captured.err
+
+    def test_stderr_line_suppressed_when_init_missing_field(self, capsys):
+        # init present but apiKeySource absent → no stderr line (DEC-012).
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "session_id": "abc",
+            },
+        )
+        self._run_with_stream(fake)
+        captured = capsys.readouterr()
+        assert "apiKeySource=" not in captured.err
+
+    def test_init_apikeysource_non_string_ignored(self):
+        # Defensive: a non-string apiKeySource (e.g. a dict or int from a
+        # buggy CLI build) is ignored rather than crashing.
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": 42,
+            },
+        )
+        result = self._run_with_stream(fake)
+        assert result.api_key_source is None
+
+    def test_system_event_without_init_subtype_ignored(self):
+        # type=="system" but subtype!="init" must not populate the field
+        # (DEC-017).
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "hook",
+                "apiKeySource": "should-be-ignored",
+            },
+        )
+        result = self._run_with_stream(fake)
+        assert result.api_key_source is None
+
+
 class TestEnvWithoutApiKey:
     """Pure-unit tests for :func:`clauditor.runner._env_without_api_key`.
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -19,6 +19,7 @@ from clauditor.runner import (  # noqa: E402
     SkillRunner,
     _classify_result_message,
     _detect_interactive_hang,
+    _env_without_api_key,
 )
 from tests.conftest import (  # noqa: E402
     _FakePopen,
@@ -2260,3 +2261,66 @@ class TestInteractiveHangDetection:
             w.startswith(_INTERACTIVE_HANG_WARNING_PREFIX)
             for w in result.warnings
         )
+
+
+class TestEnvWithoutApiKey:
+    """Pure-unit tests for :func:`clauditor.runner._env_without_api_key`.
+
+    Covers DEC-007 (strip both auth vars), DEC-011 (non-mutating pure
+    helper), and DEC-016 (preserve non-auth Anthropic env vars). No
+    subprocess mocks — the helper is pure.
+    """
+
+    def test_strips_both_auth_vars(self):
+        base = {
+            "ANTHROPIC_API_KEY": "sk-key",
+            "ANTHROPIC_AUTH_TOKEN": "tok-abc",
+            "PATH": "/usr/bin",
+        }
+        result = _env_without_api_key(base)
+        assert "ANTHROPIC_API_KEY" not in result
+        assert "ANTHROPIC_AUTH_TOKEN" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_preserves_other_vars(self):
+        base = {
+            "ANTHROPIC_API_KEY": "sk-key",
+            "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            "PATH": "/usr/bin",
+            "UNRELATED": "value",
+        }
+        result = _env_without_api_key(base)
+        assert result == {
+            "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            "PATH": "/usr/bin",
+            "UNRELATED": "value",
+        }
+
+    def test_default_reads_os_environ(self):
+        fake_env = {
+            "ANTHROPIC_API_KEY": "sk-key",
+            "PATH": "/usr/bin",
+            "MARKER": "present",
+        }
+        with patch.dict("os.environ", fake_env, clear=True):
+            result = _env_without_api_key()
+        assert "ANTHROPIC_API_KEY" not in result
+        assert result["PATH"] == "/usr/bin"
+        assert result["MARKER"] == "present"
+
+    def test_is_non_mutating(self):
+        base = {
+            "ANTHROPIC_API_KEY": "sk-key",
+            "ANTHROPIC_AUTH_TOKEN": "tok-abc",
+            "PATH": "/usr/bin",
+        }
+        original = dict(base)
+        result = _env_without_api_key(base)
+        assert base == original
+        assert result is not base
+
+    def test_no_auth_vars_present(self):
+        base = {"PATH": "/usr/bin", "HOME": "/home/user"}
+        result = _env_without_api_key(base)
+        assert result == base
+        assert result is not base

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -314,6 +314,108 @@ class TestSkillRunnerCwd:
             assert mock_popen.call_args.kwargs["cwd"] == str(tmp_path)
 
 
+class TestSkillRunnerEnvAndTimeout:
+    """US-003: keyword-only ``env=`` and ``timeout=`` kwargs on ``run``.
+
+    Traces to DEC-010 (move ``timeout`` from ``__init__`` to a per-call
+    ``run()`` kwarg, with ``self.timeout`` as fallback) and DEC-013
+    (``env=`` kwarg shape mirrors ``cwd``; ``None`` passes through to
+    ``subprocess.Popen(env=None)`` which inherits ``os.environ``).
+    """
+
+    def test_run_env_none_popen_receives_none(self):
+        """Default ``env=None`` reaches Popen unchanged."""
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("out")
+            runner.run("my-skill", "args")
+            assert mock_popen.call_args.kwargs["env"] is None
+
+    def test_run_env_dict_popen_receives_dict(self):
+        """``env={"KEY": "VAL"}`` is forwarded to Popen verbatim."""
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        env = {"KEY": "VAL", "PATH": "/usr/bin"}
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("out")
+            runner.run("my-skill", "args", env=env)
+            assert mock_popen.call_args.kwargs["env"] == env
+
+    def test_run_timeout_override_used_in_watchdog(self):
+        """Per-call ``timeout=`` overrides ``self.timeout`` for the watchdog."""
+        runner = SkillRunner(project_dir="/tmp", timeout=180, claude_bin="claude")
+        captured: dict[str, float] = {}
+
+        class _CapturingTimer:
+            def __init__(self, interval, function, args=None, kwargs=None):
+                captured["interval"] = interval
+                self.function = function
+                self.daemon = True
+
+            def start(self):
+                pass
+
+            def cancel(self):
+                pass
+
+        with (
+            patch(
+                "clauditor.runner.subprocess.Popen",
+                return_value=make_fake_skill_stream("out"),
+            ),
+            patch("clauditor.runner.threading.Timer", _CapturingTimer),
+        ):
+            runner.run("my-skill", "args", timeout=60)
+
+        assert captured["interval"] == 60
+
+    def test_run_timeout_none_falls_back_to_self_timeout(self):
+        """``timeout=None`` (default) uses ``self.timeout``."""
+        runner = SkillRunner(project_dir="/tmp", timeout=42, claude_bin="claude")
+        captured: dict[str, float] = {}
+
+        class _CapturingTimer:
+            def __init__(self, interval, function, args=None, kwargs=None):
+                captured["interval"] = interval
+                self.function = function
+                self.daemon = True
+
+            def start(self):
+                pass
+
+            def cancel(self):
+                pass
+
+        with (
+            patch(
+                "clauditor.runner.subprocess.Popen",
+                return_value=make_fake_skill_stream("out"),
+            ),
+            patch("clauditor.runner.threading.Timer", _CapturingTimer),
+        ):
+            runner.run("my-skill", "args")
+
+        assert captured["interval"] == 42
+
+    def test_init_timeout_default_180_unchanged(self):
+        """``SkillRunner()`` with no kwargs keeps ``self.timeout == 180``."""
+        runner = SkillRunner()
+        assert runner.timeout == 180
+
+    def test_existing_call_site_unaffected(self):
+        """A ``runner.run("skill", args="")`` call with no new kwargs still
+        works and produces a normal ``SkillResult`` — back-compat check."""
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch("clauditor.runner.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = make_fake_skill_stream("hello")
+            result = runner.run("my-skill", args="")
+            # env kwarg is passed (as None), not omitted — Popen's default
+            # inheritance path requires explicit ``env=None``.
+            assert "env" in mock_popen.call_args.kwargs
+            assert mock_popen.call_args.kwargs["env"] is None
+            assert result.output == "hello"
+            assert result.exit_code == 0
+
+
 # ---------------------------------------------------------------------------
 # SkillResult.outputs dict
 # ---------------------------------------------------------------------------

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1830,6 +1830,63 @@ class TestEvalSpecFromDict:
 
         assert str(ei_file.value) == str(ei_dict.value)
 
+    def test_timeout_int_300(self, tmp_path):
+        """Positive int loads and round-trips as spec.timeout."""
+        data = {"skill_name": "s", "timeout": 300}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.timeout == 300
+
+    def test_timeout_zero_raises(self, tmp_path):
+        """``timeout=0`` is rejected with the ``> 0`` error."""
+        data = {"skill_name": "s", "timeout": 0}
+        with pytest.raises(
+            ValueError, match=r"'timeout' must be > 0, got 0"
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_timeout_negative_raises(self, tmp_path):
+        """Negative timeouts are rejected with the ``> 0`` error."""
+        data = {"skill_name": "s", "timeout": -5}
+        with pytest.raises(
+            ValueError, match=r"'timeout' must be > 0, got -5"
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_timeout_string_raises(self, tmp_path):
+        """Non-int (string) rejected at load time (no coercion)."""
+        data = {"skill_name": "s", "timeout": "300"}
+        with pytest.raises(
+            ValueError,
+            match=r"'timeout' must be an int, got str '300'",
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_timeout_bool_raises(self, tmp_path):
+        """Bool guard: ``isinstance(True, int)`` is True in Python.
+
+        Per ``.claude/rules/constant-with-type-info.md`` the validator
+        must explicitly reject ``bool`` so ``{"timeout": True}`` does
+        not silently load as ``1``.
+        """
+        data = {"skill_name": "s", "timeout": True}
+        with pytest.raises(
+            ValueError,
+            match=r"'timeout' must be an int, got bool True",
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_timeout_null_is_none(self, tmp_path):
+        """Explicit null maps to ``None`` ("unset")."""
+        data = {"skill_name": "s", "timeout": None}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.timeout is None
+
+    def test_timeout_missing_is_none(self, tmp_path):
+        """Missing key maps to ``None`` (default unset)."""
+        data = {"skill_name": "s"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.timeout is None
+
 
 class TestAllowHangHeuristic:
     """DEC-005 / US-003: ``allow_hang_heuristic`` parsing in ``from_dict``.

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -166,6 +166,8 @@ class TestRun:
             "--custom flag",
             cwd=None,
             allow_hang_heuristic=True,
+            timeout=None,
+            env=None,
         )
         assert result.output == "explicit output"
 
@@ -179,6 +181,8 @@ class TestRun:
             "--depth quick",
             cwd=None,
             allow_hang_heuristic=True,
+            timeout=None,
+            env=None,
         )
 
     def test_run_uses_empty_string_when_no_eval_no_args(
@@ -193,6 +197,8 @@ class TestRun:
             "",
             cwd=None,
             allow_hang_heuristic=True,
+            timeout=None,
+            env=None,
         )
 
 
@@ -510,7 +516,15 @@ class TestOutputFilesResolutionWithStagedInputs:
         # Side-effect: the "skill" writes cleaned.csv into its staging CWD.
         base_result = runner.run.return_value
 
-        def side_effect(skill_name, args, *, cwd=None, allow_hang_heuristic=True):
+        def side_effect(
+            skill_name,
+            args,
+            *,
+            cwd=None,
+            allow_hang_heuristic=True,
+            timeout=None,
+            env=None,
+        ):
             assert cwd == run_dir / "inputs"
             (cwd / "cleaned.csv").write_text(cleaned_text)
             return base_result
@@ -681,6 +695,81 @@ class TestAllowHangHeuristicThreading:
         assert (
             runner.run.call_args.kwargs.get("allow_hang_heuristic") is True
         )
+
+
+class TestTimeoutPrecedence:
+    """DEC-002 / US-005: ``SkillSpec.run`` resolves the effective timeout
+    as CLI > spec > default, and threads ``env_override`` through to
+    ``SkillRunner.run(env=...)`` unchanged (no precedence merge per DEC-013).
+    """
+
+    def test_cli_override_wins(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "cli-wins",
+            "test_args": "",
+            "assertions": [],
+            "timeout": 300,
+        }
+        skill_path, _ = tmp_skill_file("cli-wins", eval_data=eval_data)
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run(timeout_override=60)
+        assert runner.run.call_args.kwargs.get("timeout") == 60
+
+    def test_spec_wins_when_no_cli_override(
+        self, tmp_skill_file, mock_runner
+    ):
+        eval_data = {
+            "skill_name": "spec-wins",
+            "test_args": "",
+            "assertions": [],
+            "timeout": 300,
+        }
+        skill_path, _ = tmp_skill_file("spec-wins", eval_data=eval_data)
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run(timeout_override=None)
+        assert runner.run.call_args.kwargs.get("timeout") == 300
+
+    def test_default_when_neither_set(self, tmp_skill_file, mock_runner):
+        eval_data = {
+            "skill_name": "both-none",
+            "test_args": "",
+            "assertions": [],
+        }
+        skill_path, _ = tmp_skill_file("both-none", eval_data=eval_data)
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run()
+        assert runner.run.call_args.kwargs.get("timeout") is None
+
+    def test_env_override_threaded_through(
+        self, tmp_skill_file, mock_runner
+    ):
+        skill_path = tmp_skill_file("env-dict")
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run(env_override={"FOO": "bar"})
+        assert runner.run.call_args.kwargs.get("env") == {"FOO": "bar"}
+
+    def test_env_override_none_threaded_through(
+        self, tmp_skill_file, mock_runner
+    ):
+        skill_path = tmp_skill_file("env-none")
+        runner = mock_runner(output="ok")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+        spec.run(env_override=None)
+        assert runner.run.call_args.kwargs.get("env") is None
+
+    def test_eval_spec_none_path(self, tmp_skill_file, mock_runner):
+        # Direct-constructor path: ``eval_spec`` is None. Timeout
+        # resolution must still work and default to None (runner falls
+        # back to its own ``self.timeout``).
+        skill_path = tmp_skill_file("no-spec")
+        runner = mock_runner(output="ok")
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+        spec.run()
+        assert runner.run.call_args.kwargs.get("timeout") is None
 
 
 # Path to the checked-in example eval spec used by


### PR DESCRIPTION
## Summary

Super plan for #64 — expose subscription (Pro/Max) auth by stripping `ANTHROPIC_API_KEY` (and `ANTHROPIC_AUTH_TOKEN`) from the `claude -p` subprocess env, plus make the 180s runner timeout configurable at CLI and spec level, plus surface `apiKeySource` from the stream-json init event.

**Phase:** detailing (awaiting approval)
**Stories:** 7 implementation stories (US-001…US-007) + Quality Gate (US-008) + Patterns & Memory (US-009)
**Decisions:** 17 (DEC-001…DEC-017) traced to acceptance criteria

## Plan document

See `plans/super/64-runner-auth-timeout.md` for the full plan:
- Discovery — ticket summary, codebase scout findings, rule constraints
- Architecture Review — 6 parallel reviews; 1 blocker (ANTHROPIC_AUTH_TOKEN) + 5 concerns, all resolved
- Refinement Log — 17 decisions (scoping answers + concern fixes + implementation detail)
- Detailed Breakdown — 7 right-sized stories with TDD lists and dependencies

## Key shape decisions

- `--no-api-key` boolean flag on `validate` / `grade` / `capture` / `run` + pytest plugin option `--clauditor-no-api-key`
- `--timeout SECONDS` CLI flag; new `EvalSpec.timeout` field; precedence CLI > spec > 180s default
- `SkillRunner.run(env=, timeout=)` keyword-only kwargs mirror the `cwd` shape per `subprocess-cwd.md`
- Pure helper `_env_without_api_key()` in `runner.py` per `pure-compute-vs-io-split.md`
- `apiKeySource` parsed from `type: "system"` / `subtype: "init"` → `SkillResult.api_key_source` + stderr info line (suppressed when None)
- `docs/stream-json-schema.md` companion update bundled into US-004 per the concurrent-update rule

## Next steps

1. Review this plan PR
2. Approve in Claude Code to proceed to devolve (beads creation)
3. Execute via `/ralph-run`