### PR TITLE
docs: close post-merge gaps for #64 in README + pytest-plugin reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ clauditor implements (and extends) the workflow at [agentskills.io/skill-creatio
 | Regression + longitudinal history | `clauditor compare`, `.clauditor/history.jsonl`, `clauditor trend --metric <dotted.path>` |
 | Per-iteration workspace | `.clauditor/iteration-N/<skill>/` with sidecars + `run-*/` transcripts |
 
-**Beyond the spec**: trigger precision testing, tiered extraction, pytest plugin, `input_files` staging, blind A/B judge, baseline pair runs, transcript capture, LLM-driven skill improvement proposer (`clauditor suggest`), LLM-assisted EvalSpec bootstrap (`clauditor propose-eval`). **Out of scope**: human-in-the-loop feedback capture.
+**Beyond the spec**: trigger precision testing, tiered extraction, pytest plugin, `input_files` staging, blind A/B judge, baseline pair runs, transcript capture, LLM-driven skill improvement proposer (`clauditor suggest`), LLM-assisted EvalSpec bootstrap (`clauditor propose-eval`), Pro/Max subscription-auth option (`--no-api-key`) for research-heavy skills that exceed the API-tier rate limit. **Out of scope**: human-in-the-loop feedback capture.
 
 </details>
 

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -27,6 +27,7 @@ The following fields on `SkillResult` are the supported public surface that test
 - `input_tokens: int` — Anthropic input token count (0 if not reported).
 - `output_tokens: int` — Anthropic output token count (0 if not reported).
 - `duration_seconds: float` — wall-clock seconds from start of subprocess to exit.
+- `api_key_source: str | None` — auth source the child `claude -p` reported (parsed from the stream-json `system/init` message's `apiKeySource`). Example values: `"ANTHROPIC_API_KEY"`, `"claude.ai"`, `"none"`. `None` when the field was absent (older CLI builds) or malformed. Useful for asserting which tier a test ran against (e.g. `assert result.api_key_source == "claude.ai"` when running under `--clauditor-no-api-key`). See `docs/stream-json-schema.md` for the parser contract.
 
 The following fields on `SkillResult` are internal-observability-only and may change without notice; do not assert on them in tests: `raw_messages`, `stream_events`, `warnings`, `outputs`.
 
@@ -36,8 +37,11 @@ Options:
 pytest --clauditor-project-dir /path/to/project
 pytest --clauditor-timeout 300
 pytest --clauditor-claude-bin /usr/local/bin/claude
+pytest --clauditor-no-api-key         # Strip ANTHROPIC_{API_KEY,AUTH_TOKEN}
 pytest --clauditor-grade              # Enable Layer 3 tests (costs money)
 pytest --clauditor-model claude-sonnet-4-6  # Override grading model
 ```
+
+`--clauditor-no-api-key` is the plugin-option counterpart to `--no-api-key` on the CLI: strips both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the `claude -p` subprocess environment so the child falls back to whatever auth is cached in `~/.claude/` (typically a Pro/Max subscription). Scoped to the `clauditor_spec` fixture's `env_override` wiring; the bare `clauditor_runner` fixture is unaffected (its `SkillRunner` is constructed without the env scrub). For per-test overrides, `spec.run(env_override=..., timeout_override=...)` accepts both kwargs directly — the fixture wrapper forwards caller-provided values over the fixture-level default.
 
 Mark tests that need Layer 3 with `@pytest.mark.clauditor_grade`; they are skipped by default and only run under `--clauditor-grade`.


### PR DESCRIPTION
## Summary

Follow-up from the #64 merge. The PR updated `CHANGELOG.md`, `docs/cli-reference.md`, `docs/eval-spec-reference.md`, and `docs/stream-json-schema.md` but left two user-facing surfaces undocumented:

- **README.md** — no mention of the Pro/Max subscription-auth option. Added a one-line entry to the "Beyond the spec" list in the agentskills.io alignment details block. D2 lean teaser budget per `.claude/rules/readme-promotion-recipe.md` — single comma-separated append, no new section.
- **docs/pytest-plugin.md** — the options list was missing `--clauditor-no-api-key` (5 listed, 6 registered). The `SkillResult` public-fields table was missing `api_key_source`, which is an intentional test-assertable surface per DEC-005 of the plan. Added both, plus a short note on `spec.run(env_override=..., timeout_override=...)` for per-test overrides.

## Out of scope

- `docs/layers.md:116` mentions `ANTHROPIC_API_KEY` for the grader; the grader uses the Anthropic SDK directly (not `claude -p`), so subscription auth doesn't apply to Layer 3. No change.
- `docs/quick-start.md`, `docs/skill-usage.md`, `docs/architecture.md` — not touched by #64's surfaces.

## Test plan

- [x] `uv run pytest tests/test_docs_examples.py` — 26 tests pass
- [x] Manual: verified each new anchor in README and pytest-plugin.md renders and links correctly