### PR TITLE
#71: Agentskills.io spec conformance check (plan)

### DIFF
--- a/.claude/rules/skill-identity-from-frontmatter.md
+++ b/.claude/rules/skill-identity-from-frontmatter.md
@@ -5,10 +5,14 @@ from a `SKILL.md` file, consult the YAML frontmatter `name:` field
 first, validate it against `SKILL_NAME_RE`, and fall back to a
 **layout-aware** filesystem-derived name when frontmatter is absent or
 invalid. The helper is pure — it takes the already-loaded Markdown
-text, emits no stderr, and returns a `(name, warning_or_None)` tuple
-so the caller can emit warnings at the I/O boundary. Malformed
-frontmatter and regex failures are lenient: fall back, warn, keep
-going. A typo in YAML should never make a skill uncallable.
+text, emits no stderr, and returns the resolved `str` name. Malformed
+frontmatter and regex failures are lenient: fall back, keep going. A
+typo in YAML should never make a skill uncallable. Warning emission
+for invalid-name fallback and frontmatter-vs-filesystem mismatch is
+the responsibility of `clauditor.conformance.check_conformance`
+(routed through the `SkillSpec.from_file` soft-warn hook, DEC-003 /
+DEC-008 / DEC-014 of `plans/super/71-agentskills-lint.md`) — the
+identity-derivation helper itself emits no diagnostics.
 
 ## The pattern
 
@@ -24,44 +28,46 @@ def _filesystem_name(skill_path: Path) -> str:
     return skill_path.stem              # legacy: <name>.md
 
 
-def derive_skill_name(
-    skill_path: Path, skill_md_text: str,
-) -> tuple[str, str | None]:
+def derive_skill_name(skill_path: Path, skill_md_text: str) -> str:
     fs_name = _filesystem_name(skill_path)
 
     from clauditor._frontmatter import parse_frontmatter
     try:
         parsed, _body = parse_frontmatter(skill_md_text)
     except ValueError:
-        return fs_name, None  # malformed frontmatter → treat as absent
+        return fs_name  # malformed frontmatter → treat as absent
 
     if not isinstance(parsed, dict) or "name" not in parsed:
-        return fs_name, None  # no name: key → silent fallback
+        return fs_name  # no name: key → silent fallback
 
     fm_name = parsed["name"]
     if not isinstance(fm_name, str) or re.fullmatch(SKILL_NAME_RE, fm_name) is None:
-        return fs_name, (
-            f"clauditor.spec: frontmatter name {fm_name!r} is not a "
-            f"valid skill identifier — using {fs_name!r}"
-        )
+        return fs_name  # invalid frontmatter name → silent fallback;
+                        # conformance.check_conformance surfaces the
+                        # AGENTSKILLS_NAME_INVALID_CHARS warning.
 
-    if fm_name != fs_name:
-        return fm_name, (
-            f"clauditor.spec: frontmatter name {fm_name!r} overrides "
-            f"filesystem name {fs_name!r} — using {fm_name!r}"
-        )
-
-    return fm_name, None
+    # Disagreement (fm_name != fs_name) returns the frontmatter value
+    # unchanged. The conformance checker emits the
+    # AGENTSKILLS_NAME_PARENT_DIR_MISMATCH warning separately; this
+    # helper stays silent.
+    return fm_name
 ```
 
-At the call site, the I/O layer owns `read_text` and stderr:
+At the call site, the I/O layer owns `read_text` and — via the
+conformance soft-warn hook — stderr:
 
 ```python
 # src/clauditor/spec.py::SkillSpec.from_file
 text = skill_path.read_text(encoding="utf-8")
-skill_name, warning = derive_skill_name(skill_path, text)
-if warning is not None:
-    print(warning, file=sys.stderr)
+skill_name = derive_skill_name(skill_path, text)
+
+# Soft-warn hook: emit conformance warnings (including
+# AGENTSKILLS_NAME_INVALID_CHARS / AGENTSKILLS_NAME_PARENT_DIR_MISMATCH)
+# through a single seam, formatted by ``conformance.format_issue_line``.
+# ``check_conformance`` never raises.
+for issue in check_conformance(text, skill_path):
+    if issue.severity == "warning":
+        print(format_issue_line(issue), file=sys.stderr)
 return cls(..., skill_name_override=skill_name)
 ```
 
@@ -87,35 +93,58 @@ return cls(..., skill_name_override=skill_name)
   like `"foo; rm -rf /"` or `"../../../etc/passwd"`. `SKILL_NAME_RE`
   lives in `paths.py` as a shared constant; every caller uses
   `re.fullmatch` (not `re.match`) so trailing newlines don't pass.
+  Note that `SKILL_NAME_RE` is clauditor's internal safety filter and
+  is **intentionally different** from
+  `conformance.AGENTSKILLS_NAME_RE` (strict ASCII lowercase per
+  DEC-006 of `plans/super/71-agentskills-lint.md`); the two regexes
+  have different contracts (internal safety vs external publish
+  conformance) and must not be merged.
 - **Lenient on regex failure, not strict**: a malformed frontmatter
   value shouldn't make the skill uncallable — the filesystem fallback
   is the already-validated path segment (the parent dir / stem went
-  through the OS). Fall back, warn, keep going. The warning names
-  both the bad value and the fallback so the author notices without
-  being blocked.
+  through the OS). Fall back, keep going. The soft-warn hook then
+  surfaces the corresponding `AGENTSKILLS_NAME_INVALID_CHARS` (or
+  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`) warning so the author
+  notices without being blocked.
 - **Malformed frontmatter treated as absent**: `parse_frontmatter`
   raises `ValueError` on structural errors (missing closing `---`,
   empty key, etc.). A hard failure would be hostile to authors
   iterating on a skill; silent fallback preserves load-bearing
-  behavior. A future `--strict` mode could escalate if needed.
-- **Pure `(str, str | None)` tuple return**: the helper emits no
-  stderr, touches no disk. Callers emit warnings at the I/O boundary
-  (`SkillSpec.from_file`, `cli/init.py`). Satisfies
+  behavior. The conformance checker surfaces the
+  `AGENTSKILLS_FRONTMATTER_INVALID_YAML` error via `clauditor lint`
+  (exit 1), and `--strict` on `lint` can escalate additional
+  warnings per DEC-004 of `plans/super/71-agentskills-lint.md`.
+- **Pure `str` return, no warning channel**: the helper emits no
+  stderr, touches no disk, and has no side-channel. Callers that want
+  diagnostic output consult `conformance.check_conformance` through
+  the `SkillSpec.from_file` soft-warn hook (a single seam per DEC-014
+  of `plans/super/71-agentskills-lint.md`). Satisfies
   `.claude/rules/pure-compute-vs-io-split.md` — tests can assert on
-  both tuple elements without `capsys`, and the integration tests that
-  use `capsys` are a separate class from the pure-helper tests.
-- **Disagreement wins for frontmatter + warns**: when `fm_name !=
-  fs_name`, frontmatter wins but the user sees a stderr line. This
-  future-proofs against accidental renames (someone moves
-  `<dir>/SKILL.md` to `<other-dir>/SKILL.md` but forgets to update the
-  frontmatter): the skill still loads under its frontmatter-declared
-  identity, and the warning alerts the author to the mismatch.
+  the returned name without `capsys`, and the integration tests that
+  use `capsys` are a separate class that drive the conformance hook,
+  not the identity helper.
+- **Disagreement returns the frontmatter name; conformance surfaces
+  the mismatch**: when `fm_name != fs_name`, frontmatter wins
+  (identity resolution) and `check_conformance` emits
+  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH` at the `SkillSpec.from_file`
+  hook (warning). This future-proofs against accidental renames
+  (someone moves `<dir>/SKILL.md` to `<other-dir>/SKILL.md` but
+  forgets to update the frontmatter): the skill still loads under its
+  frontmatter-declared identity, and the warning alerts the author.
 - **`SKILL_NAME_RE` is a shared constant, not inlined**: two callers
   currently validate against it (`paths.py::derive_skill_name` and
   `propose_eval.py::_derive_skill_name_from_path_or_frontmatter`). A
   third caller — e.g. a future rubric proposer, a plugin uploader, or
   a registry client — should import the constant, not copy the regex.
   A drift between two inlined regexes is a silent security footgun.
+- **Single seam for conformance-warning emission**: post-#71, the
+  only place a user sees `"clauditor.conformance: ..."` stderr lines
+  during a routine spec load is the `SkillSpec.from_file` soft-warn
+  hook, which calls `check_conformance` and filters to
+  `severity="warning"`. The CLI `clauditor lint` command calls the
+  same pure helper but also surfaces `severity="error"` issues (exit
+  2). Both paths format their lines via one `format_issue_line`
+  helper — do NOT hand-roll the prefix at call sites.
 
 ## What NOT to do
 
@@ -123,8 +152,11 @@ return cls(..., skill_name_override=skill_name)
   fails the regex. The fallback path is the minimum-viable identity;
   hard-failing is hostile to authors and masks the real fix site.
 - Do NOT emit stderr from inside `derive_skill_name`. The helper is
-  pure; stderr belongs to the caller (see
-  `.claude/rules/pure-compute-vs-io-split.md`).
+  pure; diagnostics belong to the conformance layer (see
+  `.claude/rules/pure-compute-vs-io-split.md`). Re-adding a
+  `warning: str | None` return would re-introduce the dual-emission
+  bug DEC-008 of `plans/super/71-agentskills-lint.md` specifically
+  retired (two stderr lines for one root cause).
 - Do NOT return a uniform `skill_path.stem` for both layouts. That is
   the bug this rule codifies around — `stem` returns `"SKILL"` for the
   modern layout.
@@ -135,38 +167,86 @@ return cls(..., skill_name_override=skill_name)
 - Do NOT loosen `SKILL_NAME_RE` without rewriting every interpolation
   site to escape the name. The regex is the single anchor keeping
   `f"/{skill_name}"` and any `skill_name`-as-path-segment safe.
+- Do NOT re-use `SKILL_NAME_RE` for agentskills.io conformance
+  checks. The internal safety regex allows uppercase and underscores
+  (for back-compat with Claude Code slash-command names); the
+  conformance regex does not. See
+  `src/clauditor/conformance.py::AGENTSKILLS_NAME_RE` and DEC-006 of
+  `plans/super/71-agentskills-lint.md`.
 
 ## Canonical implementation
 
 - Shared regex: `src/clauditor/paths.py::SKILL_NAME_RE`.
 - Pure helpers: `src/clauditor/paths.py::_filesystem_name` +
-  `derive_skill_name`.
-- I/O caller: `src/clauditor/spec.py::SkillSpec.from_file` — reads the
-  file, calls the helper, emits any warning to stderr, passes the
-  resolved name to `SkillSpec.__init__` via the keyword-only
-  `skill_name_override=` kwarg.
+  `derive_skill_name` — the latter returns `str` (no tuple, no
+  `warning` channel) per DEC-008 of
+  `plans/super/71-agentskills-lint.md`.
+- I/O caller: `src/clauditor/spec.py::SkillSpec.from_file` — reads
+  the file, calls the pure helper for identity, and separately
+  invokes `clauditor.conformance.check_conformance(...)` + filters
+  `severity == "warning"` through `format_issue_line` (the
+  `"clauditor.conformance: <CODE>: <message>"` single seam per
+  DEC-014). Invalid-name and parent-dir-mismatch stderr lines
+  originate from the conformance module, not the identity helper.
 - Back-compat shape: `SkillSpec.__init__` accepts
   `skill_name_override: str | None = None` and falls back to a
-  layout-aware no-I/O derivation when the override is `None` (preserves
-  the direct-constructor path used by `tests/test_quality_grader.py`'s
+  layout-aware no-I/O derivation when the override is `None`
+  (preserves the direct-constructor path used by
+  `tests/test_quality_grader.py`'s
   `SkillSpec(Path("dummy.md"), ...)` fixture).
 - Second caller: `src/clauditor/cli/init.py::cmd_init` — reads the
-  file, calls the same helper, emits the warning, uses the name in the
-  starter eval's `skill_name` and `description` fields.
-- Tests: `tests/test_paths.py::TestDeriveSkillName` (seven pure-helper
-  cases, no `tmp_path`) and `tests/test_spec.py::TestFromFile` (five
-  integration cases covering both layouts + `capsys` for warning
-  emission).
+  file, calls `derive_skill_name`, uses the name in the starter
+  eval's `skill_name` and `description` fields. No warning branch
+  (DEC-008 retired it).
+- Conformance companion (single source of conformance diagnostics):
+  `src/clauditor/conformance.py::check_conformance` — the pure
+  function producing `ConformanceIssue` records (including
+  `AGENTSKILLS_NAME_INVALID_CHARS`,
+  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`,
+  `AGENTSKILLS_NAME_LEADING_HYPHEN`, etc.); and
+  `format_issue_line(issue)` — the single renderer the hook and the
+  `clauditor lint` CLI both call.
+- Tests: `tests/test_paths.py::TestDeriveSkillName` (pure-helper
+  cases, no `tmp_path`, assert on the `str` return only) and
+  `tests/test_spec.py::TestFromFile` (integration cases covering
+  both layouts + `capsys` for conformance-hook warning emission).
 - Regression test: `tests/test_bundled_skill.py::TestBundledSkillViaSpec`
   loads the project's own modern-layout bundled `SKILL.md` through
-  `SkillSpec.from_file` — a real-file self-validation.
+  `SkillSpec.from_file` — a real-file self-validation — and
+  `tests/test_bundled_skill.py::TestBundledSkillConformance`
+  asserts `check_conformance` returns `[]` for both bundled skills.
 
 Traces to DEC-001, DEC-002, DEC-008, DEC-009, DEC-012 of
-`plans/super/62-skill-md-layout.md`. Companion rules:
-`.claude/rules/pure-compute-vs-io-split.md` (the pure-helper shape),
-`.claude/rules/path-validation.md` (the regex-and-containment style
-for user-provided paths from JSON, though this rule covers
-Markdown-frontmatter identity rather than JSON paths).
+`plans/super/62-skill-md-layout.md`, extended by DEC-003, DEC-008,
+and DEC-014 of `plans/super/71-agentskills-lint.md` (which retired
+the in-helper warning tuple; see "Post-#71 update" below).
+Companion rules: `.claude/rules/pure-compute-vs-io-split.md` (the
+pure-helper shape), `.claude/rules/path-validation.md` (the
+regex-and-containment style for user-provided paths from JSON,
+though this rule covers Markdown-frontmatter identity rather than
+JSON paths).
+
+## Post-#71 update
+
+Before #71, `derive_skill_name` returned `(name, warning | None)`
+and `SkillSpec.from_file` / `cmd_init` printed the warning string
+(prefix `"clauditor.spec: ..."`) to stderr. #71 introduced
+`clauditor.conformance` (a pure module checking SKILL.md against
+the agentskills.io spec) and retired the identity helper's warning
+channel (DEC-008). The two warnings the helper used to produce —
+"frontmatter name is not a valid skill identifier" and
+"frontmatter name overrides filesystem name" — are now produced by
+`check_conformance` as `AGENTSKILLS_NAME_INVALID_CHARS` and
+`AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`, routed through the
+`SkillSpec.from_file` soft-warn hook, and formatted with the
+`"clauditor.conformance: <CODE>: <message>"` prefix (DEC-014).
+Net effect on this rule: the identity helper is now strictly pure
+(`str` return, no side-channel), and all frontmatter-name
+diagnostics flow through one seam. Every "Why each piece matters"
+bullet that used to say "the helper warns" has been rewritten to
+say "the conformance hook warns"; the "Canonical implementation"
+block now cites `conformance.check_conformance` +
+`format_issue_line` as the diagnostics source.
 
 ## When this rule applies
 
@@ -185,7 +265,10 @@ The rule also generalizes, shape-wise, to reading other frontmatter
 fields (`description:`, `allowed-tools:`, `argument-hint:`) where the
 author-provided value is authoritative and a filesystem or spec-local
 fallback exists — though each new field needs its own validation
-invariant.
+invariant, and any diagnostic-emitting validation for those fields
+should go through `conformance.check_conformance` (or a sibling
+pure-module checker) rather than back into `derive_skill_name`'s
+return channel.
 
 ## When this rule does NOT apply
 

--- a/.claude/rules/skill-identity-from-frontmatter.md
+++ b/.claude/rules/skill-identity-from-frontmatter.md
@@ -43,28 +43,39 @@ def derive_skill_name(skill_path: Path, skill_md_text: str) -> str:
     fm_name = parsed["name"]
     if not isinstance(fm_name, str) or re.fullmatch(SKILL_NAME_RE, fm_name) is None:
         return fs_name  # invalid frontmatter name → silent fallback;
-                        # conformance.check_conformance surfaces the
-                        # AGENTSKILLS_NAME_INVALID_CHARS warning.
+                        # conformance.check_conformance emits the
+                        # AGENTSKILLS_NAME_INVALID_CHARS error, which
+                        # surfaces via ``clauditor lint`` (not through
+                        # the soft-warn hook — hook filters out errors).
 
     # Disagreement (fm_name != fs_name) returns the frontmatter value
     # unchanged. The conformance checker emits the
-    # AGENTSKILLS_NAME_PARENT_DIR_MISMATCH warning separately; this
-    # helper stays silent.
+    # AGENTSKILLS_NAME_PARENT_DIR_MISMATCH error separately; this
+    # helper stays silent. That error surfaces via ``clauditor lint``
+    # only, per DEC-003's warnings-only soft-warn-hook contract.
     return fm_name
 ```
 
 At the call site, the I/O layer owns `read_text` and — via the
-conformance soft-warn hook — stderr:
+conformance soft-warn hook — stderr for the **warning** severity
+only. Name-related issues (`AGENTSKILLS_NAME_INVALID_CHARS`,
+`AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`) are emitted by
+`check_conformance` with `severity="error"`, so the hook filters
+them out — they surface via `clauditor lint` (exit 2) instead, not
+during routine skill loads. Non-name warnings (body length,
+experimental `allowed-tools`, legacy layout) DO surface here:
 
 ```python
 # src/clauditor/spec.py::SkillSpec.from_file
 text = skill_path.read_text(encoding="utf-8")
 skill_name = derive_skill_name(skill_path, text)
 
-# Soft-warn hook: emit conformance warnings (including
-# AGENTSKILLS_NAME_INVALID_CHARS / AGENTSKILLS_NAME_PARENT_DIR_MISMATCH)
-# through a single seam, formatted by ``conformance.format_issue_line``.
-# ``check_conformance`` never raises.
+# Soft-warn hook: emit conformance WARNINGS (severity="warning") —
+# e.g. AGENTSKILLS_BODY_TOO_LONG, AGENTSKILLS_LAYOUT_LEGACY.
+# Errors like AGENTSKILLS_NAME_INVALID_CHARS /
+# AGENTSKILLS_NAME_PARENT_DIR_MISMATCH are filtered out here and
+# surface only via ``clauditor lint``. Single seam formatted by
+# ``conformance.format_issue_line``. ``check_conformance`` never raises.
 for issue in check_conformance(text, skill_path):
     if issue.severity == "warning":
         print(format_issue_line(issue), file=sys.stderr)
@@ -102,10 +113,14 @@ return cls(..., skill_name_override=skill_name)
 - **Lenient on regex failure, not strict**: a malformed frontmatter
   value shouldn't make the skill uncallable — the filesystem fallback
   is the already-validated path segment (the parent dir / stem went
-  through the OS). Fall back, keep going. The soft-warn hook then
-  surfaces the corresponding `AGENTSKILLS_NAME_INVALID_CHARS` (or
-  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`) warning so the author
-  notices without being blocked.
+  through the OS). Fall back, keep going. The corresponding
+  `AGENTSKILLS_NAME_INVALID_CHARS` (or
+  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`) is emitted by
+  `check_conformance` as an **error**; it surfaces via
+  `clauditor lint` (exit 2) rather than the soft-warn hook (which
+  filters to warnings only per DEC-003), so the author notices when
+  they actively lint their skill without being blocked during routine
+  loads.
 - **Malformed frontmatter treated as absent**: `parse_frontmatter`
   raises `ValueError` on structural errors (missing closing `---`,
   empty key, etc.). A hard failure would be hostile to authors
@@ -126,11 +141,15 @@ return cls(..., skill_name_override=skill_name)
 - **Disagreement returns the frontmatter name; conformance surfaces
   the mismatch**: when `fm_name != fs_name`, frontmatter wins
   (identity resolution) and `check_conformance` emits
-  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH` at the `SkillSpec.from_file`
-  hook (warning). This future-proofs against accidental renames
-  (someone moves `<dir>/SKILL.md` to `<other-dir>/SKILL.md` but
-  forgets to update the frontmatter): the skill still loads under its
-  frontmatter-declared identity, and the warning alerts the author.
+  `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH` as an **error** (not a
+  warning). Because the soft-warn hook filters to warnings per
+  DEC-003, this error surfaces via `clauditor lint` (exit 2), not
+  during routine `SkillSpec.from_file` loads. This future-proofs
+  against accidental renames (someone moves `<dir>/SKILL.md` to
+  `<other-dir>/SKILL.md` but forgets to update the frontmatter): the
+  skill still loads under its frontmatter-declared identity, and the
+  error alerts the author the next time they run `clauditor lint` on
+  the skill before publishing.
 - **`SKILL_NAME_RE` is a shared constant, not inlined**: two callers
   currently validate against it (`paths.py::derive_skill_name` and
   `propose_eval.py::_derive_skill_name_from_path_or_frontmatter`). A
@@ -233,20 +252,22 @@ and `SkillSpec.from_file` / `cmd_init` printed the warning string
 (prefix `"clauditor.spec: ..."`) to stderr. #71 introduced
 `clauditor.conformance` (a pure module checking SKILL.md against
 the agentskills.io spec) and retired the identity helper's warning
-channel (DEC-008). The two warnings the helper used to produce —
+channel (DEC-008). The two diagnostics the helper used to produce —
 "frontmatter name is not a valid skill identifier" and
 "frontmatter name overrides filesystem name" — are now produced by
 `check_conformance` as `AGENTSKILLS_NAME_INVALID_CHARS` and
-`AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`, routed through the
-`SkillSpec.from_file` soft-warn hook, and formatted with the
+`AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`. Both are emitted at
+`severity="error"`. The `SkillSpec.from_file` soft-warn hook filters
+to warnings only per DEC-003, so these **errors do not fire at the
+hook** — they surface via `clauditor lint` (exit 2), which emits
+warnings *and* errors with the
 `"clauditor.conformance: <CODE>: <message>"` prefix (DEC-014).
 Net effect on this rule: the identity helper is now strictly pure
-(`str` return, no side-channel), and all frontmatter-name
-diagnostics flow through one seam. Every "Why each piece matters"
-bullet that used to say "the helper warns" has been rewritten to
-say "the conformance hook warns"; the "Canonical implementation"
-block now cites `conformance.check_conformance` +
-`format_issue_line` as the diagnostics source.
+(`str` return, no side-channel), and frontmatter-name diagnostics
+move to an explicit-lint surface rather than a routine-load stderr
+line. Routine loads stay silent on name issues (matching the
+pre-#71 "lenient on failure" behavior); the author sees them when
+they actively run `clauditor lint` before publishing.
 
 ## When this rule applies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     previous warnings for invalid frontmatter-name fallback and
     frontmatter-vs-filesystem mismatch are now produced by
     `check_conformance` via the soft-warn hook — single source of
-    truth for frontmatter-name warnings. The helper now always returns
-    `(name, None)`. See
+    truth for frontmatter-name warnings. The helper's return type
+    simplified from `tuple[str, str | None]` to plain `str`. See
     [`docs/cli-reference.md#lint`](docs/cli-reference.md#lint) and
     `.claude/rules/skill-identity-from-frontmatter.md`.
 - **Runner auth-source control + configurable timeout (#64).** Four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`clauditor lint` — agentskills.io spec conformance check (#71).** A
+  non-LLM static check that validates a `SKILL.md` file against the
+  [agentskills.io specification](https://agentskills.io/specification).
+  Safe to run on every commit and in CI — no tokens spent, no network
+  calls.
+  - Positional path argument; resolves absolute paths, follows
+    symlinks, rejects directories with exit 1.
+  - `--strict` promotes warnings to exit 2 (pre-publish gate).
+    Load-layer parse failures (`AGENTSKILLS_FRONTMATTER_INVALID_YAML`,
+    unreadable path) always exit 1 regardless of `--strict`.
+  - `--json` emits a single JSON envelope to stdout
+    (`{"schema_version": 1, "skill_path": ..., "passed": bool,
+    "issues": [...]}`) with identical exit codes to the human-text
+    output path.
+  - Pure compute lives in `src/clauditor/conformance.py` per
+    `.claude/rules/pure-compute-vs-io-split.md` — `check_conformance`
+    returns a `list[ConformanceIssue]` with stable `code` / `severity`
+    / `message` fields, testable without `tmp_path` or `capsys`.
+  - **Soft-warn hook on `SkillSpec.from_file`**: every skill load now
+    runs `check_conformance` and emits warning-severity issues to
+    stderr with the `clauditor.conformance: <CODE>: <message>` prefix.
+    Errors are silent at this seam — they surface through
+    `clauditor lint`. The hook never blocks spec loading.
+  - **`KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist** for frontmatter
+    keys that Claude Code uses but the agentskills.io spec does not
+    define. Initial contents: `argument-hint`,
+    `disable-model-invocation`. Keys in the allowlist do NOT trigger
+    `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY`. The bundled
+    `/review-agentskills-spec` skill maintains the allowlist against
+    Claude Code's published frontmatter documentation (DEC-013).
+  - **`paths.derive_skill_name` warning emission retired**: the
+    previous warnings for invalid frontmatter-name fallback and
+    frontmatter-vs-filesystem mismatch are now produced by
+    `check_conformance` via the soft-warn hook — single source of
+    truth for frontmatter-name warnings. The helper now always returns
+    `(name, None)`. See
+    [`docs/cli-reference.md#lint`](docs/cli-reference.md#lint) and
+    `.claude/rules/skill-identity-from-frontmatter.md`.
 - **Runner auth-source control + configurable timeout (#64).** Four
   skill-invoking CLI commands (`validate`, `grade`, `capture`, `run`)
   and the pytest plugin gained two knobs that together unblock Pro/Max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,26 +2,40 @@
 
 ## Pre-release dogfood
 
-Before tagging a new release, clauditor must pass two gates against its
-own bundled slash-command skill. These are not run in CI (see rationale
-below); they are maintainer-run immediately before any release tag.
+Before tagging a new release, clauditor must pass three gates against
+its own bundled slash-command skill. These are not run in CI (see
+rationale below); they are maintainer-run immediately before any
+release tag.
 
-### The two gates
+### The three gates
 
-1. **L1 — deterministic assertions (free, seconds):**
+1. **Static conformance — agentskills.io spec (free, instant):**
+
+   ```bash
+   uv run clauditor lint src/clauditor/skills/clauditor/SKILL.md
+   ```
+
+   Must exit 0 with the success line. The bundled skill is the
+   canonical reference for what a conforming SKILL.md looks like; a
+   lint failure here means either (a) the bundled skill drifted, or
+   (b) the `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist in
+   `src/clauditor/conformance.py` needs a new entry against Claude
+   Code's published frontmatter docs.
+
+2. **L1 — deterministic assertions (free, seconds):**
 
    ```bash
    uv run clauditor validate src/clauditor/skills/clauditor/SKILL.md
    ```
 
-2. **L3 — LLM-graded quality (costs Sonnet tokens, ~1 minute):**
+3. **L3 — LLM-graded quality (costs Sonnet tokens, ~1 minute):**
 
    ```bash
    uv run clauditor grade src/clauditor/skills/clauditor/SKILL.md \
      --eval src/clauditor/skills/clauditor/assets/clauditor.eval.json
    ```
 
-Both commands must exit 0. If either gate fails, do NOT tag the
+All three commands must exit 0. If any gate fails, do NOT tag the
 release — a failing bundled skill is the user-visible failure mode
 that this checklist exists to catch.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Stable exit-code contract (0 = pass, 1 = skill failed, 2 = input error, 3 = Anth
 ```bash
 clauditor init <skill.md>             # Starter eval.json
 clauditor propose-eval <skill.md>     # LLM-assisted EvalSpec bootstrap
+clauditor lint <skill.md>             # Static agentskills.io spec conformance
 clauditor validate <skill.md>         # Layer 1 assertions
 clauditor grade <skill.md>            # Layer 3 quality grading
 clauditor compare --skill <s> --from 1 --to 2  # Diff iterations
@@ -153,7 +154,7 @@ clauditor implements (and extends) the workflow at [agentskills.io/skill-creatio
 | Regression + longitudinal history | `clauditor compare`, `.clauditor/history.jsonl`, `clauditor trend --metric <dotted.path>` |
 | Per-iteration workspace | `.clauditor/iteration-N/<skill>/` with sidecars + `run-*/` transcripts |
 
-**Beyond the spec**: trigger precision testing, tiered extraction, pytest plugin, `input_files` staging, blind A/B judge, baseline pair runs, transcript capture, LLM-driven skill improvement proposer (`clauditor suggest`), LLM-assisted EvalSpec bootstrap (`clauditor propose-eval`). **Out of scope**: human-in-the-loop feedback capture.
+**Beyond the spec**: trigger precision testing, tiered extraction, pytest plugin, `input_files` staging, blind A/B judge, baseline pair runs, transcript capture, LLM-driven skill improvement proposer (`clauditor suggest`), LLM-assisted EvalSpec bootstrap (`clauditor propose-eval`), static spec-conformance check (`clauditor lint`). **Out of scope**: human-in-the-loop feedback capture.
 
 </details>
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,6 +6,9 @@ Full reference for every `clauditor` subcommand: arguments, flags, the persisten
 
 ```bash
 clauditor init <skill.md>              # Generate starter eval.json
+clauditor lint <skill.md>              # Static agentskills.io spec conformance
+clauditor lint <skill.md> --strict     # Treat warnings as exit-2 failures
+clauditor lint <skill.md> --json       # JSON envelope for CI
 clauditor validate <skill.md>          # Run Layer 1 assertions
 clauditor validate <skill.md> --json   # JSON output for CI
 clauditor run <skill-name> --args "…"  # Run skill, print output
@@ -31,6 +34,56 @@ clauditor propose-eval <skill.md>      # LLM-assisted EvalSpec bootstrap (SKILL.
 clauditor setup                        # Install the bundled /clauditor slash command symlink
 clauditor doctor                       # Report environment diagnostics
 ```
+
+## lint
+
+Static conformance check against the [agentskills.io specification](https://agentskills.io/specification). `clauditor lint <SKILL.md>` reads the file, parses its YAML frontmatter via the project's `_frontmatter.parse_frontmatter` helper, and runs every rule from the spec (required/optional frontmatter keys, name-vs-parent-dir match, body-line budget, layout expectations) through the pure `check_conformance` helper in `src/clauditor/conformance.py`. The command is **non-LLM** — no tokens spent, no network calls — so it is safe to run on every commit, in CI, and as a pre-publish check before uploading a skill to a registry.
+
+### Required inputs
+
+- `<skill_md>` (positional) — path to the SKILL.md file to lint. Absolute paths are accepted; symlinks are followed to their real target; directories, sockets, and missing paths exit 1.
+
+### Flags
+
+| Flag | Purpose |
+| ---- | ------- |
+| `--strict` | Treat warnings as failures (exit 2). Errors always exit 2 regardless. Parse failures (`AGENTSKILLS_FRONTMATTER_INVALID_YAML`) always exit 1 even under `--strict` — `--strict` never escalates load-layer parse failures. |
+| `--json` | Emit a JSON envelope to stdout instead of the human-readable text. Exit codes are identical to the human-output path. `schema_version: 1` is the first key in the payload. |
+
+### Examples
+
+```bash
+# Basic conformance check — exits 0 on pass with a success line.
+clauditor lint .claude/skills/my-skill/SKILL.md
+
+# Strict mode — warnings promoted to exit 2 (pre-publish gate).
+clauditor lint --strict .claude/skills/my-skill/SKILL.md
+
+# JSON envelope for CI — pipe through jq for programmatic checks.
+clauditor lint --json .claude/skills/my-skill/SKILL.md | jq .passed
+```
+
+### Exit codes
+
+Non-LLM 0/1/2 taxonomy per `.claude/rules/llm-cli-exit-code-taxonomy.md`:
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Pass — no issues, OR warning-only result without `--strict`. Success line printed to stdout. |
+| `1` | Load/parse failure — path does not resolve to a regular file, file is unreadable (OSError / UnicodeDecodeError), or frontmatter is malformed YAML (`AGENTSKILLS_FRONTMATTER_INVALID_YAML`). Never escalated by `--strict`. |
+| `2` | Conformance failure — one or more error-severity issues, OR warnings with `--strict` set. Issues rendered on stderr as `clauditor.conformance: <CODE>: <message>`. |
+
+### Claude Code extension allowlist
+
+The agentskills.io spec defines the frontmatter keys `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools`. Unknown keys normally trigger `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` (warning). Two Claude Code extension keys are allowlisted and do NOT trigger the warning: `argument-hint` and `disable-model-invocation`. The allowlist is maintained by the bundled `/review-agentskills-spec` skill, which periodically diffs Claude Code's published frontmatter documentation against the `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` constant in `src/clauditor/conformance.py` (per DEC-009 and DEC-013 of `plans/super/71-agentskills-lint.md`).
+
+### Soft-warn hook on every skill load
+
+Beyond the standalone `lint` command, `SkillSpec.from_file` calls `check_conformance` on every skill load and emits **warnings only** to stderr with the `clauditor.conformance:` prefix. Errors are silent at that seam — they surface when the user runs `clauditor lint`. The hook never blocks `from_file`; a skill that would fail `lint` today still loads for `validate`, `grade`, and downstream commands (per DEC-003).
+
+### See also
+
+- **`/review-agentskills-spec`** — the maintainer-facing sibling bundled skill (internal-only; excluded from `clauditor setup`). **`clauditor lint`** checks a user's skill against the spec; **`/review-agentskills-spec`** audits the upstream spec itself (and Claude Code's frontmatter documentation) for drift against clauditor's enforcement. Two sides of the same check: one catches user skills that drift from the spec, the other catches clauditor's enforcement drifting from the spec.
 
 ## propose-eval
 

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -41,3 +41,7 @@ pytest --clauditor-model claude-sonnet-4-6  # Override grading model
 ```
 
 Mark tests that need Layer 3 with `@pytest.mark.clauditor_grade`; they are skipped by default and only run under `--clauditor-grade`.
+
+### Related commands (not covered by fixtures)
+
+`clauditor lint` is a standalone CLI command for static agentskills.io spec conformance; it is not exposed as a pytest fixture. Invoke it directly (e.g. from a `subprocess.run` call or a release-gate script) rather than expecting a `clauditor_lint` fixture. See [`docs/cli-reference.md#lint`](cli-reference.md#lint).

--- a/plans/super/71-agentskills-lint.md
+++ b/plans/super/71-agentskills-lint.md
@@ -4,8 +4,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/71
 - **Branch:** `feature/71-agentskills-lint`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/71-agentskills-lint`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/74
+- **Epic:** `clauditor-zsf`
 - **Sessions:** 1
 - **Last session:** 2026-04-21
 
@@ -853,6 +854,32 @@ feature-relevant insight if any.
 
 ---
 
+---
+
+## Beads Manifest
+
+- **Epic:** `clauditor-zsf` — #71: Agentskills.io spec conformance check for SKILL.md
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/71-agentskills-lint`
+- **Branch:** `feature/71-agentskills-lint`
+- **PR:** https://github.com/wjduenow/clauditor/pull/74
+
+| Bead | Story | Depends on | Priority |
+|---|---|---|---|
+| `clauditor-zsf.1` | US-001 — Pure `conformance.py` module | — | P2 |
+| `clauditor-zsf.2` | US-002 — Retire `derive_skill_name` warnings | `.1` | P2 |
+| `clauditor-zsf.3` | US-003 — CLI `lint` (plain text) | `.1` | P2 |
+| `clauditor-zsf.4` | US-004 — `--strict` flag | `.3` | P2 |
+| `clauditor-zsf.5` | US-005 — `--json` output | `.3` | P2 |
+| `clauditor-zsf.6` | US-006 — Soft-warn hook in `SkillSpec.from_file` | `.1`, `.2` | P2 |
+| `clauditor-zsf.7` | US-007 — Bundled-skill conformance + regression test | `.1`, `.6` | P2 |
+| `clauditor-zsf.8` | US-008 — Docs + CHANGELOG + cross-ref | `.7` | P2 |
+| `clauditor-zsf.9` | Quality Gate | `.4`, `.5`, `.8` | P2 |
+| `clauditor-zsf.10` | Patterns & Memory | `.9` | P4 |
+
+Ready now: `clauditor-zsf.1`. Everything else blocked on the DAG above.
+
+---
+
 ## Session Notes
 
 **2026-04-21 — Discovery complete.** Three parallel subagents
@@ -876,6 +903,13 @@ agentskills.io spec — they would trigger
 `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` on every load. Three
 smaller concerns on path handling style, success-message
 shape, and `--json` scope. Moving to refinement to resolve.
+
+**2026-04-21 — Devolved to beads.** Epic `clauditor-zsf` + 10
+tasks `clauditor-zsf.1` through `clauditor-zsf.10`.
+Dependency graph matches the Story summary DAG:
+US-001 is the sole ready task; everything else gates on it or
+its downstream. Ralph can begin on US-001 via
+`bd update clauditor-zsf.1 --claim && bd show clauditor-zsf.1`.
 
 **2026-04-21 — Refinement complete.** User resolved Q6=A
 (retire `derive_skill_name` warnings; consolidate into

--- a/plans/super/71-agentskills-lint.md
+++ b/plans/super/71-agentskills-lint.md
@@ -1,0 +1,894 @@
+# Super Plan: #71 — agentskills.io spec conformance check for SKILL.md
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/71
+- **Branch:** `feature/71-agentskills-lint`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/71-agentskills-lint`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-21
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Add a static conformance checker (`clauditor lint`)
+that validates a SKILL.md file against the [agentskills.io
+specification](https://agentskills.io/specification), plus a
+soft-warn hook in `SkillSpec.from_file` so every command that
+loads a skill inherits the check. A `--strict` flag escalates
+soft warnings to hard-fail.
+
+Three-part shape:
+
+1. **`clauditor lint` command** — explicit, standalone static
+   check. Exits 0 pass, 1 load/parse failure, 2 conformance
+   failure (non-LLM taxonomy per
+   `.claude/rules/llm-cli-exit-code-taxonomy.md`).
+2. **Soft-warn hook on `SkillSpec.from_file`** — prints stderr
+   warnings for conformance issues on every load; does not
+   fail.
+3. **`--strict` escape hatch** — escalates warnings to hard
+   fail. Default-strict for `lint`, opt-in elsewhere.
+
+**Why:** `clauditor validate` checks *behavioral* output; it
+does not check whether the SKILL.md artifact itself conforms to
+the published spec. Authors publishing skills to agentskills.io
+or similar registries need a pre-flight check. The bundled
+`/review-agentskills-spec` skill (from #72) tells maintainers
+when the upstream spec drifts; `clauditor lint` is the
+user-facing counterpart that tells an author when their skill
+drifts from the spec.
+
+**Done when:**
+- `clauditor lint <path/to/SKILL.md>` exists and enforces the
+  agentskills.io spec rules (per "Rules to enforce" below).
+- `SkillSpec.from_file` emits stderr warnings for conformance
+  issues encountered during load; no command fails today's
+  skills that would produce only warnings.
+- `--strict` on `lint` promotes warnings to exit 2.
+- Pure helper `check_conformance(...)` lives in
+  `src/clauditor/conformance.py` — testable without `tmp_path`.
+- Coverage ≥80%, ruff passes, docs updated (cli-reference,
+  README, CHANGELOG).
+
+---
+
+### Key findings — codebase scout
+
+#### Frontmatter + skill-name pipeline
+
+- `src/clauditor/_frontmatter.py::parse_frontmatter` — the
+  YAML-subset parser. Accepts scalar entries, quoted values, one
+  level of nested mappings (`metadata:` block), and raw inline
+  strings (`allowed-tools: Bash(*) Read Grep` stored verbatim).
+  Raises `ValueError` on missing closing delimiter, bad `key:
+  value` shape, empty keys, multi-level nesting. Lint must
+  consume this parser's output, not re-implement it.
+- `src/clauditor/paths.py::SKILL_NAME_RE` is
+  `r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"` — **incompatible with
+  the agentskills spec** (allows uppercase, underscores, up to
+  128 chars). Conformance must NOT reuse this regex for
+  `AGENTSKILLS_NAME_*` checks. The two validators have
+  different contracts: `SKILL_NAME_RE` is clauditor's internal
+  safety filter (shell-injection / path-traversal); the spec
+  regex is the external publish contract.
+- `src/clauditor/paths.py::derive_skill_name` — pure helper
+  returning `(name: str, warning: str | None)`. Canonical
+  precedent for the soft-warn pattern lint must follow. Current
+  warnings (invalid frontmatter name, frontmatter-vs-fs
+  mismatch) overlap with the new spec-conformance warnings;
+  deduplication is a Phase 3 refinement question.
+- `src/clauditor/spec.py::SkillSpec.from_file` — reads SKILL.md,
+  calls `derive_skill_name`, prints warning to stderr if
+  returned, continues. This is the seam the new soft-warn hook
+  slots into.
+
+#### CLI subcommand scaffolding
+
+- Subcommand modules live in `src/clauditor/cli/<name>.py`.
+  Each exports `add_parser(subparsers)` and `cmd_<name>(args)`.
+  Main dispatcher at `src/clauditor/cli/__init__.py` imports
+  each module (lines 354-384), registers via
+  `<mod>.add_parser(subparsers)` (lines 395-434), and
+  dispatches via if-elif on `parsed.command` (lines 452-480).
+  14 subcommands currently wired.
+- Shared argparse helpers in `cli/__init__.py`: `_unit_float`,
+  `_positive_int`. A new `_readable_skill_path(value: str) ->
+  Path` helper matching `.claude/rules/path-validation.md`
+  would slot in alongside, reusable for future commands.
+- Error-rendering helper `_render_skill_error` in
+  `cli/__init__.py` is for `SkillResult` failures (behavioral);
+  lint produces `ConformanceIssue`s instead. Different renderer
+  entirely, but parallel shape.
+- Exit-code taxonomy in use today: 0/1/2 for non-LLM commands,
+  0/1/2/3 for LLM commands per
+  `.claude/rules/llm-cli-exit-code-taxonomy.md`. Lint is
+  non-LLM → 0/1/2.
+
+#### Bundled skills' current conformance state
+
+- `src/clauditor/skills/clauditor/SKILL.md` frontmatter:
+  `name: clauditor`, `description`, `compatibility`,
+  `metadata` (`clauditor-version`), `argument-hint`,
+  `disable-model-invocation: true`, `allowed-tools: Bash(...)`.
+  **Missing from spec perspective:** `argument-hint` and
+  `disable-model-invocation` are not in the agentskills.io
+  spec → would flag as `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY`.
+  No `license`.
+- `src/clauditor/skills/review-agentskills-spec/SKILL.md` —
+  same shape; excluded from `clauditor setup` per
+  `.claude/rules/internal-skill-live-test-tmp-symlink.md`.
+  Lint should still accept it at the filesystem level
+  (internal-only, not user-facing).
+
+#### Test conventions
+
+- Pure helper → separate test file (`tests/test_<module>.py`),
+  class-based (`TestCheckConformance`, `TestParseXxx`), no
+  `tmp_path` or `capsys` — construct inputs directly.
+- I/O-layer (CLI or `SkillSpec.from_file`) → separate class
+  using `tmp_path` for file writes and `capsys` for stderr
+  assertions.
+- `tests/test_paths.py::TestDeriveSkillName` is the closest
+  analogue for the pure-helper class, and
+  `tests/test_spec.py::TestFromFile` for the I/O-layer class.
+
+---
+
+### Key findings — convention checker
+
+Thirteen of 28 `.claude/rules/*.md` apply. The load-bearing
+ones for this ticket:
+
+1. **`pure-compute-vs-io-split.md`** — `check_conformance`
+   returns `list[ConformanceIssue]`, no stderr, no I/O. CLI
+   layer does file read, stderr emission, exit-code mapping.
+2. **`llm-cli-exit-code-taxonomy.md`** — lint is non-LLM → use
+   simpler 0/1/2 table. No `AnthropicHelperError`, no exit 3.
+3. **`skill-identity-from-frontmatter.md`** — reuse
+   `parse_frontmatter` and `derive_skill_name` shapes. Do NOT
+   duplicate frontmatter parsing. The existing helper's
+   `SKILL_NAME_RE` is different contract (see above).
+4. **`path-validation.md`** — path argument to `lint` goes
+   through the strict-resolve + containment + is_file recipe.
+5. **`constant-with-type-info.md`** — if conformance rules are
+   tabulated as a dict, carry `field_types` for type checks.
+6. **`json-schema-version.md`** — applies *only* if we emit a
+   JSON sidecar (open design decision; see Q5).
+7. **`readme-promotion-recipe.md`** — docs update for
+   `cli-reference.md` + README teaser; keep H2 anchors
+   byte-identical on any moved content.
+8. **`bundled-skill-docs-sync.md`** — applies only if the
+   bundled `/clauditor` skill workflow grows a lint step;
+   otherwise N/A.
+9. **`per-type-drift-hints.md`** — per-key "did you mean?"
+   hints for unknown frontmatter keys (if we add them).
+
+Not a workflow-project.md rule set; project-specific
+customization absent. No existing `--strict` flag precedent in
+the codebase — this is the first one.
+
+---
+
+### Key findings — spec extractor
+
+Full spec fetched at https://agentskills.io/specification
+(2026-04-21, HTTP 200). Rules enumerated with stable code
+names:
+
+#### Required frontmatter
+
+- `AGENTSKILLS_NAME_MISSING` / `_NOT_STRING` / `_EMPTY` /
+  `_TOO_LONG` / `_INVALID_CHARS` / `_LEADING_HYPHEN` /
+  `_TRAILING_HYPHEN` / `_CONSECUTIVE_HYPHENS` /
+  `_PARENT_DIR_MISMATCH` — all severity `error`. The combined
+  regex is `^[a-z0-9](?:[a-z0-9]|-(?!-))*[a-z0-9]$` with
+  length 1-64 (or 1 char if `^[a-z0-9]$`).
+- `AGENTSKILLS_DESCRIPTION_MISSING` / `_NOT_STRING` / `_EMPTY`
+  / `_TOO_LONG` — all error. 1-1024 chars.
+- `AGENTSKILLS_DESCRIPTION_MISSING_WHEN_CLAUSE` — warning
+  (SHOULD).
+- `AGENTSKILLS_DESCRIPTION_MISSING_KEYWORDS` — warning (SHOULD).
+
+#### Optional frontmatter
+
+- `AGENTSKILLS_LICENSE_NOT_STRING` — error.
+- `AGENTSKILLS_LICENSE_EMPTY` — severity decision (G2).
+- `AGENTSKILLS_COMPATIBILITY_NOT_STRING` / `_EMPTY` / `_TOO_LONG`
+  — all error. 1-500 chars.
+- `AGENTSKILLS_METADATA_NOT_MAP` / `_KEY_NOT_STRING` /
+  `_VALUE_NOT_STRING` — all error.
+- `AGENTSKILLS_METADATA_KEY_COLLISION_RISK` — warning.
+- `AGENTSKILLS_ALLOWED_TOOLS_NOT_STRING` — error.
+- `AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL` — warning.
+
+#### Unknown keys + body + layout
+
+- `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` — severity decision (G5).
+- `AGENTSKILLS_BODY_TOO_LONG` — warning. **500 lines IS in the
+  spec** (correction to ticket body). Exact quote under
+  `Progressive disclosure`: *"Keep your main SKILL.md under 500
+  lines."*
+- `AGENTSKILLS_BODY_TOKEN_BUDGET` — warning (< 5000 tokens
+  recommended per spec; ticket didn't mention). Requires a
+  tokenizer.
+- `AGENTSKILLS_SKILL_MD_FILENAME_CASE` — severity decision (G7).
+- `AGENTSKILLS_SKILL_MD_NOT_AT_ROOT` — error when layout is
+  enforceable (G8).
+
+#### Subdirs (`scripts/`, `references/`, `assets/`)
+
+- `AGENTSKILLS_FILE_REFS_RELATIVE` — warning (SHOULD).
+- `AGENTSKILLS_FILE_REFS_DEPTH` — warning (SHOULD).
+
+#### Ticket vs spec mismatches
+
+1. **Ticket says** body 500-line limit is external guidance;
+   **spec** has it under `Progressive disclosure`. Elevate
+   from "optional check" to "standard warning."
+2. **Ticket omits** the `< 5000 tokens` spec guidance. Add as
+   separate warning if we take Q4 option B/C.
+3. **Ticket qualifies** name/parent-dir match as "for modern
+   `<dir>/SKILL.md` layout"; **spec** states it unqualified.
+   The qualifier is a clauditor-side accommodation for the
+   legacy single-file layout the spec does not address (G8).
+
+#### Ten ambiguities requiring design decisions
+
+| ID | Gap | Decision point |
+|---|---|---|
+| G1 | `name` char class is spec-internally contradictory | Strict ASCII vs Unicode lowercase |
+| G2 | `license` empty-string not explicitly forbidden | Error or silent |
+| G3 | `metadata` has no length bounds | Clauditor-side caps? |
+| G4 | `allowed-tools` token grammar unspecified | Minimal check or format validation |
+| G5 | Unknown top-level frontmatter keys | Error, warning, or silent |
+| G6 | Empty body not explicitly forbidden | Accept or warn |
+| G7 | `SKILL.md` filename case sensitivity | Strict `SKILL.md` or case-insensitive |
+| G8 | Legacy single-file `<name>.md` absent from spec | Skip layout checks, warn, or error |
+| G9 | YAML-coerced non-string values (`name: true`) | Strict `isinstance(str)` |
+| G10 | YAML auto-coercion in `metadata` (`version: 1.0`) | Strict `isinstance(str)` |
+
+G9 and G10 are the "constant-with-type-info" discipline —
+strict `isinstance(str)` is the conventional clauditor choice;
+adopt by default.
+
+---
+
+### Proposed scope
+
+1. Pure module `src/clauditor/conformance.py` with
+   `ConformanceIssue` dataclass (`code`, `severity`,
+   `message`) and `check_conformance(skill_md_text: str,
+   skill_path: Path) -> list[ConformanceIssue]`.
+2. CLI module `src/clauditor/cli/lint.py` — `add_parser` +
+   `cmd_lint(args)`; path validation + file read + call pure
+   helper + render + exit-code map; `--strict` flag.
+3. Soft-warn hook in `src/clauditor/spec.py::SkillSpec.from_file`
+   — call pure helper, emit warnings (severity TBD per Q3) to
+   stderr, do not block.
+4. Tests: `tests/test_conformance.py` (pure),
+   `tests/test_cli.py::TestCmdLint` class (I/O +
+   path-validation), `tests/test_spec.py` extension (soft-warn
+   hook).
+5. Docs: new `## lint` section in `docs/cli-reference.md` +
+   quick-reference row; one-line README teaser; CHANGELOG
+   entry; cross-link to `/review-agentskills-spec`.
+6. Quality Gate (reviewer ×4 + ruff + pytest 80% gate).
+7. Patterns & Memory (update rules for the novel `--strict`
+   shape and conformance-issue-list shape if they generalize).
+
+---
+
+### Scoping decisions (from Q&A)
+
+- **Q1 — Legacy `<name>.md` single-file layout:** default pass
+  with an **explanatory migration warning** (code
+  `AGENTSKILLS_LAYOUT_LEGACY`); `--strict` promotes to error.
+  The warning message must tell the author exactly how to
+  convert: *"Move the file to `<skill-name>/SKILL.md` — create
+  directory `<skill-name>/` and rename. See
+  https://agentskills.io/specification#directory-structure."*
+- **Q2 — `name` character class:** strict ASCII `[a-z0-9-]`
+  with the combined regex
+  `^[a-z0-9](?:[a-z0-9]|-(?!-))*[a-z0-9]$|^[a-z0-9]$` and
+  length 1-64. Tie-breaks the spec's "unicode lowercase (`a-z`)"
+  contradiction in favor of the parenthetical ASCII range,
+  which matches every published example. Future Unicode
+  support is opt-in, not default.
+- **Q3 — Soft-warn hook severity:** warnings only; errors are
+  silent inside `SkillSpec.from_file` and surface through
+  `clauditor lint`. Mirrors the existing `derive_skill_name`
+  behavior (warns on non-fatal, stays silent on fallback).
+  Keeps stderr clean on the hot iteration path.
+- **Q4 — `--strict` reach:** `clauditor lint --strict` only.
+  Other commands stay soft-warn. No `--strict` on `grade` /
+  `validate` / etc. in this ticket; a follow-up can extend if
+  demand appears. An `eval.json` field is out of scope.
+- **Q5 — Body token-budget check:** skip in this ticket. Line
+  count check (`AGENTSKILLS_BODY_TOO_LONG`, warning, >500)
+  lands; `AGENTSKILLS_BODY_TOKEN_BUDGET` becomes a follow-up
+  issue (no tokenizer dependency in this PR).
+
+---
+
+---
+
+## Architecture Review
+
+### Ratings
+
+| Area | Rating | Notes |
+|---|---|---|
+| Path-argument handling | concern | CLI paths ≠ config paths; use `resolve()` + `is_file()` only, no containment anchor |
+| CLI surface (argparse, flags, exit codes) | pass | `--strict` safe; follow existing `--json` opt-in convention |
+| Output format | pass | Plain text default, `--json` opt-in — matches `audit`, `validate`, `grade` |
+| Warning prefix convention | pass | Use `"clauditor.conformance: <CODE>: <message>"` (distinct from `"clauditor.spec: ..."`) |
+| Success-message shape | concern | Project prints one-liner on pass in every existing command; lint should match (not stay Unix-silent) |
+| Warning dedup with `derive_skill_name` | **blocker** | On invalid `name:`, both helpers would emit stderr lines for the same root issue |
+| Bundled-skill conformance state | **blocker** | `src/clauditor/skills/clauditor/SKILL.md` uses `argument-hint` + `disable-model-invocation`; `src/clauditor/skills/review-agentskills-spec/SKILL.md` uses `disable-model-invocation`. Neither key is in the agentskills.io spec → `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` would fire on every skill load once the soft-warn hook lands |
+| Test structure (pure helper + I/O split) | pass | One class per rule category in `test_conformance.py`; CLI tests in dedicated `test_cli_lint.py`; hook tests extend `test_spec.py::TestFromFile` |
+| `tests/test_bundled_skill.py` regression | concern | Existing `test_skill_md_uses_disable_model_invocation` pins the unknown key; will need update depending on Q6 answer |
+| Coverage gate (80%) | pass | Six high-risk branches identified (YAML parse failure, bool/str YAML coercion, frontmatter edge cases, path-layout mismatch, whitespace-only values); each has a concrete test pattern |
+
+### Concerns requiring explicit decisions
+
+**Q6 (blocker) — Warning dedup:** When a skill has an invalid `name:` frontmatter value, `derive_skill_name` today emits *"clauditor.spec: frontmatter name '...' is not a valid skill identifier — using '...'"* AND the new soft-warn hook would emit *"clauditor.conformance: AGENTSKILLS_NAME_INVALID_CHARS: ..."*. Two messages, same root issue. Same problem for name-vs-parent-dir mismatch. How do we consolidate?
+
+**Q7 (blocker) — Bundled-skill unknown keys:** `argument-hint` and `disable-model-invocation` are Claude Code slash-command frontmatter (documented by Anthropic for CLI skills), not agentskills.io. They would trigger `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` warnings for every user whose skill also uses them. How do we treat these?
+
+**Q8 (concern) — Path validation style:** Confirm CLI-level path handling is `Path(arg).resolve()` + `is_file()` with no containment check. Accept absolute paths, follow symlinks, reject directories.
+
+**Q9 (concern) — Success message:** Silent (Unix style, exit 0 only) or one-liner (`"Conformance check passed for <path>"`)?
+
+**Q10 (concern) — `--json` support:** Add `lint --json` in this ticket (matches `audit`, `validate`, `grade`) or defer to follow-up?
+
+---
+
+## Refinement Log
+
+### Decisions
+
+- **DEC-001 — Pure module shape.** New `src/clauditor/conformance.py` exports `ConformanceIssue` dataclass
+  (`code: str`, `severity: Literal["error","warning"]`, `message: str`) and
+  `check_conformance(skill_md_text: str, skill_path: Path) -> list[ConformanceIssue]`. No I/O, no stderr, no
+  LLM. Traces to `.claude/rules/pure-compute-vs-io-split.md`.
+- **DEC-002 — CLI entry.** `src/clauditor/cli/lint.py` exports `add_parser(subparsers)` and `cmd_lint(args)`,
+  registered in `cli/__init__.py` alongside the 14 existing commands. Non-LLM 0/1/2 exit taxonomy
+  (`.claude/rules/llm-cli-exit-code-taxonomy.md`). Traces to Q&A scoping.
+- **DEC-003 — Soft-warn hook.** `SkillSpec.from_file` calls `check_conformance` after reading the SKILL.md text
+  and emits **only `severity="warning"` issues** to stderr in the form
+  `"clauditor.conformance: <CODE>: <message>"`. Errors are silent at this layer; users see them via
+  `clauditor lint`. Traces to Q3.
+- **DEC-004 — `--strict` scope.** `--strict` is a flag on `clauditor lint` only. It promotes warnings to errors
+  (exit 2 whenever any issue exists). No `--strict` added to `validate`, `grade`, `extract`, or other commands
+  in this ticket. A future ticket can extend if users ask. Traces to Q4.
+- **DEC-005 — Legacy layout handling.** `AGENTSKILLS_LAYOUT_LEGACY` fires for legacy single-file `<name>.md`
+  skills as a **warning by default**, with an explanatory message that names the required migration
+  (`mkdir <skill-name>/ && mv <name>.md <skill-name>/SKILL.md` and a link to the spec). `--strict` promotes to
+  error. This preserves back-compat for existing clauditor users while nudging them toward the modern layout.
+  Traces to Q1.
+- **DEC-006 — `name` regex (strict ASCII).** The regex is
+  `^[a-z0-9](?:[a-z0-9]|-(?!-))*[a-z0-9]$|^[a-z0-9]$` with overall length 1-64. Tie-breaks the spec's
+  self-contradictory "unicode lowercase (`a-z`)" phrase in favor of ASCII, matching every published example.
+  The existing `paths.py::SKILL_NAME_RE` stays unchanged (different contract — internal safety filter).
+  `conformance.py` defines its own `AGENTSKILLS_NAME_RE` constant; the two are not shared. Traces to Q2, G1.
+- **DEC-007 — Body checks in scope.** Line-count check lands in this ticket: `AGENTSKILLS_BODY_TOO_LONG`
+  (warning) fires when the body (post-frontmatter) exceeds 500 lines. The `< 5000 tokens` recommendation
+  (`AGENTSKILLS_BODY_TOKEN_BUDGET`) is **deferred to a follow-up issue** — it needs a tokenizer and would
+  complicate this non-LLM command's dependency graph. Traces to Q5.
+- **DEC-008 — Retire `derive_skill_name` warning emission.** `src/clauditor/paths.py::derive_skill_name`
+  becomes purely `(name, None)` — returns no warnings. The two existing warnings (invalid-name fallback,
+  frontmatter-vs-filesystem mismatch) are replaced by equivalent `check_conformance` codes
+  (`AGENTSKILLS_NAME_INVALID_CHARS`, `AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`) routed through the soft-warn
+  hook. Single source of truth for frontmatter-name warnings. Aligns with
+  `.claude/rules/skill-identity-from-frontmatter.md`'s "a future `--strict` mode could escalate" intent.
+  Updates `tests/test_paths.py::TestDeriveSkillName` and `tests/test_spec.py::TestFromFile` assertions.
+  Traces to Q6.
+- **DEC-009 — `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist.** `conformance.py` carries a
+  `frozenset[str]` allowlist of frontmatter keys that agent hosts use but the agentskills.io spec does not
+  define. Initial contents: `{"argument-hint", "disable-model-invocation"}`. Keys in this allowlist do NOT
+  trigger `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY`. The allowlist is documented in the `lint` docs as an
+  explicit clauditor extension. The `/review-agentskills-spec` skill (#72) maintains the allowlist against
+  Claude Code's published frontmatter documentation — see DEC-013. Traces to Q7.
+- **DEC-010 — Path validation style.** `cmd_lint` uses `Path(args.skill_md).resolve()` followed by
+  `is_file()`. Accepts absolute paths, follows symlinks, rejects directories. Does NOT apply the full
+  `.claude/rules/path-validation.md` containment recipe (that rule is for config-loaded paths inside a
+  spec dir; a CLI-provided path has different invariants). Matches the existing `validate`/`grade` pattern.
+  Traces to Q8.
+- **DEC-011 — Success-message shape.** On pass, `cmd_lint` prints a one-line summary to stdout:
+  `"Conformance check passed: <resolved-path>"`. Matches the existing convention in `validate`, `grade`,
+  `audit`. Traces to Q9.
+- **DEC-012 — `--json` output.** `clauditor lint --json` emits a JSON object to stdout of shape
+  `{"schema_version": 1, "skill_path": "<path>", "passed": bool, "issues": [{"code": ..., "severity": ...,
+  "message": ...}]}`. `schema_version: 1` is the first key per
+  `.claude/rules/json-schema-version.md`. Non-JSON mode prints human output. Traces to Q10.
+- **DEC-013 — #72 scope extension.** Issue #72 (the `/review-agentskills-spec` bundled skill) is extended
+  via comment to include an audit of Claude Code's published skill/command frontmatter documentation.
+  The skill becomes the maintainer of `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` by periodically diffing Claude
+  Code's field set against the allowlist. This keeps `conformance.py` offline and pure while giving the
+  allowlist a living update path. Comment URL recorded in session notes. Traces to Q7 + extension.
+- **DEC-014 — Warning prefix convention.** All conformance messages (CLI stderr, soft-warn hook stderr)
+  use the prefix `"clauditor.conformance: <CODE>: <message>"`. Distinct from the existing
+  `"clauditor.spec: ..."` prefix used by `SkillSpec`. Disambiguates which subsystem emitted the message
+  when a user sees interleaved stderr from multiple sources.
+
+### Load-bearing message copy
+
+- **`AGENTSKILLS_LAYOUT_LEGACY` (warning):** *"Legacy single-file skill layout `<filename>` is not in the
+  agentskills.io specification, which requires a `<skill-name>/SKILL.md` directory layout. To migrate:
+  `mkdir <skill-name>/ && mv <filename> <skill-name>/SKILL.md`. See
+  https://agentskills.io/specification#directory-structure."*
+- **`AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` (warning):** *"Unknown frontmatter key `<key>`; the agentskills.io
+  specification defines only: `name`, `description`, `license`, `compatibility`, `metadata`,
+  `allowed-tools`. If this is an extension recognized by a specific agent host, consider opening an issue
+  to add it to the clauditor allowlist."*
+- **`AGENTSKILLS_NAME_PARENT_DIR_MISMATCH` (error):** *"Frontmatter `name: <fm-name>` does not match parent
+  directory `<parent-dir>`; the agentskills.io specification requires these to match."*
+
+### Deferred to follow-up issues
+
+- `AGENTSKILLS_BODY_TOKEN_BUDGET` — 5000-token recommendation (DEC-007).
+- `--strict` on commands beyond `lint` (DEC-004).
+- `eval.json` field to default-strict for a specific skill (Q4 option C).
+- `AGENTSKILLS_DESCRIPTION_MISSING_WHEN_CLAUSE` / `_MISSING_KEYWORDS` (SHOULD-level prose-quality checks — not
+  mechanically verifiable without an LLM judge).
+
+---
+
+## Detailed Breakdown
+
+### Story map (dependency DAG)
+
+```
+US-001 (pure conformance module)
+    |
+    +--> US-002 (retire derive_skill_name warnings)
+    |       |
+    +-------+--> US-003 (CLI lint, plain text)
+    |       |       |
+    |       |       +--> US-004 (--strict flag)
+    |       |       +--> US-005 (--json output)
+    |       |
+    +-------+--> US-006 (soft-warn hook in SkillSpec.from_file)
+    |                       |
+    |                       +--> US-007 (bundled-skill conformance)
+    |                                       |
+    +---------------------------------------+--> US-008 (docs + CHANGELOG + cross-ref)
+                                                            |
+                                                            +--> US-QG (Quality Gate)
+                                                                        |
+                                                                        +--> US-PM (Patterns & Memory)
+```
+
+### US-001 — Pure `conformance.py` module with full rule set
+
+**Description:** Create `src/clauditor/conformance.py` with the `ConformanceIssue` dataclass and the
+`check_conformance(skill_md_text, skill_path) -> list[ConformanceIssue]` pure function implementing every
+rule from the Discovery section plus `AGENTSKILLS_LAYOUT_LEGACY`. Includes the
+`KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist and the `AGENTSKILLS_NAME_RE` constant.
+
+**Traces to:** DEC-001, DEC-005, DEC-006, DEC-007, DEC-009, and all spec rules enumerated in the Discovery
+section.
+
+**Files:**
+- `src/clauditor/conformance.py` (new; ~350-450 lines including docstrings)
+- `tests/test_conformance.py` (new; ~400-600 lines, class-per-category)
+
+**TDD:** Strong fit.
+- Minimal-valid-skill fixture. Tests mutate it per rule.
+- Classes: `TestNameValidation`, `TestDescriptionValidation`, `TestLicenseValidation`,
+  `TestCompatibilityValidation`, `TestMetadataValidation`, `TestAllowedToolsValidation`,
+  `TestFrontmatterStructure` (unknown keys + allowlist), `TestBodyChecks`, `TestLayoutChecks` (legacy +
+  parent-dir mismatch), `TestYAMLTypeCoercion` (`name: true` bool guard, `metadata.version: 1.0` coercion).
+
+**Acceptance criteria:**
+- `ConformanceIssue` dataclass with `code`, `severity: Literal["error","warning"]`, `message`.
+- `check_conformance` returns `list[ConformanceIssue]`, empty on valid input.
+- Every rule from the Discovery table produces a uniquely-coded issue with the right severity.
+- `_frontmatter.parse_frontmatter` is the only frontmatter parser used; no re-implementation.
+- `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` is a module-level `frozenset[str]` containing at least
+  `argument-hint` and `disable-model-invocation`.
+- Malformed YAML (`ValueError` from `parse_frontmatter`) surfaces as
+  `AGENTSKILLS_FRONTMATTER_INVALID_YAML` (error), not an uncaught exception.
+- No I/O: `grep -n "open(\|read_text\|print(\|sys.stderr\|sys.stdout" src/clauditor/conformance.py`
+  returns nothing.
+- Coverage ≥85% on the new module (headroom for the 80% gate).
+- `uv run ruff check src/clauditor/conformance.py tests/test_conformance.py` passes.
+
+**Done when:** Tests pass, coverage ≥85%, ruff clean.
+
+---
+
+### US-002 — Retire `derive_skill_name` warning emission
+
+**Description:** `src/clauditor/paths.py::derive_skill_name` currently returns `(name, warning | None)`. Per
+DEC-008, drop the warning branch: always return `(name, None)`. The two warnings it used to emit are now
+produced by `check_conformance` via US-006's hook. Simplify the signature to `-> str` (or keep the tuple
+with `None` always for caller compat — prefer the simpler signature change).
+
+**Traces to:** DEC-008.
+
+**Files:**
+- `src/clauditor/paths.py` — remove lines ~136-149 (warning construction); simplify return type.
+- `src/clauditor/spec.py::SkillSpec.from_file` — remove the `if warning is not None: print(...)` branch.
+- `src/clauditor/cli/init.py::cmd_init` — remove the same pattern.
+- `tests/test_paths.py::TestDeriveSkillName` — remove warning-return assertions; tests now assert on name
+  only.
+- `tests/test_spec.py::TestFromFile` — remove the stderr-warning assertions tied to `derive_skill_name`
+  (they move to US-004/US-006 and will assert on the `check_conformance` path instead).
+
+**Depends on:** US-001 (US-006 will back-fill the behavior before US-002's removal can land without a
+regression gap — but US-002 lands ahead of US-006 in code order; the gap is closed when US-006 ships. This
+ticket accepts a brief regression window within the PR; it is closed before merge).
+
+**TDD:** Light — remove existing assertions, add assertion that return is always `(name, None)` (or
+simplified `name`).
+
+**Acceptance criteria:**
+- `derive_skill_name` has no stderr emission, no warning construction, no `warning | None` in its return
+  type (or returns `(name, None)` always, caller's choice).
+- `SkillSpec.from_file` no longer has a `if warning is not None: print(...)` branch tied to
+  `derive_skill_name`'s output.
+- `cmd_init` mirror: same branch removed.
+- All existing tests for `derive_skill_name` continue to pass with updated assertions.
+- `uv run ruff check src/ tests/` passes.
+
+**Done when:** The grep `grep -rn "clauditor.spec: frontmatter name" src/` returns zero matches in
+source, and tests pass.
+
+---
+
+### US-003 — `clauditor lint` CLI command (plain text output)
+
+**Description:** Create `src/clauditor/cli/lint.py` with `add_parser(subparsers)` and `cmd_lint(args)`.
+Register in `src/clauditor/cli/__init__.py`. Positional path argument; path resolution per DEC-010. Human
+text output per DEC-011. Exit 0 on pass; exit 1 on load/parse failure (file not found, unreadable, malformed
+YAML → `AGENTSKILLS_FRONTMATTER_INVALID_YAML`); exit 2 on any conformance issue. `--strict` and `--json`
+deferred to US-004 and US-005.
+
+**Traces to:** DEC-002, DEC-010, DEC-011, DEC-014.
+
+**Files:**
+- `src/clauditor/cli/lint.py` (new; ~100-150 lines)
+- `src/clauditor/cli/__init__.py` (modify; 2 imports, 1 `add_parser` call, 1 dispatch elif)
+- `tests/test_cli_lint.py` (new; ~200-300 lines, `TestCmdLint` class)
+- `tests/test_cli.py::_MISSING_SKILL_FILE_COMMANDS` — add `["lint", "nonexistent.md"]` parametrized entry
+  per existing US-002 pattern
+
+**Depends on:** US-001.
+
+**TDD:** Fit.
+- Test "pass" path: minimal-valid skill → exit 0 + stdout success line.
+- Test "error" path: skill with an error issue → exit 2 + stderr issue lines.
+- Test "warning-only" path: skill with warnings only, no `--strict` → exit 0 + stderr warning lines (happy
+  path with warnings).
+- Test path-validation failures: absolute path to nowhere → exit 1; path is a directory → exit 1.
+- Test stdout prefix: human mode emits `"Conformance check passed: <path>"` on pass; issues go to stderr as
+  `"clauditor.conformance: <CODE>: <message>"`.
+
+**Acceptance criteria:**
+- `clauditor lint <path>` resolves the path, reads the file, calls `check_conformance`, renders issues.
+- Exit codes: 0 (pass), 1 (load/parse failure or bad path), 2 (one or more conformance issues).
+- Success message to stdout matches DEC-011 exactly.
+- Issue messages to stderr match DEC-014 prefix format exactly.
+- `cli/__init__.py` registration mirrors the existing subcommand pattern.
+- `tests/test_cli.py::test_command_missing_skill_file_exits_2` (or its rename from test_cli.py) covers
+  `lint` in its parametrized list.
+- `uv run ruff check src/ tests/` passes.
+- Coverage ≥85% on `cli/lint.py`.
+
+**Done when:** `clauditor lint src/clauditor/skills/clauditor/SKILL.md` executes with the correct exit
+code (depends on US-007's outcome; initially will likely exit 2 on the unknown-key warnings before
+US-007 lands).
+
+---
+
+### US-004 — `--strict` flag on `lint`
+
+**Description:** Add `--strict` flag to `clauditor lint`. When set, any warning produces exit 2 (same exit
+as errors). When unset, warnings do not affect exit code (still render to stderr).
+
+**Traces to:** DEC-004.
+
+**Files:**
+- `src/clauditor/cli/lint.py` — add `--strict` via `add_parser`; branch the exit-code logic.
+- `tests/test_cli_lint.py` — parametrized `(strict: bool, severity: str, expected_rc: int)` matrix per
+  Review C's sample.
+
+**Depends on:** US-003.
+
+**TDD:** Fit — the parametrized matrix is a natural TDD shape.
+
+**Acceptance criteria:**
+- `lint --strict <path>` exits 2 on warnings that would otherwise exit 0.
+- `lint <path>` (no `--strict`) exits 0 on warning-only input.
+- `lint --strict` does NOT change the rendering of warnings (they still emit to stderr identically).
+- Help text (`clauditor lint --help`) describes the flag's behavior in one sentence.
+
+**Done when:** All six cells of the parametrized test matrix pass.
+
+---
+
+### US-005 — `--json` output on `lint`
+
+**Description:** Add `--json` flag to `clauditor lint`. When set, emit a JSON object to stdout of shape
+`{"schema_version": 1, "skill_path": "<resolved-path>", "passed": bool, "issues": [{"code": ...,
+"severity": ..., "message": ...}, ...]}`. `"passed"` is `true` iff no errors AND (with `--strict`) no
+warnings. Suppresses the human text stdout/stderr.
+
+**Traces to:** DEC-012.
+
+**Files:**
+- `src/clauditor/cli/lint.py` — add `--json` flag; branch output rendering.
+- `tests/test_cli_lint.py` — JSON-mode tests (`json.loads(captured.out)` assertions).
+
+**Depends on:** US-003.
+
+**TDD:** Fit.
+
+**Acceptance criteria:**
+- `lint --json <path>` emits a single JSON object to stdout; stderr is empty.
+- `schema_version: 1` is the first key in the payload (per `.claude/rules/json-schema-version.md`).
+- `issues[]` entries include all three `ConformanceIssue` fields.
+- `passed` is derived correctly under both `--strict` and non-strict modes.
+- Exit codes are identical to the human-output path (DEC-012 does not change exit codes).
+- `json.loads(captured.out)["issues"][0]["code"].startswith("AGENTSKILLS_")` passes on an invalid skill.
+- Help text documents `--json` in one sentence.
+
+**Done when:** JSON output parses cleanly and contains the expected keys + types in a representative
+fixture.
+
+---
+
+### US-006 — Soft-warn hook in `SkillSpec.from_file`
+
+**Description:** After reading the SKILL.md text in `SkillSpec.from_file`, call `check_conformance(text,
+skill_path)` and emit **only `severity="warning"` issues** to stderr with the
+`"clauditor.conformance: <CODE>: <message>"` prefix. Errors are silent at this seam; they surface when
+the user runs `clauditor lint`. The hook never raises; spec loading continues regardless.
+
+**Traces to:** DEC-003, DEC-014.
+
+**Files:**
+- `src/clauditor/spec.py::SkillSpec.from_file` — add the hook after `derive_skill_name` call (~5-10 lines).
+- `tests/test_spec.py::TestFromFile` — add tests for the hook: emits on warnings, silent on errors, never
+  blocks.
+
+**Depends on:** US-001, US-002.
+
+**TDD:** Fit.
+- Test: skill with a `warning`-severity issue (e.g. body >500 lines) → `capsys.readouterr().err` contains
+  the prefix + code.
+- Test: skill with an `error`-severity issue (e.g. missing `name:`) → no stderr from the hook (errors are
+  silent here). Spec still loads (with whatever fallback `derive_skill_name` produces).
+- Test: skill with both warnings and errors → only warnings emit to stderr.
+- Test: hook does NOT raise on malformed YAML (the `AGENTSKILLS_FRONTMATTER_INVALID_YAML` error doesn't
+  reach stderr here, so it cannot block from_file).
+
+**Acceptance criteria:**
+- The hook is ~10 lines, one loop over `check_conformance` output filtered on severity.
+- Zero new exceptions propagate out of `from_file` from the hook.
+- All existing `TestFromFile` tests continue to pass.
+- New tests cover the four cases above.
+
+**Done when:** `tests/test_spec.py` passes, and a `grep "clauditor.conformance:" src/clauditor/spec.py`
+finds exactly one occurrence (the prefix string).
+
+---
+
+### US-007 — Bundled-skill conformance audit + regression test
+
+**Description:** Verify both shipped bundled skills (`src/clauditor/skills/clauditor/SKILL.md` and
+`src/clauditor/skills/review-agentskills-spec/SKILL.md`) pass `check_conformance` with **zero errors and
+zero warnings outside the `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist**. If any drift surfaces, either
+add the key to the allowlist (with a comment referencing Claude Code's docs per DEC-013) or fix the
+frontmatter. Add `TestBundledSkillConformance` regression class to `tests/test_bundled_skill.py`.
+
+**Traces to:** DEC-009, DEC-013, `.claude/rules/bundled-skill-docs-sync.md`.
+
+**Files:**
+- `src/clauditor/skills/clauditor/SKILL.md` — potential frontmatter adjustments (expect none; `argument-hint`
+  and `disable-model-invocation` should already be allowlisted).
+- `src/clauditor/skills/review-agentskills-spec/SKILL.md` — same.
+- `src/clauditor/conformance.py` — the `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` constant may need additions after
+  the audit (discovered at impl time).
+- `tests/test_bundled_skill.py` — add `TestBundledSkillConformance` class asserting `check_conformance`
+  returns `[]` (or only allowlist-matched issues) for both skills.
+- `tests/test_bundled_skill.py::test_skill_md_uses_disable_model_invocation` — no change; the allowlist
+  preserves this field.
+
+**Depends on:** US-001, US-006.
+
+**TDD:** Fit — write the regression assertion first, it drives any allowlist additions.
+
+**Acceptance criteria:**
+- Running `check_conformance(skill_md.read_text(), skill_md)` on each bundled skill returns `[]` (empty).
+  No errors, no warnings, no allowlist-bypass.
+- `TestBundledSkillConformance` class in `tests/test_bundled_skill.py` asserts this for both skills in
+  two methods (one per skill).
+- If the audit surfaced new Claude Code extension keys, they are added to
+  `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` with a comment line citing the source (Anthropic docs URL when
+  known; "Claude Code extension — see #72's audit" otherwise).
+- The soft-warn hook is validated end-to-end:
+  `capsys.readouterr().err` on `SkillSpec.from_file(<bundled-SKILL>)` is empty.
+
+**Done when:** The regression test passes on both bundled skills, and manual `clauditor lint
+src/clauditor/skills/clauditor/SKILL.md` exits 0 with the "Conformance check passed" line.
+
+---
+
+### US-008 — Documentation: cli-reference, README, CHANGELOG, cross-ref
+
+**Description:** Per the ticket's Section 5 and `.claude/rules/readme-promotion-recipe.md`:
+1. `docs/cli-reference.md` — new `## lint` section (required inputs, flags table, examples, exit codes);
+   add `clauditor lint <path>` to the quick-reference table at the top.
+2. `README.md` — one-line addition to the "CLI Reference" subcommand list and a D2-lean teaser under the
+   "Beyond the spec" bullet list in the agentskills.io alignment block (if one exists; otherwise skip).
+3. `CHANGELOG.md` — `### Added` entry under `## [Unreleased]` covering the `lint` command, soft-warn hook,
+   `--strict`, `--json`, and the `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist.
+4. `CONTRIBUTING.md` — add `clauditor lint src/clauditor/skills/clauditor/SKILL.md` as a pre-release
+   dogfood gate (maintainer convention: bundled skill must pass lint before tag).
+5. **Cross-reference `/review-agentskills-spec`** in the new lint section so maintainers and users don't
+   conflate the two. Add an inverse cross-reference in the bundled skill's documentation.
+6. `docs/pytest-plugin.md` — one-line "lint is a standalone CLI, not exposed via pytest" pointer.
+7. `docs/eval-spec-reference.md` — no changes (no new spec fields).
+8. `docs/skill-usage.md` — no changes (bundled `/clauditor` skill workflow does NOT gain a lint step in this
+   ticket; if it did, `.claude/rules/bundled-skill-docs-sync.md`'s triangle would apply).
+9. Regression test per `.claude/rules/bundled-skill-docs-sync.md`: add a
+   `tests/test_docs_examples.py` grep assertion for `"clauditor lint"` in `docs/cli-reference.md` so a
+   future prose cleanup cannot silently drop the command.
+
+**Traces to:** DEC-002 (documented as cli-reference entry),
+`.claude/rules/readme-promotion-recipe.md`, `.claude/rules/bundled-skill-docs-sync.md`.
+
+**Files:**
+- `docs/cli-reference.md` (modify; add `## lint` section, update quick-reference table)
+- `README.md` (modify; one-line addition)
+- `CHANGELOG.md` (modify; new `### Added` entry)
+- `CONTRIBUTING.md` (modify; add `lint` to pre-release gate list)
+- `docs/pytest-plugin.md` (modify; one-line pointer)
+- `tests/test_docs_examples.py` (modify or create; grep regression assertion)
+- `src/clauditor/skills/review-agentskills-spec/SKILL.md` (modify; add inverse cross-ref to `lint`)
+
+**Depends on:** US-007 (docs describe the final state including the allowlist).
+
+**TDD:** Light — the grep-regression is a one-line prose-presence assertion.
+
+**Acceptance criteria:**
+- `docs/cli-reference.md` has a `## lint` section with Required inputs, Flags (table), Examples, Exit
+  codes. Quick-reference table lists `clauditor lint <path>`.
+- README references `clauditor lint` in the CLI Reference list.
+- CHANGELOG's `## [Unreleased]` has a new `### Added` entry covering all user-visible changes.
+- `tests/test_docs_examples.py` has a grep for `"clauditor lint"` in `docs/cli-reference.md`.
+- Cross-references between `lint` docs and `/review-agentskills-spec` skill docs are in place.
+
+**Done when:** All doc files updated, grep-regression passes, maintainer-dogfood step added to
+CONTRIBUTING.
+
+---
+
+### US-QG — Quality Gate
+
+**Description:** Run the standard clauditor quality gate across the full changeset of US-001 through
+US-008:
+1. `uv run ruff check src/ tests/` passes with zero findings.
+2. `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥80% total coverage.
+3. Code reviewer (general-purpose agent with review prompt) runs 4 times over the changeset, fixing every
+   real issue found. Passes 2-4 reference prior passes' findings.
+4. CodeRabbit review if available on the branch's PR; fix every real issue or justify false positives.
+5. Final re-run of `ruff` + `pytest` after each fix pass to confirm no regressions.
+
+**Traces to:** `.claude/rules/pytester-inprocess-coverage-hazard.md` (watch for segfault risk if any new
+pytester tests land), project convention.
+
+**Files:** None created; may modify source files during fixes.
+
+**Depends on:** US-001 through US-008 all complete.
+
+**Acceptance criteria:**
+- `uv run ruff check src/ tests/` exit 0.
+- `uv run pytest --cov=clauditor --cov-fail-under=80` exit 0.
+- Four reviewer passes completed; each pass's findings addressed.
+- Manual validation: `clauditor lint src/clauditor/skills/clauditor/SKILL.md` exits 0 with the
+  success line.
+- Manual validation: `clauditor lint src/clauditor/skills/clauditor/SKILL.md --json | jq .passed`
+  returns `true`.
+- Manual validation: `clauditor validate src/clauditor/skills/clauditor/SKILL.md` stderr is empty
+  (no conformance warnings from soft-warn hook, confirming the bundled skill is conformant).
+
+**Done when:** All acceptance criteria met and CI green.
+
+---
+
+### US-PM — Patterns & Memory
+
+**Description:** Capture any novel patterns from this ticket into `.claude/rules/` or memory. Candidates:
+1. **New rule anchor for `--strict` flag shape** — if `--strict` shape generalizes beyond `lint`, add a
+   rule doc. Likely not needed for a single-command flag; skip if the shape is local.
+2. **New rule anchor for `ConformanceIssue`-style issue lists** — the `code / severity / message` shape
+   is reusable for future static-check features (rubric conformance, trigger-file conformance, etc.). If
+   it generalizes, add a rule. Write the rule only if a second caller appears; otherwise document the
+   shape in `conformance.py`'s module docstring as the canonical reference.
+3. **Update `.claude/rules/skill-identity-from-frontmatter.md`** — with DEC-008, `derive_skill_name` is no
+   longer the emission point for frontmatter-name warnings. Update the rule's "Why each piece matters"
+   section to point at `conformance.py` as the new single source for name validation messaging.
+4. **Update `.claude/rules/bundled-skill-docs-sync.md`** — if US-008 added the bundled-skill cross-ref
+   pattern for maintainer-audience docs, extend the rule's "Canonical implementation" section.
+
+**Traces to:** Priority 99 (always last).
+
+**Files:** Updates to `.claude/rules/*.md`; possible new `.claude/rules/static-conformance-issue-list.md`.
+
+**Depends on:** US-QG.
+
+**Acceptance criteria:**
+- Any genuinely-novel shape from this ticket is captured in a rule doc or memory entry.
+- Pre-existing rules whose canonical-implementation pointers became stale (e.g. `skill-identity-from-
+  frontmatter.md` after US-002) are updated.
+- No speculative rules — skip anchors that would need a second caller to be useful.
+
+**Done when:** Rules grepped for stale references, updated where needed; memory appended with
+feature-relevant insight if any.
+
+---
+
+## Story summary
+
+| ID | Title | Files | Depends on | TDD |
+|---|---|---|---|---|
+| US-001 | Pure `conformance.py` module | `conformance.py`, `test_conformance.py` | — | Yes |
+| US-002 | Retire `derive_skill_name` warnings | `paths.py`, `spec.py`, `cli/init.py`, tests | US-001 | Light |
+| US-003 | CLI `lint` (plain text) | `cli/lint.py`, `cli/__init__.py`, `test_cli_lint.py`, `test_cli.py` | US-001 | Yes |
+| US-004 | `--strict` flag | `cli/lint.py`, `test_cli_lint.py` | US-003 | Yes |
+| US-005 | `--json` output | `cli/lint.py`, `test_cli_lint.py` | US-003 | Yes |
+| US-006 | Soft-warn hook | `spec.py`, `test_spec.py` | US-001, US-002 | Yes |
+| US-007 | Bundled-skill conformance | bundled SKILL.md files, `conformance.py`, `test_bundled_skill.py` | US-001, US-006 | Yes |
+| US-008 | Docs + CHANGELOG + cross-ref | docs/*, README.md, CHANGELOG.md, CONTRIBUTING.md, `test_docs_examples.py` | US-007 | Light |
+| US-QG | Quality Gate | (no new files) | US-001..US-008 | No |
+| US-PM | Patterns & Memory | `.claude/rules/*` | US-QG | No |
+
+---
+
+## Session Notes
+
+**2026-04-21 — Discovery complete.** Three parallel subagents
+ran: codebase scout, convention checker, spec extractor. The
+spec extractor's live fetch surfaced three ticket-vs-spec
+mismatches (500-line limit is in spec, `< 5000 tokens` limit
+is in spec, parent-dir-match is unqualified) and 10 gaps
+requiring explicit decisions. User answered all 5 scoping
+questions (Q1=D+explanatory, Q2=A, Q3=A, Q4=A, Q5=B). Moving
+to architecture review — path handling, CLI surface, warning
+dedup with existing `derive_skill_name`, testing shape.
+
+**2026-04-21 — Architecture review complete.** Three parallel
+subagents: security/CLI surface, warning-dedup/bundled-skill
+compliance, testing strategy. Two blockers surfaced: (1) the
+soft-warn hook would emit duplicate stderr lines with existing
+`derive_skill_name` warnings for the same root issue; (2) both
+shipped bundled skills use Claude Code frontmatter extensions
+(`argument-hint`, `disable-model-invocation`) not in the
+agentskills.io spec — they would trigger
+`AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` on every load. Three
+smaller concerns on path handling style, success-message
+shape, and `--json` scope. Moving to refinement to resolve.
+
+**2026-04-21 — Refinement complete.** User resolved Q6=A
+(retire `derive_skill_name` warnings; consolidate into
+`check_conformance`), Q7=A (define
+`KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist) plus an
+extension to issue #72's scope to keep the allowlist
+maintained against Claude Code's published frontmatter docs,
+Q8=A (simple `resolve()` + `is_file()` CLI path validation),
+Q9=B (one-liner success message matching project
+convention), Q10=A (ship `--json` in this ticket).
+DEC-001 through DEC-014 recorded.
+Comment added to #72:
+https://github.com/wjduenow/clauditor/issues/72#issuecomment-4289971205.
+Ten stories drafted: US-001 (pure module), US-002 (retire
+old warnings), US-003 (CLI), US-004 (`--strict`), US-005
+(`--json`), US-006 (hook), US-007 (bundled-skill conformance),
+US-008 (docs), US-QG (Quality Gate), US-PM (Patterns).

--- a/plans/super/71-agentskills-lint.md
+++ b/plans/super/71-agentskills-lint.md
@@ -4,7 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/71
 - **Branch:** `feature/71-agentskills-lint`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/71-agentskills-lint`
-- **Phase:** `detailing`
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/74
 - **Sessions:** 1
 - **Last session:** 2026-04-21
 

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -358,6 +358,7 @@ from clauditor.cli import doctor as doctor_mod  # noqa: E402
 from clauditor.cli import extract as extract_mod  # noqa: E402
 from clauditor.cli import grade as grade_mod  # noqa: E402
 from clauditor.cli import init as init_mod  # noqa: E402
+from clauditor.cli import lint as lint_mod  # noqa: E402
 from clauditor.cli import propose_eval as propose_eval_mod  # noqa: E402
 from clauditor.cli import run as run_mod  # noqa: E402
 from clauditor.cli import setup as setup_mod  # noqa: E402
@@ -375,6 +376,7 @@ from clauditor.cli.grade import (  # noqa: E402,F401
     cmd_grade,
 )
 from clauditor.cli.init import cmd_init  # noqa: E402,F401
+from clauditor.cli.lint import cmd_lint  # noqa: E402,F401
 from clauditor.cli.propose_eval import cmd_propose_eval  # noqa: E402,F401
 from clauditor.cli.run import cmd_run  # noqa: E402,F401
 from clauditor.cli.setup import cmd_setup  # noqa: E402,F401
@@ -433,6 +435,9 @@ def main(argv: list[str] | None = None) -> int:
     # doctor
     doctor_mod.add_parser(subparsers)
 
+    # lint
+    lint_mod.add_parser(subparsers)
+
     # Split argv on a literal `--` *only* when the capture subcommand is in
     # play, so other subcommands (validate/grade/...) keep argparse's native
     # `--` handling instead of having their trailing args silently stripped.
@@ -477,6 +482,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_suggest(parsed)
     elif parsed.command == "propose-eval":
         return cmd_propose_eval(parsed)
+    elif parsed.command == "lint":
+        return cmd_lint(parsed)
 
     return 1
 

--- a/src/clauditor/cli/init.py
+++ b/src/clauditor/cli/init.py
@@ -51,9 +51,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         print(f"ERROR: cannot read {skill_path}: {exc}", file=sys.stderr)
         return 1
 
-    skill_name, warning = derive_skill_name(skill_path, skill_md_text)
-    if warning is not None:
-        print(warning, file=sys.stderr)
+    skill_name = derive_skill_name(skill_path, skill_md_text)
 
     starter = {
         "skill_name": skill_name,

--- a/src/clauditor/cli/lint.py
+++ b/src/clauditor/cli/lint.py
@@ -1,8 +1,7 @@
 """``clauditor lint`` — check a SKILL.md file against the agentskills.io spec.
 
-Plain-text output (US-003) plus the ``--strict`` flag (US-004, DEC-004).
-The ``--json`` flag (US-005) is deferred to a separate bead; this
-module's argparse surface does not register it yet.
+Plain-text output (US-003), the ``--strict`` flag (US-004, DEC-004),
+and the ``--json`` flag (US-005, DEC-012).
 
 Exit-code taxonomy (non-LLM 0/1/2 per
 ``.claude/rules/llm-cli-exit-code-taxonomy.md``):
@@ -22,7 +21,15 @@ The ``--strict`` flag (DEC-004) promotes warnings to exit 2. It does
 NOT change the stderr rendering of issues and does NOT override the
 INVALID_YAML → exit 1 special case.
 
-Traces to DEC-002, DEC-004, DEC-010, DEC-011, DEC-014 of
+The ``--json`` flag (DEC-012) emits a single JSON envelope to stdout
+instead of the human-readable stderr rendering. ``schema_version: 1``
+is the FIRST key in the payload per
+``.claude/rules/json-schema-version.md``. Exit codes are identical to
+the human path. Path-level errors (not-a-file, unreadable) surface as
+synthetic ``PATH_*`` entries in the same ``issues[]`` list so JSON
+consumers have a single surface to read.
+
+Traces to DEC-002, DEC-004, DEC-010, DEC-011, DEC-012, DEC-014 of
 ``plans/super/71-agentskills-lint.md``. The pure-compute layer lives in
 ``src/clauditor/conformance.py`` per
 ``.claude/rules/pure-compute-vs-io-split.md``.
@@ -31,7 +38,9 @@ Traces to DEC-002, DEC-004, DEC-010, DEC-011, DEC-014 of
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 from clauditor.conformance import ConformanceIssue, check_conformance
@@ -39,6 +48,14 @@ from clauditor.conformance import ConformanceIssue, check_conformance
 # Code that always routes to exit 1 regardless of ``--strict`` —
 # malformed-frontmatter is a parse failure, not a conformance concern.
 _INVALID_YAML_CODE = "AGENTSKILLS_FRONTMATTER_INVALID_YAML"
+
+# Synthetic lint-side path-error codes (NOT prefixed with
+# ``AGENTSKILLS_`` — these are not spec violations). Surfaced in the
+# JSON envelope's ``issues[]`` list so consumers read one uniform
+# structure. Human-mode callers see the existing stderr ``ERROR:``
+# line instead.
+_PATH_NOT_A_FILE_CODE = "PATH_NOT_A_FILE"
+_PATH_UNREADABLE_CODE = "PATH_UNREADABLE"
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -56,6 +73,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
             "regardless."
         ),
     )
+    p_lint.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit a JSON envelope to stdout instead of human-readable "
+            "text. Exit codes unchanged."
+        ),
+    )
 
 
 def _render_issue(issue: ConformanceIssue) -> str:
@@ -68,6 +93,47 @@ def _has_error(issues: list[ConformanceIssue]) -> bool:
     return any(issue.severity == "error" for issue in issues)
 
 
+def _compute_exit_code(
+    issues: list[ConformanceIssue], *, strict: bool
+) -> int:
+    """Map a conformance-issues list + ``--strict`` to the exit code.
+
+    Shared by both the human-text and JSON rendering paths so the two
+    branches cannot drift. See module docstring for the full taxonomy.
+    """
+    if not issues:
+        return 0
+    if len(issues) == 1 and issues[0].code == _INVALID_YAML_CODE:
+        return 1
+    if _has_error(issues) or strict:
+        return 2
+    return 0
+
+
+def _emit_json_envelope(
+    skill_path_str: str,
+    issues: list[ConformanceIssue],
+    *,
+    exit_code: int,
+) -> None:
+    """Print the ``--json`` envelope to stdout (DEC-012).
+
+    ``schema_version: 1`` is inserted as the first key via an explicit
+    ordered dict construction — Python 3.7+ preserves dict insertion
+    order, so ``json.dumps`` writes keys in the order they were added.
+    Verified structurally by
+    ``tests/test_cli_lint.py::TestJsonOutput::test_json_schema_version_first_key``
+    so this property cannot silently regress.
+    """
+    payload = {
+        "schema_version": 1,
+        "skill_path": skill_path_str,
+        "passed": exit_code == 0,
+        "issues": [asdict(issue) for issue in issues],
+    }
+    print(json.dumps(payload, indent=2))
+
+
 def cmd_lint(args: argparse.Namespace) -> int:
     """Lint a SKILL.md file against the agentskills.io specification.
 
@@ -75,12 +141,33 @@ def cmd_lint(args: argparse.Namespace) -> int:
     follows DEC-010 (``Path.resolve()`` + ``is_file()``; accepts absolute
     paths, follows symlinks, rejects directories). ``--strict`` (DEC-004)
     promotes warning-only results to exit 2 without altering rendering.
+    ``--json`` (DEC-012) replaces the human-text rendering with a single
+    JSON envelope on stdout; exit codes and ``--strict`` interaction are
+    unchanged.
     """
     # Path validation (DEC-010). Accept absolute paths; follow symlinks
     # to their real target; reject directories, sockets, FIFOs, and
     # missing paths.
     skill_path = Path(args.skill_md).resolve()
     if not skill_path.is_file():
+        if args.json:
+            # Synthetic PATH_NOT_A_FILE entry in the issues list so JSON
+            # consumers have one uniform surface to read path errors
+            # alongside conformance issues. ``args.skill_md`` (the
+            # caller's original argv) is more informative than the
+            # ``resolve()``-ed path on a missing target.
+            _emit_json_envelope(
+                args.skill_md,
+                [
+                    ConformanceIssue(
+                        code=_PATH_NOT_A_FILE_CODE,
+                        severity="error",
+                        message=f"{args.skill_md} is not a regular file",
+                    )
+                ],
+                exit_code=1,
+            )
+            return 1
         print(
             f"ERROR: {args.skill_md} is not a regular file",
             file=sys.stderr,
@@ -92,6 +179,19 @@ def cmd_lint(args: argparse.Namespace) -> int:
     try:
         skill_md_text = skill_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
+        if args.json:
+            _emit_json_envelope(
+                str(skill_path),
+                [
+                    ConformanceIssue(
+                        code=_PATH_UNREADABLE_CODE,
+                        severity="error",
+                        message=f"cannot read {args.skill_md}: {exc}",
+                    )
+                ],
+                exit_code=1,
+            )
+            return 1
         print(
             f"ERROR: cannot read {args.skill_md}: {exc}",
             file=sys.stderr,
@@ -99,6 +199,15 @@ def cmd_lint(args: argparse.Namespace) -> int:
         return 1
 
     issues = check_conformance(skill_md_text, skill_path)
+    exit_code = _compute_exit_code(issues, strict=args.strict)
+
+    # JSON path: single stdout write, empty stderr, identical exit
+    # code to the human path.
+    if args.json:
+        _emit_json_envelope(str(skill_path), issues, exit_code=exit_code)
+        return exit_code
+
+    # Human path (US-003 + US-004): byte-identical to pre-US-005.
 
     # Pass — no issues at all.
     if not issues:

--- a/src/clauditor/cli/lint.py
+++ b/src/clauditor/cli/lint.py
@@ -43,7 +43,11 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
-from clauditor.conformance import ConformanceIssue, check_conformance
+from clauditor.conformance import (
+    ConformanceIssue,
+    check_conformance,
+    format_issue_line,
+)
 
 # Code that always routes to exit 1 regardless of ``--strict`` —
 # malformed-frontmatter is a parse failure, not a conformance concern.
@@ -56,6 +60,22 @@ _INVALID_YAML_CODE = "AGENTSKILLS_FRONTMATTER_INVALID_YAML"
 # line instead.
 _PATH_NOT_A_FILE_CODE = "PATH_NOT_A_FILE"
 _PATH_UNREADABLE_CODE = "PATH_UNREADABLE"
+
+
+def _sanitize_message_text(value: str) -> str:
+    """Replace newline characters with visible escape sequences.
+
+    User-controlled strings (``args.skill_md`` from argv, ``OSError.__str__``
+    from a failed ``read_text``) can contain ``\n`` or ``\r`` — POSIX
+    allows newlines in filenames, and plugin filesystems sometimes raise
+    multi-line OSError messages. Those characters, if interpolated verbatim
+    into a :class:`ConformanceIssue` message, violate the ``__post_init__``
+    single-line invariant (DEC-014) and crash the ``--json`` path before
+    it can emit its envelope. Replace with the literal escape sequences
+    ``\\n`` / ``\\r`` so the synthetic path-error issues render on one
+    line and stay grep-friendly for the human-text path.
+    """
+    return value.replace("\r", "\\r").replace("\n", "\\n")
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -83,11 +103,6 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _render_issue(issue: ConformanceIssue) -> str:
-    """Format one issue as a stderr line (DEC-014)."""
-    return f"clauditor.conformance: {issue.code}: {issue.message}"
-
-
 def _has_error(issues: list[ConformanceIssue]) -> bool:
     """Return ``True`` if any issue has ``severity == "error"``."""
     return any(issue.severity == "error" for issue in issues)
@@ -103,7 +118,13 @@ def _compute_exit_code(
     """
     if not issues:
         return 0
-    if len(issues) == 1 and issues[0].code == _INVALID_YAML_CODE:
+    # INVALID_YAML dominates: sibling pre-parse issues (e.g.
+    # ``AGENTSKILLS_LAYOUT_LEGACY``, which is appended before the
+    # frontmatter parse in ``check_conformance``) may accompany it, but
+    # the caller cannot act on them until the YAML parses. Route the
+    # whole run to exit 1 even under ``--strict`` — parse failures are
+    # never escalated by that flag.
+    if any(issue.code == _INVALID_YAML_CODE for issue in issues):
         return 1
     if _has_error(issues) or strict:
         return 2
@@ -162,14 +183,17 @@ def cmd_lint(args: argparse.Namespace) -> int:
                     ConformanceIssue(
                         code=_PATH_NOT_A_FILE_CODE,
                         severity="error",
-                        message=f"{args.skill_md} is not a regular file",
+                        message=(
+                            f"{_sanitize_message_text(args.skill_md)} is "
+                            f"not a regular file"
+                        ),
                     )
                 ],
                 exit_code=1,
             )
             return 1
         print(
-            f"ERROR: {args.skill_md} is not a regular file",
+            f"ERROR: {_sanitize_message_text(args.skill_md)} is not a regular file",
             file=sys.stderr,
         )
         return 1
@@ -186,14 +210,20 @@ def cmd_lint(args: argparse.Namespace) -> int:
                     ConformanceIssue(
                         code=_PATH_UNREADABLE_CODE,
                         severity="error",
-                        message=f"cannot read {args.skill_md}: {exc}",
+                        message=(
+                            f"cannot read "
+                            f"{_sanitize_message_text(args.skill_md)}: "
+                            f"{_sanitize_message_text(str(exc))}"
+                        ),
                     )
                 ],
                 exit_code=1,
             )
             return 1
         print(
-            f"ERROR: cannot read {args.skill_md}: {exc}",
+            f"ERROR: cannot read "
+            f"{_sanitize_message_text(args.skill_md)}: "
+            f"{_sanitize_message_text(str(exc))}",
             file=sys.stderr,
         )
         return 1
@@ -217,12 +247,13 @@ def cmd_lint(args: argparse.Namespace) -> int:
     # Render every issue to stderr in order (DEC-014). Rendering is
     # independent of ``--strict`` — the flag only influences exit code.
     for issue in issues:
-        print(_render_issue(issue), file=sys.stderr)
+        print(format_issue_line(issue), file=sys.stderr)
 
-    # Exit-1 case: the ONLY issue is malformed frontmatter (parse failure,
-    # not conformance). Preserve verbatim under ``--strict`` — parse
-    # failures are never escalated by that flag.
-    if len(issues) == 1 and issues[0].code == _INVALID_YAML_CODE:
+    # Exit-1 case: malformed frontmatter is present (may coexist with
+    # sibling pre-parse warnings like ``AGENTSKILLS_LAYOUT_LEGACY``).
+    # Parse failures dominate — the caller cannot act on sibling issues
+    # until the YAML parses. Preserved under ``--strict`` per DEC-004.
+    if any(issue.code == _INVALID_YAML_CODE for issue in issues):
         print("Cannot lint: SKILL.md frontmatter is not valid YAML")
         return 1
 

--- a/src/clauditor/cli/lint.py
+++ b/src/clauditor/cli/lint.py
@@ -1,0 +1,96 @@
+"""``clauditor lint`` — check a SKILL.md file against the agentskills.io spec.
+
+Plain-text output (US-003). The `--strict` flag (US-004) and the
+`--json` flag (US-005) are added by separate beads; this module's
+argparse surface intentionally does not register them.
+
+Exit-code taxonomy (non-LLM 0/1/2 per
+``.claude/rules/llm-cli-exit-code-taxonomy.md``):
+
+- **0** — no conformance issues returned by ``check_conformance``.
+- **1** — load/parse failure: path does not resolve to a regular file,
+  file is unreadable (OSError / UnicodeDecodeError), OR the only issue
+  is ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` (malformed frontmatter
+  is a parse problem, not spec drift).
+- **2** — one or more conformance issues present (any severity),
+  except the YAML-parse-only case above.
+
+Traces to DEC-002, DEC-010, DEC-011, DEC-014 of
+``plans/super/71-agentskills-lint.md``. The pure-compute layer lives in
+``src/clauditor/conformance.py`` per
+``.claude/rules/pure-compute-vs-io-split.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from clauditor.conformance import ConformanceIssue, check_conformance
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``lint`` subparser."""
+    p_lint = subparsers.add_parser(
+        "lint",
+        help="Check SKILL.md against the agentskills.io specification",
+    )
+    p_lint.add_argument("skill_md", help="Path to SKILL.md file")
+
+
+def _render_issue(issue: ConformanceIssue) -> str:
+    """Format one issue as a stderr line (DEC-014)."""
+    return f"clauditor.conformance: {issue.code}: {issue.message}"
+
+
+def cmd_lint(args: argparse.Namespace) -> int:
+    """Lint a SKILL.md file against the agentskills.io specification.
+
+    See module docstring for the full exit-code contract. Path resolution
+    follows DEC-010 (``Path.resolve()`` + ``is_file()``; accepts absolute
+    paths, follows symlinks, rejects directories).
+    """
+    # Path validation (DEC-010). Accept absolute paths; follow symlinks
+    # to their real target; reject directories, sockets, FIFOs, and
+    # missing paths.
+    skill_path = Path(args.skill_md).resolve()
+    if not skill_path.is_file():
+        print(
+            f"ERROR: {args.skill_md} is not a regular file",
+            file=sys.stderr,
+        )
+        return 1
+
+    # File read — tolerate OSError (permission, IO) and
+    # UnicodeDecodeError (non-UTF-8 bytes) as exit-1 parse failures.
+    try:
+        skill_md_text = skill_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(
+            f"ERROR: cannot read {args.skill_md}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    issues = check_conformance(skill_md_text, skill_path)
+
+    # Pass — no issues at all.
+    if not issues:
+        print(f"Conformance check passed: {skill_path}")
+        return 0
+
+    # Render every issue to stderr in order (DEC-014).
+    for issue in issues:
+        print(_render_issue(issue), file=sys.stderr)
+
+    # Exit-1 case: the ONLY issue is malformed frontmatter (parse failure,
+    # not conformance). Any other mix routes to exit 2.
+    invalid_yaml_code = "AGENTSKILLS_FRONTMATTER_INVALID_YAML"
+    if len(issues) == 1 and issues[0].code == invalid_yaml_code:
+        print("Cannot lint: SKILL.md frontmatter is not valid YAML")
+        return 1
+
+    # One or more conformance issues — exit 2 with stdout failure summary.
+    print(f"Conformance check failed: {len(issues)} issue(s) — see above")
+    return 2

--- a/src/clauditor/cli/lint.py
+++ b/src/clauditor/cli/lint.py
@@ -1,21 +1,28 @@
 """``clauditor lint`` — check a SKILL.md file against the agentskills.io spec.
 
-Plain-text output (US-003). The `--strict` flag (US-004) and the
-`--json` flag (US-005) are added by separate beads; this module's
-argparse surface intentionally does not register them.
+Plain-text output (US-003) plus the ``--strict`` flag (US-004, DEC-004).
+The ``--json`` flag (US-005) is deferred to a separate bead; this
+module's argparse surface does not register it yet.
 
 Exit-code taxonomy (non-LLM 0/1/2 per
 ``.claude/rules/llm-cli-exit-code-taxonomy.md``):
 
-- **0** — no conformance issues returned by ``check_conformance``.
+- **0** — either (a) no conformance issues returned by
+  ``check_conformance``, or (b) issues are all warnings AND
+  ``--strict`` is NOT set (warnings-are-soft default).
 - **1** — load/parse failure: path does not resolve to a regular file,
   file is unreadable (OSError / UnicodeDecodeError), OR the only issue
   is ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` (malformed frontmatter
-  is a parse problem, not spec drift).
-- **2** — one or more conformance issues present (any severity),
-  except the YAML-parse-only case above.
+  is a parse problem, not spec drift). Preserved verbatim under
+  ``--strict`` — parse failures are never escalated by that flag.
+- **2** — any error-severity issue, OR any warning when ``--strict``
+  is set.
 
-Traces to DEC-002, DEC-010, DEC-011, DEC-014 of
+The ``--strict`` flag (DEC-004) promotes warnings to exit 2. It does
+NOT change the stderr rendering of issues and does NOT override the
+INVALID_YAML → exit 1 special case.
+
+Traces to DEC-002, DEC-004, DEC-010, DEC-011, DEC-014 of
 ``plans/super/71-agentskills-lint.md``. The pure-compute layer lives in
 ``src/clauditor/conformance.py`` per
 ``.claude/rules/pure-compute-vs-io-split.md``.
@@ -29,6 +36,10 @@ from pathlib import Path
 
 from clauditor.conformance import ConformanceIssue, check_conformance
 
+# Code that always routes to exit 1 regardless of ``--strict`` —
+# malformed-frontmatter is a parse failure, not a conformance concern.
+_INVALID_YAML_CODE = "AGENTSKILLS_FRONTMATTER_INVALID_YAML"
+
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``lint`` subparser."""
@@ -37,6 +48,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Check SKILL.md against the agentskills.io specification",
     )
     p_lint.add_argument("skill_md", help="Path to SKILL.md file")
+    p_lint.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Treat warnings as failures (exit 2). Errors always exit 2 "
+            "regardless."
+        ),
+    )
 
 
 def _render_issue(issue: ConformanceIssue) -> str:
@@ -44,12 +63,18 @@ def _render_issue(issue: ConformanceIssue) -> str:
     return f"clauditor.conformance: {issue.code}: {issue.message}"
 
 
+def _has_error(issues: list[ConformanceIssue]) -> bool:
+    """Return ``True`` if any issue has ``severity == "error"``."""
+    return any(issue.severity == "error" for issue in issues)
+
+
 def cmd_lint(args: argparse.Namespace) -> int:
     """Lint a SKILL.md file against the agentskills.io specification.
 
     See module docstring for the full exit-code contract. Path resolution
     follows DEC-010 (``Path.resolve()`` + ``is_file()``; accepts absolute
-    paths, follows symlinks, rejects directories).
+    paths, follows symlinks, rejects directories). ``--strict`` (DEC-004)
+    promotes warning-only results to exit 2 without altering rendering.
     """
     # Path validation (DEC-010). Accept absolute paths; follow symlinks
     # to their real target; reject directories, sockets, FIFOs, and
@@ -80,17 +105,32 @@ def cmd_lint(args: argparse.Namespace) -> int:
         print(f"Conformance check passed: {skill_path}")
         return 0
 
-    # Render every issue to stderr in order (DEC-014).
+    # Render every issue to stderr in order (DEC-014). Rendering is
+    # independent of ``--strict`` — the flag only influences exit code.
     for issue in issues:
         print(_render_issue(issue), file=sys.stderr)
 
     # Exit-1 case: the ONLY issue is malformed frontmatter (parse failure,
-    # not conformance). Any other mix routes to exit 2.
-    invalid_yaml_code = "AGENTSKILLS_FRONTMATTER_INVALID_YAML"
-    if len(issues) == 1 and issues[0].code == invalid_yaml_code:
+    # not conformance). Preserve verbatim under ``--strict`` — parse
+    # failures are never escalated by that flag.
+    if len(issues) == 1 and issues[0].code == _INVALID_YAML_CODE:
         print("Cannot lint: SKILL.md frontmatter is not valid YAML")
         return 1
 
-    # One or more conformance issues — exit 2 with stdout failure summary.
-    print(f"Conformance check failed: {len(issues)} issue(s) — see above")
-    return 2
+    # Hard-fail when any error-severity issue is present, OR when
+    # ``--strict`` escalates warning-only results.
+    if _has_error(issues) or args.strict:
+        print(f"Conformance check failed: {len(issues)} issue(s) — see above")
+        return 2
+
+    # Warning-only result without ``--strict`` (DEC-004): render the
+    # stderr lines above, but return exit 0 with a success line that
+    # advertises the warning count so the caller is not misled into
+    # thinking stderr output was a hard failure.
+    warning_count = len(issues)
+    suffix = "" if warning_count == 1 else "s"
+    print(
+        f"Conformance check passed: {skill_path} "
+        f"({warning_count} warning{suffix} — see above)"
+    )
+    return 0

--- a/src/clauditor/cli/lint.py
+++ b/src/clauditor/cli/lint.py
@@ -10,9 +10,11 @@ Exit-code taxonomy (non-LLM 0/1/2 per
   ``check_conformance``, or (b) issues are all warnings AND
   ``--strict`` is NOT set (warnings-are-soft default).
 - **1** — load/parse failure: path does not resolve to a regular file,
-  file is unreadable (OSError / UnicodeDecodeError), OR the only issue
-  is ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` (malformed frontmatter
-  is a parse problem, not spec drift). Preserved verbatim under
+  file is unreadable (OSError / UnicodeDecodeError), OR
+  ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` is present among the issues
+  (malformed frontmatter is a parse problem, not spec drift; this case
+  dominates sibling pre-parse warnings like
+  ``AGENTSKILLS_LAYOUT_LEGACY``). Preserved verbatim under
   ``--strict`` — parse failures are never escalated by that flag.
 - **2** — any error-severity issue, OR any warning when ``--strict``
   is set.
@@ -174,11 +176,14 @@ def cmd_lint(args: argparse.Namespace) -> int:
         if args.json:
             # Synthetic PATH_NOT_A_FILE entry in the issues list so JSON
             # consumers have one uniform surface to read path errors
-            # alongside conformance issues. ``args.skill_md`` (the
-            # caller's original argv) is more informative than the
-            # ``resolve()``-ed path on a missing target.
+            # alongside conformance issues. The envelope's ``skill_path``
+            # field is the RESOLVED path — consistent with the success /
+            # unreadable / conformance branches so consumers can rely on
+            # a normalized-path schema. The raw argv lives in the issue
+            # ``message`` (where it is more informative for a human
+            # reading the error than the resolved target would be).
             _emit_json_envelope(
-                args.skill_md,
+                str(skill_path),
                 [
                     ConformanceIssue(
                         code=_PATH_NOT_A_FILE_CODE,

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -1,0 +1,620 @@
+"""agentskills.io specification conformance checker for SKILL.md files.
+
+This module is the pure compute layer of the ``clauditor lint`` command
+and the ``SkillSpec.from_file`` soft-warn hook. It accepts an already-
+read SKILL.md text plus a ``Path`` (used only for layout classification
+and parent-directory-match checks) and returns a ``list[ConformanceIssue]``
+enumerating every rule violation against the agentskills.io
+`specification <https://agentskills.io/specification>`_.
+
+Pure-compute contract per
+``.claude/rules/pure-compute-vs-io-split.md``:
+
+- No file I/O (no ``open`` / ``read_text``).
+- No stderr / stdout writes (``print``, ``sys.stderr``, ``sys.stdout``).
+- No network, no LLM, no subprocess.
+- ``check_conformance`` never raises — malformed frontmatter surfaces
+  as ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` (error) inside the
+  returned list.
+
+The CLI layer (``src/clauditor/cli/lint.py``) and the soft-warn hook
+(``src/clauditor/spec.py::SkillSpec.from_file``) own the I/O: path
+validation, file read, stderr emission with the
+``"clauditor.conformance: <CODE>: <message>"`` prefix (DEC-014), and
+exit-code routing (DEC-002, DEC-004).
+
+Public surface:
+
+- :class:`ConformanceIssue` — ``(code, severity, message)`` triple.
+- :func:`check_conformance` — pure entry point.
+- :data:`AGENTSKILLS_NAME_RE` — strict-ASCII name regex (DEC-006).
+- :data:`KNOWN_CLAUDE_CODE_EXTENSION_KEYS` — allowlist of Claude Code
+  frontmatter extension keys (DEC-009, DEC-013).
+
+Traces to DEC-001, DEC-005, DEC-006, DEC-007, DEC-009, DEC-014 of
+``plans/super/71-agentskills-lint.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+__all__ = [
+    "AGENTSKILLS_NAME_RE",
+    "KNOWN_CLAUDE_CODE_EXTENSION_KEYS",
+    "ConformanceIssue",
+    "check_conformance",
+]
+
+
+Severity = Literal["error", "warning"]
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Strict-ASCII name regex per DEC-006. Two alternatives:
+#  - single char ``[a-z0-9]``;
+#  - multi-char ``[a-z0-9]`` + ``([a-z0-9] | -(?!-))*`` + ``[a-z0-9]``.
+# The ``-(?!-)`` negative lookahead forbids consecutive hyphens. Overall
+# length 1-64 is enforced as a separate check (the regex alone does not
+# bound length). Tie-breaks the agentskills.io spec's self-contradictory
+# "unicode lowercase" phrase in favor of the ASCII range used in every
+# published example.
+AGENTSKILLS_NAME_RE: re.Pattern[str] = re.compile(
+    r"^[a-z0-9](?:[a-z0-9]|-(?!-))*[a-z0-9]$|^[a-z0-9]$"
+)
+
+# Allowlist per DEC-009: frontmatter keys that Claude Code understands
+# as slash-command extensions but that agentskills.io does not define.
+# Keys in this set are NOT reported as
+# ``AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY``. Maintained against Claude
+# Code's published frontmatter docs by the ``/review-agentskills-spec``
+# bundled skill (DEC-013).
+KNOWN_CLAUDE_CODE_EXTENSION_KEYS: frozenset[str] = frozenset(
+    {
+        "argument-hint",
+        "disable-model-invocation",
+    }
+)
+
+# Canonical agentskills.io frontmatter keys (2026-04 spec fetch).
+_SPEC_FRONTMATTER_KEYS: frozenset[str] = frozenset(
+    {
+        "name",
+        "description",
+        "license",
+        "compatibility",
+        "metadata",
+        "allowed-tools",
+    }
+)
+
+_NAME_MAX_LEN = 64
+_DESCRIPTION_MAX_LEN = 1024
+_COMPATIBILITY_MAX_LEN = 500
+_BODY_MAX_LINES = 500
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConformanceIssue:
+    """A single rule violation or advisory from :func:`check_conformance`.
+
+    - ``code`` — stable identifier (``AGENTSKILLS_*``); consumers may
+      branch on this string.
+    - ``severity`` — ``"error"`` or ``"warning"`` per the plan's
+      Discovery section. The CLI layer maps these to exit codes
+      (DEC-002, DEC-004).
+    - ``message`` — human-readable explanation. Does NOT include the
+      ``"clauditor.conformance: "`` prefix — callers (CLI, soft-warn
+      hook) add that when rendering to stderr per DEC-014.
+    """
+
+    code: str
+    severity: Severity
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Pure entry point
+# ---------------------------------------------------------------------------
+
+
+def check_conformance(
+    skill_md_text: str, skill_path: Path
+) -> list[ConformanceIssue]:
+    """Return a list of conformance issues for a SKILL.md artifact.
+
+    ``skill_md_text`` is the already-read Markdown text (the caller
+    owns file I/O). ``skill_path`` is used only for layout
+    classification and parent-directory-match checks; no filesystem
+    access is performed.
+
+    Empty list means the skill conforms. See module docstring for
+    purity invariants. Never raises — parse failures surface as
+    ``AGENTSKILLS_FRONTMATTER_INVALID_YAML``.
+    """
+    # Local import keeps this module's top-level clean of clauditor
+    # imports beyond the leaf ``_frontmatter`` helper. Matches the
+    # pattern used by ``paths.derive_skill_name``.
+    from clauditor._frontmatter import parse_frontmatter
+
+    issues: list[ConformanceIssue] = []
+
+    # Layout classification first — a legacy-layout warning applies
+    # regardless of frontmatter validity.
+    is_modern_layout = skill_path.name == "SKILL.md"
+    if not is_modern_layout:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_LAYOUT_LEGACY",
+                severity="warning",
+                message=(
+                    f"Legacy single-file skill layout `{skill_path.name}` is "
+                    f"not in the agentskills.io specification, which "
+                    f"requires a `<skill-name>/SKILL.md` directory layout. "
+                    f"To migrate: `mkdir {skill_path.stem}/ && mv "
+                    f"{skill_path.name} {skill_path.stem}/SKILL.md`. See "
+                    f"https://agentskills.io/specification#directory-structure."
+                ),
+            )
+        )
+
+    try:
+        parsed, body = parse_frontmatter(skill_md_text)
+    except ValueError as exc:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_FRONTMATTER_INVALID_YAML",
+                severity="error",
+                message=(
+                    f"Frontmatter YAML is malformed and could not be "
+                    f"parsed: {exc}"
+                ),
+            )
+        )
+        return issues
+
+    if parsed is None:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_FRONTMATTER_MISSING",
+                severity="error",
+                message=(
+                    "Frontmatter block is missing; the agentskills.io "
+                    "specification requires a `---`-delimited YAML "
+                    "frontmatter block at the top of SKILL.md."
+                ),
+            )
+        )
+        # Body line-count still applies even without frontmatter.
+        _check_body(body, issues)
+        return issues
+
+    _check_name(parsed, skill_path, is_modern_layout, issues)
+    _check_description(parsed, issues)
+    _check_license(parsed, issues)
+    _check_compatibility(parsed, issues)
+    _check_metadata(parsed, issues)
+    _check_allowed_tools(parsed, issues)
+    _check_unknown_keys(parsed, issues)
+    _check_body(body, issues)
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Per-field checkers (module-private)
+# ---------------------------------------------------------------------------
+
+
+def _check_name(
+    parsed: dict,
+    skill_path: Path,
+    is_modern_layout: bool,
+    issues: list[ConformanceIssue],
+) -> None:
+    """Validate the ``name`` frontmatter field.
+
+    Order: MISSING → NOT_STRING → EMPTY → TOO_LONG → hyphen-specific
+    readable codes (LEADING / TRAILING / CONSECUTIVE) → INVALID_CHARS
+    (fallback for anything else the regex rejects) → PARENT_DIR_MISMATCH
+    (modern layout only).
+
+    The hyphen-specific codes fire BEFORE ``INVALID_CHARS`` so authors
+    get an actionable diagnostic rather than the opaque "fails regex".
+    They are load-bearing per the Discovery section's stable-id list.
+    """
+    if "name" not in parsed:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_MISSING",
+                severity="error",
+                message=(
+                    "Required frontmatter field `name` is missing; the "
+                    "agentskills.io specification requires a `name` "
+                    "identifier."
+                ),
+            )
+        )
+        return
+
+    value = parsed["name"]
+    if not isinstance(value, str):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_NOT_STRING",
+                severity="error",
+                message=(
+                    f"Frontmatter `name` must be a string; got "
+                    f"{type(value).__name__}."
+                ),
+            )
+        )
+        return
+
+    if value == "":
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_EMPTY",
+                severity="error",
+                message=(
+                    "Frontmatter `name` is empty; must be a non-empty "
+                    "identifier."
+                ),
+            )
+        )
+        return
+
+    if len(value) > _NAME_MAX_LEN:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_TOO_LONG",
+                severity="error",
+                message=(
+                    f"Frontmatter `name` is {len(value)} chars; must be "
+                    f"at most {_NAME_MAX_LEN}."
+                ),
+            )
+        )
+        return
+
+    # Hyphen-specific readable diagnostics. Each branch returns after
+    # emitting so the author sees ONE actionable error rather than a
+    # cascade of overlapping codes (LEADING_HYPHEN + INVALID_CHARS for
+    # the same character would be noise).
+    if value.startswith("-"):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_LEADING_HYPHEN",
+                severity="error",
+                message=(
+                    f"Frontmatter `name` {value!r} starts with a hyphen; "
+                    f"the agentskills.io name regex requires the first "
+                    f"character to be `[a-z0-9]`."
+                ),
+            )
+        )
+    elif value.endswith("-"):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_TRAILING_HYPHEN",
+                severity="error",
+                message=(
+                    f"Frontmatter `name` {value!r} ends with a hyphen; "
+                    f"the agentskills.io name regex requires the last "
+                    f"character to be `[a-z0-9]`."
+                ),
+            )
+        )
+    elif "--" in value:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_CONSECUTIVE_HYPHENS",
+                severity="error",
+                message=(
+                    f"Frontmatter `name` {value!r} contains consecutive "
+                    f"hyphens (`--`); the agentskills.io name regex "
+                    f"forbids them."
+                ),
+            )
+        )
+    elif AGENTSKILLS_NAME_RE.fullmatch(value) is None:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_NAME_INVALID_CHARS",
+                severity="error",
+                message=(
+                    f"Frontmatter `name` {value!r} contains characters "
+                    f"outside the agentskills.io strict-ASCII set "
+                    f"`[a-z0-9-]`."
+                ),
+            )
+        )
+
+    # Parent-dir match — modern layout only (DEC-005 qualifier).
+    if is_modern_layout:
+        parent_name = skill_path.parent.name
+        if value != parent_name:
+            issues.append(
+                ConformanceIssue(
+                    code="AGENTSKILLS_NAME_PARENT_DIR_MISMATCH",
+                    severity="error",
+                    message=(
+                        f"Frontmatter `name: {value}` does not match "
+                        f"parent directory `{parent_name}`; the "
+                        f"agentskills.io specification requires these "
+                        f"to match."
+                    ),
+                )
+            )
+
+
+def _check_description(
+    parsed: dict, issues: list[ConformanceIssue]
+) -> None:
+    if "description" not in parsed:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_DESCRIPTION_MISSING",
+                severity="error",
+                message=(
+                    "Required frontmatter field `description` is missing; "
+                    "the agentskills.io specification requires a "
+                    "`description` string."
+                ),
+            )
+        )
+        return
+
+    value = parsed["description"]
+    if not isinstance(value, str):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_DESCRIPTION_NOT_STRING",
+                severity="error",
+                message=(
+                    f"Frontmatter `description` must be a string; got "
+                    f"{type(value).__name__}."
+                ),
+            )
+        )
+        return
+
+    if value == "":
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_DESCRIPTION_EMPTY",
+                severity="error",
+                message=(
+                    "Frontmatter `description` is empty; must be a "
+                    "non-empty string."
+                ),
+            )
+        )
+        return
+
+    if len(value) > _DESCRIPTION_MAX_LEN:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_DESCRIPTION_TOO_LONG",
+                severity="error",
+                message=(
+                    f"Frontmatter `description` is {len(value)} chars; "
+                    f"must be at most {_DESCRIPTION_MAX_LEN}."
+                ),
+            )
+        )
+
+
+def _check_license(parsed: dict, issues: list[ConformanceIssue]) -> None:
+    if "license" not in parsed:
+        return
+
+    value = parsed["license"]
+    if not isinstance(value, str):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_LICENSE_NOT_STRING",
+                severity="error",
+                message=(
+                    f"Frontmatter `license` must be a string; got "
+                    f"{type(value).__name__}."
+                ),
+            )
+        )
+        return
+
+    if value == "":
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_LICENSE_EMPTY",
+                severity="error",
+                message=(
+                    "Frontmatter `license` is empty; omit the key or "
+                    "provide a non-empty SPDX identifier."
+                ),
+            )
+        )
+
+
+def _check_compatibility(
+    parsed: dict, issues: list[ConformanceIssue]
+) -> None:
+    if "compatibility" not in parsed:
+        return
+
+    value = parsed["compatibility"]
+    if not isinstance(value, str):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_COMPATIBILITY_NOT_STRING",
+                severity="error",
+                message=(
+                    f"Frontmatter `compatibility` must be a string; got "
+                    f"{type(value).__name__}."
+                ),
+            )
+        )
+        return
+
+    if value == "":
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_COMPATIBILITY_EMPTY",
+                severity="error",
+                message=(
+                    "Frontmatter `compatibility` is empty; omit the key "
+                    "or provide a non-empty description."
+                ),
+            )
+        )
+        return
+
+    if len(value) > _COMPATIBILITY_MAX_LEN:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_COMPATIBILITY_TOO_LONG",
+                severity="error",
+                message=(
+                    f"Frontmatter `compatibility` is {len(value)} chars; "
+                    f"must be at most {_COMPATIBILITY_MAX_LEN}."
+                ),
+            )
+        )
+
+
+def _check_metadata(parsed: dict, issues: list[ConformanceIssue]) -> None:
+    if "metadata" not in parsed:
+        return
+
+    value = parsed["metadata"]
+    if not isinstance(value, dict):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_METADATA_NOT_MAP",
+                severity="error",
+                message=(
+                    f"Frontmatter `metadata` must be a nested mapping; "
+                    f"got {type(value).__name__}."
+                ),
+            )
+        )
+        return
+
+    for key, val in value.items():
+        if not isinstance(key, str):
+            issues.append(
+                ConformanceIssue(
+                    code="AGENTSKILLS_METADATA_KEY_NOT_STRING",
+                    severity="error",
+                    message=(
+                        f"Frontmatter `metadata` key {key!r} must be a "
+                        f"string; got {type(key).__name__}."
+                    ),
+                )
+            )
+            continue
+        if not isinstance(val, str):
+            issues.append(
+                ConformanceIssue(
+                    code="AGENTSKILLS_METADATA_VALUE_NOT_STRING",
+                    severity="error",
+                    message=(
+                        f"Frontmatter `metadata.{key}` value must be a "
+                        f"string; got {type(val).__name__}."
+                    ),
+                )
+            )
+
+
+def _check_allowed_tools(
+    parsed: dict, issues: list[ConformanceIssue]
+) -> None:
+    if "allowed-tools" not in parsed:
+        return
+
+    value = parsed["allowed-tools"]
+    if not isinstance(value, str):
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_ALLOWED_TOOLS_NOT_STRING",
+                severity="error",
+                message=(
+                    f"Frontmatter `allowed-tools` must be a string; got "
+                    f"{type(value).__name__}."
+                ),
+            )
+        )
+        # Do not cascade the experimental warning when the field is
+        # malformed — the author fixes the type first.
+        return
+
+    # Per the Discovery section, this warning ALWAYS fires whenever the
+    # field is present (regardless of value shape), flagging the spec's
+    # current "experimental" status for this field.
+    issues.append(
+        ConformanceIssue(
+            code="AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL",
+            severity="warning",
+            message=(
+                "Frontmatter `allowed-tools` is currently marked "
+                "experimental by the agentskills.io specification; its "
+                "grammar and semantics may change before stabilization."
+            ),
+        )
+    )
+
+
+def _check_unknown_keys(
+    parsed: dict, issues: list[ConformanceIssue]
+) -> None:
+    for key in parsed:
+        if key in _SPEC_FRONTMATTER_KEYS:
+            continue
+        if key in KNOWN_CLAUDE_CODE_EXTENSION_KEYS:
+            continue
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY",
+                severity="warning",
+                message=(
+                    f"Unknown frontmatter key `{key}`; the agentskills.io "
+                    f"specification defines only: `name`, `description`, "
+                    f"`license`, `compatibility`, `metadata`, "
+                    f"`allowed-tools`. If this is an extension recognized "
+                    f"by a specific agent host, consider opening an issue "
+                    f"to add it to the clauditor allowlist."
+                ),
+            )
+        )
+
+
+def _check_body(body: str, issues: list[ConformanceIssue]) -> None:
+    if body == "":
+        return
+    # splitlines avoids a trailing-newline off-by-one; an empty body
+    # short-circuits above.
+    line_count = len(body.splitlines())
+    if line_count > _BODY_MAX_LINES:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_BODY_TOO_LONG",
+                severity="warning",
+                message=(
+                    f"SKILL.md body is {line_count} lines; the "
+                    f"agentskills.io specification recommends keeping "
+                    f"the main SKILL.md under {_BODY_MAX_LINES} lines "
+                    f"(see the Progressive Disclosure section)."
+                ),
+            )
+        )

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -47,6 +47,7 @@ __all__ = [
     "KNOWN_CLAUDE_CODE_EXTENSION_KEYS",
     "ConformanceIssue",
     "check_conformance",
+    "format_issue_line",
 ]
 
 
@@ -114,14 +115,43 @@ class ConformanceIssue:
     - ``severity`` — ``"error"`` or ``"warning"`` per the plan's
       Discovery section. The CLI layer maps these to exit codes
       (DEC-002, DEC-004).
-    - ``message`` — human-readable explanation. Does NOT include the
-      ``"clauditor.conformance: "`` prefix — callers (CLI, soft-warn
-      hook) add that when rendering to stderr per DEC-014.
+    - ``message`` — human-readable **single-line** explanation. Does NOT
+      include the ``"clauditor.conformance: "`` prefix — callers (CLI,
+      soft-warn hook) add that when rendering to stderr per DEC-014.
+      Newlines are rejected at construction time so line-oriented
+      consumers (`grep "clauditor.conformance:" stderr`) cannot miss
+      continuation lines that would otherwise drop the prefix.
     """
 
     code: str
     severity: Severity
     message: str
+
+    def __post_init__(self) -> None:
+        # DEC-014 contract: one issue == one stderr line. Reject
+        # multi-line messages at construction time so future rule
+        # authors cannot silently break line-oriented consumers.
+        if "\n" in self.message or "\r" in self.message:
+            raise ValueError(
+                f"ConformanceIssue.message must be single-line "
+                f"(code={self.code!r}): {self.message!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Render helper (DEC-014)
+# ---------------------------------------------------------------------------
+
+
+def format_issue_line(issue: ConformanceIssue) -> str:
+    """Format one issue as a ``clauditor.conformance:``-prefixed stderr line.
+
+    Single authoritative formatter per DEC-014. Both CLI (``cli/lint.py``)
+    and the ``SkillSpec.from_file`` soft-warn hook must call this helper
+    — do NOT reimplement the prefix in either caller. Changes to the
+    prefix (operator-visible) must land here.
+    """
+    return f"clauditor.conformance: {issue.code}: {issue.message}"
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +181,12 @@ def check_conformance(
     issues: list[ConformanceIssue] = []
 
     # Layout classification first — a legacy-layout warning applies
-    # regardless of frontmatter validity.
+    # regardless of frontmatter validity. Ordering is load-bearing:
+    # ``AGENTSKILLS_LAYOUT_LEGACY`` can coexist with a downstream
+    # ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` issue. The CLI's
+    # ``_compute_exit_code`` in ``cli/lint.py`` uses ``any(... == INVALID_YAML)``
+    # (not ``len == 1``) to route the whole run to exit 1 when YAML is
+    # malformed; do NOT re-order this append without updating that logic.
     is_modern_layout = skill_path.name == "SKILL.md"
     if not is_modern_layout:
         issues.append(
@@ -350,8 +385,8 @@ def _check_name(
                     code="AGENTSKILLS_NAME_PARENT_DIR_MISMATCH",
                     severity="error",
                     message=(
-                        f"Frontmatter `name: {value}` does not match "
-                        f"parent directory `{parent_name}`; the "
+                        f"Frontmatter `name: {value!r}` does not match "
+                        f"parent directory `{parent_name!r}`; the "
                         f"agentskills.io specification requires these "
                         f"to match."
                     ),

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -189,6 +189,11 @@ def check_conformance(
     # malformed; do NOT re-order this append without updating that logic.
     is_modern_layout = skill_path.name == "SKILL.md"
     if not is_modern_layout:
+        # Prose migration instruction rather than a copy-pasteable shell
+        # command: filenames can legally contain spaces, quotes, or
+        # shell metacharacters, and an unquoted ``mkdir ... && mv ...``
+        # template would misbehave for those inputs. A prose description
+        # is unambiguous regardless of shell dialect and author's locale.
         issues.append(
             ConformanceIssue(
                 code="AGENTSKILLS_LAYOUT_LEGACY",
@@ -197,8 +202,9 @@ def check_conformance(
                     f"Legacy single-file skill layout `{skill_path.name}` is "
                     f"not in the agentskills.io specification, which "
                     f"requires a `<skill-name>/SKILL.md` directory layout. "
-                    f"To migrate: `mkdir {skill_path.stem}/ && mv "
-                    f"{skill_path.name} {skill_path.stem}/SKILL.md`. See "
+                    f"To migrate: create a directory named "
+                    f"`{skill_path.stem}` and move `{skill_path.name}` "
+                    f"into it, renaming the file to `SKILL.md`. See "
                     f"https://agentskills.io/specification#directory-structure."
                 ),
             )

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -207,13 +207,19 @@ def check_conformance(
     try:
         parsed, body = parse_frontmatter(skill_md_text)
     except ValueError as exc:
+        # Sanitize: YAML parser messages may include embedded newlines
+        # (caret-indicator diagnostics, multi-line context). The
+        # ``ConformanceIssue.__post_init__`` single-line invariant
+        # rejects raw ``\n`` / ``\r`` and would break
+        # ``check_conformance``'s "never raises" contract.
+        exc_str = str(exc).replace("\r", "\\r").replace("\n", "\\n")
         issues.append(
             ConformanceIssue(
                 code="AGENTSKILLS_FRONTMATTER_INVALID_YAML",
                 severity="error",
                 message=(
                     f"Frontmatter YAML is malformed and could not be "
-                    f"parsed: {exc}"
+                    f"parsed: {exc_str}"
                 ),
             )
         )
@@ -323,10 +329,12 @@ def _check_name(
         )
         return
 
-    # Hyphen-specific readable diagnostics. Each branch returns after
-    # emitting so the author sees ONE actionable error rather than a
-    # cascade of overlapping codes (LEADING_HYPHEN + INVALID_CHARS for
-    # the same character would be noise).
+    # Hyphen-specific readable diagnostics. The if/elif chain enforces
+    # mutual exclusion so the author sees ONE actionable hyphen-related
+    # diagnostic rather than a cascade (LEADING_HYPHEN + INVALID_CHARS
+    # for the same character would be noise). The parent-dir check
+    # below runs independently — a hyphen issue and a parent-dir
+    # mismatch CAN co-fire (different concerns).
     if value.startswith("-"):
         issues.append(
             ConformanceIssue(

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -88,10 +88,8 @@ def _filesystem_name(skill_path: Path) -> str:
     return skill_path.stem
 
 
-def derive_skill_name(
-    skill_path: Path, skill_md_text: str
-) -> tuple[str, str | None]:
-    """Return ``(skill_name, warning_or_None)`` — pure, no I/O.
+def derive_skill_name(skill_path: Path, skill_md_text: str) -> str:
+    """Return the resolved ``skill_name`` — pure, no I/O.
 
     Authority order (DEC-001, DEC-002, DEC-008):
 
@@ -101,17 +99,21 @@ def derive_skill_name(
        skill, and legacy ``.md`` files that never declare frontmatter
        are the common case.
     2. If the parsed dict has a ``name:`` key whose value passes
-       :data:`SKILL_NAME_RE`, the frontmatter value wins. A disagreement
-       with the filesystem-derived name returns a warning string so the
-       caller (``SkillSpec.from_file``) can emit it to stderr.
+       :data:`SKILL_NAME_RE`, the frontmatter value wins.
     3. If the parsed ``name:`` value fails the regex, fall back to the
-       filesystem-derived name and return a warning naming both the bad
-       value and the chosen fallback.
+       filesystem-derived name.
     4. If ``name:`` is absent (no frontmatter, or frontmatter has no
-       ``name:`` key), return the filesystem-derived name silently.
+       ``name:`` key), return the filesystem-derived name.
 
-    Warning strings are formatted per DEC-009. The helper never writes
-    to stderr; it hands the warning to the caller.
+    Per DEC-008 of ``plans/super/71-agentskills-lint.md``, this helper
+    no longer constructs or returns warning strings for the invalid-
+    name-fallback or frontmatter-vs-filesystem-mismatch cases. Those
+    warnings are now produced by
+    :func:`clauditor.conformance.check_conformance` via the
+    ``AGENTSKILLS_NAME_INVALID_CHARS`` and
+    ``AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`` codes, wired into
+    :meth:`clauditor.spec.SkillSpec.from_file` by US-006. This helper
+    is strictly pure — name derivation only, no side-channel.
     """
     # Local import avoids a circular dependency at module import time —
     # ``clauditor._frontmatter`` is a leaf module with no clauditor
@@ -126,27 +128,16 @@ def derive_skill_name(
         # Malformed frontmatter → treat as absent. The caller's
         # validation layer (if any) is responsible for surfacing a
         # stricter error; identity derivation stays lenient.
-        return fs_name, None
+        return fs_name
 
     if not isinstance(parsed, dict) or "name" not in parsed:
-        return fs_name, None
+        return fs_name
 
     fm_name = parsed["name"]
     if not isinstance(fm_name, str) or re.fullmatch(SKILL_NAME_RE, fm_name) is None:
-        warning = (
-            f"clauditor.spec: frontmatter name {fm_name!r} is not a "
-            f"valid skill identifier — using {fs_name!r}"
-        )
-        return fs_name, warning
+        return fs_name
 
-    if fm_name == fs_name:
-        return fm_name, None
-
-    warning = (
-        f"clauditor.spec: frontmatter name {fm_name!r} overrides "
-        f"filesystem name {fs_name!r} — using {fm_name!r}"
-    )
-    return fm_name, warning
+    return fm_name
 
 
 def derive_project_dir(skill_path: Path) -> Path:

--- a/src/clauditor/skills/review-agentskills-spec/SKILL.md
+++ b/src/clauditor/skills/review-agentskills-spec/SKILL.md
@@ -21,8 +21,12 @@ confirms — open a GitHub issue.
 - **Read-only** on the clauditor codebase. No file edits.
 - **Preview-only** for proposed changes. Nothing lands until the user
   approves a GitHub issue.
-- **Targets spec drift**, not general spec compliance of a user's skill
-  (that's what `clauditor lint` — see issue #71 — is for).
+- **Targets spec drift**, not general spec compliance of a user's skill.
+  Division of labor: **`clauditor lint <SKILL.md>`** checks a user
+  skill against the current spec (user-facing conformance); this skill
+  audits the upstream spec itself plus Claude Code's frontmatter
+  documentation against clauditor's enforcement (maintainer-facing
+  drift detection).
 
 ## Workflow
 

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 
 from clauditor.assertions import AssertionSet, run_assertions
-from clauditor.conformance import check_conformance
+from clauditor.conformance import check_conformance, format_issue_line
 from clauditor.paths import derive_project_dir, derive_skill_name
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.schemas import EvalSpec
@@ -98,12 +98,12 @@ class SkillSpec:
         # ``severity="warning"`` issues fire here — errors are silent
         # at this layer and must be discovered via ``clauditor lint``.
         # ``check_conformance`` never raises, so no try/except needed.
+        # Uses ``format_issue_line`` (conformance module) so the prefix
+        # format stays in lockstep with the CLI renderer — a single
+        # seam per DEC-014.
         for issue in check_conformance(text, skill_path):
             if issue.severity == "warning":
-                print(
-                    f"clauditor.conformance: {issue.code}: {issue.message}",
-                    file=sys.stderr,
-                )
+                print(format_issue_line(issue), file=sys.stderr)
 
         # Auto-discover eval spec
         eval_spec = None

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -6,9 +6,11 @@ Combines the skill file, eval spec, and runner into a single interface.
 from __future__ import annotations
 
 import glob
+import sys
 from pathlib import Path
 
 from clauditor.assertions import AssertionSet, run_assertions
+from clauditor.conformance import check_conformance
 from clauditor.paths import derive_project_dir, derive_skill_name
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.schemas import EvalSpec
@@ -89,6 +91,19 @@ class SkillSpec:
 
         text = skill_path.read_text(encoding="utf-8")
         skill_name = derive_skill_name(skill_path, text)
+
+        # US-006 soft-warn hook (DEC-003 / DEC-014 of
+        # ``plans/super/71-agentskills-lint.md``): surface
+        # agentskills.io conformance warnings to stderr. Only
+        # ``severity="warning"`` issues fire here — errors are silent
+        # at this layer and must be discovered via ``clauditor lint``.
+        # ``check_conformance`` never raises, so no try/except needed.
+        for issue in check_conformance(text, skill_path):
+            if issue.severity == "warning":
+                print(
+                    f"clauditor.conformance: {issue.code}: {issue.message}",
+                    file=sys.stderr,
+                )
 
         # Auto-discover eval spec
         eval_spec = None

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -6,7 +6,6 @@ Combines the skill file, eval spec, and runner into a single interface.
 from __future__ import annotations
 
 import glob
-import sys
 from pathlib import Path
 
 from clauditor.assertions import AssertionSet, run_assertions
@@ -77,18 +76,19 @@ class SkillSpec:
         The skill's identity (``skill_name``) is derived from the file's
         frontmatter ``name:`` field when present and valid; otherwise
         from the filesystem (parent dir for modern, stem for legacy).
-        When frontmatter disagrees with the filesystem name, the
-        frontmatter wins and a warning is emitted to stderr. See DEC-001,
-        DEC-002, DEC-009.
+        See DEC-001, DEC-002 of ``plans/super/62-skill-md-layout.md``.
+        Per DEC-008 of ``plans/super/71-agentskills-lint.md``, any
+        warning surfacing for invalid-name or name/filesystem
+        disagreement is now emitted by
+        :func:`clauditor.conformance.check_conformance` via the
+        soft-warn hook (US-006), not by this loader.
         """
         skill_path = Path(skill_path)
         if not skill_path.exists():
             raise FileNotFoundError(f"Skill file not found: {skill_path}")
 
         text = skill_path.read_text(encoding="utf-8")
-        skill_name, warning = derive_skill_name(skill_path, text)
-        if warning is not None:
-            print(warning, file=sys.stderr)
+        skill_name = derive_skill_name(skill_path, text)
 
         # Auto-discover eval spec
         eval_spec = None

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -23,15 +23,13 @@ import pytest
 from clauditor.schemas import EvalSpec, criterion_text
 from clauditor.spec import SkillSpec
 
-SKILL_DIR = (
-    Path(__file__).resolve().parent.parent
-    / "src"
-    / "clauditor"
-    / "skills"
-    / "clauditor"
+SKILLS_ROOT = (
+    Path(__file__).resolve().parent.parent / "src" / "clauditor" / "skills"
 )
+SKILL_DIR = SKILLS_ROOT / "clauditor"
 SKILL_MD = SKILL_DIR / "SKILL.md"
 EVAL_JSON = SKILL_DIR / "assets" / "clauditor.eval.json"
+REVIEW_SKILL_MD = SKILLS_ROOT / "review-agentskills-spec" / "SKILL.md"
 
 # agentskills.io naming constraints: lowercase a-z + digits + hyphens, with
 # hyphens between segments, 1-64 chars total.
@@ -269,3 +267,80 @@ class TestBundledEvalSpec:
             assert criterion_text(c).strip(), (
                 f"criterion id={c['id']!r} has empty text"
             )
+
+
+class TestBundledSkillConformance:
+    """#71 US-007: regression guard that both bundled skills stay conformant.
+
+    Both shipped bundled skills MUST pass ``check_conformance`` with zero
+    errors. The ``AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL`` warning is
+    expected for both skills because each declares ``allowed-tools:`` —
+    the agentskills.io spec marks that field as experimental and emits
+    the warning for every skill that uses it. This is spec-faithful
+    signal, not noise to silence, so we do NOT extend
+    ``KNOWN_CLAUDE_CODE_EXTENSION_KEYS`` (DEC-009 is scoped to
+    UNKNOWN_KEY false positives, not experimental-field true
+    positives). Instead, the test records the single expected warning
+    code in its own allowlist and flags any other unexpected warning
+    as a regression.
+    """
+
+    _ACCEPTABLE_WARNING_CODES: frozenset[str] = frozenset(
+        {
+            "AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL",
+        }
+    )
+
+    def test_bundled_clauditor_skill_has_no_errors(self) -> None:
+        from clauditor.conformance import check_conformance
+
+        issues = check_conformance(SKILL_MD.read_text(), SKILL_MD)
+        errors = [i for i in issues if i.severity == "error"]
+        assert errors == [], (
+            f"Bundled /clauditor has conformance errors: {errors}"
+        )
+
+    def test_bundled_clauditor_skill_warnings_are_acceptable(self) -> None:
+        from clauditor.conformance import check_conformance
+
+        warnings = [
+            i
+            for i in check_conformance(SKILL_MD.read_text(), SKILL_MD)
+            if i.severity == "warning"
+        ]
+        unexpected = [
+            w for w in warnings if w.code not in self._ACCEPTABLE_WARNING_CODES
+        ]
+        assert unexpected == [], (
+            f"Bundled /clauditor has unexpected warnings: {unexpected}"
+        )
+
+    def test_bundled_review_skill_has_no_errors(self) -> None:
+        from clauditor.conformance import check_conformance
+
+        issues = check_conformance(
+            REVIEW_SKILL_MD.read_text(), REVIEW_SKILL_MD
+        )
+        errors = [i for i in issues if i.severity == "error"]
+        assert errors == [], (
+            f"Bundled /review-agentskills-spec has conformance errors: "
+            f"{errors}"
+        )
+
+    def test_bundled_review_skill_warnings_are_acceptable(self) -> None:
+        from clauditor.conformance import check_conformance
+
+        warnings = [
+            i
+            for i in check_conformance(
+                REVIEW_SKILL_MD.read_text(), REVIEW_SKILL_MD
+            )
+            if i.severity == "warning"
+        ]
+        unexpected = [
+            w for w in warnings if w.code not in self._ACCEPTABLE_WARNING_CODES
+        ]
+        assert unexpected == [], (
+            f"Bundled /review-agentskills-spec has unexpected warnings: "
+            f"{unexpected}"
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2915,9 +2915,14 @@ class TestCmdInit:
         # The underlying codec error is appended to the message.
         assert "utf-8" in err or "codec" in err
 
-    def test_init_warns_on_frontmatter_disagreement(self, tmp_path, capsys):
+    def test_init_frontmatter_disagreement_silent(self, tmp_path, capsys):
         """When frontmatter ``name:`` disagrees with the filesystem-derived
-        name, stderr carries the DEC-009 warning and frontmatter wins."""
+        name, frontmatter wins. Per DEC-008 of
+        ``plans/super/71-agentskills-lint.md``, ``derive_skill_name`` no
+        longer emits a stderr warning for this case — the equivalent
+        ``AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`` conformance code moves
+        to ``clauditor.conformance.check_conformance``, wired in by
+        US-006."""
         skill_dir = tmp_path / ".claude" / "skills" / "foo"
         skill_dir.mkdir(parents=True)
         skill_path = skill_dir / "SKILL.md"
@@ -2934,9 +2939,8 @@ class TestCmdInit:
 
         assert rc == 0
         captured = capsys.readouterr()
-        assert "clauditor.spec:" in captured.err
-        assert "'bar'" in captured.err
-        assert "'foo'" in captured.err
+        assert "clauditor.spec:" not in captured.err
+        assert "frontmatter name" not in captured.err
         eval_path = skill_dir / "SKILL.eval.json"
         data = json.loads(eval_path.read_text())
         assert data["skill_name"] == "bar"

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -1,7 +1,7 @@
-"""Tests for ``clauditor lint`` CLI command (US-003).
+"""Tests for ``clauditor lint`` CLI command (US-003, US-004).
 
-Plain-text output only — ``--strict`` (US-004) and ``--json`` (US-005)
-are separate beads.
+Plain-text output plus the ``--strict`` flag (US-004, DEC-004). The
+``--json`` flag (US-005) is a separate bead.
 """
 
 from __future__ import annotations
@@ -48,8 +48,13 @@ class TestCmdLint:
         assert str(skill_path.resolve()) in captured.out
         assert captured.err == ""
 
-    def test_warning_only_exits_2(self, tmp_path, capsys):
-        """Warning-only skill (body >500 lines) exits 2 with stderr lines."""
+    def test_warning_only_no_strict_exits_0(self, tmp_path, capsys):
+        """Warning-only skill (body >500 lines) without ``--strict`` exits 0 (DEC-004).
+
+        Warnings still render to stderr, but the run is considered
+        passing. A stdout success line advertises the warning count so
+        the caller is not misled into thinking nothing was emitted.
+        """
         skill_path = tmp_path / "my-skill" / "SKILL.md"
         skill_path.parent.mkdir()
         body = "# Body\n\n" + ("line content\n" * 600)
@@ -61,11 +66,13 @@ class TestCmdLint:
 
         rc = main(["lint", str(skill_path)])
 
-        assert rc == 2
+        assert rc == 0
         captured = capsys.readouterr()
         assert "clauditor.conformance: AGENTSKILLS_BODY_TOO_LONG: " in captured.err
-        assert "Conformance check failed: " in captured.out
-        assert "1 issue" in captured.out
+        # Stdout acknowledges the warning(s) on the success line so the
+        # caller does not miss the stderr output.
+        assert "Conformance check passed" in captured.out
+        assert "1 warning" in captured.out
 
     def test_error_exits_2(self, tmp_path, capsys):
         """Skill missing ``name:`` exits 2 with error on stderr."""
@@ -129,7 +136,11 @@ class TestCmdLint:
         assert "is not a regular file" in captured.err
 
     def test_stderr_prefix_format(self, tmp_path, capsys):
-        """Any issue renders as ``clauditor.conformance: <CODE>: <message>``."""
+        """Any issue renders as ``clauditor.conformance: <CODE>: <message>``.
+
+        Uses a warning-only skill to exercise the soft-exit path under
+        DEC-004 while still asserting the stderr prefix contract.
+        """
         skill_path = tmp_path / "my-skill" / "SKILL.md"
         skill_path.parent.mkdir()
         _write_skill(
@@ -140,7 +151,8 @@ class TestCmdLint:
 
         rc = main(["lint", str(skill_path)])
 
-        assert rc == 2
+        # Unknown key is a warning; without ``--strict`` that is exit 0.
+        assert rc == 0
         err_lines = capsys.readouterr().err.strip().splitlines()
         assert any(
             line.startswith("clauditor.conformance: AGENTSKILLS_")
@@ -211,22 +223,30 @@ class TestCmdLint:
 
 
 # ---------------------------------------------------------------------------
-# Argparse surface — document that --strict and --json are NOT available in
-# this bead (US-004 and US-005 will add them).
+# Argparse surface — ``--strict`` is now registered (US-004, DEC-004);
+# ``--json`` is deferred to US-005.
 # ---------------------------------------------------------------------------
 
 
 class TestArgparseSurface:
-    """Verify the US-003 argparse surface (no --strict, no --json)."""
+    """Verify the post-US-004 argparse surface (``--strict`` on, ``--json`` off)."""
 
-    def test_strict_flag_not_available(self, tmp_path, capsys):
-        """``--strict`` is not registered by this bead (US-004)."""
+    def test_strict_flag_accepted(self, tmp_path, capsys):
+        """``--strict`` is registered and parses without error (US-004)."""
         skill_path = _make_valid_skill(tmp_path)
 
+        # A minimal-valid skill has no issues, so ``--strict`` should not
+        # change the outcome — exit 0 regardless.
+        rc = main(["lint", "--strict", str(skill_path)])
+        assert rc == 0
+
+    def test_strict_flag_in_help(self, capsys):
+        """``--strict`` appears in the ``lint --help`` output."""
         with pytest.raises(SystemExit) as exc:
-            main(["lint", "--strict", str(skill_path)])
-        # argparse exits 2 on unknown flag.
-        assert exc.value.code == 2
+            main(["lint", "--help"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "--strict" in captured.out
 
     def test_json_flag_not_available(self, tmp_path, capsys):
         """``--json`` is not registered by this bead (US-005)."""
@@ -235,3 +255,166 @@ class TestArgparseSurface:
         with pytest.raises(SystemExit) as exc:
             main(["lint", "--json", str(skill_path)])
         assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# ``--strict`` six-cell matrix (US-004, DEC-004).
+#
+# | strict | severity     | expected_rc |
+# |--------|--------------|-------------|
+# | False  | warning-only | 0           |
+# | False  | error        | 2           |
+# | False  | mixed        | 2           |
+# | True   | warning-only | 2           |
+# | True   | error        | 2           |
+# | True   | mixed        | 2           |
+#
+# Plus: ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` keeps exit 1 under
+# ``--strict`` (parse failure precedence; preserve US-003 special case).
+# ---------------------------------------------------------------------------
+
+
+def _write_warning_only(path):
+    """Write a SKILL.md whose only conformance issue is a warning.
+
+    Uses ``AGENTSKILLS_BODY_TOO_LONG`` (>500-line body) — the skill
+    has a valid modern layout, required frontmatter keys, and a body
+    that trips the warning-only line-count check.
+    """
+    path.parent.mkdir(exist_ok=True)
+    body = "# Body\n\n" + ("line content\n" * 600)
+    _write_skill(
+        path,
+        "name: my-skill\ndescription: A long-bodied skill for warning-only tests.\n",
+        body=body,
+    )
+
+
+def _write_error_only(path):
+    """Write a SKILL.md whose only conformance issue is an error.
+
+    Uses ``AGENTSKILLS_NAME_MISSING`` — the frontmatter omits the
+    required ``name`` key. Body stays under 500 lines to avoid
+    accidentally adding a warning.
+    """
+    path.parent.mkdir(exist_ok=True)
+    _write_skill(
+        path,
+        "description: Missing the required name field.\n",
+    )
+
+
+def _write_mixed(path):
+    """Write a SKILL.md with BOTH an error and a warning.
+
+    Error: missing ``name`` (``AGENTSKILLS_NAME_MISSING``).
+    Warning: body over 500 lines (``AGENTSKILLS_BODY_TOO_LONG``).
+    """
+    path.parent.mkdir(exist_ok=True)
+    body = "# Body\n\n" + ("line content\n" * 600)
+    _write_skill(
+        path,
+        "description: Missing name and oversized body.\n",
+        body=body,
+    )
+
+
+class TestStrictFlag:
+    """Six-cell matrix for ``--strict`` behavior (DEC-004)."""
+
+    @pytest.mark.parametrize(
+        "strict,fixture,expected_rc",
+        [
+            (False, _write_warning_only, 0),
+            (False, _write_error_only, 2),
+            (False, _write_mixed, 2),
+            (True, _write_warning_only, 2),
+            (True, _write_error_only, 2),
+            (True, _write_mixed, 2),
+        ],
+        ids=[
+            "nostrict-warnings-0",
+            "nostrict-errors-2",
+            "nostrict-mixed-2",
+            "strict-warnings-2",
+            "strict-errors-2",
+            "strict-mixed-2",
+        ],
+    )
+    def test_exit_code_matrix(
+        self, tmp_path, capsys, strict, fixture, expected_rc
+    ):
+        """Each (strict, severity) cell routes to the documented exit code."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        fixture(skill_path)
+
+        argv = ["lint"]
+        if strict:
+            argv.append("--strict")
+        argv.append(str(skill_path))
+
+        rc = main(argv)
+        assert rc == expected_rc, (
+            f"strict={strict} fixture={fixture.__name__} "
+            f"expected rc={expected_rc}, got {rc}"
+        )
+
+    def test_strict_warning_only_renders_stderr(self, tmp_path, capsys):
+        """``--strict`` on warning-only still renders the stderr issue line."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_warning_only(skill_path)
+
+        rc = main(["lint", "--strict", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        # Stderr rendering is identical to the non-strict warning path
+        # (the flag only changes exit code, not output format).
+        assert (
+            "clauditor.conformance: AGENTSKILLS_BODY_TOO_LONG: "
+            in captured.err
+        )
+        # Stdout shows the failure summary (not the success line).
+        assert "Conformance check failed: " in captured.out
+        assert "1 issue" in captured.out
+
+    def test_nostrict_warning_only_renders_stderr(self, tmp_path, capsys):
+        """Without ``--strict``, warning-only renders stderr identically (just rc=0)."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_warning_only(skill_path)
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Same stderr line regardless of strict — DEC-004 is exit-code
+        # only, not rendering.
+        assert (
+            "clauditor.conformance: AGENTSKILLS_BODY_TOO_LONG: "
+            in captured.err
+        )
+
+    def test_invalid_yaml_with_strict_exits_1(self, tmp_path, capsys):
+        """``--strict`` does NOT override the INVALID_YAML → exit 1 special case.
+
+        Malformed frontmatter is a parse failure, not a conformance
+        issue. Preserve the US-003 special case verbatim.
+        """
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        skill_path.write_text(
+            "---\nname: my-skill\ndescription: Missing closing fence.\n"
+            "# Body without closing ---\n",
+            encoding="utf-8",
+        )
+
+        rc = main(["lint", "--strict", str(skill_path)])
+
+        # Exit 1, same as without ``--strict`` (parse-failure taxonomy).
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert (
+            "clauditor.conformance: AGENTSKILLS_FRONTMATTER_INVALID_YAML: "
+            in captured.err
+        )
+        assert "Cannot lint: SKILL.md frontmatter is not valid YAML" in captured.out

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -1,0 +1,237 @@
+"""Tests for ``clauditor lint`` CLI command (US-003).
+
+Plain-text output only — ``--strict`` (US-004) and ``--json`` (US-005)
+are separate beads.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clauditor.cli import main
+
+
+def _write_skill(path, frontmatter: str, body: str = "# Body\n\nContent.\n") -> None:
+    """Write a SKILL.md file with the given frontmatter and body."""
+    path.write_text(f"---\n{frontmatter}---\n{body}", encoding="utf-8")
+
+
+def _make_valid_skill(tmp_path, name: str = "my-skill"):
+    """Create a minimal-valid SKILL.md at ``tmp_path/<name>/SKILL.md``.
+
+    Returns the path object. The skill conforms to the agentskills.io
+    specification: modern layout, required ``name`` + ``description`` keys,
+    body under 500 lines.
+    """
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    skill_path = skill_dir / "SKILL.md"
+    _write_skill(
+        skill_path,
+        f'name: {name}\ndescription: A minimal valid skill for testing.\n',
+    )
+    return skill_path
+
+
+class TestCmdLint:
+    """Tests for the ``clauditor lint`` subcommand."""
+
+    def test_valid_skill_exits_0(self, tmp_path, capsys):
+        """Minimal-valid SKILL.md exits 0 with success line on stdout."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Conformance check passed: " in captured.out
+        assert str(skill_path.resolve()) in captured.out
+        assert captured.err == ""
+
+    def test_warning_only_exits_2(self, tmp_path, capsys):
+        """Warning-only skill (body >500 lines) exits 2 with stderr lines."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        body = "# Body\n\n" + ("line content\n" * 600)
+        _write_skill(
+            skill_path,
+            "name: my-skill\ndescription: A skill with a long body.\n",
+            body=body,
+        )
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "clauditor.conformance: AGENTSKILLS_BODY_TOO_LONG: " in captured.err
+        assert "Conformance check failed: " in captured.out
+        assert "1 issue" in captured.out
+
+    def test_error_exits_2(self, tmp_path, capsys):
+        """Skill missing ``name:`` exits 2 with error on stderr."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        _write_skill(
+            skill_path,
+            "description: A skill without a name field.\n",
+        )
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "clauditor.conformance: AGENTSKILLS_NAME_MISSING: " in captured.err
+        assert "Conformance check failed: " in captured.out
+
+    def test_invalid_yaml_exits_1(self, tmp_path, capsys):
+        """Malformed frontmatter exits 1 (parse failure, not conformance)."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        # Frontmatter block that ``_frontmatter.parse_frontmatter`` rejects
+        # structurally: missing closing ``---``.
+        skill_path.write_text(
+            "---\nname: my-skill\ndescription: Missing closing fence.\n"
+            "# Body without closing ---\n",
+            encoding="utf-8",
+        )
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert (
+            "clauditor.conformance: AGENTSKILLS_FRONTMATTER_INVALID_YAML: "
+            in captured.err
+        )
+        assert "Cannot lint: SKILL.md frontmatter is not valid YAML" in captured.out
+
+    def test_path_not_a_file_exits_1(self, tmp_path, capsys):
+        """Passing a directory exits 1 with stderr error."""
+        some_dir = tmp_path / "not-a-file"
+        some_dir.mkdir()
+
+        rc = main(["lint", str(some_dir)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "ERROR: " in captured.err
+        assert "is not a regular file" in captured.err
+
+    def test_path_nonexistent_exits_1(self, tmp_path, capsys):
+        """Passing a nonexistent path exits 1 with stderr error."""
+        missing = tmp_path / "does-not-exist.md"
+
+        rc = main(["lint", str(missing)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "ERROR: " in captured.err
+        assert "is not a regular file" in captured.err
+
+    def test_stderr_prefix_format(self, tmp_path, capsys):
+        """Any issue renders as ``clauditor.conformance: <CODE>: <message>``."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        _write_skill(
+            skill_path,
+            "name: my-skill\ndescription: Has an unknown key.\n"
+            "some-unknown-key: whatever\n",
+        )
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 2
+        err_lines = capsys.readouterr().err.strip().splitlines()
+        assert any(
+            line.startswith("clauditor.conformance: AGENTSKILLS_")
+            and ": " in line[len("clauditor.conformance: "):]
+            for line in err_lines
+        )
+
+    def test_unreadable_file_exits_1(self, tmp_path, capsys, monkeypatch):
+        """``OSError`` on file read surfaces as exit 1 with stderr error."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        def _boom(self, *_args, **_kwargs):
+            raise OSError("simulated read failure")
+
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "ERROR: " in captured.err
+        assert "simulated read failure" in captured.err
+
+    def test_undecodable_file_exits_1(self, tmp_path, capsys):
+        """Non-UTF-8 content surfaces as exit 1 with stderr error."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        skill_path.write_bytes(b"\xff\xfe\x00\x00invalid utf-8")
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "ERROR: " in captured.err
+
+    def test_resolved_path_in_success_message(self, tmp_path, capsys):
+        """Success line prints the *resolved* absolute path, not the argv."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        # The resolved path is absolute.
+        resolved = str(skill_path.resolve())
+        assert resolved in captured.out
+
+    def test_multiple_issues_count_in_summary(self, tmp_path, capsys):
+        """Failure summary reports the total issue count."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        _write_skill(
+            skill_path,
+            # Two distinct issues: missing name (error) + unknown key (warning).
+            "description: Missing name and has an unknown key.\n"
+            "some-unknown-key: whatever\n",
+        )
+
+        rc = main(["lint", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        # Check the summary line has a numeric count.
+        assert "Conformance check failed: " in captured.out
+        assert "2 issue(s)" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Argparse surface — document that --strict and --json are NOT available in
+# this bead (US-004 and US-005 will add them).
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseSurface:
+    """Verify the US-003 argparse surface (no --strict, no --json)."""
+
+    def test_strict_flag_not_available(self, tmp_path, capsys):
+        """``--strict`` is not registered by this bead (US-004)."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        with pytest.raises(SystemExit) as exc:
+            main(["lint", "--strict", str(skill_path)])
+        # argparse exits 2 on unknown flag.
+        assert exc.value.code == 2
+
+    def test_json_flag_not_available(self, tmp_path, capsys):
+        """``--json`` is not registered by this bead (US-005)."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        with pytest.raises(SystemExit) as exc:
+            main(["lint", "--json", str(skill_path)])
+        assert exc.value.code == 2

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -618,6 +618,28 @@ class TestJsonOutput:
         assert issue["code"] == "PATH_NOT_A_FILE"
         assert issue["severity"] == "error"
 
+    def test_json_envelope_skill_path_is_always_resolved(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """``skill_path`` in the JSON envelope is the resolved path on every branch.
+
+        Regression for Copilot comment #2: the PATH_NOT_A_FILE branch
+        used to emit ``args.skill_md`` (raw argv) while every other
+        branch emitted ``str(skill_path)`` (resolved). Consumers parsing
+        the envelope expect a single normalized shape.
+        """
+        # Use a relative path via chdir so args.skill_md != str(resolved).
+        monkeypatch.chdir(tmp_path)
+        some_dir = tmp_path / "not-a-file"
+        some_dir.mkdir()
+
+        rc = main(["lint", "--json", "not-a-file"])
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        # Resolved path is absolute; raw argv was "not-a-file".
+        assert payload["skill_path"] == str(some_dir.resolve())
+        assert payload["skill_path"] != "not-a-file"
+
     def test_json_silences_stderr(self, tmp_path, capsys):
         """``--json`` on a failing case emits NO stderr output."""
         skill_path = tmp_path / "my-skill" / "SKILL.md"

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -1,10 +1,12 @@
-"""Tests for ``clauditor lint`` CLI command (US-003, US-004).
+"""Tests for ``clauditor lint`` CLI command (US-003, US-004, US-005).
 
-Plain-text output plus the ``--strict`` flag (US-004, DEC-004). The
-``--json`` flag (US-005) is a separate bead.
+Plain-text output, the ``--strict`` flag (US-004, DEC-004), and the
+``--json`` flag (US-005, DEC-012).
 """
 
 from __future__ import annotations
+
+import json
 
 import pytest
 
@@ -223,13 +225,13 @@ class TestCmdLint:
 
 
 # ---------------------------------------------------------------------------
-# Argparse surface — ``--strict`` is now registered (US-004, DEC-004);
-# ``--json`` is deferred to US-005.
+# Argparse surface — ``--strict`` (US-004, DEC-004) and ``--json``
+# (US-005, DEC-012) are both registered.
 # ---------------------------------------------------------------------------
 
 
 class TestArgparseSurface:
-    """Verify the post-US-004 argparse surface (``--strict`` on, ``--json`` off)."""
+    """Verify the post-US-005 argparse surface (``--strict`` + ``--json``)."""
 
     def test_strict_flag_accepted(self, tmp_path, capsys):
         """``--strict`` is registered and parses without error (US-004)."""
@@ -248,13 +250,22 @@ class TestArgparseSurface:
         captured = capsys.readouterr()
         assert "--strict" in captured.out
 
-    def test_json_flag_not_available(self, tmp_path, capsys):
-        """``--json`` is not registered by this bead (US-005)."""
+    def test_json_flag_accepted(self, tmp_path, capsys):
+        """``--json`` is registered and parses without error (US-005)."""
         skill_path = _make_valid_skill(tmp_path)
 
+        # A minimal-valid skill has no issues, so ``--json`` should not
+        # change the exit code — exit 0 regardless.
+        rc = main(["lint", "--json", str(skill_path)])
+        assert rc == 0
+
+    def test_json_flag_in_help(self, capsys):
+        """``--json`` appears in the ``lint --help`` output."""
         with pytest.raises(SystemExit) as exc:
-            main(["lint", "--json", str(skill_path)])
-        assert exc.value.code == 2
+            main(["lint", "--help"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "--json" in captured.out
 
 
 # ---------------------------------------------------------------------------
@@ -418,3 +429,209 @@ class TestStrictFlag:
             in captured.err
         )
         assert "Cannot lint: SKILL.md frontmatter is not valid YAML" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# ``--json`` output envelope (US-005, DEC-012).
+#
+# Envelope shape:
+#
+#   {
+#     "schema_version": 1,
+#     "skill_path": "<resolved-path>",
+#     "passed": bool,
+#     "issues": [
+#       {"code": "...", "severity": "error"|"warning", "message": "..."}
+#     ]
+#   }
+#
+# ``schema_version: 1`` is the FIRST key in the payload per
+# ``.claude/rules/json-schema-version.md``. When ``--json`` is set,
+# stderr is empty and exit codes are identical to the non-JSON path
+# (including ``--strict`` interaction and the INVALID_YAML → exit 1
+# special case).
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutput:
+    """Tests for ``clauditor lint --json`` (US-005, DEC-012)."""
+
+    def test_json_pass_envelope(self, tmp_path, capsys):
+        """Minimal-valid skill with ``--json`` emits a pass envelope, exit 0."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["schema_version"] == 1
+        assert payload["passed"] is True
+        assert payload["issues"] == []
+        assert payload["skill_path"] == str(skill_path.resolve())
+
+    def test_json_schema_version_first_key(self, tmp_path, capsys):
+        """``schema_version`` is the FIRST key in the payload (structural).
+
+        Verified by reading the raw JSON string — not just that the key
+        is present, but that it is the first one in insertion order.
+        """
+        skill_path = _make_valid_skill(tmp_path)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Locate the first quoted key in the raw JSON string. The first
+        # opening double-quote inside the object belongs to the first key.
+        brace_idx = out.index("{")
+        first_key_start = out.index('"', brace_idx)
+        first_key_end = out.index('"', first_key_start + 1)
+        first_key = out[first_key_start + 1 : first_key_end]
+        assert first_key == "schema_version"
+
+    def test_json_warning_envelope_no_strict(self, tmp_path, capsys):
+        """Warning-only + ``--json`` (no strict) → passed=True, exit 0."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_warning_only(skill_path)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is True
+        assert len(payload["issues"]) >= 1
+        assert all(i["severity"] == "warning" for i in payload["issues"])
+        codes = [i["code"] for i in payload["issues"]]
+        assert "AGENTSKILLS_BODY_TOO_LONG" in codes
+
+    def test_json_warning_envelope_with_strict(self, tmp_path, capsys):
+        """Warning-only + ``--strict --json`` → passed=False, exit 2.
+
+        ``--strict`` promotes warnings to failures; the JSON envelope's
+        ``passed`` must mirror the effective exit-code outcome.
+        """
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_warning_only(skill_path)
+
+        rc = main(["lint", "--strict", "--json", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        codes = [i["code"] for i in payload["issues"]]
+        assert "AGENTSKILLS_BODY_TOO_LONG" in codes
+
+    def test_json_error_envelope(self, tmp_path, capsys):
+        """Error-severity skill + ``--json`` → passed=False, exit 2."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_error_only(skill_path)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        codes = [i["code"] for i in payload["issues"]]
+        assert "AGENTSKILLS_NAME_MISSING" in codes
+        assert any(i["severity"] == "error" for i in payload["issues"])
+
+    def test_json_invalid_yaml_envelope(self, tmp_path, capsys):
+        """Malformed frontmatter + ``--json`` → passed=False, exit 1.
+
+        Preserves the INVALID_YAML → exit 1 special case from US-003.
+        """
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        skill_path.parent.mkdir()
+        skill_path.write_text(
+            "---\nname: my-skill\ndescription: Missing closing fence.\n"
+            "# Body without closing ---\n",
+            encoding="utf-8",
+        )
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        assert len(payload["issues"]) == 1
+        assert payload["issues"][0]["code"] == "AGENTSKILLS_FRONTMATTER_INVALID_YAML"
+
+    def test_json_path_not_a_file_envelope(self, tmp_path, capsys):
+        """Directory + ``--json`` → passed=False, exit 1, synthetic PATH_* issue."""
+        some_dir = tmp_path / "not-a-file"
+        some_dir.mkdir()
+
+        rc = main(["lint", "--json", str(some_dir)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        assert len(payload["issues"]) == 1
+        issue = payload["issues"][0]
+        assert issue["code"] == "PATH_NOT_A_FILE"
+        assert issue["severity"] == "error"
+
+    def test_json_silences_stderr(self, tmp_path, capsys):
+        """``--json`` on a failing case emits NO stderr output."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_error_only(skill_path)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        # And no conformance-prefix lines leaked into stdout either.
+        assert "clauditor.conformance:" not in captured.out
+
+    def test_json_issue_fields(self, tmp_path, capsys):
+        """Each JSON issue has exactly 3 keys: code, severity, message."""
+        skill_path = tmp_path / "my-skill" / "SKILL.md"
+        _write_mixed(skill_path)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert len(payload["issues"]) >= 1
+        for issue in payload["issues"]:
+            assert set(issue.keys()) == {"code", "severity", "message"}
+            assert isinstance(issue["code"], str)
+            assert issue["severity"] in ("error", "warning")
+            assert isinstance(issue["message"], str)
+
+    def test_json_unreadable_file_envelope(self, tmp_path, capsys, monkeypatch):
+        """``OSError`` on read + ``--json`` → exit 1, PATH_UNREADABLE issue."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        def _boom(self, *_args, **_kwargs):
+            raise OSError("simulated read failure")
+
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        assert len(payload["issues"]) == 1
+        assert payload["issues"][0]["code"] == "PATH_UNREADABLE"
+        assert payload["issues"][0]["severity"] == "error"

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -430,6 +430,41 @@ class TestStrictFlag:
         )
         assert "Cannot lint: SKILL.md frontmatter is not valid YAML" in captured.out
 
+    def test_invalid_yaml_on_legacy_layout_exits_1(self, tmp_path, capsys):
+        """Legacy-layout file with malformed YAML still exits 1.
+
+        Regression for quality-gate pass-1 finding: the prior
+        ``len(issues) == 1 and code == INVALID_YAML`` guard broke when
+        ``AGENTSKILLS_LAYOUT_LEGACY`` (appended pre-parse in
+        ``check_conformance``) coexisted with INVALID_YAML. Exit
+        routing must handle both issues simultaneously — parse
+        failure dominates regardless of siblings or ``--strict``.
+        """
+        # Legacy layout: filename is ``<name>.md``, not ``SKILL.md``.
+        skill_path = tmp_path / "my-skill.md"
+        skill_path.write_text(
+            "---\nname: my-skill\ndescription: Missing closing fence.\n"
+            "# Body without closing ---\n",
+            encoding="utf-8",
+        )
+
+        # Without --strict
+        rc = main(["lint", str(skill_path)])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert (
+            "clauditor.conformance: AGENTSKILLS_LAYOUT_LEGACY: " in captured.err
+        )
+        assert (
+            "clauditor.conformance: AGENTSKILLS_FRONTMATTER_INVALID_YAML: "
+            in captured.err
+        )
+        assert "Cannot lint: SKILL.md frontmatter is not valid YAML" in captured.out
+
+        # With --strict — still exit 1 (parse failure never escalated).
+        rc = main(["lint", "--strict", str(skill_path)])
+        assert rc == 1
+
 
 # ---------------------------------------------------------------------------
 # ``--json`` output envelope (US-005, DEC-012).
@@ -635,3 +670,84 @@ class TestJsonOutput:
         assert len(payload["issues"]) == 1
         assert payload["issues"][0]["code"] == "PATH_UNREADABLE"
         assert payload["issues"][0]["severity"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# QG pass-3: newline-injection hardening on synthetic PATH_* issues.
+#
+# POSIX allows ``\n`` / ``\r`` in filenames, and some plugin filesystems
+# raise multi-line OSError messages on ``read_text``. Both flows feed
+# user-controlled strings into a ``ConformanceIssue(message=...)`` in
+# the ``--json`` path; since QG-pass-2 added ``__post_init__`` rejecting
+# newlines in messages (M9), these paths would crash before emitting
+# their envelope. The ``_sanitize_message_text`` helper replaces newline
+# characters with their literal escape sequences so the synthetic issue
+# constructs cleanly and grep-friendly single-line output is preserved.
+# ---------------------------------------------------------------------------
+
+
+class TestNewlineSanitization:
+    """Regression: user-provided path / OSError messages with ``\\n`` must
+    not crash the lint CLI (QG-pass-3 finding)."""
+
+    def test_json_path_with_newline_does_not_crash(self, capsys):
+        """``clauditor lint --json $'foo\\nbar'`` → clean exit 1, no crash."""
+        # Path that contains a literal newline — argparse + Path both
+        # accept this, and resolve() does not reject it.
+        rc = main(["lint", "--json", "bogus\nwith-newline.md"])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        assert len(payload["issues"]) == 1
+        issue = payload["issues"][0]
+        assert issue["code"] == "PATH_NOT_A_FILE"
+        # Newline was replaced with ``\n`` escape so the message is
+        # single-line and the construct did not violate the DEC-014
+        # ``ConformanceIssue.__post_init__`` invariant.
+        assert "\n" not in issue["message"]
+        assert "\r" not in issue["message"]
+        assert "\\n" in issue["message"]
+
+    def test_text_path_with_newline_is_single_line(self, capsys):
+        """Human-text path with a newline in argv renders as one stderr line."""
+        rc = main(["lint", "bogus\nwith-newline.md"])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        # The stderr error line contains the escape, not a raw newline,
+        # so ``grep`` consumers see exactly one matching line.
+        err_lines = [
+            line for line in captured.err.splitlines()
+            if line.startswith("ERROR:")
+        ]
+        assert len(err_lines) == 1
+        assert "\\n" in err_lines[0]
+
+    def test_json_unreadable_multiline_oserror_does_not_crash(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Multi-line OSError messages do not crash the JSON envelope."""
+        skill_path = _make_valid_skill(tmp_path)
+
+        def _boom(self, *_args, **_kwargs):
+            raise OSError("first line\nsecond line of error")
+
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+
+        rc = main(["lint", "--json", str(skill_path)])
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["passed"] is False
+        assert len(payload["issues"]) == 1
+        issue = payload["issues"][0]
+        assert issue["code"] == "PATH_UNREADABLE"
+        assert "\n" not in issue["message"]
+        assert "\\n" in issue["message"]

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,618 @@
+"""Tests for :mod:`clauditor.conformance` — agentskills.io spec checker.
+
+The pure helper ``check_conformance(skill_md_text, skill_path)`` takes
+already-read Markdown text plus a ``Path`` (used only for layout-shape
+classification and parent-dir-match checks) and returns a
+``list[ConformanceIssue]``. No I/O, no stderr emission.
+
+Tests are organized one class per rule category, matching DEC-001 and
+the plan's US-001 TDD outline. Every rule from the Discovery section
+gets a dedicated test so a regression surfaces with a clear signal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clauditor.conformance import (
+    AGENTSKILLS_NAME_RE,
+    KNOWN_CLAUDE_CODE_EXTENSION_KEYS,
+    ConformanceIssue,
+    check_conformance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _modern_path(name: str = "my-skill") -> Path:
+    """Return a representative modern-layout path (``<name>/SKILL.md``).
+
+    No tmp_path: the helper is pure and the path is used only for
+    ``name == "SKILL.md"`` classification and ``parent.name`` comparison.
+    """
+    return Path(name) / "SKILL.md"
+
+
+def _legacy_path(name: str = "my-skill") -> Path:
+    """Return a representative legacy-layout path (``<name>.md``)."""
+    return Path(f"{name}.md")
+
+
+def _build_skill(
+    *,
+    name: str | None = "my-skill",
+    description: str | None = "A test skill description.",
+    license: str | None = None,
+    compatibility: str | None = None,
+    metadata: dict[str, str] | None = None,
+    allowed_tools: str | None = None,
+    extra: dict | None = None,
+    body: str = "# Body\n\nSome content.\n",
+) -> str:
+    """Build a SKILL.md text from a conformant baseline.
+
+    Any kwarg set to ``None`` omits the field. ``extra`` lets a test
+    inject additional key/value lines (e.g. unknown keys or extension
+    keys from the allowlist) verbatim.
+    """
+    lines = ["---"]
+    if name is not None:
+        lines.append(f"name: {name}")
+    if description is not None:
+        lines.append(f"description: {description}")
+    if license is not None:
+        lines.append(f"license: {license}")
+    if compatibility is not None:
+        lines.append(f"compatibility: {compatibility}")
+    if metadata is not None:
+        lines.append("metadata:")
+        for k, v in metadata.items():
+            lines.append(f"  {k}: {v}")
+    if allowed_tools is not None:
+        lines.append(f"allowed-tools: {allowed_tools}")
+    if extra is not None:
+        for k, v in extra.items():
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    text = "\n".join(lines) + "\n" + body
+    return text
+
+
+def _codes(issues: list[ConformanceIssue]) -> list[str]:
+    return [i.code for i in issues]
+
+
+def _by_code(
+    issues: list[ConformanceIssue], code: str
+) -> list[ConformanceIssue]:
+    return [i for i in issues if i.code == code]
+
+
+# ---------------------------------------------------------------------------
+# Baseline: a valid minimal skill produces zero issues
+# ---------------------------------------------------------------------------
+
+
+class TestMinimalValidSkill:
+    def test_minimal_valid_skill_produces_zero_issues(self):
+        """A conformant modern-layout skill has no issues."""
+        text = _build_skill()
+        issues = check_conformance(text, _modern_path())
+        assert issues == []
+
+    def test_full_optional_fields_produce_zero_issues(self):
+        text = _build_skill(
+            license="MIT",
+            compatibility="Requires Python 3.11+",
+            metadata={"author": "alice"},
+            allowed_tools="Bash(ls) Read",
+        )
+        # allowed_tools experimental WARNING still fires; assert error-free
+        issues = check_conformance(text, _modern_path())
+        errors = [i for i in issues if i.severity == "error"]
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter structure
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatterStructure:
+    def test_frontmatter_missing_reports_error(self):
+        text = "# No frontmatter here\n\nJust markdown.\n"
+        issues = check_conformance(text, _modern_path())
+        codes = _codes(issues)
+        assert "AGENTSKILLS_FRONTMATTER_MISSING" in codes
+        issue = _by_code(issues, "AGENTSKILLS_FRONTMATTER_MISSING")[0]
+        assert issue.severity == "error"
+
+    def test_frontmatter_invalid_yaml_reports_error(self):
+        # Missing closing delimiter → parse_frontmatter raises ValueError.
+        text = "---\nname: my-skill\ndescription: d\n\n# No closing\n"
+        issues = check_conformance(text, _modern_path())
+        codes = _codes(issues)
+        assert "AGENTSKILLS_FRONTMATTER_INVALID_YAML" in codes
+        issue = _by_code(issues, "AGENTSKILLS_FRONTMATTER_INVALID_YAML")[0]
+        assert issue.severity == "error"
+
+    def test_malformed_yaml_does_not_raise(self):
+        # The colon-less line inside frontmatter makes parse_frontmatter
+        # raise; check_conformance must convert that to an issue, not
+        # let the exception escape.
+        text = "---\nno colon here\n---\n"
+        # Must not raise.
+        issues = check_conformance(text, _modern_path())
+        assert any(
+            i.code == "AGENTSKILLS_FRONTMATTER_INVALID_YAML" for i in issues
+        )
+
+    def test_unknown_key_reports_warning(self):
+        text = _build_skill(extra={"bogus-field": "value"})
+        issues = check_conformance(text, _modern_path())
+        unknown = _by_code(issues, "AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY")
+        assert len(unknown) == 1
+        assert unknown[0].severity == "warning"
+        assert "bogus-field" in unknown[0].message
+
+    def test_allowlisted_claude_code_extension_keys_accepted(self):
+        text = _build_skill(
+            extra={
+                "argument-hint": '"[skill-path]"',
+                "disable-model-invocation": "true",
+            }
+        )
+        issues = check_conformance(text, _modern_path())
+        unknown = _by_code(issues, "AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY")
+        assert unknown == []
+
+    def test_allowlist_is_frozenset_with_required_entries(self):
+        assert isinstance(KNOWN_CLAUDE_CODE_EXTENSION_KEYS, frozenset)
+        assert "argument-hint" in KNOWN_CLAUDE_CODE_EXTENSION_KEYS
+        assert "disable-model-invocation" in KNOWN_CLAUDE_CODE_EXTENSION_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Name validation
+# ---------------------------------------------------------------------------
+
+
+class TestNameValidation:
+    def test_name_missing_reports_error(self):
+        text = _build_skill(name=None)
+        issues = check_conformance(text, _modern_path())
+        codes = _codes(issues)
+        assert "AGENTSKILLS_NAME_MISSING" in codes
+        issue = _by_code(issues, "AGENTSKILLS_NAME_MISSING")[0]
+        assert issue.severity == "error"
+
+    def test_name_empty_reports_error(self):
+        # Empty scalar "name:" produces an empty-string value.
+        text = "---\nname:\ndescription: d\n---\n\nbody\n"
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_NAME_EMPTY" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_NAME_EMPTY")[0]
+        assert issue.severity == "error"
+
+    def test_name_too_long_reports_error(self):
+        long_name = "a" * 65  # > 64 chars
+        # Parent dir matches so PARENT_DIR_MISMATCH does not fire.
+        text = _build_skill(name=long_name)
+        issues = check_conformance(text, _modern_path(long_name))
+        assert "AGENTSKILLS_NAME_TOO_LONG" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_NAME_TOO_LONG")[0]
+        assert issue.severity == "error"
+
+    def test_name_uppercase_reports_invalid_chars(self):
+        text = _build_skill(name="MySkill")
+        issues = check_conformance(text, _modern_path("MySkill"))
+        assert "AGENTSKILLS_NAME_INVALID_CHARS" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_NAME_INVALID_CHARS")[0]
+        assert issue.severity == "error"
+
+    def test_name_underscore_reports_invalid_chars(self):
+        text = _build_skill(name="my_skill")
+        issues = check_conformance(text, _modern_path("my_skill"))
+        assert "AGENTSKILLS_NAME_INVALID_CHARS" in _codes(issues)
+
+    def test_name_leading_hyphen_reports_error(self):
+        text = _build_skill(name="-bad")
+        issues = check_conformance(text, _modern_path("-bad"))
+        codes = _codes(issues)
+        assert "AGENTSKILLS_NAME_LEADING_HYPHEN" in codes
+        issue = _by_code(issues, "AGENTSKILLS_NAME_LEADING_HYPHEN")[0]
+        assert issue.severity == "error"
+
+    def test_name_trailing_hyphen_reports_error(self):
+        text = _build_skill(name="bad-")
+        issues = check_conformance(text, _modern_path("bad-"))
+        codes = _codes(issues)
+        assert "AGENTSKILLS_NAME_TRAILING_HYPHEN" in codes
+        issue = _by_code(issues, "AGENTSKILLS_NAME_TRAILING_HYPHEN")[0]
+        assert issue.severity == "error"
+
+    def test_name_consecutive_hyphens_reports_error(self):
+        text = _build_skill(name="foo--bar")
+        issues = check_conformance(text, _modern_path("foo--bar"))
+        codes = _codes(issues)
+        assert "AGENTSKILLS_NAME_CONSECUTIVE_HYPHENS" in codes
+        issue = _by_code(issues, "AGENTSKILLS_NAME_CONSECUTIVE_HYPHENS")[0]
+        assert issue.severity == "error"
+
+    def test_name_parent_dir_mismatch_reports_error_modern_only(self):
+        # Frontmatter says "my-skill", parent dir is "other-dir".
+        text = _build_skill(name="my-skill")
+        path = Path("other-dir") / "SKILL.md"
+        issues = check_conformance(text, path)
+        codes = _codes(issues)
+        assert "AGENTSKILLS_NAME_PARENT_DIR_MISMATCH" in codes
+        issue = _by_code(issues, "AGENTSKILLS_NAME_PARENT_DIR_MISMATCH")[0]
+        assert issue.severity == "error"
+
+    def test_parent_dir_mismatch_not_fired_for_legacy_layout(self):
+        # Legacy <name>.md skip parent-dir-match check.
+        text = _build_skill(name="my-skill")
+        issues = check_conformance(text, _legacy_path("anything"))
+        assert "AGENTSKILLS_NAME_PARENT_DIR_MISMATCH" not in _codes(issues)
+
+    def test_valid_single_char_name_accepted(self):
+        # Regex has an explicit 1-char branch.
+        text = _build_skill(name="a")
+        issues = check_conformance(text, _modern_path("a"))
+        # No name-related issues.
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_NAME_"), (
+                f"unexpected name issue on single-char name: {code}"
+            )
+
+    def test_valid_numeric_name_accepted(self):
+        text = _build_skill(name="skill42")
+        issues = check_conformance(text, _modern_path("skill42"))
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_NAME_"), (
+                f"unexpected name issue on numeric-suffix name: {code}"
+            )
+
+
+class TestNameRegexConstant:
+    def test_name_regex_is_compiled_pattern(self):
+        # re.Pattern acceptance — must fullmatch-callable.
+        assert AGENTSKILLS_NAME_RE.fullmatch("ok-name") is not None
+        assert AGENTSKILLS_NAME_RE.fullmatch("") is None
+        assert AGENTSKILLS_NAME_RE.fullmatch("-bad") is None
+        assert AGENTSKILLS_NAME_RE.fullmatch("bad-") is None
+        assert AGENTSKILLS_NAME_RE.fullmatch("foo--bar") is None
+        assert AGENTSKILLS_NAME_RE.fullmatch("a") is not None
+
+
+# ---------------------------------------------------------------------------
+# Description validation
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptionValidation:
+    def test_description_missing_reports_error(self):
+        text = _build_skill(description=None)
+        issues = check_conformance(text, _modern_path())
+        codes = _codes(issues)
+        assert "AGENTSKILLS_DESCRIPTION_MISSING" in codes
+        issue = _by_code(issues, "AGENTSKILLS_DESCRIPTION_MISSING")[0]
+        assert issue.severity == "error"
+
+    def test_description_empty_reports_error(self):
+        text = "---\nname: my-skill\ndescription:\n---\n\nbody\n"
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_DESCRIPTION_EMPTY" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_DESCRIPTION_EMPTY")[0]
+        assert issue.severity == "error"
+
+    def test_description_too_long_reports_error(self):
+        text = _build_skill(description="x" * 1025)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_DESCRIPTION_TOO_LONG" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_DESCRIPTION_TOO_LONG")[0]
+        assert issue.severity == "error"
+
+    def test_description_exactly_1024_chars_accepted(self):
+        text = _build_skill(description="x" * 1024)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_DESCRIPTION_TOO_LONG" not in _codes(issues)
+
+
+# ---------------------------------------------------------------------------
+# License validation
+# ---------------------------------------------------------------------------
+
+
+class TestLicenseValidation:
+    def test_license_absent_is_silently_accepted(self):
+        text = _build_skill(license=None)
+        issues = check_conformance(text, _modern_path())
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_LICENSE_"), (
+                f"license issue on absent license: {code}"
+            )
+
+    def test_license_valid_is_silently_accepted(self):
+        text = _build_skill(license="MIT")
+        issues = check_conformance(text, _modern_path())
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_LICENSE_"), code
+
+    def test_license_empty_string_reports_error(self):
+        text = "---\nname: my-skill\ndescription: d\nlicense:\n---\n\nbody\n"
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_LICENSE_EMPTY" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_LICENSE_EMPTY")[0]
+        assert issue.severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# Compatibility validation
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibilityValidation:
+    def test_compatibility_absent_is_silently_accepted(self):
+        text = _build_skill(compatibility=None)
+        issues = check_conformance(text, _modern_path())
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_COMPATIBILITY_"), code
+
+    def test_compatibility_empty_reports_error(self):
+        text = (
+            "---\nname: my-skill\ndescription: d\ncompatibility:\n---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_COMPATIBILITY_EMPTY" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_COMPATIBILITY_EMPTY")[0]
+        assert issue.severity == "error"
+
+    def test_compatibility_too_long_reports_error(self):
+        text = _build_skill(compatibility="c" * 501)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_COMPATIBILITY_TOO_LONG" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_COMPATIBILITY_TOO_LONG")[0]
+        assert issue.severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# Metadata validation
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataValidation:
+    def test_metadata_nested_map_accepted(self):
+        text = _build_skill(metadata={"author": "alice", "version": '"1.0"'})
+        issues = check_conformance(text, _modern_path())
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_METADATA_"), code
+
+    def test_metadata_scalar_reports_not_map(self):
+        # Scalar "metadata: value" produces a string, not a dict.
+        text = (
+            "---\nname: my-skill\ndescription: d\nmetadata: plain-string\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_METADATA_NOT_MAP" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_METADATA_NOT_MAP")[0]
+        assert issue.severity == "error"
+
+    def test_metadata_absent_is_silently_accepted(self):
+        text = _build_skill(metadata=None)
+        issues = check_conformance(text, _modern_path())
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_METADATA_"), code
+
+
+# ---------------------------------------------------------------------------
+# Allowed-tools validation
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedToolsValidation:
+    def test_allowed_tools_absent_is_silently_accepted(self):
+        text = _build_skill(allowed_tools=None)
+        issues = check_conformance(text, _modern_path())
+        for code in _codes(issues):
+            assert not code.startswith("AGENTSKILLS_ALLOWED_TOOLS_"), code
+
+    def test_allowed_tools_present_always_fires_experimental_warning(self):
+        text = _build_skill(allowed_tools="Bash(ls) Read")
+        issues = check_conformance(text, _modern_path())
+        experimental = _by_code(
+            issues, "AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL"
+        )
+        assert len(experimental) == 1
+        assert experimental[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Body validation
+# ---------------------------------------------------------------------------
+
+
+class TestBodyChecks:
+    def test_body_under_500_lines_accepted(self):
+        # 400 lines of prose; no warning.
+        body = "\n".join(f"Line {i}" for i in range(400)) + "\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_BODY_TOO_LONG" not in _codes(issues)
+
+    def test_body_over_500_lines_reports_warning(self):
+        body = "\n".join(f"Line {i}" for i in range(600)) + "\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_BODY_TOO_LONG" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_BODY_TOO_LONG")[0]
+        assert issue.severity == "warning"
+
+    def test_body_empty_is_silently_accepted(self):
+        text = _build_skill(body="")
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_BODY_TOO_LONG" not in _codes(issues)
+
+
+# ---------------------------------------------------------------------------
+# Layout validation
+# ---------------------------------------------------------------------------
+
+
+class TestLayoutChecks:
+    def test_modern_layout_produces_no_layout_warning(self):
+        text = _build_skill()
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_LAYOUT_LEGACY" not in _codes(issues)
+
+    def test_legacy_layout_reports_warning(self):
+        text = _build_skill()
+        issues = check_conformance(text, _legacy_path("my-skill"))
+        assert "AGENTSKILLS_LAYOUT_LEGACY" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_LAYOUT_LEGACY")[0]
+        assert issue.severity == "warning"
+        # Load-bearing copy from DEC's "Load-bearing message copy".
+        assert "agentskills.io" in issue.message
+        assert "SKILL.md" in issue.message
+
+
+# ---------------------------------------------------------------------------
+# YAML type coercion / non-string guard
+# ---------------------------------------------------------------------------
+
+
+class TestYAMLTypeCoercion:
+    """Strict ``isinstance(str)`` guards for every string-typed field.
+
+    The in-tree ``_frontmatter.parse_frontmatter`` does not auto-coerce
+    scalars (``name: true`` yields the string ``"true"``), so these
+    tests drive the non-string branch by using YAML-subset nested-map
+    shapes — e.g. writing ``name:\\n  sub: val`` to force
+    ``parsed["name"]`` to be a ``dict`` instead of a ``str``. G9 / G10
+    of the plan mandate that every string-typed field assert
+    ``isinstance(val, str)`` and emit ``_NOT_STRING`` otherwise.
+    """
+
+    def test_name_nested_dict_reports_not_string(self):
+        text = (
+            "---\n"
+            "name:\n"
+            "  nested: whatever\n"
+            "description: d\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_NAME_NOT_STRING" in _codes(issues)
+        issue = _by_code(issues, "AGENTSKILLS_NAME_NOT_STRING")[0]
+        assert issue.severity == "error"
+
+    def test_description_nested_dict_reports_not_string(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description:\n"
+            "  nested: whatever\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_DESCRIPTION_NOT_STRING" in _codes(issues)
+
+    def test_license_nested_dict_reports_not_string(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: d\n"
+            "license:\n"
+            "  nested: x\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_LICENSE_NOT_STRING" in _codes(issues)
+
+    def test_compatibility_nested_dict_reports_not_string(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: d\n"
+            "compatibility:\n"
+            "  nested: x\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_COMPATIBILITY_NOT_STRING" in _codes(issues)
+
+    def test_allowed_tools_nested_dict_reports_not_string(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: d\n"
+            "allowed-tools:\n"
+            "  nested: x\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_ALLOWED_TOOLS_NOT_STRING" in _codes(issues)
+        # Experimental warning should NOT fire when the field is the
+        # wrong type — the not-string error is the only signal the
+        # author needs.
+        assert "AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL" not in _codes(
+            issues
+        )
+
+    def test_metadata_key_non_string_is_impossible_but_value_check_fires(
+        self,
+    ):
+        # parse_frontmatter mapping keys come from _split_key_value
+        # which always returns str, so we can't easily construct a
+        # non-string metadata key via the parser. We exercise the
+        # value-side guard by synthesizing the dict directly via a
+        # value whose parsed form is non-string. The YAML subset never
+        # produces non-string nested values either (all scalars go
+        # through _strip_quotes → str). So this test exists primarily
+        # to pin the rule's code existence at module load time via
+        # TestFrontmatterStructure; here we verify normal string-valued
+        # metadata does NOT trigger the error.
+        text = _build_skill(metadata={"author": "alice"})
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_METADATA_VALUE_NOT_STRING" not in _codes(issues)
+        assert "AGENTSKILLS_METADATA_KEY_NOT_STRING" not in _codes(issues)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass surface + return-type sanity
+# ---------------------------------------------------------------------------
+
+
+class TestConformanceIssueShape:
+    def test_issue_has_required_fields(self):
+        issue = ConformanceIssue(
+            code="AGENTSKILLS_NAME_MISSING",
+            severity="error",
+            message="Missing `name` field.",
+        )
+        assert issue.code == "AGENTSKILLS_NAME_MISSING"
+        assert issue.severity == "error"
+        assert issue.message == "Missing `name` field."
+
+    def test_check_conformance_returns_empty_list_for_valid_input(self):
+        text = _build_skill()
+        result = check_conformance(text, _modern_path())
+        assert isinstance(result, list)
+        assert result == []
+
+    @pytest.mark.parametrize(
+        "severity",
+        ["error", "warning"],
+    )
+    def test_issue_severity_values_are_the_two_canonical_choices(
+        self, severity
+    ):
+        issue = ConformanceIssue(
+            code="TEST_CODE", severity=severity, message="msg"
+        )
+        assert issue.severity in {"error", "warning"}

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -12,11 +12,19 @@ gets a dedicated test so a regression surfaces with a clear signal.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
 
-from clauditor.conformance import (
+import clauditor.conformance as _conformance_mod
+
+# Module is imported by the pytest plugin (via spec.py) before coverage
+# instrumentation starts, so reload to get accurate per-line coverage
+# (matches the ``tests/test_schemas.py`` pattern documented in CLAUDE.md).
+importlib.reload(_conformance_mod)
+
+from clauditor.conformance import (  # noqa: E402
     AGENTSKILLS_NAME_RE,
     KNOWN_CLAUDE_CODE_EXTENSION_KEYS,
     ConformanceIssue,
@@ -458,6 +466,20 @@ class TestBodyChecks:
         issues = check_conformance(text, _modern_path())
         assert "AGENTSKILLS_BODY_TOO_LONG" not in _codes(issues)
 
+    def test_body_exactly_500_lines_no_warning(self):
+        """500 lines is the inclusive ceiling — no warning."""
+        body = "\n".join(f"Line {i}" for i in range(500)) + "\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_BODY_TOO_LONG" not in _codes(issues)
+
+    def test_body_501_lines_triggers_warning(self):
+        """501 lines crosses the threshold — warning fires."""
+        body = "\n".join(f"Line {i}" for i in range(501)) + "\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert "AGENTSKILLS_BODY_TOO_LONG" in _codes(issues)
+
 
 # ---------------------------------------------------------------------------
 # Layout validation
@@ -564,23 +586,43 @@ class TestYAMLTypeCoercion:
             issues
         )
 
-    def test_metadata_key_non_string_is_impossible_but_value_check_fires(
-        self,
-    ):
-        # parse_frontmatter mapping keys come from _split_key_value
-        # which always returns str, so we can't easily construct a
-        # non-string metadata key via the parser. We exercise the
-        # value-side guard by synthesizing the dict directly via a
-        # value whose parsed form is non-string. The YAML subset never
-        # produces non-string nested values either (all scalars go
-        # through _strip_quotes → str). So this test exists primarily
-        # to pin the rule's code existence at module load time via
-        # TestFrontmatterStructure; here we verify normal string-valued
-        # metadata does NOT trigger the error.
+    def test_metadata_normal_string_values_pass(self):
         text = _build_skill(metadata={"author": "alice"})
         issues = check_conformance(text, _modern_path())
         assert "AGENTSKILLS_METADATA_VALUE_NOT_STRING" not in _codes(issues)
         assert "AGENTSKILLS_METADATA_KEY_NOT_STRING" not in _codes(issues)
+
+    def test_metadata_defensive_key_guard_fires_on_synthetic_non_string_key(
+        self,
+    ):
+        """`_check_metadata` rejects non-string keys.
+
+        `parse_frontmatter` cannot produce non-string keys (the YAML
+        subset parser always returns `str` from `_split_key_value`),
+        so this defensive guard is unreachable via the public API.
+        Exercise it directly to cover the G10 contract — same shape
+        as the reviewer's pass-1 diagnostic.
+        """
+        # Non-public helper; test-only import.
+        from clauditor.conformance import _check_metadata  # noqa: PLC0415
+
+        issues: list[ConformanceIssue] = []
+        _check_metadata({"metadata": {42: "not a string key"}}, issues)
+        codes = [i.code for i in issues]
+        assert "AGENTSKILLS_METADATA_KEY_NOT_STRING" in codes
+        assert all(i.severity == "error" for i in issues)
+
+    def test_metadata_defensive_value_guard_fires_on_synthetic_non_string_value(
+        self,
+    ):
+        """`_check_metadata` rejects non-string values (e.g. YAML-coerced ints)."""
+        from clauditor.conformance import _check_metadata  # noqa: PLC0415
+
+        issues: list[ConformanceIssue] = []
+        _check_metadata({"metadata": {"version": 1.0}}, issues)
+        codes = [i.code for i in issues]
+        assert "AGENTSKILLS_METADATA_VALUE_NOT_STRING" in codes
+        assert all(i.severity == "error" for i in issues)
 
 
 # ---------------------------------------------------------------------------
@@ -616,3 +658,85 @@ class TestConformanceIssueShape:
             code="TEST_CODE", severity=severity, message="msg"
         )
         assert issue.severity in {"error", "warning"}
+
+
+# ---------------------------------------------------------------------------
+# DEC-014 stderr-prefix format (shared by CLI + SkillSpec.from_file hook).
+# ---------------------------------------------------------------------------
+
+
+class TestFormatIssueLine:
+    """Byte-identical pin on the ``clauditor.conformance:`` prefix format.
+
+    The helper is the single seam per DEC-014 + QG-pass-1 M1. Any
+    reshaping of the format (e.g. changing the separator, adding
+    brackets, emitting a trailing space) should be an intentional
+    operator-visible change and should break this test loudly — not
+    silently regress the substring-only tests in `TestCmdLint` /
+    `TestFromFile`.
+    """
+
+    def test_format_is_byte_identical_to_contract(self):
+        from clauditor.conformance import format_issue_line  # noqa: PLC0415
+
+        issue = ConformanceIssue(
+            code="AGENTSKILLS_NAME_MISSING",
+            severity="error",
+            message="Required frontmatter field `name` is missing.",
+        )
+        assert format_issue_line(issue) == (
+            "clauditor.conformance: AGENTSKILLS_NAME_MISSING: "
+            "Required frontmatter field `name` is missing."
+        )
+
+    def test_format_uses_message_verbatim(self):
+        """Any valid single-line message is echoed verbatim after the prefix."""
+        from clauditor.conformance import format_issue_line  # noqa: PLC0415
+
+        issue = ConformanceIssue(
+            code="XYZ_CODE",
+            severity="warning",
+            message="a: b: c — a message that itself contains colons",
+        )
+        assert format_issue_line(issue) == (
+            "clauditor.conformance: XYZ_CODE: "
+            "a: b: c — a message that itself contains colons"
+        )
+
+
+class TestConformanceIssueInvariants:
+    """The dataclass rejects multi-line messages at construction time."""
+
+    @pytest.mark.parametrize("bad_char", ["\n", "\r"])
+    def test_message_rejects_newline_chars(self, bad_char):
+        with pytest.raises(ValueError, match="single-line"):
+            ConformanceIssue(
+                code="TEST",
+                severity="error",
+                message=f"line1{bad_char}line2",
+            )
+
+    def test_all_check_conformance_messages_are_single_line(self):
+        """Every issue emitted by the full rule set is single-line.
+
+        Walks a fixture matrix that triggers (at minimum) one error
+        and one warning per top-level rule category. Defensive guard
+        against a future author adding a rule whose message template
+        contains a newline.
+        """
+        fixtures = [
+            _build_skill(name="", description="ok"),  # NAME_EMPTY
+            _build_skill(name="", description=""),  # NAME_EMPTY + DESCRIPTION_EMPTY
+            _build_skill(description="x" * 1025),  # DESCRIPTION_TOO_LONG
+            _build_skill(metadata={"author": "alice", "extra": "2"}),
+            _build_skill(body="\n".join("line" for _ in range(600))),  # BODY_TOO_LONG
+        ]
+        for text in fixtures:
+            issues = check_conformance(text, _modern_path())
+            for issue in issues:
+                assert "\n" not in issue.message, (
+                    f"Multi-line message from {issue.code}: {issue.message!r}"
+                )
+                assert "\r" not in issue.message, (
+                    f"CR in message from {issue.code}: {issue.message!r}"
+                )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -159,6 +159,44 @@ class TestFrontmatterStructure:
             i.code == "AGENTSKILLS_FRONTMATTER_INVALID_YAML" for i in issues
         )
 
+    def test_malformed_yaml_with_multiline_exception_message_stays_single_line(
+        self, monkeypatch
+    ):
+        """ValueError messages from parse_frontmatter can contain newlines.
+
+        Regression for the CodeRabbit finding: `parse_frontmatter` may
+        raise a multi-line diagnostic (caret-indicator format or
+        embedded context). Interpolating that verbatim into the
+        ConformanceIssue message would trigger the __post_init__
+        single-line invariant and break `check_conformance`'s "never
+        raises" contract. Sanitize before embedding.
+        """
+        import clauditor.conformance as _conformance_mod  # noqa: PLC0415
+
+        def _raise_multiline(_text: str):
+            raise ValueError("line 1\nline 2 (offending token)\n  ^")
+
+        monkeypatch.setattr(
+            _conformance_mod, "parse_frontmatter", _raise_multiline, raising=False
+        )
+        # Monkeypatch the local import target — check_conformance imports
+        # inline, so patch _frontmatter directly.
+        import clauditor._frontmatter as _fm_mod  # noqa: PLC0415
+
+        monkeypatch.setattr(_fm_mod, "parse_frontmatter", _raise_multiline)
+
+        # Must NOT raise even when the exception string has newlines.
+        issues = check_conformance(
+            "---\nname: x\n---\n# body\n", _modern_path()
+        )
+        invalid_yaml = _by_code(issues, "AGENTSKILLS_FRONTMATTER_INVALID_YAML")
+        assert len(invalid_yaml) == 1
+        # Newlines replaced with visible escape sequences to preserve
+        # DEC-014 single-line stderr contract.
+        assert "\n" not in invalid_yaml[0].message
+        assert "\r" not in invalid_yaml[0].message
+        assert "\\n" in invalid_yaml[0].message  # escape is visible
+
     def test_unknown_key_reports_warning(self):
         text = _build_skill(extra={"bogus-field": "value"})
         issues = check_conformance(text, _modern_path())

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -112,6 +112,48 @@ class TestAssertionExamplesUsePerTypeKeys:
         )
 
 
+class TestLintCommandMentionedInDocs:
+    """Prose-presence regression for ``clauditor lint`` (#71, DEC-002).
+
+    Per ``.claude/rules/bundled-skill-docs-sync.md``, load-bearing
+    command names added to the CLI must appear in the human-facing
+    doc triangle so a future prose cleanup cannot silently drop the
+    reference. The assertions below are simple substring checks — NOT
+    structural (header placement, table position, line count) — so
+    they stay stable across ordinary prose rewrites while still
+    catching an accidental drop of the command from either surface.
+
+    Two surfaces are pinned:
+
+    * ``docs/cli-reference.md`` — the canonical reference page must
+      list the command (both in the quick-reference block and in a
+      dedicated ``## lint`` section).
+    * ``README.md`` — the one-line CLI Reference list must include
+      ``clauditor lint <skill.md>``.
+    """
+
+    def test_cli_reference_mentions_lint(self) -> None:
+        """``docs/cli-reference.md`` mentions ``clauditor lint``."""
+        text = (REPO_ROOT / "docs" / "cli-reference.md").read_text(
+            encoding="utf-8"
+        )
+        assert "clauditor lint" in text, (
+            "docs/cli-reference.md must mention 'clauditor lint' — "
+            "the command's canonical reference page dropped the "
+            "string. Restore the ## lint section and the "
+            "quick-reference row."
+        )
+
+    def test_readme_mentions_lint(self) -> None:
+        """``README.md`` mentions ``clauditor lint``."""
+        text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        assert "clauditor lint" in text, (
+            "README.md must mention 'clauditor lint' in the CLI "
+            "Reference subcommand list. Restore the bullet/row under "
+            "the '## CLI Reference' section."
+        )
+
+
 class TestAssertionExamplesUseNativeIntPayloads:
     """Integer payload fields (length / count) must be JSON ints.
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -130,10 +130,13 @@ class TestSkillNameRe:
 class TestDeriveSkillName:
     """Unit tests for the pure ``derive_skill_name`` helper.
 
-    The helper takes the skill path and the SKILL.md text as input and
-    returns a ``(name, warning_or_None)`` tuple without touching disk or
-    stderr. Every branch of the DEC-001/DEC-002/DEC-008 decision tree
-    has a dedicated test here per US-002.
+    Per DEC-008 of ``plans/super/71-agentskills-lint.md``, the helper
+    returns just ``str`` (no warning side-channel). Name-validity
+    warnings are now emitted by
+    :func:`clauditor.conformance.check_conformance` via the
+    ``AGENTSKILLS_NAME_INVALID_CHARS`` and
+    ``AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`` codes (US-006 wires the
+    hook into :meth:`clauditor.spec.SkillSpec.from_file`).
     """
 
     def test_frontmatter_name_matches_filesystem(self, tmp_path):
@@ -141,46 +144,36 @@ class TestDeriveSkillName:
         parent.mkdir()
         skill_path = parent / "SKILL.md"
         text = "---\nname: foo\n---\n\n# Body\n"
-        assert derive_skill_name(skill_path, text) == ("foo", None)
+        assert derive_skill_name(skill_path, text) == "foo"
 
-    def test_frontmatter_name_overrides_filesystem_with_warning(self, tmp_path):
+    def test_frontmatter_name_overrides_filesystem(self, tmp_path):
         parent = tmp_path / "foo"
         parent.mkdir()
         skill_path = parent / "SKILL.md"
         text = "---\nname: bar\n---\n\n# Body\n"
-        name, warning = derive_skill_name(skill_path, text)
-        assert name == "bar"
-        assert warning is not None
-        assert (
-            "frontmatter name 'bar' overrides filesystem name 'foo' "
-            "— using 'bar'"
-        ) in warning
-        assert warning.startswith("clauditor.spec:")
+        # Frontmatter wins; no warning is emitted by this helper anymore.
+        assert derive_skill_name(skill_path, text) == "bar"
 
     def test_missing_frontmatter_falls_back_modern(self, tmp_path):
         parent = tmp_path / "foo"
         parent.mkdir()
         skill_path = parent / "SKILL.md"
         text = "# Body without any frontmatter\n"
-        assert derive_skill_name(skill_path, text) == ("foo", None)
+        assert derive_skill_name(skill_path, text) == "foo"
 
     def test_missing_name_field_falls_back_legacy(self, tmp_path):
         skill_path = tmp_path / "my-skill.md"
         text = "---\ndescription: a skill\n---\n\n# Body\n"
-        assert derive_skill_name(skill_path, text) == ("my-skill", None)
+        assert derive_skill_name(skill_path, text) == "my-skill"
 
-    def test_invalid_regex_falls_back_with_warning(self, tmp_path):
+    def test_invalid_regex_falls_back(self, tmp_path):
         parent = tmp_path / "foo"
         parent.mkdir()
         skill_path = parent / "SKILL.md"
         text = "---\nname: bad;value\n---\n"
-        name, warning = derive_skill_name(skill_path, text)
-        assert name == "foo"
-        assert warning is not None
-        assert "not a valid skill identifier" in warning
-        assert warning.startswith("clauditor.spec:")
-        assert "'bad;value'" in warning
-        assert "'foo'" in warning
+        # Invalid frontmatter name → filesystem fallback, no warning
+        # returned. Warning emission is now conformance.py's job.
+        assert derive_skill_name(skill_path, text) == "foo"
 
     def test_malformed_frontmatter_treated_as_absent(self, tmp_path):
         parent = tmp_path / "foo"
@@ -189,12 +182,12 @@ class TestDeriveSkillName:
         # Opening '---' with no closing delimiter → parse_frontmatter
         # raises ValueError; derive_skill_name treats as absent.
         text = "---\nname: foo\n\n(no closing delimiter)\n"
-        assert derive_skill_name(skill_path, text) == ("foo", None)
+        assert derive_skill_name(skill_path, text) == "foo"
 
     def test_legacy_without_frontmatter(self, tmp_path):
         skill_path = tmp_path / "my-skill.md"
         text = "# Plain legacy skill file with no frontmatter block\n"
-        assert derive_skill_name(skill_path, text) == ("my-skill", None)
+        assert derive_skill_name(skill_path, text) == "my-skill"
 
 
 class TestDeriveProjectDir:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -111,7 +111,16 @@ class TestFromFile:
     def test_from_file_legacy_layout_matching_frontmatter(
         self, tmp_skill_file, mock_runner, capsys
     ):
-        """Legacy layout, frontmatter ``name:`` matches stem → silent."""
+        """Legacy layout, frontmatter ``name:`` matches stem → name-related
+        warnings stay silent.
+
+        Per DEC-005 + DEC-003 of ``plans/super/71-agentskills-lint.md``,
+        legacy single-file layouts unconditionally fire
+        ``AGENTSKILLS_LAYOUT_LEGACY`` (warning severity) via the US-006
+        soft-warn hook, so stderr is no longer empty — but the
+        frontmatter name matches the stem, so no
+        ``AGENTSKILLS_NAME_*`` warnings appear.
+        """
         skill_path = tmp_skill_file(
             "foo",
             content="---\nname: foo\n---\n# Foo\n",
@@ -120,14 +129,22 @@ class TestFromFile:
         spec = SkillSpec.from_file(skill_path, runner=mock_runner())
         assert spec.skill_name == "foo"
         captured = capsys.readouterr()
-        assert captured.err == ""
+        assert "AGENTSKILLS_LAYOUT_LEGACY" in captured.err
+        assert "AGENTSKILLS_NAME_" not in captured.err
 
     def test_from_file_legacy_layout_missing_name_silent(
         self, tmp_skill_file, mock_runner, capsys
     ):
-        """Legacy layout with no frontmatter → falls back to stem
-        silently (DEC-001). This mirrors today's default legacy skill
-        shape (no frontmatter)."""
+        """Legacy layout with no frontmatter → falls back to stem; name
+        path stays silent.
+
+        Per DEC-005 + DEC-003 of ``plans/super/71-agentskills-lint.md``,
+        ``AGENTSKILLS_LAYOUT_LEGACY`` (warning) fires unconditionally,
+        but ``AGENTSKILLS_NAME_MISSING`` is error-severity and the hook
+        filters errors out — so no ``AGENTSKILLS_NAME_*`` warning
+        appears here. This mirrors today's default legacy skill shape
+        (no frontmatter).
+        """
         skill_path = tmp_skill_file(
             "my-skill",
             content="# My Skill\n\nNo frontmatter here.\n",
@@ -136,7 +153,8 @@ class TestFromFile:
         spec = SkillSpec.from_file(skill_path, runner=mock_runner())
         assert spec.skill_name == "my-skill"
         captured = capsys.readouterr()
-        assert captured.err == ""
+        assert "AGENTSKILLS_LAYOUT_LEGACY" in captured.err
+        assert "AGENTSKILLS_NAME_" not in captured.err
 
     def test_init_with_nonexistent_path_uses_layout_fallback(self):
         """Direct ``SkillSpec(...)`` construction with a non-existent path
@@ -153,6 +171,131 @@ class TestFromFile:
         # Legacy fallback: path is <stem>.md.
         spec_legacy = SkillSpec(skill_path=Path("/nonexistent/bar.md"))
         assert spec_legacy.skill_name == "bar"
+
+    # ── Conformance soft-warn hook (US-006; DEC-003, DEC-014) ──────────
+
+    def test_from_file_emits_warning_conformance_to_stderr(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Modern layout + a long body → the hook emits
+        ``AGENTSKILLS_BODY_TOO_LONG`` (warning) with the
+        ``"clauditor.conformance: "`` prefix per DEC-014.
+        """
+        # Body with 501 lines (>500 threshold).
+        long_body = "\n".join(f"line {i}" for i in range(501))
+        content = (
+            "---\n"
+            "name: foo\n"
+            "description: A skill with an overly long body.\n"
+            "---\n"
+            f"{long_body}\n"
+        )
+        skill_path = tmp_skill_file(
+            "foo", content=content, layout="modern"
+        )
+        SkillSpec.from_file(skill_path, runner=mock_runner())
+        captured = capsys.readouterr()
+        assert "clauditor.conformance: AGENTSKILLS_BODY_TOO_LONG" in (
+            captured.err
+        )
+
+    def test_from_file_silent_on_error_conformance(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Modern layout with only error-severity conformance issues (and
+        no warnings) → hook emits nothing. Errors surface via
+        ``clauditor lint``, not via ``SkillSpec.from_file`` (DEC-003).
+        """
+        # Empty `name:` → AGENTSKILLS_NAME_EMPTY (error). No body
+        # issues, no other warnings.
+        content = (
+            "---\n"
+            'name: ""\n'
+            "description: test\n"
+            "---\n"
+            "# Body\n"
+        )
+        skill_path = tmp_skill_file(
+            "foo", content=content, layout="modern"
+        )
+        SkillSpec.from_file(skill_path, runner=mock_runner())
+        captured = capsys.readouterr()
+        assert "clauditor.conformance:" not in captured.err
+
+    def test_from_file_emits_only_warnings_when_mixed(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Modern layout that produces BOTH an error AND a warning → the
+        hook emits only the warning line. DEC-003: errors are silent at
+        this layer.
+        """
+        # Empty `name:` (error) + `allowed-tools` field present
+        # (AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL warning).
+        content = (
+            "---\n"
+            'name: ""\n'
+            "description: test\n"
+            "allowed-tools: Bash(ls)\n"
+            "---\n"
+            "# Body\n"
+        )
+        skill_path = tmp_skill_file(
+            "foo", content=content, layout="modern"
+        )
+        SkillSpec.from_file(skill_path, runner=mock_runner())
+        captured = capsys.readouterr()
+        assert (
+            "clauditor.conformance: AGENTSKILLS_ALLOWED_TOOLS_EXPERIMENTAL"
+            in captured.err
+        )
+        assert "AGENTSKILLS_NAME_EMPTY" not in captured.err
+
+    def test_from_file_does_not_raise_on_malformed_yaml(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """Malformed frontmatter → ``SkillSpec.from_file`` returns without
+        raising. The conformance issue ``AGENTSKILLS_FRONTMATTER_INVALID_YAML``
+        is error-severity, so the hook filters it out and stderr does
+        NOT gain a ``"clauditor.conformance:"`` line from the hook.
+        """
+        # Frontmatter block with an opening ``---`` but no closing
+        # delimiter — parse_frontmatter raises ValueError here.
+        content = (
+            "---\n"
+            "name: foo\n"
+            "description: broken\n"
+            "# body (note: missing closing ---)\n"
+        )
+        skill_path = tmp_skill_file(
+            "foo", content=content, layout="modern"
+        )
+        # Must not raise.
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec is not None
+        captured = capsys.readouterr()
+        assert "clauditor.conformance:" not in captured.err
+
+    def test_from_file_hook_preserves_skill_name(
+        self, tmp_skill_file, mock_runner, capsys
+    ):
+        """A fully-passing modern skill → ``spec.skill_name`` comes from
+        frontmatter ``name:`` and stderr stays empty (no warnings, no
+        errors).
+        """
+        content = (
+            "---\n"
+            "name: foo\n"
+            "description: A well-formed skill.\n"
+            "---\n"
+            "# Foo\n"
+        )
+        skill_path = tmp_skill_file(
+            "foo", content=content, layout="modern"
+        )
+        spec = SkillSpec.from_file(skill_path, runner=mock_runner())
+        assert spec.skill_name == "foo"
+        captured = capsys.readouterr()
+        assert captured.err == ""
 
 
 class TestRun:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -73,11 +73,16 @@ class TestFromFile:
         captured = capsys.readouterr()
         assert captured.err == ""
 
-    def test_from_file_modern_layout_disagreement_warns(
+    def test_from_file_modern_layout_disagreement_silent(
         self, tmp_skill_file, mock_runner, capsys
     ):
         """Modern layout, frontmatter ``name:`` disagrees → frontmatter
-        wins, stderr warning emitted per DEC-002 / DEC-009."""
+        wins (DEC-002). Per DEC-008 of
+        ``plans/super/71-agentskills-lint.md``, ``derive_skill_name`` no
+        longer emits a stderr warning for the mismatch — the equivalent
+        ``AGENTSKILLS_NAME_PARENT_DIR_MISMATCH`` conformance code is
+        routed through US-006's soft-warn hook (out of scope for this
+        test)."""
         skill_path = tmp_skill_file(
             "foo",
             content="---\nname: bar\n---\n# Bar\n",
@@ -86,10 +91,7 @@ class TestFromFile:
         spec = SkillSpec.from_file(skill_path, runner=mock_runner())
         assert spec.skill_name == "bar"
         captured = capsys.readouterr()
-        assert (
-            "frontmatter name 'bar' overrides filesystem name 'foo'"
-            in captured.err
-        )
+        assert "frontmatter name" not in captured.err
 
     def test_from_file_modern_layout_missing_name_silent(
         self, tmp_skill_file, mock_runner, capsys


### PR DESCRIPTION
## Summary

Super plan for #71 — add `clauditor lint`, a static agentskills.io spec conformance check for SKILL.md.

**Phase:** detailing (awaiting approval)
**Decisions:** 14 (DEC-001 through DEC-014)
**Stories:** 8 implementation + Quality Gate + Patterns & Memory

## Plan document

See [`plans/super/71-agentskills-lint.md`](plans/super/71-agentskills-lint.md) for the full plan — Discovery, Architecture Review, Refinement log, and Detailed Breakdown.

## Headline scope

- **New pure module** `src/clauditor/conformance.py` with `ConformanceIssue` + `check_conformance(skill_md_text, skill_path) -> list[ConformanceIssue]`. No I/O, no stderr, no LLM.
- **New CLI command** `clauditor lint <path>` with `--strict` (promote warnings to errors) and `--json` (machine-readable output with `schema_version: 1`).
- **Soft-warn hook** on `SkillSpec.from_file` — emits `severity="warning"` conformance issues to stderr on every skill load, but never blocks. Errors are silent at this layer; they surface through `clauditor lint`.
- **Retire** `derive_skill_name`'s own stderr warnings — consolidate all frontmatter-name warnings through `check_conformance` (single source of truth; no duplicate stderr lines on the same root issue).
- **`KNOWN_CLAUDE_CODE_EXTENSION_KEYS` allowlist** for frontmatter fields Claude Code and agent hosts use but the agentskills.io spec does not define (`argument-hint`, `disable-model-invocation`). Shipped bundled skills stay conformant.
- **Scope extension to #72** ([comment](https://github.com/wjduenow/clauditor/issues/72#issuecomment-4289971205)): the `/review-agentskills-spec` skill now also audits Claude Code's published frontmatter documentation, keeping the allowlist from drifting as Claude Code adds new fields.

## Deferred to follow-up tickets

- `AGENTSKILLS_BODY_TOKEN_BUDGET` (`< 5000 tokens` spec recommendation — needs a tokenizer).
- `--strict` on commands beyond `lint`.
- `eval.json` field to default-strict per skill.
- SHOULD-level description prose-quality checks (`_MISSING_WHEN_CLAUSE`, `_MISSING_KEYWORDS`) — not mechanically verifiable without an LLM judge.

## Next steps

1. Review this plan in the PR.
2. Approve in Claude Code to proceed to devolve (create beads tasks).
3. Ralph runs through US-001 → US-008 → Quality Gate → Patterns & Memory.