### PR TITLE
#77: clauditor badge command (shields.io endpoint JSON)

### DIFF
--- a/.claude/rules/dual-version-external-schema-embed.md
+++ b/.claude/rules/dual-version-external-schema-embed.md
@@ -1,0 +1,226 @@
+# Rule: Embedding a clauditor extension inside an external schema
+
+When clauditor emits JSON that will be consumed by an external
+system's own schema (shields.io endpoint JSON, a future GitHub
+check-run annotation, a package-registry metadata blob, an OpenGraph
+preview payload, ...), the payload carries **two independent
+schema-version fields**:
+
+1. The external system's required schema-version field (e.g.
+   shields.io's top-level `"schemaVersion": 1`) — using **their**
+   name and convention (which is often camelCase even when our
+   codebase uses snake_case).
+2. A clauditor extension block under a dedicated namespace key (e.g.
+   `"clauditor": {...}`), whose **first** key is our internal
+   `"schema_version": 1` per
+   `.claude/rules/json-schema-version.md`.
+
+The two versions bump independently. A future shields.io bump to
+`schemaVersion: 2` does not force a `clauditor.schema_version` bump,
+and vice versa. The external consumer reads their own top-level
+version; a future clauditor-side loader (e.g. a trend-audit consumer)
+reads the nested one.
+
+## The pattern
+
+```python
+# badge.py — canonical dataclass shape
+@dataclass
+class Badge:
+    """Serializable shields.io endpoint-JSON payload."""
+
+    # Shields.io's required fields (their schema):
+    label: str
+    message: str
+    color: str
+    clauditor: ClauditorExtension  # our extension block
+    style_overrides: dict[str, str | int] = field(default_factory=dict)
+
+    # Shields.io's top-level schemaVersion (camelCase per their docs).
+    schema_version: int = _SHIELDS_SCHEMA_VERSION  # == 1
+
+    def to_endpoint_json(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            # 1. External system's required field first.
+            "schemaVersion": self.schema_version,
+            "label": self.label,
+            "message": self.message,
+            "color": self.color,
+        }
+        # Style passthroughs alphabetized between the external keys
+        # and our nested namespace.
+        for key in sorted(self.style_overrides):
+            payload[key] = self.style_overrides[key]
+        # 2. Our extension block — first key inside is
+        # ``schema_version`` (snake_case, our convention).
+        payload["clauditor"] = self.clauditor.to_dict()
+        return payload
+
+
+@dataclass
+class ClauditorExtension:
+    skill_name: str
+    generated_at: str
+    iteration: int | None
+    l1: L1Summary | None
+    l3: L3Summary | None
+    variance: VarianceSummary | None
+    # Our internal version (snake_case), FIRST key in the nested
+    # dict per .claude/rules/json-schema-version.md.
+    schema_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"schema_version": self.schema_version}
+        result["skill_name"] = self.skill_name
+        result["generated_at"] = self.generated_at
+        if self.iteration is not None:
+            result["iteration"] = self.iteration
+        layers: dict[str, Any] = {}
+        if self.l1 is not None:
+            layers["l1"] = self.l1.to_dict()
+        # ... l3, variance conditional ...
+        result["layers"] = layers
+        return result
+```
+
+Resulting JSON:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "clauditor",
+  "message": "8/8 · L3 92%",
+  "color": "brightgreen",
+  "clauditor": {
+    "schema_version": 1,
+    "skill_name": "review-pr",
+    "generated_at": "2026-04-21T14:00:00Z",
+    "iteration": 42,
+    "layers": { "l1": {...}, "l3": {...} }
+  }
+}
+```
+
+## Why this shape
+
+- **Two independent lifecycles.** Shields.io can bump their
+  `schemaVersion` to 2 to change how they parse `message` / `color`;
+  that has nothing to do with whether our aggregation algorithm
+  changed. If we wired the two versions together, every shields.io
+  bump would force a clauditor-side bump even when our block's shape
+  did not change — and vice versa, a clauditor-side rename of a
+  `layers.*` field would confusingly force us to bump their
+  `schemaVersion` too. Separate fields keep the bump signal clean.
+- **Naming follows the OWNER of each field.** The external system
+  defines their field's name, type, and casing. Use theirs literally
+  (`schemaVersion` camelCase for shields.io). Our nested block is
+  ours, so it uses our convention (`schema_version` snake_case per
+  `.claude/rules/json-schema-version.md`). Mixing the two casings in
+  the same payload is not inconsistency — it is fidelity to each
+  schema's ownership.
+- **Clauditor's `schema_version` is FIRST inside the nested block.**
+  Per `.claude/rules/json-schema-version.md`: a human reading the
+  JSON diff sees the version bump immediately. The nested block's
+  first-key discipline survives even though the block itself is not
+  top-level — we own what is inside the namespace.
+- **Any future loader checks the NESTED version, not the
+  external-top-level one.** Clauditor does not read shields.io's
+  `schemaVersion` field when consuming the payload (that version
+  belongs to them). A trend-audit consumer that ever reads badge
+  JSON back in validates `payload["clauditor"]["schema_version"]`
+  against `_BADGE_CLAUDITOR_SCHEMA_VERSION = 1` following the
+  `_check_schema_version` pattern from `src/clauditor/audit.py`.
+  Keep the two checks separate in code.
+- **The extension block goes last in the top-level key order.**
+  Sorted style passthroughs land between the external-required keys
+  and the nested extension, so the nested block is always at the
+  visual bottom of the payload — the "clauditor supplemental"
+  position is unambiguous to someone reading the JSON in a GitHub
+  raw-content view.
+
+## What NOT to do
+
+- Do NOT inline our fields at the top level alongside the external
+  system's fields. A top-level `"clauditor_skill_name"` or
+  `"_clauditor_iteration"` fragments the namespace; the external
+  validator (shields.io in this case) may warn on unknown fields;
+  and future clauditor-side readers must grep for every
+  `"clauditor_*"` prefix. Use ONE namespace key.
+- Do NOT use only one version field. "Just the external one" loses
+  the clauditor-side bump signal — a trend-audit consumer has no
+  way to detect a shape change inside our block. "Just our nested
+  one" means the external validator cannot see the version it
+  requires.
+- Do NOT alias our version to theirs (e.g. copy their
+  `schemaVersion: 1` into `clauditor.schema_version: 1`). The two
+  will silently drift the first time one bumps. Emit them from
+  independent constants (`_SHIELDS_SCHEMA_VERSION = 1` and
+  `_BADGE_CLAUDITOR_SCHEMA_VERSION = 1`, or the dataclass default
+  field on `ClauditorExtension`).
+- Do NOT translate their casing to ours or vice versa. Shields.io's
+  docs say `schemaVersion`; emit that literal key. Do not emit
+  `"schema_version"` at the top level and hope shields.io is
+  lenient — their schema is their contract.
+- Do NOT sort the top-level key order alphabetically. Python 3.7+
+  preserves insertion order, and the order we emit is load-bearing:
+  external-required keys first, our namespace key last (with any
+  passthroughs in between). Alphabetical ordering would put
+  `clauditor` between `color` and `label`, interleaving our
+  namespace with theirs and breaking the visual "supplemental
+  section" convention.
+
+## Canonical implementation
+
+`src/clauditor/badge.py` — the `Badge` dataclass and
+`ClauditorExtension.to_dict`. See DEC-003, DEC-027, DEC-013 in
+`plans/super/77-clauditor-badge.md`. Regression tests:
+
+- `tests/test_badge.py::TestBadgeSerialization::test_top_level_key_order`
+  — verifies shields.io-owned keys precede our namespace.
+- `tests/test_badge.py::TestBadgeSerialization::test_shields_schema_version_is_camelcase`
+  — defends the case-fidelity invariant.
+- `tests/test_badge.py::TestBadgeSerialization::test_clauditor_schema_version_is_first_key`
+  — defends the nested-first-key invariant via
+  `list(result["clauditor"].keys())[0]`.
+
+## When this rule applies
+
+Any future clauditor feature that emits JSON for consumption by an
+external system with its own schema. Plausible future callers:
+
+- A `clauditor check-annotate` command producing GitHub check-run
+  annotations (GitHub's schema + our per-assertion breakdown).
+- A `clauditor export-opengraph` command producing OpenGraph preview
+  metadata for skill catalog pages.
+- A `clauditor publish` / `clauditor package` command emitting
+  package-registry metadata (npm, PyPI, or a hypothetical
+  agentskills.io registry) with a clauditor-provenance block.
+- Any webhook / callback payload we might emit to an external
+  tracker (Linear, Jira) with a clauditor-sourced issue-annotation
+  block.
+
+Apply the full recipe: keep the external system's required fields
+at the top with their own naming, gate our supplement under a
+dedicated namespace key (`"clauditor"` is fine and consistent with
+the badge precedent), carry our nested `schema_version` as the
+first key of that namespace, and emit the two version constants
+from independent sources.
+
+## When this rule does NOT apply
+
+- JSON artifacts that are **clauditor-only** (both writer and
+  reader are clauditor itself) — those use the flat
+  `"schema_version": 1` as first top-level key per
+  `.claude/rules/json-schema-version.md`. Sidecars like
+  `assertions.json`, `grading.json`, `extraction.json`,
+  `variance.json`, `baseline_*.json`, and `benchmark.json` all
+  follow the flat shape; there is no external schema to embed
+  within.
+- JSON artifacts consumed by a **generic JSON parser** (no specific
+  schema at all) — e.g. a debug dump, a REPL-inspection payload.
+  No external top-level version is required; use the flat shape.
+- NDJSON / streaming formats where there is no top-level object to
+  carry a `schemaVersion` on. Each line is its own message; per-line
+  versioning is the responsibility of that format's own design.
+  See `.claude/rules/stream-json-schema.md` for the defensive
+  parser-side pattern in that case.

--- a/.clauditor/badges/clauditor.json
+++ b/.clauditor/badges/clauditor.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "label": "clauditor",
+  "message": "no data",
+  "color": "lightgrey",
+  "clauditor": {
+    "schema_version": 1,
+    "skill_name": "clauditor",
+    "generated_at": "2026-04-22T04:58:56Z",
+    "iteration": null,
+    "layers": {}
+  }
+}

--- a/.clauditor/badges/clauditor.json
+++ b/.clauditor/badges/clauditor.json
@@ -1,13 +1,29 @@
 {
   "schemaVersion": 1,
   "label": "clauditor",
-  "message": "no data",
-  "color": "lightgrey",
+  "message": "2/3 · L3 50%",
+  "color": "red",
   "clauditor": {
     "schema_version": 1,
     "skill_name": "clauditor",
-    "generated_at": "2026-04-22T04:58:56Z",
-    "iteration": null,
-    "layers": {}
+    "generated_at": "2026-04-22T05:09:52Z",
+    "iteration": 2,
+    "layers": {
+      "l1": {
+        "count": 2,
+        "total": 3,
+        "pass_rate": 0.6666666666666666,
+        "passed": false
+      },
+      "l3": {
+        "pass_rate": 0.5,
+        "mean_score": 0.5,
+        "passed": false,
+        "thresholds": {
+          "min_pass_rate": 0.7,
+          "min_mean_score": 0.5
+        }
+      }
+    }
   }
 }

--- a/.clauditor/badges/clauditor.json
+++ b/.clauditor/badges/clauditor.json
@@ -1,24 +1,24 @@
 {
   "schemaVersion": 1,
   "label": "clauditor",
-  "message": "2/3 · L3 50%",
-  "color": "red",
+  "message": "3/3 · L3 100%",
+  "color": "brightgreen",
   "clauditor": {
     "schema_version": 1,
     "skill_name": "clauditor",
-    "generated_at": "2026-04-22T05:09:52Z",
-    "iteration": 2,
+    "generated_at": "2026-04-22T05:33:38Z",
+    "iteration": 3,
     "layers": {
       "l1": {
-        "count": 2,
+        "count": 3,
         "total": 3,
-        "pass_rate": 0.6666666666666666,
-        "passed": false
+        "pass_rate": 1.0,
+        "passed": true
       },
       "l3": {
-        "pass_rate": 0.5,
-        "mean_score": 0.5,
-        "passed": false,
+        "pass_rate": 1.0,
+        "mean_score": 0.935,
+        "passed": true,
         "thresholds": {
           "min_pass_rate": 0.7,
           "min_mean_score": 0.5

--- a/.clauditor/badges/review-agentskills-spec.json
+++ b/.clauditor/badges/review-agentskills-spec.json
@@ -1,13 +1,29 @@
 {
   "schemaVersion": 1,
   "label": "clauditor",
-  "message": "no data",
-  "color": "lightgrey",
+  "message": "5/5 · L3 100%",
+  "color": "brightgreen",
   "clauditor": {
     "schema_version": 1,
     "skill_name": "review-agentskills-spec",
-    "generated_at": "2026-04-22T05:06:04Z",
-    "iteration": null,
-    "layers": {}
+    "generated_at": "2026-04-22T13:59:18Z",
+    "iteration": 4,
+    "layers": {
+      "l1": {
+        "count": 5,
+        "total": 5,
+        "pass_rate": 1.0,
+        "passed": true
+      },
+      "l3": {
+        "pass_rate": 1.0,
+        "mean_score": 0.9700000000000001,
+        "passed": true,
+        "thresholds": {
+          "min_pass_rate": 0.7,
+          "min_mean_score": 0.5
+        }
+      }
+    }
   }
 }

--- a/.clauditor/badges/review-agentskills-spec.json
+++ b/.clauditor/badges/review-agentskills-spec.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "label": "clauditor",
+  "message": "no data",
+  "color": "lightgrey",
+  "clauditor": {
+    "schema_version": 1,
+    "skill_name": "review-agentskills-spec",
+    "generated_at": "2026-04-22T05:06:04Z",
+    "iteration": null,
+    "layers": {}
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.xml
 *.so
 
 # Local-only symlinked skills and agents (not part of this repo)
+.claude/skills/
 .claude/commands/super-plan.md
 .claude/commands/super-plan-team.md
 .claude/commands/chunk.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,15 @@ coverage.xml
 .claude/agents/code-reviewer.md
 .claude/agents/planner.md
 
-# Clauditor local state (history, saved grade reports)
-.clauditor/
+# Clauditor local state (history, saved grade reports) —
+# .clauditor/* (not the directory itself) so /badges/ can be
+# re-included below. Per git-ignore semantics: a directory-level
+# "/clauditor/" exclude prevents children from being re-included,
+# but "/clauditor/*" + an explicit "!" re-include works.
+.clauditor/*
+# Badges ARE committed so shields.io can serve them via
+# raw.githubusercontent.com (per docs/badges.md embedding recipe).
+!.clauditor/badges/
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`clauditor badge` — shields.io endpoint JSON for skill quality (#77).**
+  A non-LLM aggregator that reads the latest (or `--from-iteration N`)
+  iteration sidecars and produces a shields.io-compatible JSON file
+  pasted into a README as a one-line Markdown image. Badge JSON carries
+  a top-level `schemaVersion: 1` (shields.io's contract) and a nested
+  `clauditor.schema_version: 1` extension block (our internal version,
+  per `.claude/rules/json-schema-version.md`).
+  - Positional `<skill-path>` loads via `SkillSpec.from_file` (derives
+    `skill_name` from frontmatter, per
+    `.claude/rules/skill-identity-from-frontmatter.md`).
+  - Default output `.clauditor/badges/<skill>.json`; `--output PATH`
+    accepts absolute paths, `--force` required to overwrite.
+  - `--url-only` prints the Markdown image line to stdout with
+    `git remote get-url origin` + default-branch auto-detection;
+    `--repo USER/REPO [--branch NAME]` overrides; `USER/REPO/main`
+    placeholder with a stderr warning when detection fails.
+  - Color logic: `brightgreen` (L1 all-pass + L3 met or absent),
+    `yellow` (L1 all-pass + L3 below thresholds), `red` (any L1 fail
+    OR L3 all parse-failed), `lightgrey` (no iteration yet OR spec
+    declares zero L1 assertions — both write a "no data" placeholder
+    and exit 0 so CI pipelines have a persistent badge).
+  - `--style KEY=VALUE` (repeatable) passes shields.io fields through:
+    `style`, `logoSvg`, `logoColor`, `labelColor`, `cacheSeconds`,
+    `link`. Unknown keys warn but still emit (shields.io ignores).
+  - Exit codes 0 / 1 / 2 per
+    `.claude/rules/llm-cli-exit-code-taxonomy.md` (non-LLM branch):
+    0 success, 1 runtime failure (corrupt iteration, collision without
+    `--force`, explicit-missing iteration), 2 input validation (mutual
+    exclusion, bad `--output` parent, bad `--style`, bad `--label`).
+  - Pure compute lives in `src/clauditor/badge.py` per
+    `.claude/rules/pure-compute-vs-io-split.md`; CLI I/O lives in
+    `src/clauditor/cli/badge.py`; git metadata wrapper in
+    `src/clauditor/_git.py`.
+  - See [`docs/badges.md`](docs/badges.md) for the full placement
+    guide (README primary, catalog-page secondary, SKILL.md body
+    tradeoff) and the CI embedding recipe.
+
 - **`clauditor lint` — agentskills.io spec conformance check (#71).** A
   non-LLM static check that validates a `SKILL.md` file against the
   [agentskills.io specification](https://agentskills.io/specification).

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ clauditor validate <skill.md>         # Layer 1 assertions
 clauditor grade <skill.md>            # Layer 3 quality grading
 clauditor compare --skill <s> --from 1 --to 2  # Diff iterations
 clauditor trend <skill> --metric total.total   # History + sparkline
+clauditor badge <skill.md>            # Shields.io endpoint JSON for README embed
 ```
 
 **Covered in the full reference:** every subcommand flag (`--variance`, `--iteration`, `--diff`, …), exit codes, `history.jsonl` shape, `clauditor trend` metric paths. Full reference: [docs/cli-reference.md](docs/cli-reference.md).
@@ -167,6 +168,7 @@ clauditor implements (and extends) the workflow at [agentskills.io/skill-creatio
 - [`docs/eval-spec-reference.md`](docs/eval-spec-reference.md) — complete `.eval.json` schema
 - [`docs/pytest-plugin.md`](docs/pytest-plugin.md) — pytest fixtures and options
 - [`docs/skill-usage.md`](docs/skill-usage.md) — using `/clauditor` in Claude Code
+- [`docs/badges.md`](docs/badges.md) — shields.io badges from iteration sidecars (`clauditor badge`)
 - [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — `claude` stream-json parser contract
 - [`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood) — maintainer pre-release dogfood gate + contribution workflow
 

--- a/docs/badges.md
+++ b/docs/badges.md
@@ -1,0 +1,136 @@
+# Badges for clauditor skills
+
+Placement guidance, color-logic reference, and embedding recipe for the quality badge `clauditor badge` generates from a skill's latest iteration sidecars. Read this when you want a one-glance quality signal next to a skill in your README, a skill-catalog page, or (with tradeoffs) the SKILL.md body itself. For the CLI flag surface, see [cli-reference.md#badge](cli-reference.md#badge).
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a summary with code examples.
+
+## Why a badge
+
+A shields.io badge compresses L1 pass rate + L3 quality + (optional) variance stability into a single SVG next to the skill link. CI pipelines that already run `clauditor grade` on every commit regenerate `.clauditor/badges/<skill>.json` for free; the rendered badge then stays live without any extra hosting, SVG-generation, or PR-comment plumbing. A reader scanning a repo sees at a glance which skills pass their gate, which are yellow (L1 clean but L3 below threshold), and which are red.
+
+## The shields.io endpoint pattern
+
+`clauditor badge` writes a JSON file; [shields.io](https://shields.io) renders the SVG on demand from that JSON. The image URL is constant — it only needs to be pasted once, into whatever page hosts the badge. Each run of `clauditor badge` updates the JSON content in place, and the next time the page is loaded shields.io re-fetches the JSON and re-renders the SVG.
+
+The net effect: one Markdown image line, no hosting, no action-bot commits beyond the JSON file itself.
+
+## Placement hierarchy
+
+clauditor supports three placement strategies. Pick the one that matches where your users encounter the skill.
+
+### 1. Primary — README next to the skill link
+
+The default. A skill listed in the project README's catalog table or feature section gets its badge embedded directly next to the link. Humans browsing the repo see the signal immediately, and the badge stays visible to anyone who never runs the skill.
+
+```markdown
+- [`my-skill`](.claude/skills/my-skill/SKILL.md) — one-line summary ![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/USER/REPO/main/.clauditor/badges/my-skill.json)
+```
+
+Generate that exact line with `clauditor badge <skill.md> --url-only` (auto-detects repo + branch; see [Embedding recipe](#embedding-recipe-url-only) below).
+
+### 2. Secondary — dedicated `docs/skills.md` catalog page
+
+When the project ships many skills, a dedicated catalog page (`docs/skills.md`, or similar) with a table of skills + per-row badges gives a single-pane quality view. This is the right placement when you want a maintainer-facing dashboard that the README does not need to carry.
+
+```markdown
+| Skill | Purpose | Quality |
+| ----- | ------- | ------- |
+| [`my-skill`](../.claude/skills/my-skill/SKILL.md) | Find restaurants | ![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/USER/REPO/main/.clauditor/badges/my-skill.json) |
+| [`other-skill`](../.claude/skills/other-skill/SKILL.md) | Draft PR descriptions | ![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/USER/REPO/main/.clauditor/badges/other-skill.json) |
+```
+
+### 3. Tradeoff — SKILL.md body embedding
+
+Technically supported — a SKILL.md is just Markdown, so a badge image line renders fine. But Claude Code loads SKILL.md bodies **into agent context** when the skill is invoked. An image line in the body costs tokens on every skill run for zero agent utility (the agent does not render the image, and the badge's color/message is not operational information the agent needs).
+
+Only put the badge in SKILL.md if:
+
+- The skill is the only thing in its repo (no README to host the badge), AND
+- You accept the per-run token cost on every invocation.
+
+Otherwise prefer the README or catalog-page placement.
+
+## Color logic
+
+The badge color summarizes the combined L1 + L3 signal. The message surfaces the underlying counts. `clauditor badge` classifies per this table (DEC-007, DEC-009, DEC-020, DEC-024 of `plans/super/77-clauditor-badge.md`):
+
+| Situation | Color | Message |
+| --------- | ----- | ------- |
+| L1 all pass + L3 passed, OR L1 all pass + L3 absent | `brightgreen` | `N/M` or `N/M · L3 XX%` |
+| L1 all pass + L3 below thresholds | `yellow` | `N/M · L3 XX%` |
+| Any L1 assertion failed | `red` | `N/M` |
+| L1 all pass + L3 present but all results parse-failed | `red` | `N/M` (L3 fragment omitted) |
+| No iteration exists, OR iteration exists but spec declares zero L1 assertions | `lightgrey` | `no data` |
+
+When a `variance.json` sidecar is present, the message gains a `· XX% stable` tail (e.g. `8/8 · L3 92% · 80% stable`). The variance layer is optional and degrades gracefully when the sidecar is absent (today's steady state — no `variance.json` writer ships yet).
+
+L3 `passed` is evaluated against the `thresholds` block the grading run itself already persisted to `grading.json` — the badge does not re-interpret `EvalSpec.grade_thresholds` (DEC-004). Whatever threshold was in force at grade time is the source of truth.
+
+## Embedding recipe (`--url-only`)
+
+The fastest way to get the exact Markdown image line for your README:
+
+```bash
+clauditor badge .claude/skills/my-skill/SKILL.md --url-only
+```
+
+Output:
+
+```markdown
+![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/USER/REPO/main/.clauditor/badges/my-skill.json)
+```
+
+clauditor auto-detects the repo slug (from `git remote get-url origin`) and the default branch (from `git symbolic-ref refs/remotes/origin/HEAD`). When auto-detection fails it falls back to the literal placeholder `USER/REPO/main` with a stderr warning so the next paste is obvious. Override either with `--repo USER/REPO` or `--branch NAME`:
+
+```bash
+clauditor badge .claude/skills/my-skill/SKILL.md --url-only \
+  --repo my-org/my-skills --branch release
+```
+
+## CI integration
+
+A typical pipeline runs `clauditor grade` on every commit to keep the iteration-N sidecars fresh, then `clauditor badge` to regenerate the JSON. Commit the regenerated `.clauditor/badges/<skill>.json` back to a branch that shields.io can fetch (usually your default branch; or a `badges` branch dedicated to the rendered JSON). Alternatives that avoid pushing commits back to the default branch:
+
+- Publish the JSON to GitHub Pages (`--output PATH` accepts absolute paths for this case; DEC-005).
+- Use [`schneegans/dynamic-badges-action`](https://github.com/schneegans/dynamic-badges-action) to write the JSON into a gist shields.io already knows how to read.
+
+A first-class `clauditor-action@v1` GitHub Action that wires this up end-to-end is a future ticket (listed as "optional phase 2" on issue #77); for now, wire `clauditor badge` into your existing CI as any other post-grade step.
+
+## Schema reference
+
+The badge JSON carries **two** independent schema versions (DEC-027):
+
+- **Top-level `schemaVersion`** — shields.io's own endpoint contract (camelCase, per their docs). Currently `1`. First top-level key.
+- **Nested `clauditor.schema_version`** — our extension-block contract (snake_case, per `.claude/rules/json-schema-version.md`). Currently `1`. First key of the `clauditor` block.
+
+They bump independently — a future shields.io schema revision does not force a clauditor bump and vice versa.
+
+Sample output (no variance sidecar present; the `layers.variance` block is omitted entirely per DEC-003):
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "clauditor",
+  "message": "8/8 · L3 92%",
+  "color": "brightgreen",
+  "clauditor": {
+    "schema_version": 1,
+    "skill_name": "my-skill",
+    "generated_at": "2026-04-21T14:00:00Z",
+    "iteration": 4,
+    "layers": {
+      "l1": {"count": 8, "total": 8, "pass_rate": 1.0, "passed": true},
+      "l3": {
+        "pass_rate": 0.92,
+        "mean_score": 0.85,
+        "passed": true,
+        "thresholds": {"min_pass_rate": 0.7, "min_mean_score": 0.5}
+      }
+    }
+  }
+}
+```
+
+L1 and L3 both carry a `passed: bool` field with **different semantics** (DEC-010): L1 `passed = true` means "every declared assertion passed"; L3 `passed = true` means "pass rate ≥ `min_pass_rate` AND mean score ≥ `min_mean_score`" (the grade met the thresholds the grading run used). The dataclass docstrings in `src/clauditor/badge.py` are the authoritative reference for each field.
+
+For the complete list of pure helpers that compose this payload, see [`src/clauditor/badge.py`](../src/clauditor/badge.py) (`compute_badge`, `Badge`, `ClauditorExtension`, `L1Summary`, `L3Summary`, `VarianceSummary`).

--- a/docs/badges.md
+++ b/docs/badges.md
@@ -30,7 +30,7 @@ Generate that exact line with `clauditor badge <skill.md> --url-only` (auto-dete
 
 ### 2. Secondary — dedicated `docs/skills.md` catalog page
 
-When the project ships many skills, a dedicated catalog page (`docs/skills.md`, or similar) with a table of skills + per-row badges gives a single-pane quality view. This is the right placement when you want a maintainer-facing dashboard that the README does not need to carry.
+When the project ships many skills, a dedicated catalog page (`docs/skills.md`, or similar) with a table of skills + per-row badges gives a single-pane quality view. This is the right placement when you want a maintainer-facing dashboard that the README does not need to carry. This repo ships one itself — see [docs/skills.md](./skills.md).
 
 ```markdown
 | Skill | Purpose | Quality |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,6 +31,7 @@ clauditor capture <skill> -- "args"    # Run skill, save stdout to tests/eval/ca
 clauditor audit <skill>                # Aggregate per-assertion pass rates across iterations
 clauditor suggest <skill.md>           # Propose SKILL.md edits from prior failing iterations
 clauditor propose-eval <skill.md>      # LLM-assisted EvalSpec bootstrap (SKILL.md + optional capture)
+clauditor badge <skill.md>             # Shields.io endpoint JSON from latest iteration sidecars
 clauditor setup                        # Install the bundled /clauditor slash command symlink
 clauditor doctor                       # Report environment diagnostics
 ```
@@ -155,6 +156,60 @@ Captured skill output is scrubbed through `clauditor.transcripts.redact` before 
 - `clauditor init` writes a **skill stub** (`SKILL.md` + starter `eval.json`) for a brand-new skill. Use it first when the skill itself does not yet exist.
 - `clauditor propose-eval` fills in an `eval.json` for a skill whose **SKILL.md already exists**. It does not write a skill stub and does not regenerate SKILL.md.
 - `clauditor capture <skill> -- "args"` produces the captured run that `propose-eval` reads as grounding context. Capturing before `propose-eval` typically lifts the quality of the generated spec (the proposer sees what real output looks like).
+
+## badge
+
+Generate a [shields.io](https://shields.io)-compatible endpoint JSON from a skill's latest iteration sidecars. `clauditor badge <skill.md>` reads the most recent `.clauditor/iteration-N/<skill>/assertions.json` (L1) and, when present, `grading.json` (L3) / `variance.json`, classifies color and message per the project's rules, and writes the result to `.clauditor/badges/<skill>.json` (or a path passed to `--output`). Point any shields.io endpoint URL at the raw JSON and the rendered SVG updates whenever the JSON changes.
+
+The command is a **read-only aggregator** — it does NOT run the skill and does NOT call Anthropic. Run `clauditor validate` (for L1 coverage) and `clauditor grade` (for L3 coverage) first; the badge surfaces whatever those iterations already produced. When no iteration exists, the command writes a `lightgrey` "no data" placeholder and exits 0 (DEC-001), so CI pipelines that always run `clauditor badge` keep a persistent placeholder even before the first grade.
+
+### Required inputs
+
+- `<skill_md>` (positional) — path to the SKILL.md file. The skill name is derived via the same `skill-identity-from-frontmatter` helper `clauditor validate` and `clauditor grade` use, so the iteration lookup matches what those commands wrote.
+
+### Flags
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--from-iteration N` | latest | Read sidecars from `.clauditor/iteration-N/<skill>/` instead of the latest. N must be a positive integer. A missing N exits 1 with the available-iterations list on stderr (DEC-016). |
+| `--output PATH` | `.clauditor/badges/<skill>.json` | Write the badge JSON to PATH. Absolute paths are accepted (DEC-005 — common for GitHub Pages dirs outside the repo). Parent directory must already exist (DEC-022). Mutually exclusive with `--url-only`. |
+| `--url-only` | off | Print the Markdown image line to stdout instead of writing JSON. Mutually exclusive with `--output`. |
+| `--force` | off | Overwrite an existing badge JSON file. Without it, a collision exits 1 (DEC-011). The DEC-001 lightgrey placeholder write honors `--force` too — it does not silently clobber a "real" badge. |
+| `--repo USER/REPO` | git auto-detect | Override the origin-slug auto-detect used by `--url-only` (DEC-002). Falls back to the literal placeholder `USER/REPO` with a stderr warning when auto-detect fails and no override is supplied. |
+| `--branch NAME` | git auto-detect | Override the default-branch auto-detect used by `--url-only` (DEC-002). Falls back to `main` with a stderr warning when auto-detect fails. |
+| `--label TEXT` | `"clauditor"` | Shields.io badge label text (the left side of the rendered SVG). |
+| `--style KEY=VALUE` | none | Shields.io style passthrough; repeatable. Whitelist: `style`, `logoSvg`, `logoColor`, `labelColor`, `cacheSeconds`, `link` (DEC-015). Unknown keys emit a stderr warning but still land in the JSON (shields.io silently ignores what it does not know). Values are rejected on control characters or length >512 (DEC-023). |
+| `-v, --verbose` | off | On success, print a stderr info line naming the written path and iteration (`clauditor.badge: wrote <path> (iteration N)`) per DEC-018. |
+
+### Examples
+
+```bash
+# Basic: populate an iteration first, then generate the badge JSON.
+clauditor grade .claude/skills/my-skill/SKILL.md
+clauditor badge .claude/skills/my-skill/SKILL.md
+# → writes .clauditor/badges/my-skill.json (brightgreen "8/8 · L3 92%")
+
+# --url-only: get a Markdown image line for pasting into a README.
+clauditor badge .claude/skills/my-skill/SKILL.md --url-only
+# → ![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/USER/REPO/main/.clauditor/badges/my-skill.json)
+
+# Advanced: shields.io style passthrough, custom label, force-overwrite.
+clauditor badge .claude/skills/my-skill/SKILL.md \
+  --style cacheSeconds=300 --style style=flat-square \
+  --label "my skill" --force
+```
+
+### Exit codes
+
+Non-LLM 0/1/2 taxonomy per `.claude/rules/llm-cli-exit-code-taxonomy.md` (the "does not apply" clause — no Anthropic call, so no exit 3):
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success. Badge JSON written or `--url-only` Markdown image line printed. The DEC-001 / DEC-007 lightgrey placeholder writes (no iteration found, or iteration present but spec declares zero L1 assertions) also return 0. |
+| `1` | Runtime failure. Corrupt iteration — iteration dir exists but `assertions.json` is missing (DEC-008). Existing badge JSON without `--force` (DEC-011). `--from-iteration N` referring to a missing iteration (DEC-016). OS-level disk I/O error on write. |
+| `2` | Input-validation failure. Mutually exclusive `--url-only` + `--output` both passed (DEC-014). `--output` parent dir does not exist (DEC-022). `--style` malformed (missing `=`, empty key) or value rejected (control characters / length >512) (DEC-015, DEC-023). Skill path missing, not a regular file, or `SkillSpec.from_file` fails to load. |
+
+See also [docs/badges.md](./badges.md) for placement guidance (README vs SKILL.md vs catalog page), the full color-logic table, and a CI integration stub.
 
 ## Shared runner flags (`validate`, `grade`, `capture`, `run`)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -177,8 +177,8 @@ The command is a **read-only aggregator** — it does NOT run the skill and does
 | `--force` | off | Overwrite an existing badge JSON file. Without it, a collision exits 1 (DEC-011). The DEC-001 lightgrey placeholder write honors `--force` too — it does not silently clobber a "real" badge. |
 | `--repo USER/REPO` | git auto-detect | Override the origin-slug auto-detect used by `--url-only` (DEC-002). Falls back to the literal placeholder `USER/REPO` with a stderr warning when auto-detect fails and no override is supplied. |
 | `--branch NAME` | git auto-detect | Override the default-branch auto-detect used by `--url-only` (DEC-002). Falls back to `main` with a stderr warning when auto-detect fails. |
-| `--label TEXT` | `"clauditor"` | Shields.io badge label text (the left side of the rendered SVG). |
-| `--style KEY=VALUE` | none | Shields.io style passthrough; repeatable. Whitelist: `style`, `logoSvg`, `logoColor`, `labelColor`, `cacheSeconds`, `link` (DEC-015). Unknown keys emit a stderr warning but still land in the JSON (shields.io silently ignores what it does not know). Values are rejected on control characters or length >512 (DEC-023). |
+| `--label TEXT` | `"clauditor"` | Shields.io badge label text (the left side of the rendered SVG). Rejects `[`, `]`, `(`, `)`, and newlines (would break the Markdown `![alt](url)` syntax) and empty/whitespace values with exit 2. |
+| `--style KEY=VALUE` | none | Shields.io style passthrough; repeatable. Whitelist: `style`, `logoSvg`, `logoColor`, `labelColor`, `cacheSeconds`, `link` (DEC-015). Unknown keys emit a stderr warning but still land in the JSON (shields.io silently ignores what it does not know). Values are rejected on control characters or length >512 (DEC-023). `cacheSeconds` is coerced to `int`; non-numeric input exits 2. |
 | `-v, --verbose` | off | On success, print a stderr info line naming the written path and iteration (`clauditor.badge: wrote <path> (iteration N)`) per DEC-018. |
 
 ### Examples

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,84 @@
+# Skills catalog
+
+Catalog of skills shipped with this repository, with live [clauditor
+badge](./badges.md) status next to each entry. Each badge reflects
+the skill's most recent iteration data on the `dev` branch; the URL
+is constant, so the image updates automatically when CI re-runs
+`clauditor grade` + `clauditor badge` and commits the refreshed
+`.clauditor/badges/<skill>.json` artifact.
+
+> Returning from the [root README](../README.md). This doc is the
+> secondary placement for badges — per the
+> [placement hierarchy](./badges.md#placement-hierarchy), a catalog
+> page is the canonical one-glance view when the repo ships multiple
+> skills. For the full placement guide, the color-logic table, and
+> the embedding recipe, see [docs/badges.md](./badges.md).
+
+## How this catalog is populated
+
+1. Each skill lives under `src/clauditor/skills/<name>/SKILL.md`.
+2. `clauditor grade src/clauditor/skills/<name>/SKILL.md` produces
+   the iteration sidecars under `.clauditor/iteration-N/<name>/`.
+3. `clauditor badge src/clauditor/skills/<name>/SKILL.md` aggregates
+   those sidecars into `.clauditor/badges/<name>.json`, which is
+   committed so shields.io can fetch it via
+   `raw.githubusercontent.com`.
+4. This page's badges point at those JSON files via the shields.io
+   `endpoint` pattern — one Markdown image per skill.
+
+Adding a new skill? Run `clauditor badge src/clauditor/skills/<new>/
+SKILL.md --url-only --repo wjduenow/clauditor --branch dev` to get
+a ready-to-paste image line, then add a row below.
+
+## Skills
+
+### `/clauditor`
+
+![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/wjduenow/clauditor/dev/.clauditor/badges/clauditor.json)
+
+The bundled Claude Code skill for the clauditor workflow itself —
+activates when a user's prompt mentions quality-testing or grading
+a Claude Code skill. Walks the author through `clauditor validate`
+(L1) and `clauditor grade` (L3), and can propose an eval spec via
+`clauditor propose-eval` when one is missing.
+
+Source: [`src/clauditor/skills/clauditor/SKILL.md`](../src/clauditor/skills/clauditor/SKILL.md) · Eval: [`clauditor.eval.json`](../src/clauditor/skills/clauditor/assets/clauditor.eval.json)
+
+The eval spec is maintainer-only — `test_args` references
+`.claude/commands/chunk.md` in this repo's dev-local tree — so the
+badge's live metadata comes from CI runs against that fixture
+rather than from a user's project. The badge currently shows
+`lightgrey · no data` because no iteration exists on the
+`dev` branch yet; the first CI run of `clauditor grade` on the
+bundled skill will populate real L1/L3 scores.
+
+## Interpreting a badge
+
+| Color | Meaning |
+|---|---|
+| `brightgreen` | L1 assertions all pass; L3 grade met thresholds (or L3 not declared). |
+| `yellow` | L1 all pass but L3 fell below the declared pass-rate / mean-score threshold. |
+| `red` | Any L1 assertion failed, or L3 grading produced no scorable results. |
+| `lightgrey` | No iteration has been recorded yet for this skill, or the eval spec declares zero L1 assertions. Run `clauditor grade` to populate. |
+
+See [`docs/badges.md#color-logic`](./badges.md#color-logic) for the
+full decision table, including the DEC-007 "zero L1 assertions"
+edge case and the DEC-009 "L3 all parse-failed → red" branch.
+
+## Regenerating a badge locally
+
+```bash
+# Produce the sidecars (spends Anthropic tokens via `claude -p`).
+clauditor grade src/clauditor/skills/clauditor/SKILL.md
+
+# Aggregate the latest iteration into the badge JSON.
+clauditor badge src/clauditor/skills/clauditor/SKILL.md
+
+# Commit the regenerated artifact so shields.io re-fetches.
+git add .clauditor/badges/clauditor.json
+git commit -m "Refresh clauditor badge"
+```
+
+Or bundle the two steps into a CI workflow — see
+[`docs/badges.md#ci-integration`](./badges.md#ci-integration) for
+the pattern.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -30,7 +30,7 @@ Adding a new skill? Run `clauditor badge src/clauditor/skills/<new>/
 SKILL.md --url-only --repo wjduenow/clauditor --branch dev` to get
 a ready-to-paste image line, then add a row below.
 
-## Skills
+## User-facing skills
 
 ### `/clauditor`
 
@@ -51,6 +51,33 @@ rather than from a user's project. The badge currently shows
 `lightgrey · no data` because no iteration exists on the
 `dev` branch yet; the first CI run of `clauditor grade` on the
 bundled skill will populate real L1/L3 scores.
+
+## Internal skills (maintainer-only)
+
+> These skills are bundled with the repo but are **not** exposed via
+> `clauditor setup` and are **not** intended for end-user invocation.
+> They exist for clauditor's own release workflow and development
+> dogfooding. Listed here so maintainers have a one-glance quality
+> view alongside the user-facing catalog above.
+
+### `/review-agentskills-spec`
+
+![review-agentskills-spec](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/wjduenow/clauditor/dev/.clauditor/badges/review-agentskills-spec.json)
+
+Live audit of the [agentskills.io specification](https://agentskills.io/specification)
+— fetches the current spec text, diffs it against clauditor's
+internal conformance assumptions (encoded in
+`src/clauditor/conformance.py`), and reports deltas. Run this when
+the spec is suspected to have shifted so `clauditor lint` can be
+updated in lockstep.
+
+Source: [`src/clauditor/skills/review-agentskills-spec/SKILL.md`](../src/clauditor/skills/review-agentskills-spec/SKILL.md) · Eval: [`review-agentskills-spec.eval.json`](../src/clauditor/skills/review-agentskills-spec/assets/review-agentskills-spec.eval.json)
+
+Excluded from `clauditor setup`'s install symlinks so it does not
+appear in a user's `/` slash-command menu. Maintainers invoke it
+via the direct-path live-runner pattern — see
+[`.claude/rules/internal-skill-live-test-tmp-symlink.md`](../.claude/rules/internal-skill-live-test-tmp-symlink.md)
+for the testing contract.
 
 ## Interpreting a badge
 

--- a/plans/super/77-clauditor-badge.md
+++ b/plans/super/77-clauditor-badge.md
@@ -1,0 +1,1208 @@
+# Super Plan: #77 — `clauditor badge` command (shields.io endpoint JSON)
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/77
+- **Branch:** `feature/77-clauditor-badge`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/77-clauditor-badge`
+- **Phase:** `detailing`
+- **Sessions:** 1
+- **Last session:** 2026-04-21
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** A new `clauditor badge <skill-path> [options]` CLI subcommand
+that generates a shields.io-compatible JSON endpoint file from a
+skill's latest (or `--from-iteration N`) iteration sidecars.
+Shields.io renders the SVG from the JSON; users embed a single
+Markdown image line (the URL is constant; only the JSON content
+updates per CI run).
+
+**Why:** Teams publishing skills want a one-glance quality signal
+next to the skill in their README (or in a skill catalog page).
+Per-run scores clauditor already computes (`AssertionSet.pass_rate`,
+`GradingReport.pass_rate` + `mean_score` + threshold-based `passed`,
+optional `VarianceReport.stability`) are exactly the data a badge
+needs. The shields.io endpoint pattern is the cheapest path — no SVG
+rendering, no hosting, no PR comment plumbing.
+
+**Done when:**
+- `clauditor badge src/skills/<name>/SKILL.md` writes a
+  shields.io-compatible JSON file under
+  `.clauditor/badges/<skill>.json` (default) with top-level
+  `schemaVersion`, `label`, `message`, `color` + a nested
+  `clauditor:` extension block carrying full state.
+- Color and message reflect L1 + L3 + (optional) variance results
+  per the ticket's table.
+- `--url-only` prints a README-ready Markdown image line and exits
+  without writing JSON.
+- `--from-iteration N` selects a specific iteration.
+- `--output PATH`, `--label TEXT`, `--style KEY=VALUE` (repeatable)
+  pass-throughs land.
+- Exit codes follow the project convention (0 success, 1 load-time
+  failure / missing sidecar, 2 input validation).
+- `ruff` passes; coverage stays ≥80%; no new lint suppressions.
+
+### Key findings — codebase scout
+
+#### Sidecar sources (already persisted, already versioned)
+
+- **`.clauditor/iteration-N/<skill>/assertions.json`** — L1.
+  Structure holds `results: [...]`, `input_tokens`, `output_tokens`
+  and carries `schema_version: 1`. Aggregates via
+  `AssertionSet.pass_rate` (`sum(passed) / len(results)`) and
+  `AssertionSet.passed` (`all(passed)`) — see
+  `src/clauditor/assertions.py` lines 78–132.
+- **`.clauditor/iteration-N/<skill>/grading.json`** — L3.
+  `GradingReport.pass_rate`, `.mean_score`, `.thresholds` (the
+  `GradeThresholds{min_pass_rate, min_mean_score}` dataclass defined
+  in `src/clauditor/schemas.py` lines 199–203, defaults 0.7 / 0.5),
+  and `.passed` (pass_rate ≥ min_pass_rate AND mean_score ≥
+  min_mean_score). Defined in
+  `src/clauditor/quality_grader.py` lines 52–159.
+- **`.clauditor/iteration-N/<skill>/extraction.json`** — L2. Not
+  consumed by the badge in v1 (see ticket open question #3).
+- **Variance sidecar**: NOT currently written anywhere. The codebase
+  scout verified `VarianceConfig` exists on `EvalSpec` but no
+  `variance.json` writer ships today. The ticket's variance layer
+  assumes a sidecar that does not yet exist.
+
+#### Iteration discovery helper
+
+`src/clauditor/audit.py::load_iterations` walks
+`.clauditor/iteration-N/` dirs (discovered by `_scan_iteration_dirs`,
+sorted descending by iteration number), reads each sidecar via
+`_read_json` (returns `None` on missing / parse error), checks
+`_check_schema_version` before consuming. Pattern for "latest
+iteration for skill X": call `_scan_iteration_dirs` and find the
+highest N where `iteration-N/<skill>/` exists. Per-sidecar loaders
+(`_records_from_assertions`, `_records_from_extraction`,
+`_records_from_grading`) are the closest reference for safe
+dict → dataclass conversion.
+
+#### Closest pure-compute-vs-I/O anchors
+
+- `src/clauditor/baseline.py::compute_baseline` — pure function taking
+  pre-run result dataclasses, returns `BaselineReports` with
+  `.to_json_map()` → `{filename: json_str}`. Best structural match
+  for "compute an aggregate dataclass from sidecars + serialize".
+- `src/clauditor/benchmark.py::compute_benchmark` — pure aggregator
+  returning a `Benchmark` dataclass with `.to_json()` (schema_version
+  first). Shows the schema-version-first-key discipline.
+- `src/clauditor/setup.py::plan_setup` — pure decision function
+  returning an enum for the CLI layer to dispatch on. Not a data
+  aggregator, but demonstrates the pure-helper shape for a CLI-only
+  feature.
+
+#### CLI command recipe
+
+Every subcommand under `src/clauditor/cli/` exposes two symbols:
+
+```python
+def add_parser(subparsers: argparse._SubParsersAction) -> None: ...
+def cmd_<name>(args: argparse.Namespace) -> int: ...
+```
+
+Dispatcher wiring lives in `src/clauditor/cli/__init__.py::main`:
+lazy-import the module, call `<mod>.add_parser(subparsers)` before
+`args = parser.parse_args()`, and add an `elif parsed.command ==
+"<name>": return cmd_<name>(parsed)` branch in the dispatch block.
+`cmd_*` returns the exit code; stderr-facing errors use `print(...,
+file=sys.stderr)`.
+
+#### Existing test shape to mirror
+
+- `tests/test_benchmark.py::TestComputeBenchmark` — pure-helper tests
+  with dataclass fixtures, no `tmp_path`, no mocks.
+- `tests/test_baseline.py::TestComputeBaseline` — same shape, with
+  async-grader mocks since `compute_baseline` awaits.
+- CLI integration: `tests/test_cli_suggest.py` style — `capsys` for
+  stdout/stderr, `tmp_path` for output path fixtures.
+
+### Key findings — convention checker (rules that apply)
+
+All `.claude/rules/*.md` files were read. Rule constraints that
+apply to this feature:
+
+1. **`json-schema-version.md`** — The badge JSON has TWO version
+   fields:
+   - Top-level `schemaVersion: 1` (shields.io's schema — required by
+     them, not us).
+   - Nested `clauditor.schema_version: 1` (our extension block).
+   The nested version follows the project's discipline: first key of
+   the `clauditor:` block; any future bump requires matching loader
+   logic. No loader exists yet for the badge JSON (we only write it),
+   but a future `clauditor badge --read` or trend-audit consumer
+   would follow `_check_schema_version`.
+2. **`pure-compute-vs-io-split.md`** — `src/clauditor/badge.py` is
+   the pure module (`compute_badge(...)` takes pre-parsed dicts,
+   returns a `Badge` dataclass with `to_endpoint_json()`).
+   `src/clauditor/cli/badge.py` owns all I/O (sidecar reads, output
+   writes, stderr printing, exit-code mapping).
+3. **`llm-cli-exit-code-taxonomy.md`** — Badge makes NO LLM call, so
+   use the simpler 0/1/2 taxonomy (not 0/1/2/3). Exit 0 on success,
+   1 on load-time / parse-layer / disk failure, 2 on input
+   validation. No `api_error` field, no `AnthropicHelperError` path.
+4. **`path-validation.md`** — If `--output` accepts a user-provided
+   path, validate via the existing recipe (non-empty string, not
+   absolute OR allow absolute explicitly — decision point, flagged
+   as Q5 below, `resolve(strict=False)` because the output path may
+   not exist yet, `is_file()` is wrong since we're writing not
+   reading).
+5. **`in-memory-dict-loader-path.md`** — Sidecars are already
+   finalized on disk; `compute_badge` accepts parsed `dict`s, not
+   file paths. No `from_dict`/`from_file` split needed (sidecars are
+   clauditor-owned, not LLM-proposed).
+6. **`constant-with-type-info.md`** — The color-logic table is a
+   fixed map from classification → color string. If a dataclass
+   constant emerges (e.g., `BadgeStatus` with typed fields), declare
+   `field_types` per the rule; for a flat string-valued constant the
+   rule is lighter-weight.
+7. **`skill-identity-from-frontmatter.md`** — The skill argument is
+   a SKILL.md path; pass through `SkillSpec.from_file` (which already
+   uses `derive_skill_name`) to get the `skill_name`. Do not
+   re-implement frontmatter parsing.
+8. **`project-root-home-exclusion.md`** — N/A if the CLI argument
+   provides an explicit skill path. Relevant only if we add a
+   default "discover project root" behavior (which we are NOT, in
+   v1).
+9. **`sidecar-during-staging.md`** — Badge reads *finalized*
+   iterations; the badge JSON output lives outside the iteration
+   tree (at `.clauditor/badges/<skill>.json`), so staging discipline
+   does not apply to the output. Reads of iteration sidecars happen
+   after `workspace.finalize()` has already renamed the iteration.
+10. **`readme-promotion-recipe.md`** — Badge docs may grow enough to
+    promote to `docs/badge-reference.md`. The root README teaser
+    (D2 lean) + `docs/badges.md` or `docs/badge-reference.md` full
+    reference pattern applies.
+11. **`bundled-skill-docs-sync.md`** — Unlikely to apply in v1; the
+    bundled `/clauditor` SKILL.md does not currently invoke `badge`
+    as a workflow step. If a future PR teaches the skill to run
+    `clauditor badge` after `grade`, the three-way sync (SKILL.md +
+    skill-usage.md + README + cli-reference.md) applies.
+12. **`non-mutating-scrub.md`** — N/A for v1 (no redaction path).
+    Flag for future `--redact-evidence` flag if anyone ever wants to
+    publish a badge without leaking skill-output snippets.
+
+### Proposed scope
+
+**In scope (v1)**
+- Pure `compute_badge` + `Badge` dataclass with `to_endpoint_json()`
+  and `to_json()`.
+- CLI command `clauditor badge <skill-path>` with flags:
+  `--from-iteration N`, `--output PATH`, `--url-only`,
+  `--style KEY=VALUE`, `--label TEXT`.
+- L1 (required), L3 (optional), variance (optional, graceful degrade
+  when sidecar absent, which is today's steady state).
+- Color logic per ticket table; message format per ticket.
+- Exit codes 0 / 1 / 2.
+- Unit tests (`tests/test_badge.py`) — per-branch color logic +
+  round-trip schema + threshold edge cases.
+- CLI integration tests (`tests/test_cli_badge.py`) — capsys for
+  `--url-only`, tmp_path for `--output`, exit-code assertions.
+- Docs: `docs/cli-reference.md#badge` subsection + new
+  `docs/badges.md` covering placement tradeoffs (README vs SKILL.md
+  vs catalog page) per the ticket's "Can badges go on SKILL.md
+  files?" discussion.
+
+**Out of scope (defer)**
+- Multi-skill catalog badge (ticket open question #2) — issue
+  separately.
+- L2 inclusion in badge message (ticket open question #3) — issue
+  separately if requested.
+- Blind-compare A/B badge (ticket open question #4) — separate
+  command.
+- GitHub Action that commits badges back — ticket "optional phase
+  2"; defer.
+- Auto-mutating README to embed the badge line — ticket non-goal.
+- Variance sidecar writer — out of this epic; badge gracefully
+  degrades today.
+
+### Scoping questions
+
+**Q1. "No iteration found" behavior.** When a user runs `clauditor
+badge <skill>` but no `iteration-N/<skill>/` exists:
+
+- **A.** Exit 1 with a stderr error (`"no iteration found for
+  skill X — run clauditor validate/grade first"`). No badge JSON
+  written. Simplest.
+- **B.** Write a `lightgrey` "no data" badge JSON and exit 0.
+  Matches the ticket's color table row (`"No iteration exists for
+  this skill" → lightgrey`). CI pipelines that always run
+  `clauditor badge` then commit get a persistent placeholder.
+- **C.** Default to exit 1, but add `--allow-empty` flag that
+  writes the lightgrey placeholder. Explicit opt-in for CI.
+- **D.** `--url-only` mode always prints (it needs no data, just
+  the skill name for the filename in the URL). JSON-writing mode
+  exits 1 when no iteration.
+
+**Q2. `--url-only` URL construction.** The ticket's example is
+`![clauditor](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/USER/REPO/main/.clauditor/badges/<skill>.json)`.
+How does the command know the user's repo path?
+
+- **A.** Print a placeholder (`USER/REPO/main`) — user edits once
+  when pasting. Ticket's literal example does this. Zero magic, no
+  network, no git dependency.
+- **B.** Auto-detect from `git remote get-url origin` + `git
+  symbolic-ref refs/remotes/origin/HEAD`. Fall back to placeholder
+  if detection fails. Nice UX; adds subprocess complexity.
+- **C.** Require `--repo USER/REPO [--branch main]` flags.
+  Explicit, testable, but user has to remember the flags.
+- **D.** Hybrid: auto-detect by default; placeholder on failure;
+  `--repo` flag to override auto-detect.
+
+**Q3. Variance layer.** The ticket spec includes `layers.variance`
+and the `80% stable` message fragment. But no `variance.json` writer
+exists today.
+
+- **A.** Include it in the schema with graceful degrade — badge
+  reads `variance.json` if present, omits the block if not. Today
+  the block is always omitted; if a future ticket adds the
+  writer, badge "just works".
+- **B.** Defer variance entirely from v1 — do not mention
+  `layers.variance` in the schema at all until the writer exists.
+  File variance as a separate issue.
+- **C.** Block on variance sidecar landing — close this issue as a
+  dependency on the variance-writer issue and come back.
+
+**Q4. L3 threshold source.** `GradingReport` already carries its
+own `thresholds` (the ones the grade was evaluated against,
+persisted in `grading.json`). The ticket mentions a possible
+`--thresholds min_pass_rate=0.8` flag for override. What should
+the badge's L3 `passed` reflect?
+
+- **A.** Use `grading.json`'s own `thresholds` block — the badge
+  shows what the grade already decided. No CLI override. The
+  source of truth is the sidecar.
+- **B.** Load `EvalSpec.grade_thresholds` from the spec fresh;
+  fall back to defaults (0.7 / 0.5). No CLI override. Allows
+  "reinterpret the grade with the current eval spec" semantics
+  when the spec evolves.
+- **C.** Option A by default, but `--thresholds min_pass_rate=X
+  [--thresholds min_mean_score=Y]` overrides for the badge only.
+  Users can show a harsher/softer bar on the badge than the
+  grade used.
+- **D.** Let the user pick at call-time: `--threshold-source
+  sidecar|spec|cli`, default `sidecar`.
+
+**Q5. Output path location and policy.** Default is
+`.clauditor/badges/<skill>.json` per the ticket. Two sub-questions:
+
+- **Q5a. Path policy for `--output PATH`:**
+  - **A.** Allow absolute paths (user may write to `~/public/` or
+    a docs site dir).
+  - **B.** Reject absolute paths (per the spirit of
+    `path-validation.md`); keep writes rooted at project root.
+  - **C.** Allow absolute if `--force-absolute` is set; default is
+    relative-only.
+
+- **Q5b. Default location:**
+  - **A.** `.clauditor/badges/<skill>.json` (per ticket) — dedicated
+    badges dir, persists across iterations.
+  - **B.** `.clauditor/iteration-N/<skill>/badge.json` — inside the
+    iteration (colocated with other sidecars, but the URL changes
+    per iteration → badge URL would have to point to a "latest"
+    symlink or to the current iteration number).
+  - **C.** Next to the SKILL.md (`<skill-dir>/badge.json`) — badge
+    lives with the skill source, naturally picked up by README
+    relative links.
+
+**Q6. Color edge cases.** Beyond the ticket's four rows:
+
+- **Q6a. Iteration exists but has zero L1 assertions** (a spec that
+  declares only L3 criteria):
+  - **A.** `lightgrey` (no L1 signal).
+  - **B.** L1 is trivially green (0/0 passes), badge reflects L3
+    only.
+  - **C.** Error — the spec must declare ≥1 L1 assertion for the
+    badge to make sense.
+
+- **Q6b. Iteration exists but `assertions.json` is missing** (shouldn't
+  normally happen post-`validate`):
+  - **A.** Exit 1 (corrupt iteration).
+  - **B.** Treat as `lightgrey` / "no data".
+
+- **Q6c. L3 run but all parse-failed** (grading couldn't score):
+  - **A.** `red` — grading failure is a failure.
+  - **B.** Treat as L3 absent (omit the L3 fragment).
+
+### Discovery-phase proposed defaults
+
+Before the user answers, my leaning (to pressure-test each option):
+
+- **Q1 → A.** Exit 1 is the simplest default. Teams that want a
+  persistent placeholder can follow up with `--allow-empty` later;
+  bundling it into v1 bloats the surface.
+- **Q2 → D.** Auto-detect with `--repo` override. `git remote
+  get-url origin` is one subprocess call, the failure path falls
+  through to the placeholder (same as A), and `--repo` is the
+  testable explicit path.
+- **Q3 → A.** Graceful degrade. The badge schema already allows
+  optional blocks; supporting `variance.json` when it eventually
+  ships is additive and costs almost nothing now.
+- **Q4 → A.** Use sidecar's own thresholds. Source of truth is the
+  grade that actually ran; reinterpreting at badge-time invites
+  drift between "what the grade said" and "what the badge shows."
+  CLI override can be added later if requested.
+- **Q5a → A.** Allow absolute paths. The badge JSON often lands
+  outside the repo (e.g. in a GitHub Pages dir at
+  `~/work/pages-site/badges/`); blocking absolute paths here
+  creates real friction for a benign use case.
+- **Q5b → A.** `.clauditor/badges/<skill>.json` per ticket.
+  Persistent location, stable URL, outside the iteration tree.
+- **Q6a → A.** `lightgrey`. A spec with zero L1 assertions is
+  unusual; surfacing that as "no data" is clearer than faking a
+  trivially-green pass.
+- **Q6b → A.** Exit 1. Corrupt iteration.
+- **Q6c → A.** `red`. A graded-but-unscorable run is a failure
+  signal worth surfacing.
+
+---
+
+## Architecture Review
+
+### Scoping answers (Phase 1 close-out)
+
+- **Q1 → B.** No iteration found → write `lightgrey` "no data" badge,
+  exit 0 (persistent placeholder for CI pipelines).
+- **Q2 → D.** Hybrid `--url-only`: auto-detect via `git remote
+  get-url origin` + default branch; `--repo`/`--branch` overrides;
+  placeholder on detection failure.
+- **Q3 → A.** Variance block graceful-degrades — include when
+  `variance.json` sidecar exists, omit when absent (today's steady
+  state).
+- **Q4 → A.** L3 thresholds come from `grading.json`'s own
+  `thresholds` block; no CLI override.
+- **Q5a → A.** `--output PATH` accepts absolute paths.
+- **Q5b → A.** Default output `.clauditor/badges/<skill>.json`.
+- **Q6a → A.** Zero L1 assertions → `lightgrey`.
+- **Q6b → A.** `assertions.json` missing from an otherwise-present
+  iteration → exit 1 (corrupt iteration).
+- **Q6c → A.** L3 all parse-failed → `red`.
+
+### Review ratings
+
+| Area | Rating | Summary |
+|---|---|---|
+| Security | concern | `--output` parent-dir validation; git subprocess error handling; `--style` URL encoding |
+| Data model | concern (+ 1 blocker) | L1/L3 field-naming inconsistency (blocker); `generated_at` timestamp format; dataclass nesting shape |
+| API / CLI design | concern (+ 1 blocker) | Missing `--force` flag (blocker); `--url-only`+`--output` interaction; `--style` parsing; `--from-iteration N` missing behavior |
+| Testing strategy | concern | Schema-drift guard via fixture round-trip; git subprocess mocking shape; 0/0 edge-case message |
+| Observability | pass | Silent-by-default + `--verbose`; stderr warnings for placeholder and git fallback |
+| Performance | pass | All costs negligible (<100ms even with git call); no caching needed |
+
+### Blockers (must resolve before Phase 4)
+
+- **BLK-1 (data model) — L1 field naming.** Ticket shape has
+  `clauditor.layers.l1.all_passed: bool` but
+  `clauditor.layers.l3.passed: bool`. `AssertionSet.passed` in the
+  existing code is `all(r.passed for r in results)` (equals
+  `all_passed`); `GradingReport.passed` is threshold-based. The
+  two `passed` fields on the badge would mean different things. Pick
+  a convention and document.
+
+- **BLK-2 (API) — Overwrite policy.** Existing commands that write
+  persisted JSON (`propose_eval`, `init`) require `--force` to
+  overwrite an existing file; otherwise exit 1. Badge has no such
+  flag defined. A silent overwrite diverges from project convention
+  and could blow away a user's badge on an accidental re-run.
+
+### Concerns (to resolve in Phase 3)
+
+- **C-1 (data model) — `generated_at` ISO-8601 format.** Ticket
+  shows `"2026-04-21T14:00:00Z"`; Python's
+  `datetime.now(timezone.utc).isoformat()` produces
+  `"2026-04-21T14:00:00+00:00"`. Both are valid; shields.io accepts
+  both. Pick one for canonical output.
+
+- **C-2 (data model) — Dataclass nesting shape.** Existing anchor
+  `Benchmark` in `src/clauditor/benchmark.py` uses nested dataclasses
+  (`RunSummary`, etc.) rather than raw nested dicts. The badge's
+  `clauditor:` extension block has three optional sub-layers (l1,
+  l3, variance); idiomatic choice is nested dataclasses with
+  `to_dict()` methods vs. a single `Badge` carrying raw dicts for
+  the nested layers.
+
+- **C-3 (API) — `--url-only` + `--output` interaction.** Ticket
+  treats these as mutually exclusive ("do NOT write the JSON"). Need
+  an explicit mutual-exclusion check returning exit 2 rather than
+  silent precedence.
+
+- **C-4 (API) — `--style KEY=VALUE` validation.** No prior art in
+  the codebase for this flag shape. Options:
+  - **A.** Whitelist shields.io keys (`style`, `logoSvg`,
+    `logoColor`, `labelColor`, `cacheSeconds`, `link`) with a
+    stderr warning on unknown (non-fatal; ship the badge anyway
+    since shields.io silently ignores).
+  - **B.** Blind passthrough — any key/value goes into the JSON.
+  - **C.** Whitelist with exit 2 on unknown.
+
+- **C-5 (API) — `--from-iteration N` missing behavior.** If a user
+  explicitly asks for iteration 42 and it doesn't exist, that's
+  different from DEC-001 "no iteration exists at all". Options:
+  - **A.** Exit 1 with `"iteration 42 not found for skill X"`.
+    Explicit request means explicit failure.
+  - **B.** Same as DEC-001 — write lightgrey, exit 0.
+  - **C.** Exit 2 — treat as user-input error.
+
+- **C-6 (testing) — Git subprocess wrapper.** `--url-only` needs
+  `git remote get-url origin` + default-branch detection. Two
+  patterns:
+  - **A.** Extract `src/clauditor/_git.py` wrapper (`get_repo_url()
+    -> str | None`, `get_default_branch() -> str | None`); tests
+    patch the wrapper, not subprocess.
+  - **B.** Call `subprocess.run` directly in
+    `cli/badge.py`; tests patch `subprocess.run`.
+
+- **C-7 (observability) — `--verbose` flag.** Default silent-on-
+  success, always-print-errors; add `--verbose` to opt into
+  "wrote <path>" style info lines? Or ship without `--verbose` in
+  v1 and add later if requested?
+
+- **C-8 (testing) — Schema-drift guard.** Use a checked-in fixture
+  `tests/fixtures/grading.json` (or generate via `GradingReport(
+  ...).to_json()`) consumed by `tests/test_badge.py` to catch future
+  `GradingReport.to_json` shape changes. Also applies to
+  `assertions.json`.
+
+- **C-9 (data model) — 0/0 L1 message format.** What does the
+  `message` field read when `N/M` is `0/0`? Options:
+  - **A.** `"no data"` (treat lightgrey uniformly).
+  - **B.** `"0/0"` (literal).
+  - **C.** `"no assertions"`.
+
+- **C-10 (observability) — Stderr warnings for placeholder cases.**
+  When writing the lightgrey "no iteration" badge or falling back to
+  the `USER/REPO/main` placeholder in `--url-only`, should stderr
+  emit a one-line warning so users notice? (Quiet-by-default vs.
+  loud-on-uncertainty.)
+
+- **C-11 (security) — `--output` parent-dir validation.** Allowing
+  absolute paths means a typo could land on `/etc/passwd`. Mitigate
+  with a `Path(output).parent.resolve(strict=False).is_dir()` check
+  that fails exit 2 when the parent is a file/socket/symlink-to-
+  dir-that-doesn't-exist. `mkdir(parents=True, exist_ok=True)` for
+  the default `.clauditor/badges/` case.
+
+- **C-12 (security) — `--style` URL encoding.** Values flow into the
+  badge JSON (shields.io reads them from the JSON body, not the
+  badge URL), so URL-encoding is NOT the right protection — string
+  validation (reject control chars, reject values > N chars) is.
+  Needs clarification on exactly how shields.io consumes these
+  fields from the endpoint JSON.
+
+---
+
+## Refinement Log
+
+### Decisions
+
+**DEC-001. Lightgrey placeholder on "no iteration found".** When
+`clauditor badge <skill>` runs for a skill with no discoverable
+iteration, write a `lightgrey` "no data" badge JSON and exit 0.
+Rationale: CI pipelines that always run `clauditor badge` need a
+persistent placeholder rather than a transient error. (Q1=B.)
+
+**DEC-002. Hybrid `--url-only` URL construction.** Auto-detect via
+`git remote get-url origin` + default-branch detection; accept
+`--repo USER/REPO` and `--branch NAME` explicit overrides; fall back
+to `USER/REPO/main` placeholder when auto-detection fails. (Q2=D.)
+
+**DEC-003. Variance layer graceful-degrade.** Include the
+`clauditor.layers.variance` block when `variance.json` sidecar is
+present; omit the block entirely when absent. Today's steady state
+is "always absent" (no writer ships yet); future variance-writer
+ticket lands additively. (Q3=A.)
+
+**DEC-004. L3 thresholds read from `grading.json` sidecar.** The
+`thresholds` block already persisted in `grading.json` (written by
+`GradingReport.to_json`) is the source of truth for the badge's L3
+`passed` field. No CLI override, no re-interpretation against a
+possibly-evolved `EvalSpec.grade_thresholds`. (Q4=A.)
+
+**DEC-005. `--output PATH` accepts absolute paths.** Common use is
+writing the badge JSON into a GitHub Pages dir outside the repo.
+Absolute path is a supported user request, not a spec-driven path,
+so the `path-validation.md` restrictions don't apply. (Q5a=A.)
+
+**DEC-006. Default output at `.clauditor/badges/<skill>.json`.**
+Project-root-relative, outside the iteration tree. Stable URL,
+persistent across iterations. (Q5b=A.)
+
+**DEC-007. Zero L1 assertions → `lightgrey`.** A spec with no L1
+assertions has no L1 signal to surface; lightgrey is clearer than
+faking a trivially-green 0/0 pass. (Q6a=A.)
+
+**DEC-008. `assertions.json` missing from an otherwise-present
+iteration → exit 1.** Distinct from DEC-001. DEC-001 handles "no
+iteration at all" (a valid state — no grading has run yet). A
+present iteration with missing `assertions.json` is a corrupted
+iteration; bail loudly. (Q6b=A.)
+
+**DEC-009. L3 all parse-failed → `red`.** A grading run that
+produces no scorable results is a failure signal and deserves a red
+badge rather than silent omission. (Q6c=A.)
+
+**DEC-010. Use `passed` (not `all_passed`) for both L1 and L3
+layers; document semantic difference in dataclass docstrings.** L1
+`passed = true` means "every assertion passed"; L3 `passed = true`
+means "pass rate ≥ min_pass_rate AND mean_score ≥ min_mean_score"
+(i.e., the grade met its thresholds). Shields.io extension stays
+concise and avoids two names for "did this layer succeed". (BLK-1=A.)
+
+**DEC-011. `--force` required to overwrite existing badge JSON.**
+Matches `propose_eval` / `init` convention. If
+`.clauditor/badges/<skill>.json` (or a custom `--output`) exists and
+`--force` was not passed, exit 1 with a stderr error.
+**Exception:** The DEC-001 lightgrey placeholder write does NOT
+overwrite an existing badge without `--force` — a stale "real"
+badge is less bad than silently clobbering it on a misfire. (BLK-2=A.)
+
+**DEC-012. `generated_at` uses `Z` suffix form
+(`2026-04-21T14:00:00Z`).** Python's
+`datetime.now(timezone.utc).isoformat()` produces `+00:00`;
+post-process with `.replace("+00:00", "Z")` at the single
+serialization seam. (C-1=A.)
+
+**DEC-013. Nested dataclasses matching `Benchmark` idiom.** Define
+`L1Summary`, `L3Summary`, `VarianceSummary`, `ClauditorExtension`,
+and `Badge` dataclasses with `to_endpoint_json()` methods that emit
+the shields.io-compatible dict. Raw-dict fields only where
+passthrough (e.g., `thresholds` block copied verbatim from
+`grading.json`). (C-2=A.)
+
+**DEC-014. `--url-only` and `--output` are mutually exclusive; both
+passed → exit 2.** Both flags define conflicting outputs; silent
+precedence is a trap. (C-3=A.)
+
+**DEC-015. `--style KEY=VALUE` whitelist + stderr warning on unknown
+key.** Whitelist = `style`, `logoSvg`, `logoColor`, `labelColor`,
+`cacheSeconds`, `link` (per shields.io docs). Unknown keys warn to
+stderr (`"clauditor.badge: unknown --style key 'foo' — passing
+through anyway"`) but are still emitted in the JSON; shields.io
+ignores unknowns so the badge still renders. Non-fatal, exit 0.
+(C-4=A.)
+
+**DEC-016. `--from-iteration N` with N not found → exit 1.**
+Distinct from DEC-001. An explicit iteration request that fails is
+an explicit error; stderr message names N and the available
+iteration numbers. (C-5=A.)
+
+**DEC-017. Extract `src/clauditor/_git.py` wrapper.** Two pure
+helpers: `get_repo_slug(cwd: Path) -> str | None` (returns
+`"USER/REPO"` parsed from the origin URL; handles HTTPS, SSH, and
+custom git hosts) and `get_default_branch(cwd: Path) -> str | None`
+(returns the branch name from `git symbolic-ref
+refs/remotes/origin/HEAD`, or `None` on failure). Both wrap
+`subprocess.run` with `FileNotFoundError` + `CalledProcessError`
+handling; both return `None` instead of raising. CLI translates
+`None` → placeholder fallback. Tests patch the wrapper functions,
+not `subprocess.run` directly. (C-6=A.)
+
+**DEC-018. `--verbose` flag, silent-by-default.** Default silent on
+success; errors always print to stderr regardless of flag.
+`--verbose` opts into info lines like `"wrote
+.clauditor/badges/review-pr.json"`. (C-7=A.)
+
+**DEC-019. Schema-drift fixtures generated in-test via
+`to_json()`.** `tests/test_badge.py` factories mirror
+`tests/test_benchmark.py` / `tests/test_baseline.py` — hand-author
+`GradingReport`, `AssertionSet`, etc. via test helpers, serialize
+with `to_json()`, parse back, pass to `compute_badge`. No fixture
+dir created. (C-8=B.)
+
+**DEC-020. 0/0 L1 message format is `"no data"`.** Applies to both
+DEC-001 (no iteration) and DEC-007 (iteration exists but zero L1
+assertions). Consistent lightgrey + "no data" string across both
+"no signal" cases. (C-9=A.)
+
+**DEC-021. Stderr warnings on lightgrey placeholder + git fallback.**
+- Writing a DEC-001 lightgrey placeholder → stderr `"warning: no
+  iteration found for skill {name} — wrote lightgrey placeholder
+  (run 'clauditor grade' to populate)"`.
+- Writing a DEC-007 lightgrey placeholder → stderr `"warning:
+  eval spec declares 0 L1 assertions — wrote lightgrey 'no data'
+  badge"`.
+- `--url-only` with git auto-detect failure → stderr `"warning:
+  git auto-detect failed; using placeholder USER/REPO/main — pass
+  --repo USER/REPO to override"`.
+Loud-on-uncertainty is the right default for a command whose
+output is visible to everyone reading the user's README. (C-10=A.)
+
+**DEC-022. `--output` parent-dir validation.** Resolve
+`Path(output).parent` with `strict=False`, then check `.is_dir()`.
+If parent does not exist or is not a directory, exit 2. Default
+`.clauditor/badges/` is created via `mkdir(parents=True,
+exist_ok=True)` — only a user-provided `--output` is validated.
+(C-11=A.)
+
+**DEC-023. `--style` value validation.** Each value: reject control
+characters (`\x00-\x1f`, `\x7f`) via `str.isprintable()` or
+equivalent; enforce ≤512 chars. Bad value → exit 2 with stderr
+naming the offending key. Keys use the same character class as
+shields.io's documented keys (already safe). (C-12=A.)
+
+**DEC-024. Message format.** Per ticket table:
+- L1 only: `"{passed}/{total}"` (e.g. `"8/8"`)
+- L1 + L3 present: `"{N}/{M} · L3 {pct}%"` (percent rounded via
+  `round(pass_rate * 100)`)
+- L1 + L3 + variance present: `"{N}/{M} · L3 {pct}% · {stability}%
+  stable"`.
+- Zero L1 case (DEC-020): `"no data"`.
+
+**DEC-025. Exit-code taxonomy: 0 / 1 / 2 (no exit 3).** Badge makes
+no LLM call; the four-exit-code taxonomy from
+`.claude/rules/llm-cli-exit-code-taxonomy.md` does not apply. Per
+the taxonomy rule's own "When this rule does NOT apply" section,
+non-LLM commands use 0/1/2.
+- **0** — success (badge written or URL printed; DEC-001/-007
+  lightgrey placeholder writes also return 0).
+- **1** — runtime failure: corrupt iteration (DEC-008), existing
+  file without `--force` (DEC-011), missing `--from-iteration N`
+  (DEC-016), disk I/O errors.
+- **2** — input-validation failure: bad skill spec, mutually
+  exclusive flags (DEC-014), `--output` parent-dir check failure
+  (DEC-022), `--style` value rejected (DEC-023).
+
+**DEC-026. Pure compute vs. I/O split.** `src/clauditor/badge.py`
+is pure (no stderr, no file I/O, no subprocess); takes pre-parsed
+dicts and known identifiers (skill_name, iteration, generated_at).
+`src/clauditor/cli/badge.py` owns sidecar reads, git subprocess
+calls, output writes, stderr progress lines, and exit-code mapping.
+Per `.claude/rules/pure-compute-vs-io-split.md`.
+
+**DEC-027. Schema version layering.** Top-level `schemaVersion: 1`
+is shields.io's schema (camelCase per their docs). Nested
+`clauditor.schema_version: 1` is our internal extension version,
+first key of the `clauditor` block per
+`.claude/rules/json-schema-version.md`. The two versions bump
+independently; a future shields.io bump to `schemaVersion: 2` does
+not force a `clauditor.schema_version` bump and vice versa. No
+loader exists yet (we only write the badge in v1); when a future
+`clauditor badge --read` or trend-audit consumer lands, it follows
+`audit.py::_check_schema_version` shape, checking the
+`clauditor.schema_version` field (not the shields.io one, which is
+THEIR contract).
+
+### Session notes
+
+- Session 1 (2026-04-21): Discovery → architecture → refinement
+  completed in one sitting. User accepted all proposed defaults in
+  both scoping and refinement rounds. No blockers remained at end
+  of Phase 2 after DEC-010 and DEC-011 resolved BLK-1 and BLK-2.
+  Variance-writer absence confirmed — badge ships with the
+  graceful-degrade branch that is always-taken today.
+
+---
+
+## Detailed Breakdown
+
+Ordering follows the feature's natural architecture: pure compute
+core first (US-001), supporting pure helpers (US-002, US-003),
+then the CLI integration that composes them (US-004), then docs
+(US-005), then Quality Gate (US-006) and Patterns & Memory
+(US-007).
+
+---
+
+### US-001 — Pure `compute_badge` + `Badge` dataclass family
+
+**Description.** Implement the pure aggregation core in a new
+`src/clauditor/badge.py` module. Takes pre-parsed sidecar dicts and
+identity fields, returns a `Badge` dataclass whose
+`to_endpoint_json()` method emits the shields.io-compatible dict.
+No I/O; no stderr; no subprocess.
+
+**Traces to:** DEC-003, DEC-009, DEC-010, DEC-012, DEC-013,
+DEC-020, DEC-024, DEC-026, DEC-027.
+
+**Files:**
+- **New** `src/clauditor/badge.py` — nested dataclasses
+  (`L1Summary`, `L3Summary`, `VarianceSummary`,
+  `ClauditorExtension`, `Badge`), `compute_badge(...)` function,
+  color-logic table as a module-level constant, message-format
+  helper, `Badge.to_endpoint_json() -> dict`.
+- **New** `tests/test_badge.py` — `TestComputeBadge` with
+  parametrized color-logic table + per-branch message-format tests;
+  `TestBadgeSerialization` for round-trip + schema_version
+  first-key invariants.
+- **No change** to `src/clauditor/__init__.py` — badge is internal;
+  only CLI imports it.
+
+**Acceptance criteria:**
+- `compute_badge(assertions, grading, variance, *, skill_name,
+  iteration, generated_at)` returns a `Badge` dataclass. All three
+  sidecar args accept `None`: `assertions=None` represents the
+  DEC-001 / DEC-008 "no L1 signal" case; `grading=None` omits L3;
+  `variance=None` omits variance.
+- Color logic (DEC-003, 007, 009, 020): L1 assertions count == 0
+  → `lightgrey` + message `"no data"`; any L1 failed → `red`; L1
+  all-pass + L3 below thresholds → `yellow`; L1 all-pass + L3
+  parse-failed (empty results OR all results have
+  `passed=False` AND no score) → `red`; L1 all-pass + L3 passed /
+  omitted → `brightgreen`.
+- Message format (DEC-024): L1 only → `"{N}/{M}"`; L1+L3 →
+  `"{N}/{M} · L3 {round(pass_rate*100)}%"`; L1+L3+variance →
+  `"{N}/{M} · L3 {pct}% · {stab_pct}% stable"`; lightgrey →
+  `"no data"`.
+- `Badge.to_endpoint_json()` returns a dict with top-level keys in
+  order: `schemaVersion`, `label`, `message`, `color`, then any
+  `--style`-injected passthrough keys (alphabetical), then
+  `clauditor`. Inside `clauditor`, first key is `schema_version:
+  1` per `.claude/rules/json-schema-version.md`; subsequent:
+  `skill_name`, `generated_at`, `iteration`, `layers`.
+- `generated_at` uses `Z` suffix (DEC-012); test asserts the
+  trailing character.
+- L1 and L3 layer dicts both carry a `passed: bool` field (DEC-010)
+  with docstring explaining the two semantic meanings.
+- Variance block omitted when `variance is None` (DEC-003); test
+  asserts `"variance" not in result["clauditor"]["layers"]`.
+- `ruff check src/clauditor/badge.py tests/test_badge.py` passes.
+- Coverage for `badge.py` ≥95% (it's pure logic; every branch
+  should be hit).
+
+**Done when:**
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest tests/test_badge.py --cov=clauditor.badge
+  --cov-report=term-missing` passes with `badge.py` ≥95%.
+- Entire-project coverage stays ≥80% (unchanged CLI + helpers
+  still cover themselves).
+
+**Depends on:** none.
+
+**TDD:**
+Write parametrized failing tests first, then implement.
+Test cases (one `@pytest.mark.parametrize` table per group):
+- Color + message matrix: (l1_passed, l1_total, l3_state, variance
+  present) → (color, message). Include every row of the DEC color
+  table.
+- Schema-version first-key: `list(result.keys())[0] ==
+  "schemaVersion"`; `list(result["clauditor"].keys())[0] ==
+  "schema_version"`.
+- `generated_at` Z-suffix: `result["clauditor"]["generated_at"].
+  endswith("Z")`.
+- L1 vs L3 `passed` semantic: L1 `passed` mirrors `all_passed`; L3
+  `passed` mirrors the thresholds-based calculation on the input
+  `grading` dict.
+- Variance-present vs omitted.
+- Thresholds pass-through from `grading["thresholds"]` dict.
+- Empty thresholds block (grading has no `thresholds` key) →
+  either include defaults or omit the key (pick one behavior; test
+  it; document on the dataclass).
+
+---
+
+### US-002 — Git wrapper (`_git.py`)
+
+**Description.** New private module `src/clauditor/_git.py` with
+two pure helpers that wrap `subprocess.run` for git metadata
+lookups needed by `clauditor badge --url-only`. Each helper
+returns `None` instead of raising so the CLI can fall through to
+the `USER/REPO/main` placeholder.
+
+**Traces to:** DEC-002, DEC-017.
+
+**Files:**
+- **New** `src/clauditor/_git.py` — `get_repo_slug(cwd: Path) ->
+  str | None` (parses `git remote get-url origin` output; handles
+  `https://github.com/USER/REPO.git`,
+  `git@github.com:USER/REPO.git`, and `https://gitlab.com/USER/REPO`
+  shapes; strips trailing `.git`); `get_default_branch(cwd: Path)
+  -> str | None` (parses `git symbolic-ref
+  refs/remotes/origin/HEAD` output, returns the branch name).
+- **New** `tests/test_git.py` — `TestGetRepoSlug` and
+  `TestGetDefaultBranch` patching `subprocess.run` via
+  `unittest.mock.patch`.
+
+**Acceptance criteria:**
+- `get_repo_slug` returns `"USER/REPO"` from any of:
+  `https://github.com/USER/REPO.git`,
+  `https://github.com/USER/REPO`, `git@github.com:USER/REPO.git`,
+  `git@github.com:USER/REPO`, `https://gitlab.com/group/sub/REPO`.
+- `get_repo_slug` returns `None` on: `FileNotFoundError` (git not
+  installed), `CalledProcessError` with non-zero exit (no origin,
+  not a git repo), parse failure on unknown URL shape.
+- `get_default_branch` returns the branch name (e.g. `"main"`,
+  `"master"`, `"dev"`) from parsed `refs/remotes/origin/HEAD`.
+- `get_default_branch` returns `None` on the same error set as
+  `get_repo_slug`.
+- Both helpers accept `cwd: Path` and pass it as `cwd=str(cwd)` to
+  `subprocess.run`.
+- Neither helper raises under any of the documented error
+  conditions.
+- `ruff check` passes; coverage on `_git.py` ≥95%.
+
+**Done when:**
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest tests/test_git.py` passes.
+
+**Depends on:** none.
+
+**TDD:**
+Write failing `TestGetRepoSlug` cases for each URL shape + each
+error branch before implementing. Same for `TestGetDefaultBranch`.
+
+---
+
+### US-003 — Sidecar discovery + URL builder (pure helpers)
+
+**Description.** Extend `src/clauditor/badge.py` with two more pure
+helpers: one that locates "the iteration to read for skill X"
+given a project dir and optional explicit iteration number, and
+one that builds the `--url-only` Markdown image line from pure
+inputs. No I/O beyond reading files where required for iteration
+sidecar loading (wrapped via `audit.py::_read_json`).
+
+**Traces to:** DEC-001, DEC-002, DEC-006, DEC-008, DEC-016,
+DEC-026.
+
+**Files:**
+- **Edit** `src/clauditor/badge.py` — add:
+  - `discover_iteration(project_dir: Path, skill_name: str,
+    explicit: int | None) -> tuple[int, Path] | None` —
+    `explicit=None` returns the latest iteration that has a
+    `<skill_name>/` subdir; `explicit=N` returns
+    `(N, iteration-N/<skill>)` if it exists, else `None`.
+    Distinguishes "no iteration at all" (DEC-001) from "explicit
+    missing" (DEC-016) via caller inspection — helper returns
+    `None` for both; caller branches on `explicit is not None`.
+  - `load_iteration_sidecars(iteration_skill_dir: Path) ->
+    IterationSidecars` — dataclass with `assertions: dict | None`,
+    `grading: dict | None`, `variance: dict | None`,
+    `assertions_missing: bool` (True when the dir exists but
+    `assertions.json` does not — DEC-008 corrupt iteration).
+    Uses `audit._read_json` for each file.
+  - `build_markdown_image(*, skill_name: str, repo_slug: str,
+    branch: str, output_relpath: str, label: str) -> str` —
+    pure URL builder returning the `![label](https://img.shields.io/
+    endpoint?url=https://raw.githubusercontent.com/{repo_slug}/
+    {branch}/{output_relpath})` string. URL-encodes each component
+    via `urllib.parse.quote` (path-safe).
+- **Edit** `tests/test_badge.py` — add `TestDiscoverIteration`,
+  `TestLoadIterationSidecars`, `TestBuildMarkdownImage` test
+  classes.
+
+**Acceptance criteria:**
+- `discover_iteration(project_dir, "X", None)` walks
+  `.clauditor/iteration-*/` via existing `audit._scan_iteration_
+  dirs`, picks the highest N where `iteration-N/X/` exists,
+  returns `(N, iteration-N/X)`.
+- `discover_iteration(project_dir, "X", 42)` returns
+  `(42, iteration-42/X)` if the dir exists, else `None`.
+- `discover_iteration` returns `None` when no iteration contains
+  `<skill_name>/`.
+- `load_iteration_sidecars(path)` reads present files; each absent
+  file → `None` for that attribute.
+- `load_iteration_sidecars(path).assertions_missing` is `True` when
+  the iteration's skill dir exists but `assertions.json` does not,
+  `False` when both are absent (DEC-001) or both present.
+- `build_markdown_image(...)` produces the exact Markdown image
+  shape from the ticket example; URL encoding on `skill_name` /
+  `output_relpath` / `repo_slug` / `branch` handles edge chars
+  (though `SKILL_NAME_RE` prevents most).
+- All three helpers have no stderr, no subprocess, no mutation of
+  inputs.
+- Coverage ≥95% on the new symbols.
+
+**Done when:**
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest tests/test_badge.py` passes.
+
+**Depends on:** US-001 (shares the `badge.py` module and reuses
+dataclass imports).
+
+**TDD:**
+Failing tests first. `TestDiscoverIteration` uses `tmp_path` to
+construct fake iteration dirs. `TestLoadIterationSidecars` uses
+`tmp_path` with hand-written JSON fixtures (assertions present /
+grading only / all absent / assertions_missing case).
+`TestBuildMarkdownImage` is pure-string assertions with
+parametrized input combinations including edge-char inputs to
+prove URL encoding.
+
+---
+
+### US-004 — CLI command + dispatcher wiring
+
+**Description.** New `src/clauditor/cli/badge.py` exposing
+`add_parser` + `cmd_badge`; wire into `cli/__init__.py::main`.
+Composes US-001 / US-002 / US-003 helpers with argparse, sidecar
+I/O, git subprocess calls, file writes, stderr progress, and
+exit-code mapping.
+
+**Traces to:** DEC-001, DEC-002, DEC-005, DEC-006, DEC-011,
+DEC-014, DEC-015, DEC-016, DEC-018, DEC-021, DEC-022, DEC-023,
+DEC-025, DEC-026.
+
+**Files:**
+- **New** `src/clauditor/cli/badge.py` — `add_parser`, `cmd_badge`,
+  `_parse_style_arg(raw: str) -> tuple[str, str]`,
+  `_validate_style_value(value: str) -> None`, any other small
+  CLI-local helpers.
+- **Edit** `src/clauditor/cli/__init__.py` — add lazy import of
+  `cli.badge`, re-export `cmd_badge`, register `add_parser` in
+  `main()`, add dispatch branch.
+- **New** `tests/test_cli_badge.py` — CLI integration tests via
+  `tmp_path`, `capsys`, and `unittest.mock.patch` on
+  `clauditor._git.get_repo_slug`, `clauditor._git.get_default_branch`.
+
+**Acceptance criteria:**
+- Positional `skill` arg loads via `SkillSpec.from_file`
+  (preserves frontmatter-first skill-name derivation — per
+  `.claude/rules/skill-identity-from-frontmatter.md`).
+- Flags: `--from-iteration N`, `--output PATH`, `--url-only`,
+  `--force`, `--repo USER/REPO`, `--branch NAME`, `--label TEXT`
+  (default `"clauditor"`), `--style KEY=VALUE` (append), `--verbose`.
+- `--url-only` + `--output` both present → exit 2 with stderr
+  `"ERROR: --url-only and --output are mutually exclusive"` (DEC-014).
+- `--output` absolute path accepted (DEC-005); parent-dir check:
+  `Path(output).parent.resolve(strict=False).is_dir()` must be
+  true → else exit 2 (DEC-022).
+- `--style` parsed via `raw.split("=", 1)`; key whitelist check
+  (DEC-015 allowed set); unknown key → stderr warning but key
+  still lands in the JSON; each value validated via DEC-023 rules
+  → bad value exits 2.
+- No `--from-iteration`, no iteration found for skill → write
+  `lightgrey` "no data" badge (via `compute_badge(assertions=None,
+  ...)`) at default or `--output` path; DEC-021 stderr warning;
+  exit 0 (DEC-001).
+- `--from-iteration N`, iteration N missing → exit 1 with stderr
+  naming N and available iteration numbers (DEC-016).
+- Present iteration with `assertions.json` missing (but skill-dir
+  exists) → exit 1 (DEC-008).
+- Output file already exists at the target path, no `--force` →
+  exit 1 `"ERROR: {path} already exists (pass --force to
+  overwrite)"` (DEC-011). Exception: DEC-001 lightgrey write also
+  respects `--force` — do not clobber existing badge with
+  placeholder unless `--force` was passed.
+- `--url-only` mode: call `get_repo_slug` / `get_default_branch`
+  unless `--repo` / `--branch` provided; on failure fall back to
+  `"USER/REPO"` / `"main"` + DEC-021 stderr warning. Print the
+  Markdown image line to stdout; do NOT write JSON; exit 0.
+- `--verbose` + successful write → stderr info line
+  `"clauditor.badge: wrote {path} (iteration {N})"` (DEC-018).
+- Dispatcher in `cli/__init__.py` adds `elif parsed.command ==
+  "badge": return cmd_badge(parsed)`.
+
+**Done when:**
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest tests/test_cli_badge.py` passes with ≥90%
+  coverage on `cli/badge.py`.
+- `clauditor badge --help` renders the expected flag surface.
+
+**Depends on:** US-001, US-002, US-003.
+
+**TDD:**
+Moderate. CLI tests are integration-heavy; write failing
+parametrized tests for each exit-code branch (0 success, 0
+lightgrey placeholder, 1 corrupt iteration, 1 explicit-missing
+iteration, 1 overwrite-without-force, 2 mutual exclusion, 2
+bad `--output` parent, 2 bad `--style` value) before wiring. Git
+auto-detect branches: happy path (mock returns slug + branch),
+slug-missing (mock returns None), branch-missing, both-missing,
+explicit `--repo`/`--branch` overrides.
+
+---
+
+### US-005 — Docs: `docs/cli-reference.md#badge` + `docs/badges.md`
+
+**Description.** Add a `## badge` subsection to
+`docs/cli-reference.md` (flag-by-flag reference) and a new
+`docs/badges.md` doc covering placement tradeoffs (README vs
+SKILL.md vs catalog page) per the ticket's "Can badges go on
+SKILL.md files?" discussion. If the new docs push the root README
+past its teaser budget, apply the `readme-promotion-recipe` to
+anchor a D2 lean teaser from the README.
+
+**Traces to:** Ticket "Suggested breakdown" item 3; rule anchor
+`.claude/rules/readme-promotion-recipe.md`.
+
+**Files:**
+- **Edit** `docs/cli-reference.md` — add `## badge` subsection
+  matching the shape of `## propose-eval` and `## suggest`
+  (description, synopsis, flag table, example session, exit
+  codes).
+- **New** `docs/badges.md` — opens with the breadcrumb blockquote
+  (`> Returning from the [root README](../README.md). …`), then
+  sections: "Why badges", "Placement hierarchy (README primary;
+  catalog-page secondary; SKILL.md tradeoffs)", "Color logic
+  table", "Embedding recipe (`--url-only`)", "CI integration"
+  (placeholder stub — defer real GitHub Action to future ticket).
+- **Edit** `README.md` — if the badge feature warrants a teaser,
+  add a D2 lean teaser in the appropriate section per
+  `readme-promotion-recipe.md`. If not (reference-only), skip.
+
+**Acceptance criteria:**
+- `docs/cli-reference.md` has a `## badge` anchor; all flags
+  documented with the same phrasing pattern as sibling
+  subsections.
+- `docs/badges.md` opens with the breadcrumb blockquote.
+- `docs/badges.md` color-logic table matches the ticket's table +
+  the DEC-007/-009/-020 additions (zero L1 → lightgrey + "no
+  data"; L3 parse-failed → red).
+- Example sessions copy-paste cleanly (matches the ticket's
+  `clauditor badge src/skills/review-pr/SKILL.md --url-only`
+  example).
+- No broken internal links (spot-check
+  `../README.md`, `./cli-reference.md#badge`, rule-anchor links
+  if used).
+
+**Done when:**
+- Lint passes (no doc linter in the project, but spot-check Markdown
+  renders on GitHub preview).
+- Manual review of the new doc confirms the placement hierarchy
+  reads as the ticket described it.
+
+**Depends on:** US-004 (CLI behavior must be stable before docs
+freeze the flag surface).
+
+**TDD:** N/A for docs.
+
+---
+
+### US-006 — Quality Gate (code review x4 + CodeRabbit)
+
+**Description.** Full changeset quality gate before merge. Run
+the `code-review` skill four times across the entire diff, fixing
+every real finding each pass. Run CodeRabbit on the PR and
+reconcile. Project validation (`uv run ruff check src/ tests/`
++ `uv run pytest --cov=clauditor --cov-report=term-missing` with
+the 80% gate) must pass at the end.
+
+**Traces to:** All DECs (invariant verification).
+
+**Files:** all changed files from US-001 through US-005 (exact
+list from `git diff --name-only <base>`).
+
+**Acceptance criteria:**
+- 4 passes of code review; every real bug fixed, every concern
+  either resolved or deferred with a new beads issue.
+- CodeRabbit comments triaged: each comment either fixed or
+  documented as false-positive with a short note (per the
+  `pr-reviewer` agent's contract).
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+  with overall coverage ≥80%.
+
+**Done when:**
+- Last code-review pass returns zero real findings.
+- CodeRabbit PR comments all addressed or documented.
+- CI (if wired) green.
+
+**Depends on:** US-001, US-002, US-003, US-004, US-005.
+
+**TDD:** N/A.
+
+---
+
+### US-007 — Patterns & Memory (update conventions + docs)
+
+**Description.** Capture any new patterns learned in this epic
+into the `.claude/rules/` directory or project memory, and update
+existing rules if a decision here extended them. Always-last
+story per the `/super-plan` contract.
+
+**Candidate patterns:**
+
+- **Rule: dual-version JSON payloads.** The badge JSON carries
+  shields.io's `schemaVersion` (THEIR contract) + our
+  `clauditor.schema_version` (OUR contract). Extending
+  `.claude/rules/json-schema-version.md` (or adding a sibling
+  rule) to cover "external-schema + embedded-extension" shape
+  would codify this for future commands. Decision point: add the
+  rule if a second command needs dual-version shaping; otherwise
+  document in the `badge.py` module docstring and skip the rule
+  file.
+- **Rule: git-metadata wrapper.** `src/clauditor/_git.py` is a
+  new canonical anchor. If a second command later needs git
+  metadata, promote `_git.py` + the patch-the-wrapper test
+  pattern into a short `.claude/rules/git-subprocess-wrapper.md`.
+- **Rule: placeholder-on-no-data CLI pattern.** DEC-001's "write
+  a lightgrey placeholder + exit 0" is a new CLI pattern
+  (distinct from the exit-2 "bad input" and exit-1 "bad state"
+  branches). If a future CLI command emits placeholders for
+  similar reasons, document the pattern.
+- **Rule: dual-lightgrey source collision.** DEC-001 (no
+  iteration) and DEC-007 (zero L1 assertions) both produce
+  lightgrey with the same `"no data"` message. If this causes
+  downstream confusion (e.g. a future audit consumer can't tell
+  them apart from the badge alone), add a differentiating field
+  inside the `clauditor` extension block.
+
+**Files:**
+- **New or edit** `.claude/rules/<name>.md` — only if one of the
+  candidate patterns above materializes into enough repetition
+  across the codebase to justify a rule. Otherwise skip.
+- **Edit** the user-level memory at
+  `~/.claude/projects/-home-wesd-Projects-clauditor/memory/` only
+  if a genuinely cross-conversation fact emerged (unlikely for
+  this epic).
+
+**Acceptance criteria:**
+- At least one short review pass: "Did this epic introduce a
+  pattern that recurs elsewhere in the codebase?" — answer
+  recorded as a commit message note even if the answer is "no new
+  rule needed".
+- If a rule file was added or edited, it is referenced from the
+  driving code comment (so future greppers find it).
+
+**Done when:**
+- Committed (and pushed) per session-close protocol.
+
+**Depends on:** US-006.
+
+**TDD:** N/A.
+
+---
+
+### Dependency graph summary
+
+```
+US-001 (pure compute) ──┐
+US-002 (_git.py)     ───┤
+US-003 (sidecar + URL) ─┘→ US-004 (CLI) → US-005 (docs) → US-006 (QG) → US-007 (P&M)
+```
+
+US-001, US-002, and US-003 can be worked in any order (US-003
+imports `badge.py` symbols, so logically after US-001 lands
+first, but the stories are independent enough to parallelize if
+two workers pick them up). US-004 blocks on all three. US-005
+blocks on US-004 for flag stability.
+
+### Rules compliance gate (pre-Phase-5 check)
+
+- ✅ `json-schema-version.md` — DEC-027; `clauditor.schema_version:
+  1` as first key of the `clauditor` block (US-001).
+- ✅ `pure-compute-vs-io-split.md` — DEC-026; US-001 pure + US-004
+  I/O.
+- ✅ `llm-cli-exit-code-taxonomy.md` — DEC-025; non-LLM command
+  uses 0/1/2 (rule's own "does not apply" clause).
+- ✅ `path-validation.md` — DEC-022 parent-dir check (US-004).
+- ✅ `in-memory-dict-loader-path.md` — N/A (sidecars are
+  clauditor-written, not LLM-proposed; direct `json.load` is
+  appropriate).
+- ✅ `constant-with-type-info.md` — N/A at v1; color-logic table
+  is a flat string-valued constant with no mixed-type payload.
+- ✅ `skill-identity-from-frontmatter.md` — US-004 loads skill via
+  `SkillSpec.from_file`.
+- ✅ `project-root-home-exclusion.md` — N/A (explicit skill path
+  argument; no marker walk).
+- ✅ `sidecar-during-staging.md` — N/A (reads finalized
+  iterations; writes outside the iteration tree).
+- ✅ `readme-promotion-recipe.md` — US-005 docs plan.
+- ✅ `bundled-skill-docs-sync.md` — N/A (bundled `/clauditor`
+  SKILL.md workflow does not invoke badge in v1).
+- ✅ `non-mutating-scrub.md` — N/A (no redaction path in v1).
+- ✅ `monotonic-time-indirection.md` — N/A (no async / no
+  duration-tracking).
+- ✅ `centralized-sdk-call.md` — N/A (no Anthropic calls).
+- ✅ `eval-spec-stable-ids.md` — N/A (no new EvalSpec fields).
+
+---
+
+## Beads Manifest
+
+_(To be completed in Phase 7.)_

--- a/plans/super/77-clauditor-badge.md
+++ b/plans/super/77-clauditor-badge.md
@@ -4,7 +4,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/77
 - **Branch:** `feature/77-clauditor-badge`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/77-clauditor-badge`
-- **Phase:** `detailing`
+- **Phase:** `devolved`
+- **PR:** https://github.com/wjduenow/clauditor/pull/81
+- **Epic:** `clauditor-wnv`
 - **Sessions:** 1
 - **Last session:** 2026-04-21
 
@@ -1205,4 +1207,25 @@ blocks on US-004 for flag stability.
 
 ## Beads Manifest
 
-_(To be completed in Phase 7.)_
+- **Epic:** `clauditor-wnv` — #77: clauditor badge command (shields.io endpoint JSON)
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/77-clauditor-badge`
+- **PR:** https://github.com/wjduenow/clauditor/pull/81
+
+### Tasks
+
+| Bead | Title | Deps |
+|---|---|---|
+| `clauditor-wnv.1` | US-001 — Pure compute_badge + Badge dataclass family | none |
+| `clauditor-wnv.2` | US-002 — Git wrapper (_git.py) for repo-slug + default-branch | none |
+| `clauditor-wnv.3` | US-003 — Sidecar discovery + URL builder (pure helpers) | wnv.1 |
+| `clauditor-wnv.4` | US-004 — CLI command cli/badge.py + dispatcher wiring | wnv.1, wnv.2, wnv.3 |
+| `clauditor-wnv.5` | US-005 — Docs: cli-reference.md#badge + new docs/badges.md | wnv.4 |
+| `clauditor-wnv.6` | US-006 — Quality Gate: code-review x4 + CodeRabbit | wnv.1, wnv.2, wnv.3, wnv.4, wnv.5 |
+| `clauditor-wnv.7` | US-007 — Patterns & Memory: update conventions + docs | wnv.6 |
+
+### Ready-to-work (no blockers)
+
+- `clauditor-wnv.1` — US-001 pure compute_badge
+- `clauditor-wnv.2` — US-002 git wrapper
+
+Run `bd ready` in the worktree to confirm.

--- a/src/clauditor/_git.py
+++ b/src/clauditor/_git.py
@@ -1,0 +1,146 @@
+"""Internal git metadata helpers for ``clauditor badge --url-only``.
+
+This module is private (underscore-prefixed) and exists specifically
+to support the badge CLI's repo auto-detection path. Two pure
+helpers wrap :func:`subprocess.run` calls to ``git``:
+
+- :func:`get_repo_slug` — parses ``git remote get-url origin`` into a
+  ``"USER/REPO"`` string. Handles HTTPS, SSH, and custom git hosts
+  (github.com, gitlab.com including nested groups, bitbucket.org,
+  self-hosted installations).
+- :func:`get_default_branch` — parses ``git symbolic-ref
+  refs/remotes/origin/HEAD`` into the default branch name.
+
+Both helpers return ``None`` instead of raising under any documented
+error condition (git not installed, not a git repository, no origin
+remote, timeout, parse failure on unknown URL shape). The CLI
+translates ``None`` into the ``USER/REPO/main`` placeholder fallback
+per DEC-002 of ``plans/super/77-clauditor-badge.md``.
+
+Neither helper raises. Callers can treat a ``None`` return as "git
+metadata unavailable; fall through to placeholders".
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+__all__ = ["get_default_branch", "get_repo_slug"]
+
+# Protect against hung ``git`` invocations. Ten seconds is generous
+# for what should be cheap local metadata lookups but tight enough
+# that a wedged subprocess cannot stall the badge command.
+_GIT_TIMEOUT_SECONDS = 10
+
+# SSH-style URL: git@host:path/to/repo[.git]
+_SSH_URL_RE = re.compile(r"^[^@]+@[^:]+:(?P<slug>.+?)(?:\.git)?$")
+
+# HTTPS/HTTP URL: scheme://host/path/to/repo[.git]
+_HTTP_URL_RE = re.compile(r"^https?://[^/]+/(?P<slug>.+?)(?:\.git)?$")
+
+
+def _parse_remote_url(url: str) -> str | None:
+    """Return the ``USER/REPO`` slug for a remote URL, or ``None``.
+
+    Supports:
+
+    - ``https://host/path/to/repo[.git]`` (HTTPS, any host, nested
+      group paths like gitlab's ``group/sub/repo``).
+    - ``git@host:path/to/repo[.git]`` (SSH).
+
+    Returns ``None`` for unrecognized shapes.
+    """
+    url = url.strip()
+    if not url:
+        return None
+
+    for pattern in (_HTTP_URL_RE, _SSH_URL_RE):
+        match = pattern.match(url)
+        if match is not None:
+            slug = match.group("slug").strip("/")
+            if slug:
+                return slug
+
+    return None
+
+
+def _parse_symbolic_ref(output: str) -> str | None:
+    """Return the branch name from ``git symbolic-ref`` output.
+
+    Input shape: ``refs/remotes/origin/<branch>\\n``. Returns the
+    trailing component, or ``None`` when the shape does not match.
+    """
+    line = output.strip()
+    prefix = "refs/remotes/origin/"
+    if not line.startswith(prefix):
+        return None
+    branch = line[len(prefix) :]
+    if not branch:
+        return None
+    return branch
+
+
+def get_repo_slug(cwd: Path) -> str | None:
+    """Return ``"USER/REPO"`` from the origin remote, or ``None``.
+
+    Invokes ``git remote get-url origin`` in ``cwd`` and parses the
+    output. Returns ``None`` when:
+
+    - ``git`` is not installed (``FileNotFoundError``),
+    - the invocation fails (non-zero exit — not a repo, no origin),
+    - the invocation times out,
+    - any other ``subprocess.SubprocessError`` fires,
+    - the URL shape is unrecognized.
+
+    Never raises under any of the above conditions.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        return None
+    except subprocess.SubprocessError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    return _parse_remote_url(result.stdout)
+
+
+def get_default_branch(cwd: Path) -> str | None:
+    """Return the default branch name, or ``None``.
+
+    Invokes ``git symbolic-ref refs/remotes/origin/HEAD`` in ``cwd``
+    and parses the output. Returns ``None`` under the same error set
+    as :func:`get_repo_slug` (git missing, non-zero exit, timeout,
+    generic subprocess error, unexpected output shape).
+
+    Never raises under any of the above conditions.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        return None
+    except subprocess.SubprocessError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    return _parse_symbolic_ref(result.stdout)

--- a/src/clauditor/_git.py
+++ b/src/clauditor/_git.py
@@ -34,11 +34,13 @@ __all__ = ["get_default_branch", "get_repo_slug"]
 # that a wedged subprocess cannot stall the badge command.
 _GIT_TIMEOUT_SECONDS = 10
 
-# SSH-style URL: git@host:path/to/repo[.git]
-_SSH_URL_RE = re.compile(r"^[^@]+@[^:]+:(?P<slug>.+?)(?:\.git)?$")
+# SSH-style URL: [ssh://]git@host[:port]:path/to/repo[.git]  (scp-like)
+_SSH_URL_RE = re.compile(r"^[^@]+@[^:]+:(?P<slug>.+?)(?:\.git)?/?$")
 
-# HTTPS/HTTP URL: scheme://host/path/to/repo[.git]
-_HTTP_URL_RE = re.compile(r"^https?://[^/]+/(?P<slug>.+?)(?:\.git)?$")
+# HTTPS/HTTP/SSH URL: scheme://[user@]host[:port]/path/to/repo[.git]
+_URL_RE = re.compile(
+    r"^(?:https?|ssh|git)://[^/]+/(?P<slug>.+?)(?:\.git)?/?$"
+)
 
 
 def _parse_remote_url(url: str) -> str | None:
@@ -48,19 +50,29 @@ def _parse_remote_url(url: str) -> str | None:
 
     - ``https://host/path/to/repo[.git]`` (HTTPS, any host, nested
       group paths like gitlab's ``group/sub/repo``).
-    - ``git@host:path/to/repo[.git]`` (SSH).
+    - ``ssh://[user@]host/path/to/repo[.git]`` (explicit SSH scheme).
+    - ``git@host:path/to/repo[.git]`` (scp-like SSH).
+    - Trailing slash after the path is stripped before matching.
 
-    Returns ``None`` for unrecognized shapes.
+    Returns ``None`` for:
+
+    - Unrecognized URL shapes.
+    - Single-path-component slugs like ``USER`` alone (review pass 3,
+      C3-2 — a valid GitHub/GitLab slug has at least one ``/`` between
+      owner and repo).
     """
     url = url.strip()
     if not url:
         return None
 
-    for pattern in (_HTTP_URL_RE, _SSH_URL_RE):
+    for pattern in (_URL_RE, _SSH_URL_RE):
         match = pattern.match(url)
         if match is not None:
             slug = match.group("slug").strip("/")
-            if slug:
+            # A valid slug carries at least one ``/`` (owner/repo or
+            # group/.../repo). Single-component slugs produce broken
+            # shields.io URLs.
+            if slug and "/" in slug:
                 return slug
 
     return None

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -56,15 +56,23 @@ Decisions traced (see ``plans/super/77-clauditor-badge.md``):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+from urllib.parse import quote
+
+from clauditor.audit import _read_json, _scan_iteration_dirs
 
 __all__ = [
     "Badge",
     "ClauditorExtension",
+    "IterationSidecars",
     "L1Summary",
     "L3Summary",
     "VarianceSummary",
+    "build_markdown_image",
     "compute_badge",
+    "discover_iteration",
+    "load_iteration_sidecars",
 ]
 
 
@@ -573,3 +581,189 @@ def compute_badge(
         ),
         style_overrides=dict(style_overrides) if style_overrides else {},
     )
+
+
+# ---------------------------------------------------------------------------
+# Sidecar discovery + URL-builder pure helpers (US-003).
+#
+# These helpers extend ``clauditor.badge`` additively with the pure
+# pieces the CLI layer (``cli/badge.py``) composes in US-004:
+#
+# * :func:`discover_iteration` walks ``<project_dir>/.clauditor/
+#   iteration-*/`` via the existing ``audit._scan_iteration_dirs``
+#   helper and returns the latest iteration dir that contains a
+#   ``<skill_name>/`` subdir (or, when the caller supplies an
+#   explicit iteration number, resolves that specific dir).
+# * :func:`load_iteration_sidecars` reads the three per-layer sidecar
+#   files via ``audit._read_json`` (best-effort; returns ``None`` on
+#   absent / malformed) and packages them into an
+#   :class:`IterationSidecars` dataclass with the DEC-008
+#   ``assertions_missing`` flag.
+# * :func:`build_markdown_image` renders the ``--url-only`` shields.io
+#   endpoint Markdown image line with URL-encoded path components.
+#
+# All three are pure per ``.claude/rules/pure-compute-vs-io-split.md``:
+# no stderr, no subprocess, no mutation of inputs. The file reads in
+# :func:`load_iteration_sidecars` go through ``audit._read_json``,
+# which is a best-effort helper that swallows missing-file / parse-
+# error failures — the thinnest possible I/O seam and the only one
+# this module owns.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IterationSidecars:
+    """Container for the three per-layer sidecar dicts.
+
+    All three sidecar fields are ``None`` when the corresponding file
+    is absent or fails to parse (via :func:`audit._read_json`).
+
+    ``assertions_missing`` distinguishes the DEC-008 "corrupt
+    iteration" branch from the DEC-001 "no data yet" branch:
+
+    * ``True`` — the iteration-skill dir exists on disk, but
+      ``assertions.json`` does not. The CLI treats this as a
+      corrupt iteration and exits 1 (DEC-008).
+    * ``False`` — either both the dir and ``assertions.json`` are
+      absent (the "no iteration found" DEC-001 case; the caller
+      uses :func:`discover_iteration`'s ``None`` return to detect
+      that upstream), or the iteration is present and
+      ``assertions.json`` is present too (the happy path).
+
+    The flag is a property of the sidecar-loading step rather than
+    of the returned dicts themselves — an empty-but-present
+    ``assertions.json`` loads as an (empty) dict, with
+    ``assertions_missing=False``.
+    """
+
+    assertions: dict | None
+    grading: dict | None
+    variance: dict | None
+    assertions_missing: bool
+
+
+def discover_iteration(
+    project_dir: Path,
+    skill_name: str,
+    explicit: int | None,
+) -> tuple[int, Path] | None:
+    """Locate the iteration dir whose sidecars feed the badge.
+
+    Two modes:
+
+    * ``explicit=None`` — walk
+      ``<project_dir>/.clauditor/iteration-*/`` via
+      :func:`audit._scan_iteration_dirs` (returns dirs sorted
+      descending by iteration number) and return the first
+      ``(N, iteration-N/<skill_name>)`` tuple whose skill-dir
+      exists. Returns ``None`` when no iteration contains a
+      ``<skill_name>/`` subdir. Missing ``.clauditor/`` is
+      handled by the scanner, which returns an empty list — no
+      raise.
+    * ``explicit=N`` — check
+      ``<project_dir>/.clauditor/iteration-N/<skill_name>/``
+      directly. Returns ``(N, that_path)`` if it exists, else
+      ``None``.
+
+    The caller distinguishes DEC-001 (no iteration at all, lightgrey
+    placeholder, exit 0) from DEC-016 (explicit ``--from-iteration
+    N`` that doesn't resolve, exit 1) by branching on
+    ``explicit is not None`` after this helper returns ``None``.
+
+    Pure: no stderr, no subprocess, no mutation of inputs. Only
+    filesystem reads (via the scanner and ``Path.is_dir``).
+    """
+    clauditor_dir = project_dir / ".clauditor"
+    if explicit is not None:
+        target = clauditor_dir / f"iteration-{explicit}" / skill_name
+        if target.is_dir():
+            return explicit, target
+        return None
+
+    for iter_num, iter_dir in _scan_iteration_dirs(clauditor_dir):
+        skill_dir = iter_dir / skill_name
+        if skill_dir.is_dir():
+            return iter_num, skill_dir
+    return None
+
+
+def load_iteration_sidecars(iteration_skill_dir: Path) -> IterationSidecars:
+    """Read the three per-layer sidecars from an iteration skill dir.
+
+    Reads ``assertions.json``, ``grading.json``, and ``variance.json``
+    under ``iteration_skill_dir`` via :func:`audit._read_json`. That
+    helper returns ``None`` on absent file or JSON parse error; we
+    propagate that signal into each dataclass field so the caller
+    can cleanly distinguish present-and-loaded from absent-or-
+    malformed.
+
+    ``assertions_missing`` is set per the DEC-008 contract — ``True``
+    when the iteration-skill dir exists but ``assertions.json`` does
+    not. When the dir itself does not exist, ``assertions_missing``
+    is ``False`` (the DEC-001 "no iteration" path, which the caller
+    should already have detected via
+    :func:`discover_iteration` returning ``None``).
+
+    Pure from the caller's perspective: the helper performs file
+    reads but never raises on the common error paths and never
+    mutates the input path.
+    """
+    dir_exists = iteration_skill_dir.is_dir()
+    assertions_path = iteration_skill_dir / "assertions.json"
+    assertions = _read_json(assertions_path)
+    grading = _read_json(iteration_skill_dir / "grading.json")
+    variance = _read_json(iteration_skill_dir / "variance.json")
+    assertions_missing = dir_exists and not assertions_path.is_file()
+    return IterationSidecars(
+        assertions=assertions,
+        grading=grading,
+        variance=variance,
+        assertions_missing=assertions_missing,
+    )
+
+
+def build_markdown_image(
+    *,
+    skill_name: str,
+    repo_slug: str,
+    branch: str,
+    output_relpath: str,
+    label: str,
+) -> str:
+    """Build the Markdown image line for ``clauditor badge --url-only``.
+
+    Constructs a shields.io endpoint URL that points at the raw
+    badge JSON hosted under ``<repo_slug>/<branch>/<output_relpath>``
+    on GitHub (``raw.githubusercontent.com``). Each URL path
+    component is percent-encoded via
+    ``urllib.parse.quote(..., safe="/")`` so path separators pass
+    through unchanged while spaces and other URL-unsafe characters
+    are escaped.
+
+    The label is preserved verbatim inside the Markdown
+    ``![label](...)`` syntax — shields.io does not consume the
+    Markdown alt-text, and keeping it human-readable makes the
+    rendered README more accessible.
+
+    ``skill_name`` is not directly interpolated into the URL — the
+    caller bakes it into ``output_relpath`` (e.g.
+    ``.clauditor/badges/<skill>.json``). Accepting it as a keyword
+    argument keeps the signature stable for future tweaks and gives
+    the caller a single entry point that carries all badge identity
+    on one call.
+
+    Pure: no stderr, no subprocess, no mutation of inputs.
+    """
+    # Path components can legitimately contain ``/`` (the repo_slug
+    # is ``USER/REPO``; output_relpath is ``.clauditor/badges/<n>.json``),
+    # so ``safe="/"`` preserves the separator while escaping spaces,
+    # ``?``, ``#``, ``&``, and other URL-reserved characters.
+    _ = skill_name  # intentionally unused; see docstring rationale.
+    encoded_slug = quote(repo_slug, safe="/")
+    encoded_branch = quote(branch, safe="/")
+    encoded_relpath = quote(output_relpath, safe="/")
+    inner_url = (
+        f"https://raw.githubusercontent.com/"
+        f"{encoded_slug}/{encoded_branch}/{encoded_relpath}"
+    )
+    return f"![{label}](https://img.shields.io/endpoint?url={inner_url})"

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -1,0 +1,575 @@
+"""Pure compute core for ``clauditor badge`` — shields.io endpoint JSON.
+
+Aggregates per-iteration L1 assertions, L3 grading, and (optional)
+variance sidecars into a shields.io endpoint-schema JSON payload plus
+a nested ``clauditor`` extension block carrying full state. The CLI
+layer (:mod:`clauditor.cli.badge`) owns all I/O — sidecar reads,
+output writes, stderr warnings, exit-code mapping, and git subprocess
+calls; this module is pure per ``.claude/rules/pure-compute-vs-io-split.md``.
+
+Decisions traced (see ``plans/super/77-clauditor-badge.md``):
+
+- **DEC-003** — ``clauditor.layers.variance`` block is optional;
+  omitted entirely when ``variance=None`` (the always-absent steady
+  state today).
+- **DEC-009** — L3 all parse-failed (empty ``results`` OR no result
+  carries a numeric score) renders the badge ``red`` with the L3
+  fragment omitted from the message.
+- **DEC-010** — Both L1 and L3 layer blocks carry a ``passed: bool``
+  field; they mean different things. L1 ``passed`` = "every
+  assertion passed". L3 ``passed`` = "pass rate ≥ min_pass_rate AND
+  mean score ≥ min_mean_score" (i.e., the grade met its thresholds).
+- **DEC-012** — ``generated_at`` uses the ``Z`` suffix form
+  (``2026-04-21T14:00:00Z``) rather than ``+00:00``. The CLI layer
+  constructs the string via
+  ``datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")``
+  and passes it in; this module does no timestamp formatting.
+- **DEC-013** — Nested dataclasses mirror the ``Benchmark`` idiom:
+  :class:`L1Summary`, :class:`L3Summary`, :class:`VarianceSummary`,
+  :class:`ClauditorExtension`, :class:`Badge`. Raw-dict passthrough
+  only for the ``thresholds`` block copied verbatim from
+  ``grading.json``.
+- **DEC-020** — Zero L1 assertions (``assertions=None`` OR a
+  sidecar dict with ``runs=[]`` / all-empty ``results``) renders
+  ``color=lightgrey`` + ``message="no data"``. Applies uniformly to
+  DEC-001 (no iteration) and DEC-007 (spec declares zero L1
+  assertions).
+- **DEC-024** — Message format:
+    * L1 only → ``"{N}/{M}"`` (e.g. ``"8/8"``).
+    * L1 + L3 → ``"{N}/{M} · L3 {round(pr*100)}%"``.
+    * L1 + L3 + variance → ``"{N}/{M} · L3 {pr}% · {stab}% stable"``.
+    * Zero-L1 (lightgrey) → ``"no data"``.
+- **DEC-026** — Pure compute vs. I/O split; this module takes
+  pre-parsed dicts and returns a :class:`Badge` dataclass ready to
+  serialize.
+- **DEC-027** — Two independent schema-version fields on the JSON
+  payload:
+    * Top-level ``schemaVersion: 1`` — shields.io's contract
+      (camelCase per their docs), first top-level key of the endpoint
+      JSON.
+    * Nested ``clauditor.schema_version: 1`` — our extension
+      contract, first key of the ``clauditor`` block per
+      ``.claude/rules/json-schema-version.md``.
+  The two versions bump independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "Badge",
+    "ClauditorExtension",
+    "L1Summary",
+    "L3Summary",
+    "VarianceSummary",
+    "compute_badge",
+]
+
+
+# ---------------------------------------------------------------------------
+# Schema versions (see DEC-027).
+# ---------------------------------------------------------------------------
+
+# shields.io's endpoint-JSON schema version (their contract, camelCase
+# key at the top of the emitted dict).
+_SHIELDS_SCHEMA_VERSION: int = 1
+
+# The ``clauditor`` extension block's own version — first key of the
+# block per ``.claude/rules/json-schema-version.md``.
+_CLAUDITOR_EXTENSION_SCHEMA_VERSION: int = 1
+
+
+# ---------------------------------------------------------------------------
+# Color constants (see DEC-020 / the ticket's color table).
+#
+# Kept as module-level strings rather than a dict/enum: downstream
+# consumers (tests, audit readers) grep for these exact strings, and
+# the set is small + stable.
+# ---------------------------------------------------------------------------
+
+_COLOR_BRIGHT_GREEN: str = "brightgreen"
+_COLOR_YELLOW: str = "yellow"
+_COLOR_RED: str = "red"
+_COLOR_LIGHTGREY: str = "lightgrey"
+
+# Message fragment for the no-data case (DEC-020).
+_NO_DATA_MESSAGE: str = "no data"
+
+
+# ---------------------------------------------------------------------------
+# Nested dataclasses (see DEC-013).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class L1Summary:
+    """Layer 1 (assertion) summary for the badge.
+
+    ``passed`` semantic (DEC-010): ``all(r.passed for r in results)``
+    — i.e., every declared assertion passed in the iteration being
+    reported. Contrast with :attr:`L3Summary.passed`, which means
+    "the grade met its thresholds".
+    """
+
+    count: int
+    total: int
+    pass_rate: float
+    passed: bool
+
+
+@dataclass
+class L3Summary:
+    """Layer 3 (quality grading) summary for the badge.
+
+    ``passed`` semantic (DEC-010): ``pass_rate ≥ min_pass_rate AND
+    mean_score ≥ min_mean_score`` — the threshold-gated "this grade
+    is good enough" signal. Contrast with :attr:`L1Summary.passed`,
+    which means "every assertion passed".
+
+    ``thresholds`` is the raw passthrough dict from ``grading.json``'s
+    own ``thresholds`` block (DEC-004 — the badge shows what the
+    grade already decided, no re-interpretation).
+    """
+
+    pass_rate: float
+    mean_score: float
+    passed: bool
+    thresholds: dict[str, Any]
+
+
+@dataclass
+class VarianceSummary:
+    """Variance sidecar summary for the badge.
+
+    ``passed`` semantic: ``stability ≥ min_stability`` (the variance
+    writer, when it exists, sets this field; the badge consumes it
+    verbatim). ``n_runs`` and ``stability`` are copied from the
+    sidecar's own fields.
+    """
+
+    n_runs: int
+    stability: float
+    passed: bool
+
+
+@dataclass
+class ClauditorExtension:
+    """The nested ``clauditor`` block on the badge JSON.
+
+    ``schema_version`` is the first field and is emitted as the first
+    key of the serialized block per
+    ``.claude/rules/json-schema-version.md``. ``layers`` is built on
+    the fly at serialization time from the (optional) summary fields
+    — omit any layer whose summary is ``None``.
+    """
+
+    skill_name: str
+    generated_at: str
+    iteration: int | None
+    l1: L1Summary | None = None
+    l3: L3Summary | None = None
+    variance: VarianceSummary | None = None
+    schema_version: int = _CLAUDITOR_EXTENSION_SCHEMA_VERSION
+
+
+@dataclass
+class Badge:
+    """Serializable shields.io endpoint-JSON payload.
+
+    Top-level fields match the shields.io endpoint schema:
+    ``schemaVersion``, ``label``, ``message``, ``color``. Any
+    ``style_overrides`` land alphabetically between ``color`` and the
+    ``clauditor`` extension block per the DEC-015 passthrough rule.
+    """
+
+    label: str
+    message: str
+    color: str
+    clauditor: ClauditorExtension
+    style_overrides: dict[str, str] = field(default_factory=dict)
+    schema_version: int = _SHIELDS_SCHEMA_VERSION
+
+    def to_endpoint_json(self) -> dict[str, Any]:
+        """Return the shields.io-compatible dict with canonical key order.
+
+        Top-level keys in order: ``schemaVersion``, ``label``,
+        ``message``, ``color``, then ``style_overrides`` sorted
+        alphabetically, then ``clauditor``. Inside ``clauditor``,
+        first key is ``schema_version`` (per
+        ``.claude/rules/json-schema-version.md``), followed by
+        ``skill_name``, ``generated_at``, ``iteration``, ``layers``.
+
+        Python 3.7+ preserves dict insertion order, so building the
+        dict literal-by-literal in the desired order is the entire
+        mechanism.
+        """
+        payload: dict[str, Any] = {
+            "schemaVersion": self.schema_version,
+            "label": self.label,
+            "message": self.message,
+            "color": self.color,
+        }
+        for key in sorted(self.style_overrides):
+            payload[key] = self.style_overrides[key]
+        payload["clauditor"] = _extension_to_dict(self.clauditor)
+        return payload
+
+
+def _extension_to_dict(ext: ClauditorExtension) -> dict[str, Any]:
+    """Serialize the ``clauditor`` block with ``schema_version`` first.
+
+    Layers are omitted entirely when their summary is ``None``
+    (DEC-003 for variance; DEC-020 for L1-when-no-data; absent L3
+    when grading sidecar is missing).
+    """
+    block: dict[str, Any] = {
+        "schema_version": ext.schema_version,
+        "skill_name": ext.skill_name,
+        "generated_at": ext.generated_at,
+        "iteration": ext.iteration,
+    }
+    layers: dict[str, Any] = {}
+    if ext.l1 is not None:
+        layers["l1"] = {
+            "count": ext.l1.count,
+            "total": ext.l1.total,
+            "pass_rate": ext.l1.pass_rate,
+            "passed": ext.l1.passed,
+        }
+    if ext.l3 is not None:
+        layers["l3"] = {
+            "pass_rate": ext.l3.pass_rate,
+            "mean_score": ext.l3.mean_score,
+            "passed": ext.l3.passed,
+            "thresholds": ext.l3.thresholds,
+        }
+    if ext.variance is not None:
+        layers["variance"] = {
+            "n_runs": ext.variance.n_runs,
+            "stability": ext.variance.stability,
+            "passed": ext.variance.passed,
+        }
+    block["layers"] = layers
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Pure compute: L1 / L3 / variance sidecar classification.
+# ---------------------------------------------------------------------------
+
+
+def _summarize_l1(assertions: dict | None) -> L1Summary | None:
+    """Collapse an ``assertions.json`` payload into an :class:`L1Summary`.
+
+    ``assertions=None`` represents DEC-001 (no iteration at all) /
+    DEC-008 (caller signaled the no-L1-signal case). Returns ``None``
+    to trigger the DEC-020 lightgrey "no data" path.
+
+    A sidecar dict with no results (``runs=[]`` or every run carrying
+    an empty ``results`` list) also returns ``None`` — DEC-007's
+    "iteration exists but spec declares zero L1 assertions" path.
+
+    Two sidecar layouts are accepted:
+
+    * Modern (from ``cli/grade.py::_write_assertions_sidecar``):
+      top-level ``runs: [{"run": 0, "input_tokens": ..., "results":
+      [...]}, ...]`` — results are flattened across runs.
+    * Flat (from older ``AssertionSet.to_json`` or tests):
+      top-level ``results: [...]`` directly.
+
+    Both cases sum ``count`` = ``total`` across all results and set
+    ``passed = (count == total)``. A mixed-run sidecar with 8/8
+    in run-0 and 7/8 in run-1 collapses to 15/16.
+    """
+    if assertions is None:
+        return None
+
+    results = _collect_assertion_results(assertions)
+    if not results:
+        return None
+
+    total = len(results)
+    count = sum(1 for r in results if _result_passed(r))
+    pass_rate = count / total if total > 0 else 0.0
+    return L1Summary(
+        count=count,
+        total=total,
+        pass_rate=pass_rate,
+        passed=count == total,
+    )
+
+
+def _collect_assertion_results(assertions: dict) -> list[dict]:
+    """Extract the flat list of per-assertion result dicts.
+
+    Handles both the ``runs`` (modern) and ``results`` (flat) layouts.
+    Tolerates missing / non-list fields by returning ``[]`` — the
+    caller treats that as the no-L1-signal case (DEC-007).
+    """
+    runs = assertions.get("runs")
+    if isinstance(runs, list):
+        collected: list[dict] = []
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            run_results = run.get("results")
+            if isinstance(run_results, list):
+                collected.extend(r for r in run_results if isinstance(r, dict))
+        return collected
+
+    # Flat layout.
+    flat = assertions.get("results")
+    if isinstance(flat, list):
+        return [r for r in flat if isinstance(r, dict)]
+    return []
+
+
+def _result_passed(result: dict) -> bool:
+    """Strict-``True`` check on an assertion result's ``passed`` field.
+
+    Missing / non-bool / truthy-but-non-bool values count as failed.
+    The L1 sidecar is clauditor-owned, so the strict check is
+    appropriate — a malformed entry is a corruption signal.
+    """
+    return result.get("passed") is True
+
+
+def _summarize_l3(grading: dict | None) -> tuple[L3Summary | None, bool]:
+    """Collapse a ``grading.json`` payload into an :class:`L3Summary`.
+
+    Returns ``(summary, parse_failed)`` where:
+
+    * ``summary is None and parse_failed is False`` — grading sidecar
+      absent (caller passed ``grading=None``). Caller omits the L3
+      block from the badge entirely.
+    * ``summary is None and parse_failed is True`` — grading ran but
+      no result carries a numeric score, OR the sidecar's
+      ``results`` list is empty. DEC-009: this is a red badge; L3
+      fragment is omitted from the message.
+    * ``summary is not None`` — happy path. ``summary.passed``
+      reflects the thresholds-based calculation against the sidecar's
+      own ``thresholds`` block (DEC-004).
+    """
+    if grading is None:
+        return None, False
+
+    results = grading.get("results")
+    if not isinstance(results, list) or len(results) == 0:
+        return None, True
+
+    # "No result carries a score" is the parse-failed signal — a
+    # graded-but-all-failed run with real scores is just a failing
+    # grade, not a parse failure. The strict ``isinstance(score,
+    # (int, float))`` check tolerates integer and float scores while
+    # rejecting None / string.
+    scored = [
+        r
+        for r in results
+        if isinstance(r, dict) and isinstance(r.get("score"), (int, float))
+    ]
+    if not scored:
+        return None, True
+
+    pass_rate_val = _compute_grading_pass_rate(results)
+    mean_score_val = _compute_grading_mean_score(scored)
+
+    thresholds_block = grading.get("thresholds")
+    if not isinstance(thresholds_block, dict):
+        thresholds_block = {}
+
+    min_pass_rate = _coerce_float(thresholds_block.get("min_pass_rate"), 0.7)
+    min_mean_score = _coerce_float(thresholds_block.get("min_mean_score"), 0.5)
+    passed = pass_rate_val >= min_pass_rate and mean_score_val >= min_mean_score
+
+    return (
+        L3Summary(
+            pass_rate=pass_rate_val,
+            mean_score=mean_score_val,
+            passed=passed,
+            thresholds=dict(thresholds_block),
+        ),
+        False,
+    )
+
+
+def _compute_grading_pass_rate(results: list[Any]) -> float:
+    """Fraction of grading results where ``passed is True``."""
+    valid = [r for r in results if isinstance(r, dict)]
+    if not valid:
+        return 0.0
+    return sum(1 for r in valid if r.get("passed") is True) / len(valid)
+
+
+def _compute_grading_mean_score(scored: list[dict]) -> float:
+    """Mean of the numeric ``score`` fields across scored results."""
+    if not scored:
+        return 0.0
+    return sum(float(r["score"]) for r in scored) / len(scored)
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    """Tolerant float coercion — returns ``default`` for non-numeric inputs."""
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    return default
+
+
+def _summarize_variance(variance: dict | None) -> VarianceSummary | None:
+    """Collapse a ``variance.json`` payload into a :class:`VarianceSummary`.
+
+    DEC-003: returns ``None`` when ``variance is None`` so the caller
+    omits the variance block entirely. The variance sidecar format
+    is documented (no writer ships today) to carry:
+
+    * ``n_runs: int`` — number of replicate runs.
+    * ``stability: float`` — 0.0–1.0 stability score.
+    * ``passed: bool`` — ``stability ≥ min_stability``.
+
+    All three fields are optional on read; missing-or-wrong-type
+    falls back to ``0``/``0.0``/``False`` rather than raising — the
+    badge degrades gracefully on malformed variance data rather than
+    failing the whole command.
+    """
+    if variance is None:
+        return None
+
+    n_runs_raw = variance.get("n_runs")
+    n_runs = n_runs_raw if isinstance(n_runs_raw, int) and not isinstance(
+        n_runs_raw, bool
+    ) else 0
+
+    stability = _coerce_float(variance.get("stability"), 0.0)
+    passed = variance.get("passed") is True
+    return VarianceSummary(n_runs=n_runs, stability=stability, passed=passed)
+
+
+# ---------------------------------------------------------------------------
+# Color + message classification (see DEC-009, DEC-020, DEC-024).
+# ---------------------------------------------------------------------------
+
+
+def _compute_color(
+    l1: L1Summary | None,
+    l3: L3Summary | None,
+    l3_parse_failed: bool,
+) -> str:
+    """Decide the badge color.
+
+    Precedence (most-specific-first):
+
+    1. No L1 signal → ``lightgrey`` (DEC-020 covers DEC-001 and
+       DEC-007).
+    2. Any L1 assertion failed → ``red``.
+    3. L1 all-pass + L3 parse-failed → ``red`` (DEC-009).
+    4. L1 all-pass + L3 present but not passed → ``yellow``.
+    5. L1 all-pass + L3 passed OR L3 omitted → ``brightgreen``.
+    """
+    if l1 is None:
+        return _COLOR_LIGHTGREY
+    if not l1.passed:
+        return _COLOR_RED
+    if l3_parse_failed:
+        return _COLOR_RED
+    if l3 is not None and not l3.passed:
+        return _COLOR_YELLOW
+    return _COLOR_BRIGHT_GREEN
+
+
+def _compute_message(
+    l1: L1Summary | None,
+    l3: L3Summary | None,
+    variance: VarianceSummary | None,
+) -> str:
+    """Render the shields.io ``message`` field per DEC-024.
+
+    Delegates the L3 decision to the caller's classification: when
+    ``l3 is None`` (either absent or parse-failed), the L3 fragment
+    is omitted.
+    """
+    if l1 is None:
+        return _NO_DATA_MESSAGE
+
+    base = f"{l1.count}/{l1.total}"
+    if l3 is None:
+        return base
+
+    l3_pct = round(l3.pass_rate * 100)
+    with_l3 = f"{base} · L3 {l3_pct}%"
+    if variance is None:
+        return with_l3
+
+    stab_pct = round(variance.stability * 100)
+    return f"{with_l3} · {stab_pct}% stable"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+
+
+def compute_badge(
+    assertions: dict | None,
+    grading: dict | None,
+    variance: dict | None,
+    *,
+    skill_name: str,
+    iteration: int | None,
+    generated_at: str,
+    label: str = "clauditor",
+    style_overrides: dict[str, str] | None = None,
+) -> Badge:
+    """Aggregate per-iteration sidecars into a :class:`Badge`.
+
+    All three sidecar args are optional:
+
+    * ``assertions=None`` represents the DEC-001 / DEC-008 no-L1-
+      signal case. An ``assertions`` dict whose collected results
+      are empty (DEC-007 — iteration exists but spec declares zero
+      L1 assertions) is treated identically: lightgrey badge,
+      ``"no data"`` message, no ``layers.l1`` block.
+    * ``grading=None`` omits L3 entirely. A grading dict whose
+      ``results`` list is empty OR whose results carry no numeric
+      ``score`` triggers DEC-009 (L3 parse-failed → red, L3 fragment
+      omitted from the message, and ``layers.l3`` still omitted).
+    * ``variance=None`` (DEC-003's always-absent steady state) omits
+      the variance block entirely.
+
+    ``generated_at`` should use the ISO-8601 ``Z``-suffix form
+    (DEC-012); the caller is expected to post-process
+    ``datetime.now(timezone.utc).isoformat()`` with
+    ``.replace("+00:00", "Z")``. This function performs no timestamp
+    formatting — it is pure compute over pre-resolved inputs.
+
+    ``iteration`` may be ``None`` when no iteration has been discovered
+    (the DEC-001 placeholder path); the value is passed through
+    verbatim to the JSON payload.
+
+    ``style_overrides`` is a dict of shields.io ``--style`` passthrough
+    keys (DEC-015); alphabetically serialized between the top-level
+    ``color`` and ``clauditor`` keys.
+    """
+    l1 = _summarize_l1(assertions)
+    l3, l3_parse_failed = _summarize_l3(grading)
+    var = _summarize_variance(variance)
+
+    color = _compute_color(l1, l3, l3_parse_failed)
+    message = _compute_message(l1, l3, var)
+
+    return Badge(
+        label=label,
+        message=message,
+        color=color,
+        clauditor=ClauditorExtension(
+            skill_name=skill_name,
+            generated_at=generated_at,
+            iteration=iteration,
+            l1=l1,
+            l3=l3,
+            variance=var,
+        ),
+        style_overrides=dict(style_overrides) if style_overrides else {},
+    )

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -374,11 +374,17 @@ def _summarize_l3(grading: dict | None) -> tuple[L3Summary | None, bool]:
     # graded-but-all-failed run with real scores is just a failing
     # grade, not a parse failure. The strict ``isinstance(score,
     # (int, float))`` check tolerates integer and float scores while
-    # rejecting None / string.
+    # rejecting None / string. ``bool`` is a subclass of ``int`` in
+    # Python, so explicitly exclude it — a ``{"score": true}``
+    # malformed payload should NOT be treated as a 1.0 score
+    # (per-type bool-vs-int guard also applied in schemas.py via the
+    # ``constant-with-type-info`` rule).
     scored = [
         r
         for r in results
-        if isinstance(r, dict) and isinstance(r.get("score"), (int, float))
+        if isinstance(r, dict)
+        and isinstance(r.get("score"), (int, float))
+        and not isinstance(r.get("score"), bool)
     ]
     if not scored:
         return None, True

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -196,7 +196,10 @@ class Badge:
     message: str
     color: str
     clauditor: ClauditorExtension
-    style_overrides: dict[str, str] = field(default_factory=dict)
+    # Values are ``str | int`` because shields.io types some style
+    # keys (``cacheSeconds``) as integers per their endpoint schema;
+    # the CLI layer coerces those at parse time (review pass 3, C3-1).
+    style_overrides: dict[str, str | int] = field(default_factory=dict)
     schema_version: int = _SHIELDS_SCHEMA_VERSION
 
     def to_endpoint_json(self) -> dict[str, Any]:
@@ -528,7 +531,7 @@ def compute_badge(
     iteration: int | None,
     generated_at: str,
     label: str = "clauditor",
-    style_overrides: dict[str, str] | None = None,
+    style_overrides: dict[str, str | int] | None = None,
 ) -> Badge:
     """Aggregate per-iteration sidecars into a :class:`Badge`.
 
@@ -675,12 +678,24 @@ def discover_iteration(
     """
     clauditor_dir = project_dir / ".clauditor"
     if explicit is not None:
+        if explicit < 1:
+            # Iteration numbers start at 1 (see ``workspace.py``).
+            # An in-process caller that bypasses argparse validation
+            # should not be able to coerce this helper into a
+            # "missing" signal for what is actually a malformed
+            # request (review pass 1, C-3).
+            return None
         target = clauditor_dir / f"iteration-{explicit}" / skill_name
         if target.is_dir():
             return explicit, target
         return None
 
     for iter_num, iter_dir in _scan_iteration_dirs(clauditor_dir):
+        # Mirror the explicit<1 defensive guard (review pass 3, N3-3)
+        # — ``iteration-0`` or any ``iteration--N`` dir is not a valid
+        # iteration per ``workspace.py`` invariants.
+        if iter_num < 1:
+            continue
         skill_dir = iter_dir / skill_name
         if skill_dir.is_dir():
             return iter_num, skill_dir

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -352,6 +352,7 @@ def _relative_to_repo(clauditor_dir: Path, final_skill_dir: Path) -> str:
 # per-command modules that lazily import shared helpers from ``clauditor.cli``
 # see them already defined when their ``cmd_<name>`` function runs.
 from clauditor.cli import audit as audit_mod  # noqa: E402
+from clauditor.cli import badge as badge_mod  # noqa: E402
 from clauditor.cli import capture as capture_mod  # noqa: E402
 from clauditor.cli import compare as compare_mod  # noqa: E402
 from clauditor.cli import doctor as doctor_mod  # noqa: E402
@@ -367,6 +368,7 @@ from clauditor.cli import trend as trend_mod  # noqa: E402
 from clauditor.cli import triggers as triggers_mod  # noqa: E402
 from clauditor.cli import validate as validate_mod  # noqa: E402
 from clauditor.cli.audit import cmd_audit  # noqa: E402,F401
+from clauditor.cli.badge import cmd_badge  # noqa: E402,F401
 from clauditor.cli.capture import cmd_capture  # noqa: E402,F401
 from clauditor.cli.compare import cmd_compare  # noqa: E402,F401
 from clauditor.cli.doctor import cmd_doctor  # noqa: E402,F401
@@ -438,6 +440,9 @@ def main(argv: list[str] | None = None) -> int:
     # lint
     lint_mod.add_parser(subparsers)
 
+    # badge
+    badge_mod.add_parser(subparsers)
+
     # Split argv on a literal `--` *only* when the capture subcommand is in
     # play, so other subcommands (validate/grade/...) keep argparse's native
     # `--` handling instead of having their trailing args silently stripped.
@@ -484,6 +489,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_propose_eval(parsed)
     elif parsed.command == "lint":
         return cmd_lint(parsed)
+    elif parsed.command == "badge":
+        return cmd_badge(parsed)
 
     return 1
 

--- a/src/clauditor/cli/badge.py
+++ b/src/clauditor/cli/badge.py
@@ -1,0 +1,635 @@
+"""``clauditor badge`` — generate a shields.io endpoint JSON from sidecars.
+
+Thin CLI I/O layer wrapping the pure compute in :mod:`clauditor.badge`
+(see ``.claude/rules/pure-compute-vs-io-split.md``). This module owns
+the argparse surface, sidecar-file reads, git subprocess calls (via
+:mod:`clauditor._git`), output writes, stderr progress/warning lines,
+and the DEC-025 exit-code mapping. The pure module owns badge
+aggregation, color classification, message formatting, and Markdown
+image URL building.
+
+Exit codes (DEC-025 — non-LLM, 0/1/2 taxonomy per
+``.claude/rules/llm-cli-exit-code-taxonomy.md`` "does not apply"
+clause):
+
+- ``0`` — success: badge JSON written (including DEC-001 / DEC-007
+  lightgrey placeholder writes) or Markdown image line printed via
+  ``--url-only``.
+- ``1`` — runtime failure: corrupt iteration (DEC-008 — iteration
+  exists but ``assertions.json`` is missing), existing file without
+  ``--force`` (DEC-011), explicit ``--from-iteration N`` not found
+  (DEC-016), disk I/O error on write.
+- ``2`` — input-validation failure: bad skill spec load (missing or
+  unreadable SKILL.md), mutually exclusive flags (DEC-014), ``--output``
+  parent-dir check failure (DEC-022), ``--style`` malformed or
+  validation failure (DEC-015 / DEC-023).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+
+from clauditor import _git
+from clauditor.badge import (
+    build_markdown_image,
+    compute_badge,
+    discover_iteration,
+    load_iteration_sidecars,
+)
+from clauditor.spec import SkillSpec
+
+# ---------------------------------------------------------------------------
+# --style key whitelist (DEC-015).
+#
+# The accepted shields.io endpoint-JSON passthrough keys. Unknown keys
+# are NOT rejected — they warn to stderr and still land in the JSON
+# (shields.io silently ignores what it doesn't know, so the badge
+# still renders).
+# ---------------------------------------------------------------------------
+
+_ALLOWED_STYLE_KEYS: frozenset[str] = frozenset(
+    {"style", "logoSvg", "logoColor", "labelColor", "cacheSeconds", "link"}
+)
+
+# Upper bound on a ``--style`` value (DEC-023). 512 chars is generous
+# for any reasonable shields.io field (even inline SVG data URLs stay
+# well under that when they show up in practice).
+_STYLE_VALUE_MAX_LEN: int = 512
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``badge`` subparser."""
+    p = subparsers.add_parser(
+        "badge",
+        help=(
+            "Generate a shields.io endpoint JSON from a skill's latest "
+            "iteration sidecars"
+        ),
+    )
+    p.add_argument(
+        "skill",
+        help="Path to a SKILL.md file",
+    )
+    p.add_argument(
+        "--from-iteration",
+        default=None,
+        metavar="N",
+        help=(
+            "Read sidecars from iteration N instead of the latest "
+            "(DEC-016 — missing N exits 1)"
+        ),
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write the badge JSON to PATH; mutually exclusive with "
+            "--url-only (defaults to <project>/.clauditor/badges/"
+            "<skill>.json)"
+        ),
+    )
+    p.add_argument(
+        "--url-only",
+        action="store_true",
+        help=(
+            "Print the Markdown image line to stdout; do NOT write a "
+            "badge JSON file"
+        ),
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Overwrite the target badge JSON if it already exists "
+            "(required by DEC-011)"
+        ),
+    )
+    p.add_argument(
+        "--repo",
+        default=None,
+        metavar="USER/REPO",
+        help=(
+            "Override the git-detected origin slug for --url-only "
+            "(DEC-002 placeholder fallback)"
+        ),
+    )
+    p.add_argument(
+        "--branch",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Override the git-detected default branch for --url-only "
+            "(DEC-002 placeholder fallback)"
+        ),
+    )
+    p.add_argument(
+        "--label",
+        default="clauditor",
+        metavar="TEXT",
+        help='Badge label text (default: "clauditor")',
+    )
+    p.add_argument(
+        "--style",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help=(
+            "Shields.io style passthrough; may be repeated. Whitelist: "
+            "style, logoSvg, logoColor, labelColor, cacheSeconds, link "
+            "(DEC-015). Unknown keys warn but still emit."
+        ),
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help=(
+            "On success, print a stderr info line naming the written "
+            "path and iteration (DEC-018)"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI-local helpers.
+# ---------------------------------------------------------------------------
+
+
+def _parse_style_arg(raw: str) -> tuple[str, str]:
+    """Split a ``KEY=VALUE`` ``--style`` entry into its two halves.
+
+    Raises :class:`ValueError` when the input does not contain exactly
+    one ``=`` separator (either missing entirely, or the input is
+    empty). Trailing-only-separator inputs like ``"key="`` parse as
+    ``("key", "")`` — a legitimate "clear the value" shape for
+    shields.io passthrough.
+    """
+    if "=" not in raw:
+        raise ValueError(f"--style must be KEY=VALUE, got: {raw!r}")
+    key, value = raw.split("=", 1)
+    if not key:
+        raise ValueError(f"--style must be KEY=VALUE, got: {raw!r}")
+    return key, value
+
+
+def _validate_style_value(key: str, value: str) -> None:
+    """Reject a ``--style`` value per DEC-023.
+
+    - Control characters (via ``str.isprintable()``) are rejected as a
+      catch-all for ``\\x00-\\x1f`` and ``\\x7f``.
+    - Values longer than :data:`_STYLE_VALUE_MAX_LEN` are rejected.
+
+    Raises :class:`ValueError` with a message suitable for stderr
+    surfacing when either check fails. Empty values are accepted
+    (they are valid shields.io passthrough — "clear this field").
+    """
+    if value and not value.isprintable():
+        raise ValueError(
+            f"--style value for {key!r} is invalid: contains control "
+            "characters"
+        )
+    if len(value) > _STYLE_VALUE_MAX_LEN:
+        raise ValueError(
+            f"--style value for {key!r} is invalid: length "
+            f"{len(value)} exceeds max {_STYLE_VALUE_MAX_LEN}"
+        )
+
+
+def _now_iso_z() -> str:
+    """Return the current UTC time in the DEC-012 ``Z``-suffix form.
+
+    Python's ``datetime.now(timezone.utc).isoformat()`` produces
+    ``+00:00``; we normalize to ``Z`` at this single seam so every
+    badge JSON renders consistently.
+    """
+    raw = datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")
+    return raw.replace("+00:00", "Z")
+
+
+def _list_available_iterations(project_dir: Path, skill_name: str) -> list[int]:
+    """Return sorted list of iteration numbers containing ``skill_name/``.
+
+    Used for DEC-016's "available iterations" stderr message when an
+    explicit ``--from-iteration N`` lookup fails. Falls back to an
+    empty list when ``.clauditor/`` is absent or contains no matching
+    iteration dirs — the caller renders ``"none"`` in that case.
+    """
+    clauditor_dir = project_dir / ".clauditor"
+    if not clauditor_dir.is_dir():
+        return []
+    found: list[int] = []
+    for child in clauditor_dir.iterdir():
+        if not child.is_dir() or not child.name.startswith("iteration-"):
+            continue
+        suffix = child.name[len("iteration-") :]
+        try:
+            n = int(suffix)
+        except ValueError:
+            continue
+        if (child / skill_name).is_dir():
+            found.append(n)
+    return sorted(found)
+
+
+def _write_badge_json(
+    target: Path,
+    payload: dict,
+    *,
+    force: bool,
+    iteration: int | None,
+    verbose: bool,
+) -> int:
+    """Write the badge JSON payload to ``target``.
+
+    Handles the DEC-011 overwrite-policy check: if ``target`` exists
+    and ``force`` is ``False``, print the error to stderr and return
+    exit 1 without writing. On a successful write, optionally prints
+    the DEC-018 stderr info line when ``verbose=True``.
+
+    ``iteration=None`` renders the verbose line with a
+    ``(no iteration)`` fragment to signal the DEC-001 lightgrey
+    placeholder path; otherwise ``(iteration N)``.
+
+    Returns the exit code the caller should surface (0 on success,
+    1 on collision).
+    """
+    if target.exists() and not force:
+        print(
+            f"ERROR: {target} already exists (pass --force to overwrite)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # For non-default paths (passed via --output) the parent dir was
+    # validated already (DEC-022). For the default path we create the
+    # parent chain unconditionally; re-running after a pruned tree
+    # should not error.
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        target.write_text(
+            json.dumps(payload, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(
+            f"ERROR: could not write {target}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if verbose:
+        tail = (
+            f"(iteration {iteration})"
+            if iteration is not None
+            else "(no iteration)"
+        )
+        print(
+            f"clauditor.badge: wrote {target} {tail}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def _resolve_url_only_slug_and_branch(
+    args: argparse.Namespace,
+    project_dir: Path,
+) -> tuple[str, str]:
+    """Resolve the ``--url-only`` repo slug and branch (DEC-002).
+
+    Precedence:
+
+    1. ``--repo USER/REPO`` and ``--branch NAME`` win when passed.
+    2. Otherwise :func:`clauditor._git.get_repo_slug` and
+       :func:`clauditor._git.get_default_branch` are invoked.
+    3. Missing values fall back to ``"USER/REPO"`` / ``"main"``.
+
+    When ANY auto-detect call returns ``None`` AND the caller did
+    not pass the matching explicit override, emit the DEC-021 stderr
+    warning naming the placeholder. The warning lists BOTH fallback
+    values in one line so the user can paste a single ``--repo`` /
+    ``--branch`` invocation to fix it.
+    """
+    repo_slug = args.repo
+    branch = args.branch
+
+    slug_auto_failed = False
+    branch_auto_failed = False
+
+    if repo_slug is None:
+        detected_slug = _git.get_repo_slug(project_dir)
+        if detected_slug is None:
+            repo_slug = "USER/REPO"
+            slug_auto_failed = True
+        else:
+            repo_slug = detected_slug
+
+    if branch is None:
+        detected_branch = _git.get_default_branch(project_dir)
+        if detected_branch is None:
+            branch = "main"
+            branch_auto_failed = True
+        else:
+            branch = detected_branch
+
+    # DEC-021: warn loudly when the user is relying on auto-detect
+    # AND any detection fell through. We only warn when the slug
+    # auto-detect failed; a branch auto-detect failure with a
+    # successful slug still falls back to "main" (a reasonable
+    # default on GitHub), so the warning stays quiet unless the
+    # slug itself had to be replaced.
+    if slug_auto_failed:
+        fallback_msg = (
+            f"warning: git auto-detect failed; using placeholder "
+            f"{repo_slug}/{branch} — pass --repo USER/REPO to override"
+        )
+        print(fallback_msg, file=sys.stderr)
+    elif branch_auto_failed:
+        # Quietly defaulting to main when we DID detect a slug — but
+        # surface it anyway so the user knows where the branch came
+        # from when the remote happens to not use main.
+        print(
+            "warning: git default-branch auto-detect failed; using "
+            "'main' — pass --branch NAME to override",
+            file=sys.stderr,
+        )
+
+    return repo_slug, branch
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+
+
+def cmd_badge(args: argparse.Namespace) -> int:
+    """Entry point for ``clauditor badge``.
+
+    Follows the four-branch shape described in US-004 of
+    ``plans/super/77-clauditor-badge.md``:
+
+    1. No iteration found and ``--from-iteration`` NOT passed →
+       DEC-001 lightgrey placeholder, exit 0 (respects ``--force``).
+    2. Explicit ``--from-iteration N`` but N not found → DEC-016
+       exit 1 with available-iterations list.
+    3. Iteration found, ``assertions.json`` missing → DEC-008 corrupt
+       iteration, exit 1.
+    4. Iteration found, sidecars loaded → happy path; classify via
+       :func:`clauditor.badge.compute_badge` and either write JSON
+       or print the ``--url-only`` Markdown image.
+    """
+    # DEC-014 mutual exclusion — must run before SkillSpec load so a
+    # misconfigured call does not pay the load cost.
+    if args.url_only and args.output is not None:
+        print(
+            "ERROR: --url-only and --output are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Parse --style flags up-front (DEC-015 / DEC-023). A bad value
+    # here blocks before any sidecar read / disk write.
+    style_overrides: dict[str, str] = {}
+    for raw in args.style or []:
+        try:
+            key, value = _parse_style_arg(raw)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        try:
+            _validate_style_value(key, value)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        if key not in _ALLOWED_STYLE_KEYS:
+            print(
+                f"warning: clauditor.badge: unknown --style key {key!r} — "
+                "passing through anyway",
+                file=sys.stderr,
+            )
+        style_overrides[key] = value
+
+    # Skill spec load. Any load error is a pre-call input error → 2.
+    skill_path = Path(args.skill)
+    if not skill_path.exists():
+        print(
+            f"ERROR: skill file not found: {skill_path}",
+            file=sys.stderr,
+        )
+        return 2
+    if not skill_path.is_file():
+        print(
+            f"ERROR: skill path is not a regular file: {skill_path}",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        spec = SkillSpec.from_file(skill_path)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        print(
+            f"ERROR: could not load skill spec {skill_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    skill_name = spec.skill_name
+    project_dir = Path.cwd()
+
+    # Parse --from-iteration to int here so validation errors surface
+    # before any disk walk. argparse takes the raw string to give the
+    # error message a clean shape.
+    explicit_iter: int | None = None
+    if args.from_iteration is not None:
+        try:
+            explicit_iter = int(args.from_iteration)
+            if explicit_iter < 1:
+                raise ValueError("must be >= 1")
+        except ValueError as exc:
+            print(
+                f"ERROR: --from-iteration must be a positive integer, "
+                f"got {args.from_iteration!r}: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+
+    # Resolve the output path target. DEC-005 accepts absolute paths;
+    # DEC-022 validates parent-dir existence when the user supplied
+    # --output. The default .clauditor/badges/<skill>.json is created
+    # unconditionally via mkdir below.
+    if args.output is not None:
+        target_path = Path(args.output)
+        parent = target_path.parent.resolve(strict=False)
+        if not parent.is_dir():
+            print(
+                f"ERROR: --output parent directory does not exist: {parent}",
+                file=sys.stderr,
+            )
+            return 2
+    else:
+        target_path = (
+            project_dir / ".clauditor" / "badges" / f"{skill_name}.json"
+        )
+
+    # -----------------------------------------------------------------
+    # Sidecar discovery + branch on the four code paths.
+    # -----------------------------------------------------------------
+    discovered = discover_iteration(
+        project_dir=project_dir,
+        skill_name=skill_name,
+        explicit=explicit_iter,
+    )
+
+    if discovered is None and explicit_iter is None:
+        # Code path 1 — DEC-001 lightgrey placeholder (exit 0 after
+        # write).
+        return _handle_no_iteration(
+            target_path=target_path,
+            skill_name=skill_name,
+            args=args,
+            style_overrides=style_overrides,
+            project_dir=project_dir,
+        )
+
+    if discovered is None and explicit_iter is not None:
+        # Code path 2 — DEC-016 explicit-missing iteration.
+        available = _list_available_iterations(project_dir, skill_name)
+        if available:
+            rendered = ", ".join(str(n) for n in available)
+        else:
+            rendered = "none"
+        print(
+            f"ERROR: iteration {explicit_iter} not found for skill "
+            f"{skill_name}. Available iterations with this skill: "
+            f"{rendered}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # From here, discovered is not None.
+    assert discovered is not None
+    iteration_n, iter_skill_dir = discovered
+
+    sidecars = load_iteration_sidecars(iter_skill_dir)
+
+    if sidecars.assertions_missing:
+        # Code path 3 — DEC-008 corrupt iteration.
+        print(
+            f"ERROR: iteration {iteration_n} for skill {skill_name} "
+            "is corrupt — assertions.json is missing. Re-run "
+            "'clauditor validate' to regenerate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Code path 4 — happy path. Compute and dispatch on --url-only.
+    badge = compute_badge(
+        assertions=sidecars.assertions,
+        grading=sidecars.grading,
+        variance=sidecars.variance,
+        skill_name=skill_name,
+        iteration=iteration_n,
+        generated_at=_now_iso_z(),
+        label=args.label,
+        style_overrides=style_overrides,
+    )
+
+    # DEC-021 sibling to DEC-001: if the badge came out lightgrey with
+    # an iteration loaded, the L1 spec has zero assertions (DEC-007).
+    # Warn so users notice the spec is under-specified.
+    if badge.color == "lightgrey":
+        print(
+            "warning: eval spec declares 0 L1 assertions — wrote "
+            "lightgrey 'no data' badge",
+            file=sys.stderr,
+        )
+
+    if args.url_only:
+        return _render_url_only(
+            args=args,
+            project_dir=project_dir,
+            skill_name=skill_name,
+        )
+
+    return _write_badge_json(
+        target_path,
+        badge.to_endpoint_json(),
+        force=args.force,
+        iteration=iteration_n,
+        verbose=args.verbose,
+    )
+
+
+def _handle_no_iteration(
+    *,
+    target_path: Path,
+    skill_name: str,
+    args: argparse.Namespace,
+    style_overrides: dict[str, str],
+    project_dir: Path,
+) -> int:
+    """DEC-001: no iteration → lightgrey placeholder + exit 0.
+
+    When ``--url-only`` is set, just render the Markdown image line
+    (no JSON write). Otherwise compose the lightgrey Badge, emit the
+    DEC-021 placeholder warning, and route the write through
+    :func:`_write_badge_json` (which still respects DEC-011 ``--force``
+    — the placeholder does NOT clobber a "real" badge silently).
+    """
+    if args.url_only:
+        # --url-only doesn't depend on sidecar state — render and go.
+        return _render_url_only(
+            args=args,
+            project_dir=project_dir,
+            skill_name=skill_name,
+        )
+
+    badge = compute_badge(
+        assertions=None,
+        grading=None,
+        variance=None,
+        skill_name=skill_name,
+        iteration=None,
+        generated_at=_now_iso_z(),
+        label=args.label,
+        style_overrides=style_overrides,
+    )
+    print(
+        f"warning: no iteration found for skill {skill_name} — "
+        "wrote lightgrey placeholder (run 'clauditor grade' to populate)",
+        file=sys.stderr,
+    )
+    return _write_badge_json(
+        target_path,
+        badge.to_endpoint_json(),
+        force=args.force,
+        iteration=None,
+        verbose=args.verbose,
+    )
+
+
+def _render_url_only(
+    *,
+    args: argparse.Namespace,
+    project_dir: Path,
+    skill_name: str,
+) -> int:
+    """DEC-002: print the shields.io Markdown image line to stdout."""
+    repo_slug, branch = _resolve_url_only_slug_and_branch(args, project_dir)
+    # The raw-content URL always points at the default badge JSON
+    # location; --output is mutually exclusive with --url-only so we
+    # do not need to reconcile against a user-provided path.
+    output_relpath = f".clauditor/badges/{skill_name}.json"
+    markdown = build_markdown_image(
+        skill_name=skill_name,
+        repo_slug=repo_slug,
+        branch=branch,
+        output_relpath=output_relpath,
+        label=args.label,
+    )
+    print(markdown)
+    return 0

--- a/src/clauditor/cli/badge.py
+++ b/src/clauditor/cli/badge.py
@@ -64,6 +64,17 @@ _ALLOWED_STYLE_KEYS: frozenset[str] = frozenset(
 # input with exit 2.
 _INT_STYLE_KEYS: frozenset[str] = frozenset({"cacheSeconds"})
 
+# Keys that are canonical top-level fields in the badge JSON and
+# MUST NOT be overwritten by ``--style`` passthroughs (Copilot PR
+# review, 2026-04-22). ``Badge.to_endpoint_json`` emits the
+# style_overrides dict AFTER the canonical fields, so a user passing
+# ``--style schemaVersion=2`` or ``--style label=hijacked`` would
+# silently clobber the shields.io-required fields and break the
+# badge. Reject at the CLI parse boundary with exit 2.
+_RESERVED_STYLE_KEYS: frozenset[str] = frozenset(
+    {"schemaVersion", "label", "message", "color", "clauditor"}
+)
+
 # Upper bound on a ``--style`` value (DEC-023). 512 chars is generous
 # for any reasonable shields.io field (even inline SVG data URLs stay
 # well under that when they show up in practice).
@@ -424,9 +435,18 @@ def _resolve_url_only_slug_and_branch(
     # default on GitHub), so the warning stays quiet unless the
     # slug itself had to be replaced.
     if slug_auto_failed:
+        # When BOTH auto-detects fell through, mention both flags so
+        # the user has the complete remediation in one line (Copilot
+        # PR review, 2026-04-22 — the prior message only named --repo
+        # even when --branch was also replaced with the placeholder).
+        override_hint = (
+            "pass --repo USER/REPO --branch NAME to override"
+            if branch_auto_failed
+            else "pass --repo USER/REPO to override"
+        )
         fallback_msg = (
             f"warning: git auto-detect failed; using placeholder "
-            f"{repo_slug}/{branch} — pass --repo USER/REPO to override"
+            f"{repo_slug}/{branch} — {override_hint}"
         )
         print(fallback_msg, file=sys.stderr)
     elif branch_auto_failed:
@@ -494,6 +514,21 @@ def cmd_badge(args: argparse.Namespace) -> int:
             _validate_style_value(key, value)
         except ValueError as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        # Reserved-key collision guard: a passthrough key that
+        # matches a canonical shields.io / clauditor top-level
+        # field would silently clobber the real value inside
+        # ``Badge.to_endpoint_json`` (Copilot PR review,
+        # 2026-04-22).
+        if key in _RESERVED_STYLE_KEYS:
+            print(
+                f"ERROR: --style {key}=... would overwrite the "
+                f"canonical badge field {key!r}. Use --label for "
+                f"the label text; other reserved fields "
+                f"(schemaVersion, message, color, clauditor) are "
+                f"not user-overridable.",
+                file=sys.stderr,
+            )
             return 2
         if key not in _ALLOWED_STYLE_KEYS:
             print(

--- a/src/clauditor/cli/badge.py
+++ b/src/clauditor/cli/badge.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -40,6 +41,7 @@ from clauditor.badge import (
     discover_iteration,
     load_iteration_sidecars,
 )
+from clauditor.cli import _positive_int
 from clauditor.spec import SkillSpec
 
 # ---------------------------------------------------------------------------
@@ -55,10 +57,24 @@ _ALLOWED_STYLE_KEYS: frozenset[str] = frozenset(
     {"style", "logoSvg", "logoColor", "labelColor", "cacheSeconds", "link"}
 )
 
+# Shields.io style keys whose values are typed as integers in the
+# endpoint schema (review pass 3, C3-1). A string-typed value in
+# these slots is not guaranteed to be honored by shields.io; the
+# CLI coerces to ``int`` at serialization and rejects non-numeric
+# input with exit 2.
+_INT_STYLE_KEYS: frozenset[str] = frozenset({"cacheSeconds"})
+
 # Upper bound on a ``--style`` value (DEC-023). 512 chars is generous
 # for any reasonable shields.io field (even inline SVG data URLs stay
 # well under that when they show up in practice).
 _STYLE_VALUE_MAX_LEN: int = 512
+
+# Characters that break Markdown ``![alt](url)`` syntax when interpolated
+# into the alt-text slot. Rejected at the CLI layer so users get exit 2
+# instead of a silently-broken badge line (review pass 1, B-3).
+_LABEL_FORBIDDEN_CHARS: frozenset[str] = frozenset(
+    {"[", "]", "(", ")", "\n", "\r"}
+)
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -76,6 +92,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--from-iteration",
+        type=_positive_int,
         default=None,
         metavar="N",
         help=(
@@ -200,6 +217,41 @@ def _validate_style_value(key: str, value: str) -> None:
         )
 
 
+def _validate_label(label: str) -> None:
+    """Reject label values that would break Markdown ``![label](...)`` syntax.
+
+    Raises :class:`ValueError` for:
+
+    - ``[``, ``]``, ``(``, ``)``, or newline characters: these are
+      structural Markdown chars that, if interpolated verbatim into
+      the alt-text slot, close it early or break the URL portion.
+    - Empty or whitespace-only labels: ``![]`` renders accessibility-
+      hostile empty alt-text (review pass 3, N3-2). Non-default labels
+      are the common case for distinguishing skills in a catalog, so
+      an explicit rejection is cheaper than a silent degradation.
+    - Values longer than :data:`_STYLE_VALUE_MAX_LEN` — same cap as
+      ``--style`` passthrough values for belt-and-suspenders.
+    """
+    if not label.strip():
+        raise ValueError("--label must not be empty or whitespace-only")
+    for ch in label:
+        if ch in _LABEL_FORBIDDEN_CHARS:
+            # Name the offending char + show a truncated preview so
+            # the user can locate the problem quickly when the label
+            # is pasted from elsewhere (review pass 2, C2-1).
+            preview = label if len(label) <= 60 else label[:57] + "..."
+            raise ValueError(
+                f"--label contains forbidden char {ch!r} (Markdown "
+                f"alt-text syntax — '[', ']', '(', ')', or newline): "
+                f"{preview!r}"
+            )
+    if len(label) > _STYLE_VALUE_MAX_LEN:
+        raise ValueError(
+            f"--label is too long ({len(label)} chars, max "
+            f"{_STYLE_VALUE_MAX_LEN})"
+        )
+
+
 def _now_iso_z() -> str:
     """Return the current UTC time in the DEC-012 ``Z``-suffix form.
 
@@ -231,6 +283,8 @@ def _list_available_iterations(project_dir: Path, skill_name: str) -> list[int]:
             n = int(suffix)
         except ValueError:
             continue
+        if n < 1:
+            continue  # iteration-0 / iteration--1 shapes don't count
         if (child / skill_name).is_dir():
             found.append(n)
     return sorted(found)
@@ -243,20 +297,27 @@ def _write_badge_json(
     force: bool,
     iteration: int | None,
     verbose: bool,
+    post_write_warning: str | None = None,
 ) -> int:
-    """Write the badge JSON payload to ``target``.
+    """Write the badge JSON payload to ``target`` atomically.
 
-    Handles the DEC-011 overwrite-policy check: if ``target`` exists
-    and ``force`` is ``False``, print the error to stderr and return
-    exit 1 without writing. On a successful write, optionally prints
-    the DEC-018 stderr info line when ``verbose=True``.
+    DEC-011 overwrite policy: if ``target`` exists and ``force`` is
+    ``False``, print the error and return exit 1 without writing.
+
+    Atomic publication (review pass 2, C2-3): writes to a sibling
+    temp file first, then :func:`os.replace` publishes it into
+    place. A mid-write failure (disk full, EIO) leaves the existing
+    target untouched rather than truncating it to empty.
+
+    ``post_write_warning`` — optional stderr line printed AFTER a
+    successful write (review pass 2, N2-4). A write-claim message
+    like "wrote lightgrey placeholder" is gated on actual success,
+    not pre-write intent, so collisions or disk errors don't leave
+    a misleading stderr trail.
 
     ``iteration=None`` renders the verbose line with a
     ``(no iteration)`` fragment to signal the DEC-001 lightgrey
     placeholder path; otherwise ``(iteration N)``.
-
-    Returns the exit code the caller should surface (0 on success,
-    1 on collision).
     """
     if target.exists() and not force:
         print(
@@ -271,17 +332,36 @@ def _write_badge_json(
     # should not error.
     target.parent.mkdir(parents=True, exist_ok=True)
 
+    # Atomic write via sibling tempfile + os.replace (review pass 2,
+    # C2-3). A TOCTOU race between the ``target.exists()`` check and
+    # the rename is still possible under concurrent ``clauditor
+    # badge`` runs, but the artifact is regenerable and the consequence
+    # is a lost update — not data corruption.
+    tmp_target = target.with_name(f".{target.name}.tmp")
     try:
-        target.write_text(
-            json.dumps(payload, indent=2) + "\n",
+        # ``ensure_ascii=False`` writes the UTF-8 middle-dot glyph in
+        # the message verbatim (review pass 3, C3-4) so the on-disk
+        # bytes match the sample JSON in ``docs/badges.md``. Shields.io
+        # decodes either form fine.
+        tmp_target.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8",
         )
+        os.replace(tmp_target, target)
     except OSError as exc:
+        # Best-effort cleanup of the tmp file; ignore if already gone.
+        try:
+            tmp_target.unlink()
+        except OSError:
+            pass
         print(
             f"ERROR: could not write {target}: {exc}",
             file=sys.stderr,
         )
         return 1
+
+    if post_write_warning is not None:
+        print(post_write_warning, file=sys.stderr)
 
     if verbose:
         tail = (
@@ -392,9 +472,18 @@ def cmd_badge(args: argparse.Namespace) -> int:
         )
         return 2
 
+    # Label validation (review pass 1, B-3). Reject chars that break
+    # Markdown ``![label](url)`` syntax up-front so a user typo does
+    # not produce a silently-broken badge line.
+    try:
+        _validate_label(args.label)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
     # Parse --style flags up-front (DEC-015 / DEC-023). A bad value
     # here blocks before any sidecar read / disk write.
-    style_overrides: dict[str, str] = {}
+    style_overrides: dict[str, str | int] = {}
     for raw in args.style or []:
         try:
             key, value = _parse_style_arg(raw)
@@ -412,7 +501,21 @@ def cmd_badge(args: argparse.Namespace) -> int:
                 "passing through anyway",
                 file=sys.stderr,
             )
-        style_overrides[key] = value
+        # Coerce integer-typed style keys (review pass 3, C3-1).
+        # Shields.io's endpoint schema types ``cacheSeconds`` as int;
+        # a string slot is not guaranteed to be honored.
+        if key in _INT_STYLE_KEYS:
+            try:
+                style_overrides[key] = int(value)
+            except ValueError:
+                print(
+                    f"ERROR: --style {key} must be an integer, got "
+                    f"{value!r}",
+                    file=sys.stderr,
+                )
+                return 2
+        else:
+            style_overrides[key] = value
 
     # Skill spec load. Any load error is a pre-call input error → 2.
     skill_path = Path(args.skill)
@@ -440,22 +543,10 @@ def cmd_badge(args: argparse.Namespace) -> int:
     skill_name = spec.skill_name
     project_dir = Path.cwd()
 
-    # Parse --from-iteration to int here so validation errors surface
-    # before any disk walk. argparse takes the raw string to give the
-    # error message a clean shape.
-    explicit_iter: int | None = None
-    if args.from_iteration is not None:
-        try:
-            explicit_iter = int(args.from_iteration)
-            if explicit_iter < 1:
-                raise ValueError("must be >= 1")
-        except ValueError as exc:
-            print(
-                f"ERROR: --from-iteration must be a positive integer, "
-                f"got {args.from_iteration!r}: {exc}",
-                file=sys.stderr,
-            )
-            return 2
+    # argparse ``type=_positive_int`` already rejected non-int / <=0
+    # --from-iteration values with exit 2 before we got here (pass 1
+    # review B-2 — move validation ahead of the SKILL.md load cost).
+    explicit_iter: int | None = args.from_iteration
 
     # Resolve the output path target. DEC-005 accepts absolute paths;
     # DEC-022 validates parent-dir existence when the user supplied
@@ -526,7 +617,17 @@ def cmd_badge(args: argparse.Namespace) -> int:
         )
         return 1
 
-    # Code path 4 — happy path. Compute and dispatch on --url-only.
+    # Code path 4 — happy path. Short-circuit --url-only BEFORE
+    # compute_badge (review pass 2, C2-4) — the Markdown image URL
+    # does not depend on sidecar data, so computing a Badge we'll
+    # discard is wasted work.
+    if args.url_only:
+        return _render_url_only(
+            args=args,
+            project_dir=project_dir,
+            skill_name=skill_name,
+        )
+
     badge = compute_badge(
         assertions=sidecars.assertions,
         grading=sidecars.grading,
@@ -540,19 +641,14 @@ def cmd_badge(args: argparse.Namespace) -> int:
 
     # DEC-021 sibling to DEC-001: if the badge came out lightgrey with
     # an iteration loaded, the L1 spec has zero assertions (DEC-007).
-    # Warn so users notice the spec is under-specified.
+    # The warning is deferred to post-write so a collision-without-
+    # --force exit 1 does not leave a false "wrote ..." trail on
+    # stderr (review pass 2, N2-4).
+    post_write_warning: str | None = None
     if badge.color == "lightgrey":
-        print(
+        post_write_warning = (
             "warning: eval spec declares 0 L1 assertions — wrote "
-            "lightgrey 'no data' badge",
-            file=sys.stderr,
-        )
-
-    if args.url_only:
-        return _render_url_only(
-            args=args,
-            project_dir=project_dir,
-            skill_name=skill_name,
+            "lightgrey 'no data' badge"
         )
 
     return _write_badge_json(
@@ -561,6 +657,7 @@ def cmd_badge(args: argparse.Namespace) -> int:
         force=args.force,
         iteration=iteration_n,
         verbose=args.verbose,
+        post_write_warning=post_write_warning,
     )
 
 
@@ -569,7 +666,7 @@ def _handle_no_iteration(
     target_path: Path,
     skill_name: str,
     args: argparse.Namespace,
-    style_overrides: dict[str, str],
+    style_overrides: dict[str, str | int],
     project_dir: Path,
 ) -> int:
     """DEC-001: no iteration → lightgrey placeholder + exit 0.
@@ -598,17 +695,20 @@ def _handle_no_iteration(
         label=args.label,
         style_overrides=style_overrides,
     )
-    print(
-        f"warning: no iteration found for skill {skill_name} — "
-        "wrote lightgrey placeholder (run 'clauditor grade' to populate)",
-        file=sys.stderr,
-    )
+    # The "wrote lightgrey placeholder" stderr line is deferred to
+    # post-write so a collision-without-force exit 1 doesn't leave a
+    # false trail (review pass 2, N2-4).
     return _write_badge_json(
         target_path,
         badge.to_endpoint_json(),
         force=args.force,
         iteration=None,
         verbose=args.verbose,
+        post_write_warning=(
+            f"warning: no iteration found for skill {skill_name} — "
+            "wrote lightgrey placeholder (run 'clauditor grade' to "
+            "populate)"
+        ),
     )
 
 

--- a/src/clauditor/skills/clauditor/assets/clauditor.eval.json
+++ b/src/clauditor/skills/clauditor/assets/clauditor.eval.json
@@ -5,9 +5,9 @@
   "user_prompt": "Validate the skill at .claude/commands/chunk.md — report which clauditor layers you would run (L1 assertions, L3 grading) and the concrete commands involved.",
   "assertions": [
     {
-      "id": "mentions-assertions",
-      "type": "contains",
-      "needle": "assertion"
+      "id": "mentions-layer-vocabulary",
+      "type": "regex",
+      "pattern": "(?i)(assert|\\bL1\\b|\\bL3\\b|layer|rubric)"
     },
     {
       "id": "no-error-trace",
@@ -22,8 +22,8 @@
   ],
   "grading_criteria": [
     {
-      "id": "identifies-layer-correctly",
-      "criterion": "The response correctly distinguishes between L1 deterministic assertions and L3 LLM-graded rubric criteria, naming at least one layer accurately."
+      "id": "routes-by-eval-presence",
+      "criterion": "The response correctly identifies whether a sibling eval spec exists for the target skill and routes accordingly — proposing one via 'clauditor propose-eval' (or acknowledging a bootstrap step is needed) when no eval exists, or proceeding to 'clauditor validate' / 'clauditor grade' when an eval is already present. This is the Step-3 workflow branch of the /clauditor skill."
     },
     {
       "id": "provides-concrete-guidance",

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -24,6 +24,8 @@ from clauditor.badge import (
     L1Summary,
     L3Summary,
     VarianceSummary,
+    _compute_grading_mean_score,
+    _compute_grading_pass_rate,
     build_markdown_image,
     compute_badge,
     discover_iteration,
@@ -276,6 +278,35 @@ class TestComputeBadge:
         )
         assert badge.color == "red"
         assert badge.message == "8/8"
+
+    def test_l3_bool_scores_treated_as_parse_failed(self):
+        """Copilot PR review, 2026-04-22: ``bool`` is a subclass of ``int``
+        in Python. ``isinstance(True, (int, float))`` returns True, which
+        without an explicit bool guard would treat a malformed
+        ``{"score": true}`` grading entry as a valid 1.0 score and
+        bypass the DEC-009 parse-failed path. The guard excludes bool
+        explicitly so the DEC-009 branch fires.
+        """
+        grading = {
+            "schema_version": 1,
+            "results": [
+                {"id": "a", "passed": True, "score": True},
+                {"id": "b", "passed": False, "score": False},
+            ],
+        }
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            grading,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "red"
+        assert badge.message == "8/8"
+        # L3 block omitted — parse-failed path.
+        layers = badge.clauditor.l3
+        assert layers is None
 
     def test_l1_pass_l3_pass_variance_present_full_message(self):
         """DEC-024: L1 + L3 + variance → full three-fragment message."""
@@ -1129,3 +1160,68 @@ class TestBuildMarkdownImage:
         assert isinstance(md, str)
         # Verify the double-layer URL structure.
         assert md.count("https://") == 2
+
+
+# ---------------------------------------------------------------------------
+# Defensive-guard coverage (Codecov PR review, 2026-04-22).
+#
+# The branches below are unreachable from the public ``compute_badge``
+# entry point because upstream filters already short-circuit before
+# these helpers receive an empty list. They exist to protect direct
+# callers and to be audit-clear when a future refactor removes the
+# upstream guard. Cover them directly so the coverage report does not
+# ship with them pink.
+# ---------------------------------------------------------------------------
+
+
+class TestComputeGradingPassRateDefensive:
+    def test_non_dict_only_results_returns_zero(self):
+        """``_compute_grading_pass_rate`` returns 0.0 when every entry
+        is filtered out as non-dict (line 418 defensive branch)."""
+        # Pass a list where every entry is rejected by
+        # ``isinstance(r, dict)``. Upstream flow in ``_summarize_l3``
+        # would short-circuit at ``if not results`` before reaching
+        # here, so this branch is only reachable via direct call.
+        assert _compute_grading_pass_rate(["not-a-dict", 42, None]) == 0.0
+
+    def test_empty_list_returns_zero(self):
+        assert _compute_grading_pass_rate([]) == 0.0
+
+
+class TestComputeGradingMeanScoreDefensive:
+    def test_empty_list_returns_zero(self):
+        """``_compute_grading_mean_score`` returns 0.0 on empty input
+        (line 425 defensive branch)."""
+        # Upstream ``_summarize_l3`` returns ``(None, True)`` before
+        # reaching this helper with an empty list, so the guard is
+        # only reachable via direct call.
+        assert _compute_grading_mean_score([]) == 0.0
+
+
+class TestDiscoverIterationSkipsIterationZero:
+    def test_iteration_zero_dir_skipped_in_scan(self, tmp_path):
+        """Line 704: the latest-scan branch of ``discover_iteration``
+        mirrors the ``explicit < 1`` defensive guard by skipping
+        ``iteration-0/`` dirs during the walk.
+
+        A manually placed ``iteration-0/<skill>/`` must not resolve as
+        the latest iteration even if it is the only dir present (per
+        the ``workspace.py`` invariant that iteration numbers start
+        at 1).
+        """
+        clauditor = tmp_path / ".clauditor"
+        iter_zero_skill = clauditor / "iteration-0" / "demo"
+        iter_zero_skill.mkdir(parents=True)
+        # No other iterations present — with iteration-0 skipped, the
+        # helper returns None (DEC-001 path).
+        assert discover_iteration(tmp_path, "demo", None) is None
+
+    def test_iteration_zero_skipped_alongside_valid_iteration(self, tmp_path):
+        """Iteration-0 is skipped; iteration-1 is returned."""
+        clauditor = tmp_path / ".clauditor"
+        (clauditor / "iteration-0" / "demo").mkdir(parents=True)
+        (clauditor / "iteration-1" / "demo").mkdir(parents=True)
+        result = discover_iteration(tmp_path, "demo", None)
+        assert result is not None
+        n, _path = result
+        assert n == 1

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -928,6 +928,22 @@ class TestDiscoverIteration:
         (tmp_path / ".clauditor" / "badges").mkdir()  # unrelated subdir
         assert discover_iteration(tmp_path, "demo", None) is None
 
+    def test_explicit_zero_returns_none(self, tmp_path):
+        """``explicit=0`` rejected defensively (review pass 1, C-3).
+
+        Iteration numbers start at 1; a direct in-process caller that
+        bypasses argparse ``_positive_int`` validation should not be
+        able to coerce this helper into returning a "missing" signal
+        for a malformed request.
+        """
+        _mk_iteration(tmp_path, 1, "demo")
+        assert discover_iteration(tmp_path, "demo", 0) is None
+
+    def test_explicit_negative_returns_none(self, tmp_path):
+        """Same defensive guard for negative iteration numbers."""
+        _mk_iteration(tmp_path, 1, "demo")
+        assert discover_iteration(tmp_path, "demo", -1) is None
+
 
 class TestLoadIterationSidecars:
     """Tests for :func:`clauditor.badge.load_iteration_sidecars`."""

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1,0 +1,842 @@
+"""Tests for ``clauditor.badge`` — pure compute for the shields.io endpoint.
+
+Covers the TDD cases from US-001 of
+``plans/super/77-clauditor-badge.md``. Traces: DEC-003, DEC-009,
+DEC-010, DEC-012, DEC-013, DEC-020, DEC-024, DEC-026, DEC-027.
+
+All tests here are pure — no ``tmp_path``, no subprocess mocks, no
+async. Fixture factories produce dicts shaped like the real sidecars
+(``AssertionSet.to_json()``, ``GradingReport.to_json()``) per
+DEC-019's "generate-in-test via to_json" policy.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.badge import (
+    Badge,
+    ClauditorExtension,
+    L1Summary,
+    L3Summary,
+    VarianceSummary,
+    compute_badge,
+)
+from clauditor.quality_grader import GradingReport, GradingResult
+from clauditor.schemas import GradeThresholds
+
+# ---------------------------------------------------------------------------
+# Fixture factories — produce real sidecar shapes.
+# ---------------------------------------------------------------------------
+
+
+def _make_assertions_dict(
+    *,
+    passed: int = 8,
+    total: int = 8,
+    runs_layout: bool = True,
+) -> dict:
+    """Build an ``assertions.json``-shaped dict.
+
+    ``runs_layout=True`` produces the modern two-level
+    (``{runs: [{results: [...]}, ...]}``) shape written by
+    ``cli/grade.py::_write_assertions_sidecar``. ``runs_layout=False``
+    produces the flat ``AssertionSet.to_json()`` shape used by older
+    callers and tests.
+    """
+    results = [
+        AssertionResult(
+            name=f"check_{i}",
+            passed=i < passed,
+            message="ok" if i < passed else "fail",
+            kind="presence",
+        )
+        for i in range(total)
+    ]
+    aset = AssertionSet(results=results, input_tokens=100, output_tokens=50)
+    if not runs_layout:
+        return aset.to_json()
+    return {
+        "schema_version": 1,
+        "skill": "demo",
+        "iteration": 1,
+        "runs": [{"run": 0, **aset.to_json()}],
+    }
+
+
+def _make_grading_dict(
+    *,
+    pass_fractions: tuple[bool, ...] = (True, True, True),
+    scores: tuple[float, ...] | None = None,
+    thresholds: GradeThresholds | None = None,
+    empty_results: bool = False,
+    no_scores: bool = False,
+) -> dict:
+    """Build a ``grading.json``-shaped dict.
+
+    ``empty_results=True`` produces a DEC-009 parse-failed shape
+    (``results: []``). ``no_scores=True`` produces results lacking
+    numeric ``score`` values (also DEC-009 parse-failed).
+    """
+    if thresholds is None:
+        thresholds = GradeThresholds()
+    if empty_results:
+        results = []
+    else:
+        if scores is None:
+            scores = tuple(1.0 if p else 0.0 for p in pass_fractions)
+        results = [
+            GradingResult(
+                criterion=f"c{i}",
+                passed=p,
+                score=s,
+                evidence="",
+                reasoning="",
+                id=f"c{i}",
+            )
+            for i, (p, s) in enumerate(zip(pass_fractions, scores, strict=False))
+        ]
+    report = GradingReport(
+        skill_name="demo",
+        results=results,
+        model="test-model",
+        thresholds=thresholds,
+        metrics={},
+        duration_seconds=1.0,
+        input_tokens=200,
+        output_tokens=100,
+    )
+    parsed = json.loads(report.to_json())
+    if no_scores and not empty_results:
+        # Strip score fields to simulate a judge that returned no
+        # scorable data (DEC-009).
+        for r in parsed["results"]:
+            r.pop("score", None)
+    return parsed
+
+
+def _make_variance_dict(
+    *,
+    n_runs: int = 5,
+    stability: float = 0.85,
+    passed: bool = True,
+) -> dict:
+    """Build the expected ``variance.json`` shape.
+
+    No writer ships for this sidecar today (DEC-003), so this factory
+    encodes the expected fields by spec alone. When a writer lands,
+    this factory may be replaced with a real ``VarianceReport.to_json``.
+    """
+    return {
+        "schema_version": 1,
+        "n_runs": n_runs,
+        "stability": stability,
+        "passed": passed,
+    }
+
+
+_GEN_AT = "2026-04-21T14:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Color + message matrix (DEC-009, DEC-020, DEC-024).
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBadge:
+    """Parametrized color + message matrix covering each DEC row."""
+
+    def test_assertions_none_is_lightgrey_no_data(self):
+        """DEC-001 / DEC-008: assertions=None → lightgrey + ``no data``."""
+        badge = compute_badge(
+            None,
+            None,
+            None,
+            skill_name="demo",
+            iteration=None,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "lightgrey"
+        assert badge.message == "no data"
+
+    def test_empty_assertions_is_lightgrey(self):
+        """DEC-007: iteration with zero L1 assertions → lightgrey."""
+        # Flat layout with empty results.
+        empty = {"input_tokens": 0, "output_tokens": 0, "results": []}
+        badge = compute_badge(
+            empty,
+            None,
+            None,
+            skill_name="demo",
+            iteration=3,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "lightgrey"
+        assert badge.message == "no data"
+
+    def test_runs_layout_with_empty_results_is_lightgrey(self):
+        """DEC-007: modern ``runs`` layout where every run has no results."""
+        payload = {
+            "schema_version": 1,
+            "skill": "demo",
+            "iteration": 2,
+            "runs": [{"run": 0, "input_tokens": 0, "output_tokens": 0, "results": []}],
+        }
+        badge = compute_badge(
+            payload, None, None, skill_name="demo", iteration=2, generated_at=_GEN_AT
+        )
+        assert badge.color == "lightgrey"
+        assert badge.message == "no data"
+
+    def test_l1_any_failed_is_red(self):
+        """Any L1 failure → red badge, ``N/M`` message."""
+        assertions = _make_assertions_dict(passed=7, total=8)
+        badge = compute_badge(
+            assertions,
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "red"
+        assert badge.message == "7/8"
+
+    def test_l1_all_pass_l3_omitted_is_brightgreen(self):
+        """L1 all-pass + no L3 sidecar → brightgreen, ``N/M`` message."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "brightgreen"
+        assert badge.message == "8/8"
+
+    def test_l1_all_pass_l3_passed_is_brightgreen(self):
+        """L1 pass + L3 above thresholds → brightgreen, ``N/M · L3 P%``."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True, True)),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "brightgreen"
+        assert badge.message == "8/8 · L3 100%"
+
+    def test_l1_all_pass_l3_below_thresholds_is_yellow(self):
+        """L1 pass + L3 below thresholds → yellow, ``N/M · L3 P%``."""
+        # 2/4 passed → pass_rate 0.5 < default 0.7 threshold.
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, False, False)),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "yellow"
+        assert badge.message == "8/8 · L3 50%"
+
+    def test_l1_pass_l3_parse_failed_empty_results_is_red(self):
+        """DEC-009: L3 with empty results → red, L3 fragment omitted."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(empty_results=True),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "red"
+        assert badge.message == "8/8"
+
+    def test_l1_pass_l3_parse_failed_no_scores_is_red(self):
+        """DEC-009: L3 where no result has a score → red, L3 omitted."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(
+                pass_fractions=(True, True, True), no_scores=True
+            ),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "red"
+        assert badge.message == "8/8"
+
+    def test_l1_pass_l3_pass_variance_present_full_message(self):
+        """DEC-024: L1 + L3 + variance → full three-fragment message."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True, True)),
+            _make_variance_dict(n_runs=5, stability=0.80, passed=True),
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "brightgreen"
+        assert badge.message == "8/8 · L3 100% · 80% stable"
+
+    def test_l1_fail_takes_priority_over_l3_parse_failed(self):
+        """L1 failure short-circuits the L3 parse-failed branch."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=7, total=8),
+            _make_grading_dict(empty_results=True),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "red"
+        # L3 parse-failed → L3 fragment is also omitted from the message.
+        assert badge.message == "7/8"
+
+    def test_flat_assertions_layout_works(self):
+        """Flat ``AssertionSet.to_json`` layout (no ``runs`` wrapper) parses."""
+        flat = _make_assertions_dict(passed=5, total=5, runs_layout=False)
+        badge = compute_badge(
+            flat,
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "brightgreen"
+        assert badge.message == "5/5"
+
+
+# ---------------------------------------------------------------------------
+# Layer-specific semantics (DEC-010 + thresholds passthrough).
+# ---------------------------------------------------------------------------
+
+
+class TestLayerSemantics:
+    def test_l1_passed_means_all_passed(self):
+        """DEC-010: L1 ``passed`` mirrors ``all(r.passed)``."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.l1 is not None
+        assert badge.clauditor.l1.passed is True
+
+        badge2 = compute_badge(
+            _make_assertions_dict(passed=7, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge2.clauditor.l1 is not None
+        assert badge2.clauditor.l1.passed is False
+
+    def test_l3_passed_means_met_thresholds(self):
+        """DEC-010: L3 ``passed`` mirrors the thresholds-based calc."""
+        # 4/4 passed with default thresholds → passed.
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True, True)),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.l3 is not None
+        assert badge.clauditor.l3.passed is True
+
+        # 2/4 passed (pass_rate 0.5 < 0.7) → not passed.
+        badge2 = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, False, False)),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge2.clauditor.l3 is not None
+        assert badge2.clauditor.l3.passed is False
+
+    def test_l3_thresholds_passthrough(self):
+        """``grading.json`` thresholds are copied verbatim (DEC-004)."""
+        custom_thresholds = GradeThresholds(min_pass_rate=0.9, min_mean_score=0.8)
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(
+                pass_fractions=(True, True, True, True),
+                thresholds=custom_thresholds,
+            ),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.l3 is not None
+        assert badge.clauditor.l3.thresholds == {
+            "min_pass_rate": 0.9,
+            "min_mean_score": 0.8,
+        }
+
+    def test_l3_thresholds_block_missing_uses_defaults(self):
+        """When grading dict has no ``thresholds`` key, default to 0.7/0.5."""
+        grading = _make_grading_dict(pass_fractions=(True, True, True))
+        grading.pop("thresholds", None)
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            grading,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        # 3/3 with default thresholds → passed.
+        assert badge.clauditor.l3 is not None
+        assert badge.clauditor.l3.passed is True
+        # Empty thresholds dict passed through (no spurious defaults
+        # injected into the serialized payload).
+        assert badge.clauditor.l3.thresholds == {}
+
+    def test_variance_summary_fields_from_sidecar(self):
+        """Variance fields flow through verbatim."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True)),
+            _make_variance_dict(n_runs=5, stability=0.85, passed=True),
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.variance == VarianceSummary(
+            n_runs=5, stability=0.85, passed=True
+        )
+
+    def test_variance_malformed_degrades_gracefully(self):
+        """Malformed variance sidecar → zero-filled summary, not an error."""
+        bad_variance = {"schema_version": 1}  # no n_runs, stability, passed
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True)),
+            bad_variance,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.variance == VarianceSummary(
+            n_runs=0, stability=0.0, passed=False
+        )
+
+    def test_pass_rate_rounding_in_message(self):
+        """DEC-024: L3 percent uses ``round(pr * 100)`` not floor."""
+        # 2/3 → 66.666… → rounds to 67.
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, False)),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert "L3 67%" in badge.message
+
+
+# ---------------------------------------------------------------------------
+# Serialization invariants (DEC-012, DEC-013, DEC-027).
+# ---------------------------------------------------------------------------
+
+
+class TestBadgeSerialization:
+    def test_top_level_key_order(self):
+        """Endpoint JSON top-level key order is fixed."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        keys = list(result.keys())
+        assert keys[0] == "schemaVersion"
+        assert keys[1] == "label"
+        assert keys[2] == "message"
+        assert keys[3] == "color"
+        assert keys[-1] == "clauditor"
+
+    def test_shields_schema_version_is_camelcase(self):
+        """DEC-027: shields.io's field is camelCase ``schemaVersion``."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        assert result["schemaVersion"] == 1
+        # The snake_case form is reserved for the nested block.
+        assert "schema_version" not in result
+
+    def test_clauditor_schema_version_is_first_key(self):
+        """DEC-027: nested block obeys json-schema-version first-key rule."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        inner_keys = list(result["clauditor"].keys())
+        assert inner_keys[0] == "schema_version"
+        assert result["clauditor"]["schema_version"] == 1
+
+    def test_clauditor_key_order(self):
+        """Inside ``clauditor``: schema_version, skill_name, generated_at,
+        iteration, layers."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        keys = list(result["clauditor"].keys())
+        assert keys == ["schema_version", "skill_name", "generated_at",
+                        "iteration", "layers"]
+
+    def test_generated_at_z_suffix(self):
+        """DEC-012: generated_at carries the trailing ``Z``."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        assert result["clauditor"]["generated_at"].endswith("Z")
+
+    def test_variance_omitted_when_absent(self):
+        """DEC-003: no variance sidecar → no ``layers.variance`` key."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True)),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        assert "variance" not in result["clauditor"]["layers"]
+
+    def test_l3_omitted_when_grading_absent(self):
+        """No grading sidecar → no ``layers.l3`` key."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        assert "l3" not in result["clauditor"]["layers"]
+        assert "l1" in result["clauditor"]["layers"]
+
+    def test_l3_omitted_when_parse_failed(self):
+        """DEC-009: L3 parse-failed → ``layers.l3`` omitted AND color red."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(empty_results=True),
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        assert "l3" not in result["clauditor"]["layers"]
+        assert result["color"] == "red"
+
+    def test_l1_omitted_when_no_l1_signal(self):
+        """DEC-020: assertions=None → ``layers.l1`` omitted entirely."""
+        badge = compute_badge(
+            None,
+            None,
+            None,
+            skill_name="demo",
+            iteration=None,
+            generated_at=_GEN_AT,
+        )
+        result = badge.to_endpoint_json()
+        assert "l1" not in result["clauditor"]["layers"]
+        # And iteration is None (placeholder case).
+        assert result["clauditor"]["iteration"] is None
+
+    def test_style_overrides_alphabetized(self):
+        """DEC-015: ``--style`` passthroughs land alphabetically."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+            style_overrides={
+                "logoSvg": "<svg/>",
+                "cacheSeconds": "3600",
+                "style": "flat",
+            },
+        )
+        result = badge.to_endpoint_json()
+        keys = list(result.keys())
+        # After color, before clauditor, in alphabetical order.
+        color_idx = keys.index("color")
+        clauditor_idx = keys.index("clauditor")
+        style_slice = keys[color_idx + 1 : clauditor_idx]
+        assert style_slice == ["cacheSeconds", "logoSvg", "style"]
+        assert result["style"] == "flat"
+        assert result["cacheSeconds"] == "3600"
+        assert result["logoSvg"] == "<svg/>"
+
+    def test_default_label_is_clauditor(self):
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.label == "clauditor"
+        assert badge.to_endpoint_json()["label"] == "clauditor"
+
+    def test_custom_label(self):
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+            label="review-pr",
+        )
+        assert badge.label == "review-pr"
+
+    def test_payload_is_json_serializable(self):
+        """The returned dict must round-trip through ``json``."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True, True)),
+            _make_variance_dict(),
+            skill_name="demo",
+            iteration=7,
+            generated_at=_GEN_AT,
+            style_overrides={"style": "flat"},
+        )
+        raw = json.dumps(badge.to_endpoint_json())
+        round_trip = json.loads(raw)
+        assert round_trip["color"] == "brightgreen"
+        assert round_trip["clauditor"]["skill_name"] == "demo"
+        assert round_trip["clauditor"]["iteration"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Dataclass construction smoke tests — guard against field drift.
+# ---------------------------------------------------------------------------
+
+
+class TestDataclassShapes:
+    def test_l1_summary_fields(self):
+        s = L1Summary(count=7, total=8, pass_rate=0.875, passed=False)
+        assert s.count == 7
+        assert s.total == 8
+        assert s.pass_rate == pytest.approx(0.875)
+        assert s.passed is False
+
+    def test_l3_summary_fields(self):
+        s = L3Summary(
+            pass_rate=1.0,
+            mean_score=0.9,
+            passed=True,
+            thresholds={"min_pass_rate": 0.7, "min_mean_score": 0.5},
+        )
+        assert s.passed is True
+        assert s.thresholds["min_pass_rate"] == 0.7
+
+    def test_variance_summary_fields(self):
+        s = VarianceSummary(n_runs=5, stability=0.9, passed=True)
+        assert s.n_runs == 5
+        assert s.stability == pytest.approx(0.9)
+        assert s.passed is True
+
+    def test_clauditor_extension_defaults(self):
+        ext = ClauditorExtension(
+            skill_name="demo",
+            generated_at=_GEN_AT,
+            iteration=1,
+        )
+        assert ext.schema_version == 1
+        assert ext.l1 is None
+        assert ext.l3 is None
+        assert ext.variance is None
+
+    def test_badge_defaults(self):
+        ext = ClauditorExtension(skill_name="demo", generated_at=_GEN_AT, iteration=1)
+        b = Badge(label="demo", message="8/8", color="brightgreen", clauditor=ext)
+        assert b.schema_version == 1
+        assert b.style_overrides == {}
+
+
+# ---------------------------------------------------------------------------
+# Defensive edge cases — malformed-but-survivable sidecar shapes.
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveBranches:
+    """Cover malformed-but-recoverable input paths in the pure helpers."""
+
+    def test_runs_with_non_dict_entries_skipped(self):
+        """Non-dict entries in ``runs`` are skipped without error."""
+        payload = {
+            "schema_version": 1,
+            "runs": [
+                "not-a-dict",
+                {"run": 0, "results": [{"name": "x", "passed": True}]},
+                None,
+            ],
+        }
+        badge = compute_badge(
+            payload, None, None, skill_name="demo", iteration=1, generated_at=_GEN_AT
+        )
+        assert badge.clauditor.l1 == L1Summary(
+            count=1, total=1, pass_rate=1.0, passed=True
+        )
+
+    def test_results_with_non_dict_entries_skipped(self):
+        """Non-dict entries in a flat ``results`` list are skipped."""
+        payload = {
+            "results": [
+                "bogus",
+                {"name": "x", "passed": True},
+                42,
+            ],
+        }
+        badge = compute_badge(
+            payload, None, None, skill_name="demo", iteration=1, generated_at=_GEN_AT
+        )
+        assert badge.clauditor.l1 == L1Summary(
+            count=1, total=1, pass_rate=1.0, passed=True
+        )
+
+    def test_neither_runs_nor_results_key(self):
+        """Payload with neither ``runs`` nor ``results`` → lightgrey."""
+        badge = compute_badge(
+            {"schema_version": 1},  # pathological
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "lightgrey"
+        assert badge.message == "no data"
+
+    def test_l3_results_key_is_not_a_list(self):
+        """Grading dict with ``results`` not a list → parse-failed."""
+        payload = {"results": "corrupted"}
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            payload,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.color == "red"
+        assert "l3" not in badge.to_endpoint_json()["clauditor"]["layers"]
+
+    def test_l3_thresholds_non_dict_falls_back_to_defaults(self):
+        """Grading dict with ``thresholds`` not a dict → defaults applied."""
+        grading = _make_grading_dict(pass_fractions=(True, True, True))
+        grading["thresholds"] = "garbage"
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            grading,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.l3 is not None
+        assert badge.clauditor.l3.passed is True
+        assert badge.clauditor.l3.thresholds == {}
+
+    def test_l3_threshold_values_non_numeric_fall_back_to_defaults(self):
+        """Non-numeric threshold values (e.g. strings) fall back to defaults."""
+        grading = _make_grading_dict(pass_fractions=(True, True, True))
+        # 3/3 passed, mean 1.0 — passes default 0.7/0.5, fails only if
+        # thresholds push above 1.0. Replace with strings to exercise
+        # the coerce_float fallback.
+        grading["thresholds"] = {"min_pass_rate": "nope", "min_mean_score": None}
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            grading,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        # Fallback thresholds are 0.7 / 0.5; 3/3 all-pass passes both.
+        assert badge.clauditor.l3 is not None
+        assert badge.clauditor.l3.passed is True
+
+    def test_l3_threshold_bool_treated_as_non_numeric(self):
+        """Bool is an int subclass — ``_coerce_float`` rejects bool explicitly."""
+        grading = _make_grading_dict(pass_fractions=(True, True, True))
+        grading["thresholds"] = {"min_pass_rate": True, "min_mean_score": False}
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            grading,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        # Both thresholds fall back to defaults (0.7 / 0.5); still passes.
+        assert badge.clauditor.l3 is not None
+        assert badge.clauditor.l3.passed is True
+
+    def test_variance_with_bool_n_runs_is_zeroed(self):
+        """``n_runs=True`` (bool) is rejected; falls back to 0."""
+        bad = {"n_runs": True, "stability": 0.9, "passed": True}
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True)),
+            bad,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        assert badge.clauditor.variance == VarianceSummary(
+            n_runs=0, stability=0.9, passed=True
+        )

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -20,10 +20,14 @@ from clauditor.assertions import AssertionResult, AssertionSet
 from clauditor.badge import (
     Badge,
     ClauditorExtension,
+    IterationSidecars,
     L1Summary,
     L3Summary,
     VarianceSummary,
+    build_markdown_image,
     compute_badge,
+    discover_iteration,
+    load_iteration_sidecars,
 )
 from clauditor.quality_grader import GradingReport, GradingResult
 from clauditor.schemas import GradeThresholds
@@ -840,3 +844,272 @@ class TestDefensiveBranches:
         assert badge.clauditor.variance == VarianceSummary(
             n_runs=0, stability=0.9, passed=True
         )
+
+
+# ---------------------------------------------------------------------------
+# US-003 — Sidecar discovery + URL builder helpers.
+#
+# DEC-001 / DEC-002 / DEC-006 / DEC-008 / DEC-016 / DEC-026.
+# ---------------------------------------------------------------------------
+
+
+def _mk_iteration(project_dir, iter_num: int, skill_name: str | None) -> None:
+    """Create ``<project_dir>/.clauditor/iteration-N/[<skill>/]``.
+
+    ``skill_name=None`` creates the iteration dir but no skill
+    subdir — simulating an iteration that holds another skill's
+    sidecars but not the one we're looking up.
+    """
+    iter_dir = project_dir / ".clauditor" / f"iteration-{iter_num}"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    if skill_name is not None:
+        (iter_dir / skill_name).mkdir(parents=True, exist_ok=True)
+
+
+class TestDiscoverIteration:
+    """Tests for :func:`clauditor.badge.discover_iteration`."""
+
+    def test_returns_latest_when_explicit_none(self, tmp_path):
+        """Pick highest N where ``iteration-N/<skill>/`` exists."""
+        _mk_iteration(tmp_path, 1, "demo")
+        _mk_iteration(tmp_path, 3, "demo")
+        _mk_iteration(tmp_path, 2, "demo")
+        result = discover_iteration(tmp_path, "demo", None)
+        assert result is not None
+        n, path = result
+        assert n == 3
+        assert path == tmp_path / ".clauditor" / "iteration-3" / "demo"
+
+    def test_explicit_hit(self, tmp_path):
+        """``explicit=N`` returns that dir when it exists."""
+        _mk_iteration(tmp_path, 42, "demo")
+        result = discover_iteration(tmp_path, "demo", 42)
+        assert result is not None
+        n, path = result
+        assert n == 42
+        assert path == tmp_path / ".clauditor" / "iteration-42" / "demo"
+
+    def test_explicit_missing_returns_none(self, tmp_path):
+        """``explicit=N`` returns ``None`` when the iteration-skill dir is absent."""
+        # iteration exists but without the skill subdir
+        _mk_iteration(tmp_path, 7, skill_name=None)
+        assert discover_iteration(tmp_path, "demo", 7) is None
+
+    def test_explicit_iteration_dir_absent(self, tmp_path):
+        """``explicit=N`` returns ``None`` when iteration-N itself is absent."""
+        _mk_iteration(tmp_path, 1, "demo")
+        assert discover_iteration(tmp_path, "demo", 99) is None
+
+    def test_no_clauditor_dir_returns_none(self, tmp_path):
+        """Missing ``.clauditor/`` — scanner returns empty — helper returns None."""
+        # project_dir has no .clauditor/ at all
+        assert discover_iteration(tmp_path, "demo", None) is None
+
+    def test_no_iteration_has_skill_returns_none(self, tmp_path):
+        """Iterations exist but none contain ``<skill>/``."""
+        _mk_iteration(tmp_path, 1, "other")
+        _mk_iteration(tmp_path, 2, "other")
+        assert discover_iteration(tmp_path, "demo", None) is None
+
+    def test_skips_iterations_without_skill_dir(self, tmp_path):
+        """Latest iteration may lack the skill; walk down to the first hit."""
+        _mk_iteration(tmp_path, 5, skill_name=None)  # no demo/
+        _mk_iteration(tmp_path, 4, "demo")  # has demo/
+        _mk_iteration(tmp_path, 3, "demo")  # has demo/ (but older)
+        result = discover_iteration(tmp_path, "demo", None)
+        assert result is not None
+        n, path = result
+        assert n == 4
+        assert path == tmp_path / ".clauditor" / "iteration-4" / "demo"
+
+    def test_no_explicit_with_clauditor_dir_but_no_iterations(self, tmp_path):
+        """``.clauditor/`` exists but has no ``iteration-*/`` children."""
+        (tmp_path / ".clauditor").mkdir()
+        (tmp_path / ".clauditor" / "badges").mkdir()  # unrelated subdir
+        assert discover_iteration(tmp_path, "demo", None) is None
+
+
+class TestLoadIterationSidecars:
+    """Tests for :func:`clauditor.badge.load_iteration_sidecars`."""
+
+    def test_all_three_present(self, tmp_path):
+        """All three sidecars present → all three dicts returned."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "assertions.json").write_text(json.dumps({"results": []}))
+        (skill_dir / "grading.json").write_text(json.dumps({"results": []}))
+        (skill_dir / "variance.json").write_text(json.dumps({"n_runs": 3}))
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.assertions == {"results": []}
+        assert sidecars.grading == {"results": []}
+        assert sidecars.variance == {"n_runs": 3}
+        assert sidecars.assertions_missing is False
+
+    def test_only_assertions_present(self, tmp_path):
+        """Only ``assertions.json`` present → grading/variance are None."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "assertions.json").write_text(json.dumps({"results": []}))
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.assertions == {"results": []}
+        assert sidecars.grading is None
+        assert sidecars.variance is None
+        assert sidecars.assertions_missing is False
+
+    def test_only_grading_present(self, tmp_path):
+        """Only grading sidecar — assertions_missing True (DEC-008)."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "grading.json").write_text(json.dumps({"results": []}))
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.assertions is None
+        assert sidecars.grading == {"results": []}
+        assert sidecars.variance is None
+        assert sidecars.assertions_missing is True
+
+    def test_variance_optional(self, tmp_path):
+        """Assertions + grading present, variance absent → variance is None."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "assertions.json").write_text(json.dumps({"results": []}))
+        (skill_dir / "grading.json").write_text(json.dumps({"results": []}))
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.variance is None
+        assert sidecars.assertions_missing is False
+
+    def test_assertions_missing_true_when_dir_exists_without_assertions(
+        self, tmp_path
+    ):
+        """DEC-008: dir exists, ``assertions.json`` absent → flag True."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        # No assertions.json, no other sidecars either.
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.assertions is None
+        assert sidecars.assertions_missing is True
+
+    def test_assertions_missing_false_when_dir_absent(self, tmp_path):
+        """DEC-001: dir itself absent → flag False (not "corrupt")."""
+        skill_dir = tmp_path / "does-not-exist"
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.assertions is None
+        assert sidecars.grading is None
+        assert sidecars.variance is None
+        assert sidecars.assertions_missing is False
+
+    def test_all_absent_returns_all_none(self, tmp_path):
+        """Dir absent → all three sidecar dicts None, flag False."""
+        skill_dir = tmp_path / "missing"
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars == IterationSidecars(
+            assertions=None,
+            grading=None,
+            variance=None,
+            assertions_missing=False,
+        )
+
+    def test_parse_error_returns_none_for_that_sidecar(self, tmp_path):
+        """Malformed JSON → ``_read_json`` returns None for that sidecar."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "assertions.json").write_text("{not valid json")
+        (skill_dir / "grading.json").write_text(json.dumps({"ok": True}))
+        sidecars = load_iteration_sidecars(skill_dir)
+        assert sidecars.assertions is None
+        assert sidecars.grading == {"ok": True}
+        # The file exists even though it's unparseable, so the flag
+        # reflects filesystem presence rather than parse success.
+        assert sidecars.assertions_missing is False
+
+
+class TestBuildMarkdownImage:
+    """Tests for :func:`clauditor.badge.build_markdown_image`."""
+
+    def test_basic_shape(self):
+        """Verbatim shape from the ticket example."""
+        md = build_markdown_image(
+            skill_name="review-pr",
+            repo_slug="USER/REPO",
+            branch="main",
+            output_relpath=".clauditor/badges/review-pr.json",
+            label="clauditor",
+        )
+        assert md == (
+            "![clauditor](https://img.shields.io/endpoint?"
+            "url=https://raw.githubusercontent.com/"
+            "USER/REPO/main/.clauditor/badges/review-pr.json)"
+        )
+
+    def test_url_encoding_on_branch_with_slash(self):
+        """Slashes in branch name are preserved (path-safe encoding)."""
+        md = build_markdown_image(
+            skill_name="demo",
+            repo_slug="acme/widget",
+            branch="feature/branch",
+            output_relpath=".clauditor/badges/demo.json",
+            label="clauditor",
+        )
+        # ``feature/branch`` stays as ``feature/branch`` (the ``/``
+        # is in the ``safe=`` set).
+        assert "/feature/branch/" in md
+
+    def test_url_encoding_on_output_relpath_with_space(self):
+        """Spaces in output_relpath get percent-encoded to ``%20``."""
+        md = build_markdown_image(
+            skill_name="demo",
+            repo_slug="acme/widget",
+            branch="main",
+            output_relpath=".clauditor/badges/my skill.json",
+            label="clauditor",
+        )
+        assert "my%20skill.json" in md
+        # And the raw space did NOT survive.
+        assert " " not in md.split("](")[1]
+
+    def test_label_preserved_verbatim(self):
+        """Label is interpolated into the ``![label](...)`` syntax as-is."""
+        md = build_markdown_image(
+            skill_name="demo",
+            repo_slug="acme/widget",
+            branch="main",
+            output_relpath=".clauditor/badges/demo.json",
+            label="My Cool Badge",
+        )
+        # Spaces in the alt-text are preserved for human readability.
+        assert md.startswith("![My Cool Badge](")
+
+    def test_repo_slug_preserved_with_slashes(self):
+        """``USER/REPO`` slug survives encoding."""
+        md = build_markdown_image(
+            skill_name="demo",
+            repo_slug="my-org/my-repo",
+            branch="main",
+            output_relpath=".clauditor/badges/demo.json",
+            label="clauditor",
+        )
+        assert "/my-org/my-repo/" in md
+
+    def test_special_chars_in_repo_slug_encoded(self):
+        """Unusual chars in the slug get percent-encoded."""
+        md = build_markdown_image(
+            skill_name="demo",
+            repo_slug="user/repo with space",
+            branch="main",
+            output_relpath=".clauditor/badges/demo.json",
+            label="clauditor",
+        )
+        assert "repo%20with%20space" in md
+
+    def test_returns_pure_string_no_mutation(self):
+        """Helper returns a string; no inputs are lists/dicts (no mutation risk
+        to assert, but verify return type)."""
+        md = build_markdown_image(
+            skill_name="demo",
+            repo_slug="u/r",
+            branch="main",
+            output_relpath="a.json",
+            label="x",
+        )
+        assert isinstance(md, str)
+        # Verify the double-layer URL structure.
+        assert md.count("https://") == 2

--- a/tests/test_cli_badge.py
+++ b/tests/test_cli_badge.py
@@ -671,6 +671,41 @@ class TestCmdBadgeStyleValidation:
         assert "cacheSeconds" in err
         assert "integer" in err
 
+    @pytest.mark.parametrize(
+        "reserved_key",
+        ["schemaVersion", "label", "message", "color", "clauditor"],
+    )
+    def test_reserved_key_rejected_exit_2(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+        reserved_key: str,
+    ) -> None:
+        """Copilot PR review, 2026-04-22: --style cannot overwrite the
+        canonical shields.io / clauditor top-level fields.
+
+        ``Badge.to_endpoint_json`` emits ``style_overrides`` AFTER the
+        canonical keys, so a user passing ``--style schemaVersion=2``
+        or ``--style clauditor=hijacked`` would silently clobber the
+        real value. The CLI now rejects reserved keys at parse time
+        with exit 2 naming the offending key.
+        """
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--style",
+                f"{reserved_key}=attacker",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert reserved_key in err
+        assert "canonical badge field" in err
+
 
 # ---------------------------------------------------------------------------
 # --label validation (review pass 1, B-3).
@@ -818,6 +853,43 @@ class TestCmdBadgeUrlOnly:
         assert "USER/REPO/main" in captured.out
         assert "git auto-detect failed" in captured.err
         assert "USER/REPO/main" in captured.err
+        # Copilot PR review, 2026-04-22: when BOTH auto-detects fell
+        # through, the warning must name --branch too (not just --repo)
+        # so the user has the complete remediation in one line.
+        assert "--repo" in captured.err
+        assert "--branch" in captured.err
+
+    def test_slug_missing_but_branch_detected_warns_only_about_repo(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """When the branch was detected but the slug was not, the
+        warning should mention only ``--repo`` (not ``--branch``).
+        Mirror to ``test_auto_detect_slug_missing_uses_placeholder``
+        where both fell through and the message names both flags.
+        """
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            return_value=None,
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            return_value="develop",
+        ):
+            rc = main(["badge", str(skill_md), "--url-only"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "USER/REPO/develop" in captured.out
+        assert "git auto-detect failed" in captured.err
+        assert "--repo" in captured.err
+        # Branch auto-detect succeeded — do NOT mention --branch in
+        # the remediation hint.
+        assert "--branch" not in captured.err.split(
+            "git auto-detect failed"
+        )[1].split("\n")[0]
 
     def test_auto_detect_branch_missing_falls_back_to_main(
         self, tmp_path: Path, monkeypatch, capsys
@@ -1109,6 +1181,34 @@ class TestCmdBadgeListAvailableIterations:
         err = capsys.readouterr().err
         # Only the valid iteration 2 should be listed.
         assert "Available iterations with this skill: 2" in err
+
+    def test_iteration_zero_filtered_from_available_list(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Codecov PR review, 2026-04-22: ``_list_available_iterations``
+        filters ``n < 1`` (line 298 defensive branch).
+
+        A manually-placed ``iteration-0/<skill>/`` dir must not appear
+        in the DEC-016 "available iterations" stderr list — iteration
+        numbers start at 1 per the ``workspace.py`` invariant.
+        """
+        skill_md = _write_skill(tmp_path)
+        # Real valid iteration present for the skill.
+        _setup_iteration(tmp_path, 3)
+        # Plant an iteration-0/<skill>/ dir that should be filtered.
+        (tmp_path / ".clauditor" / "iteration-0" / "demo").mkdir(
+            parents=True
+        )
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--from-iteration", "99"])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        # Only iteration 3 should be listed — no "0".
+        assert "Available iterations with this skill: 3" in err
+        assert ", 0" not in err
+        assert "0, " not in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_badge.py
+++ b/tests/test_cli_badge.py
@@ -1,0 +1,891 @@
+"""Tests for ``clauditor badge`` (#77 US-004 — DEC-025 exit codes).
+
+CLI integration tests that wire the US-001 / US-002 / US-003 helpers
+together. The tests use ``tmp_path`` + ``monkeypatch.chdir`` to pin
+``Path.cwd()`` per-test, and ``unittest.mock.patch`` on
+``clauditor._git.get_repo_slug`` / ``get_default_branch`` to exercise
+the ``--url-only`` detect/override branches without touching any real
+``git`` process.
+
+Traces to DEC-001, DEC-002, DEC-005, DEC-006, DEC-011, DEC-014,
+DEC-015, DEC-016, DEC-018, DEC-021, DEC-022, DEC-023, DEC-025,
+DEC-026.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.cli import main
+from clauditor.quality_grader import GradingReport, GradingResult
+from clauditor.schemas import GradeThresholds
+
+# ---------------------------------------------------------------------------
+# Test helpers — skill staging + iteration sidecar fixtures.
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(tmp_path: Path, name: str = "demo") -> Path:
+    """Stage a SKILL.md under ``<tmp_path>/.claude/skills/<name>/SKILL.md``.
+
+    Uses the modern layout so ``SkillSpec.from_file`` derives the
+    ``skill_name`` from the frontmatter ``name:`` field (falling back
+    to the parent dir name — both produce ``name``).
+    """
+    skill_dir = tmp_path / ".claude" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        f"---\nname: {name}\n---\n# {name.title()}\n\nA demo skill.\n"
+    )
+    return skill_md
+
+
+def _write_assertions_sidecar(
+    iter_skill_dir: Path,
+    *,
+    passed: int = 3,
+    total: int = 3,
+) -> None:
+    """Write an ``assertions.json`` under ``iter_skill_dir``.
+
+    Uses the flat :meth:`AssertionSet.to_json` shape — the badge
+    module accepts both the flat and modern ``runs`` layouts.
+    """
+    results = [
+        AssertionResult(
+            name=f"check_{i}",
+            passed=i < passed,
+            message="ok" if i < passed else "fail",
+            kind="presence",
+        )
+        for i in range(total)
+    ]
+    aset = AssertionSet(results=results)
+    (iter_skill_dir / "assertions.json").write_text(json.dumps(aset.to_json()))
+
+
+def _write_grading_sidecar(
+    iter_skill_dir: Path,
+    *,
+    passed: bool = True,
+    score: float = 0.9,
+) -> None:
+    """Write a ``grading.json`` under ``iter_skill_dir`` via GradingReport."""
+    results = [
+        GradingResult(
+            id="c0",
+            criterion="is it good",
+            passed=passed,
+            score=score,
+            evidence="",
+            reasoning="",
+        )
+    ]
+    report = GradingReport(
+        skill_name="demo",
+        results=results,
+        model="test-model",
+        thresholds=GradeThresholds(),
+        metrics={},
+        duration_seconds=1.0,
+        input_tokens=100,
+        output_tokens=50,
+    )
+    (iter_skill_dir / "grading.json").write_text(report.to_json())
+
+
+def _setup_iteration(
+    tmp_path: Path,
+    iter_num: int,
+    skill_name: str = "demo",
+    *,
+    write_assertions: bool = True,
+    write_grading: bool = False,
+    l1_all_pass: bool = True,
+) -> Path:
+    """Stage an iteration dir + sidecars under ``tmp_path``.
+
+    Returns the per-skill iteration dir path. Callers write any
+    additional sidecars (``variance.json``) directly using that path.
+    """
+    iter_skill_dir = (
+        tmp_path / ".clauditor" / f"iteration-{iter_num}" / skill_name
+    )
+    iter_skill_dir.mkdir(parents=True)
+    if write_assertions:
+        _write_assertions_sidecar(
+            iter_skill_dir,
+            passed=3 if l1_all_pass else 2,
+            total=3,
+        )
+    if write_grading:
+        _write_grading_sidecar(iter_skill_dir)
+    return iter_skill_dir
+
+
+# ---------------------------------------------------------------------------
+# Happy-path writes (DEC-026 pure-compute composition sanity checks).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeHappyPath:
+    """Code path 4 — iteration found, sidecars loaded, write the JSON."""
+
+    def test_writes_badge_json_default_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Default output lands at ``.clauditor/badges/<skill>.json``."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        # Shields.io contract keys + our nested extension.
+        assert data["schemaVersion"] == 1
+        assert data["label"] == "clauditor"
+        assert data["color"] == "brightgreen"
+        assert data["message"] == "3/3"
+        assert data["clauditor"]["skill_name"] == "demo"
+        assert data["clauditor"]["iteration"] == 1
+
+    def test_writes_badge_json_custom_output(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``--output PATH`` writes there (DEC-005 accepts absolute paths)."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        out_dir = tmp_path / "custom"
+        out_dir.mkdir()
+        target = out_dir / "my-badge.json"
+
+        rc = main(["badge", str(skill_md), "--output", str(target)])
+        assert rc == 0
+        assert target.exists()
+
+        default_target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        assert not default_target.exists()
+
+    def test_verbose_prints_success_line(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """DEC-018: ``--verbose`` emits ``wrote {path} (iteration N)``."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 7)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--verbose"])
+        assert rc == 0
+
+        err = capsys.readouterr().err
+        assert "clauditor.badge: wrote" in err
+        assert "(iteration 7)" in err
+
+    def test_happy_path_with_grading_sidecar(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Grading present → L3 fragment lands in the message."""
+        skill_md = _write_skill(tmp_path)
+        iter_dir = _setup_iteration(tmp_path, 1, write_grading=True)
+        assert iter_dir.exists()
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        data = json.loads(
+            (tmp_path / ".clauditor" / "badges" / "demo.json").read_text()
+        )
+        assert "L3" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# DEC-001 — no iteration → lightgrey placeholder, exit 0.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeNoIteration:
+    def test_writes_lightgrey_placeholder_exit_0(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert data["color"] == "lightgrey"
+        assert data["message"] == "no data"
+        assert data["clauditor"]["iteration"] is None
+
+    def test_emits_dec021_warning(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        err = capsys.readouterr().err
+        assert "no iteration found for skill demo" in err
+        assert "lightgrey placeholder" in err
+
+    def test_placeholder_respects_force(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """DEC-011 exception: lightgrey placeholder does NOT clobber
+        without --force (a stale real badge is better than silent
+        clobber on a misfire)."""
+        skill_md = _write_skill(tmp_path)
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        target.parent.mkdir(parents=True)
+        target.write_text('{"pre-existing": true}\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        assert "already exists" in err
+        # Pre-existing content untouched.
+        assert target.read_text() == '{"pre-existing": true}\n'
+
+    def test_placeholder_with_force_overwrites(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        target.parent.mkdir(parents=True)
+        target.write_text('{"pre-existing": true}\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--force"])
+        assert rc == 0
+        data = json.loads(target.read_text())
+        assert data["color"] == "lightgrey"
+
+
+# ---------------------------------------------------------------------------
+# DEC-016 — explicit --from-iteration N that is missing.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeExplicitIterationMissing:
+    def test_exit_1_with_available_list(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        _setup_iteration(tmp_path, 3)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--from-iteration", "42"])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        assert "iteration 42 not found for skill demo" in err
+        # Available iteration numbers rendered in ascending order.
+        assert "1, 3" in err
+
+    def test_exit_1_with_no_available_message(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        # No iterations exist at all.
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--from-iteration", "1"])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        assert "iteration 1 not found for skill demo" in err
+        assert "none" in err
+
+    def test_non_integer_from_iteration_exits_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(skill_md), "--from-iteration", "abc"])
+        assert rc == 2
+
+        err = capsys.readouterr().err
+        assert "--from-iteration must be a positive integer" in err
+
+    def test_zero_from_iteration_exits_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(skill_md), "--from-iteration", "0"])
+        assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# DEC-008 — corrupt iteration (assertions.json missing).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeCorruptIteration:
+    def test_assertions_missing_exit_1(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        # Iteration dir exists, but no assertions.json
+        _setup_iteration(tmp_path, 1, write_assertions=False)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        assert "iteration 1 for skill demo is corrupt" in err
+        assert "assertions.json is missing" in err
+
+
+# ---------------------------------------------------------------------------
+# DEC-011 — force overwrite policy.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeForceOverwrite:
+    def test_existing_without_force_exit_1(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        target.parent.mkdir(parents=True)
+        target.write_text('{"preserved": true}\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        assert "already exists" in err
+        assert target.read_text() == '{"preserved": true}\n'
+
+    def test_existing_with_force_overwrites(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        target.parent.mkdir(parents=True)
+        target.write_text('{"preserved": true}\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--force"])
+        assert rc == 0
+        data = json.loads(target.read_text())
+        assert data["color"] == "brightgreen"
+
+
+# ---------------------------------------------------------------------------
+# DEC-014 — --url-only and --output mutually exclusive.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeMutualExclusion:
+    def test_url_only_and_output_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--url-only",
+                "--output",
+                str(tmp_path / "foo.json"),
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--url-only and --output are mutually exclusive" in err
+
+
+# ---------------------------------------------------------------------------
+# DEC-022 — --output parent-dir validation.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeOutputValidation:
+    def test_missing_parent_dir_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        bad_path = tmp_path / "does" / "not" / "exist" / "badge.json"
+        rc = main(["badge", str(skill_md), "--output", str(bad_path)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "parent directory does not exist" in err
+
+    def test_absolute_path_accepted(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """DEC-005: absolute paths are accepted."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        abs_target = tmp_path / "abs-badge.json"
+        rc = main(["badge", str(skill_md), "--output", str(abs_target)])
+        assert rc == 0
+        assert abs_target.exists()
+
+
+# ---------------------------------------------------------------------------
+# DEC-015 / DEC-023 — --style parsing + validation.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeStyleValidation:
+    @pytest.mark.parametrize(
+        "raw, expected_code",
+        [
+            # Missing separator → exit 2.
+            ("foo", 2),
+            # Empty key → exit 2.
+            ("=value", 2),
+            # Empty value (allowed) → exit 0.
+            ("style=", 0),
+            # Known key → exit 0.
+            ("style=flat", 0),
+            # Unknown key → exit 0 (warns to stderr).
+            ("customKey=value", 0),
+        ],
+    )
+    def test_parsing(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        raw: str,
+        expected_code: int,
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--style", raw])
+        assert rc == expected_code
+
+    def test_unknown_key_warns_passes_through(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            ["badge", str(skill_md), "--style", "customKey=customVal"]
+        )
+        assert rc == 0
+
+        err = capsys.readouterr().err
+        assert "unknown --style key 'customKey'" in err
+
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        data = json.loads(target.read_text())
+        # Unknown key still emitted (DEC-015 — shields.io ignores it).
+        assert data["customKey"] == "customVal"
+
+    def test_multiple_style_flags_all_emitted(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--style",
+                "style=flat",
+                "--style",
+                "cacheSeconds=300",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(
+            (tmp_path / ".clauditor" / "badges" / "demo.json").read_text()
+        )
+        assert data["style"] == "flat"
+        assert data["cacheSeconds"] == "300"
+
+    def test_control_char_rejects_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        # \x01 is a control character.
+        rc = main(["badge", str(skill_md), "--style", "style=flat\x01bad"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "control characters" in err
+
+    def test_overlong_value_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        big = "x" * 600
+        rc = main(["badge", str(skill_md), "--style", f"style={big}"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "length 600" in err
+
+
+# ---------------------------------------------------------------------------
+# DEC-002 — --url-only branches (auto-detect + fallback).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeUrlOnly:
+    def test_explicit_repo_and_branch(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        # --repo and --branch are explicit, so git helpers should not
+        # even be called. Patch them to raise if invoked to prove it.
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            side_effect=AssertionError("slug should not be queried"),
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            side_effect=AssertionError("branch should not be queried"),
+        ):
+            rc = main(
+                [
+                    "badge",
+                    str(skill_md),
+                    "--url-only",
+                    "--repo",
+                    "acme/widget",
+                    "--branch",
+                    "dev",
+                ]
+            )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "acme/widget/dev/.clauditor/badges/demo.json" in out
+
+    def test_auto_detect_success(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            return_value="myorg/myrepo",
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            return_value="master",
+        ):
+            rc = main(["badge", str(skill_md), "--url-only"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "myorg/myrepo/master" in out
+        # No placeholder warning when auto-detect succeeds.
+        err = capsys.readouterr().err
+        assert "placeholder" not in err
+
+    def test_auto_detect_slug_missing_uses_placeholder(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            return_value=None,
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            return_value=None,
+        ):
+            rc = main(["badge", str(skill_md), "--url-only"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "USER/REPO/main" in captured.out
+        assert "git auto-detect failed" in captured.err
+        assert "USER/REPO/main" in captured.err
+
+    def test_auto_detect_branch_missing_falls_back_to_main(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            return_value="real/slug",
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            return_value=None,
+        ):
+            rc = main(["badge", str(skill_md), "--url-only"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "real/slug/main" in captured.out
+        # Slug detected — the user-actionable warning should mention
+        # the branch-specific fallback, not the global placeholder.
+        assert "default-branch auto-detect failed" in captured.err
+
+    def test_url_only_does_not_write_file(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            return_value="u/r",
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            return_value="main",
+        ):
+            rc = main(["badge", str(skill_md), "--url-only"])
+
+        assert rc == 0
+        assert not (
+            tmp_path / ".clauditor" / "badges" / "demo.json"
+        ).exists()
+
+    def test_url_only_without_iteration_also_works(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """DEC-001 + --url-only: no sidecar data, still prints the line."""
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.badge._git.get_repo_slug",
+            return_value="u/r",
+        ), patch(
+            "clauditor.cli.badge._git.get_default_branch",
+            return_value="main",
+        ):
+            rc = main(["badge", str(skill_md), "--url-only"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "https://img.shields.io/endpoint?" in out
+        # No badge JSON was written either (--url-only short-circuits).
+        assert not (
+            tmp_path / ".clauditor" / "badges" / "demo.json"
+        ).exists()
+
+
+# ---------------------------------------------------------------------------
+# Skill spec load errors (exit 2).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeSpecLoad:
+    def test_missing_skill_file_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(tmp_path / "does-not-exist.md")])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "skill file not found" in err
+
+    def test_directory_instead_of_file_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        a_dir = tmp_path / "not-a-file"
+        a_dir.mkdir()
+        rc = main(["badge", str(a_dir)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "is not a regular file" in err
+
+    def test_skill_load_raises_is_exit_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """``SkillSpec.from_file`` raising maps to exit 2 (DEC-025 input)."""
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Patch SkillSpec.from_file at the badge module's import site
+        # so the except block runs.
+        with patch(
+            "clauditor.cli.badge.SkillSpec.from_file",
+            side_effect=ValueError("bad eval json"),
+        ):
+            rc = main(["badge", str(skill_md)])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "could not load skill spec" in err
+        assert "bad eval json" in err
+
+
+# ---------------------------------------------------------------------------
+# DEC-007 — iteration present, zero L1 assertions → lightgrey + warn.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeZeroL1Assertions:
+    def test_zero_assertions_emits_dec007_warning(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """An iteration whose assertions.json has empty results → lightgrey
+        + DEC-007 stderr warning (distinct from the DEC-001 warning)."""
+        skill_md = _write_skill(tmp_path)
+        iter_skill_dir = (
+            tmp_path / ".clauditor" / "iteration-1" / "demo"
+        )
+        iter_skill_dir.mkdir(parents=True)
+        # Empty results → DEC-007 path.
+        (iter_skill_dir / "assertions.json").write_text(
+            json.dumps({"input_tokens": 0, "output_tokens": 0, "results": []})
+        )
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        err = capsys.readouterr().err
+        assert "eval spec declares 0 L1 assertions" in err
+
+        data = json.loads(
+            (tmp_path / ".clauditor" / "badges" / "demo.json").read_text()
+        )
+        assert data["color"] == "lightgrey"
+        assert data["message"] == "no data"
+
+
+# ---------------------------------------------------------------------------
+# Disk-write error path (exit 1).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeDiskWriteError:
+    def test_write_os_error_exit_1(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """An OSError during write maps to exit 1 (DEC-025 runtime failure)."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        # Patch Path.write_text at the badge module's use site. Using
+        # the module's imported Path symbol keeps the patch scoped.
+        from unittest.mock import MagicMock
+
+        with patch(
+            "clauditor.cli.badge.Path.write_text",
+            MagicMock(side_effect=OSError("disk full")),
+        ):
+            rc = main(["badge", str(skill_md)])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "could not write" in err
+        assert "disk full" in err
+
+
+# ---------------------------------------------------------------------------
+# _list_available_iterations defensive branches (exit 1 corner cases).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeListAvailableIterations:
+    def test_ignores_non_iteration_entries(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """``.clauditor/`` children that are not ``iteration-N`` dirs skipped.
+
+        Covers the ``_list_available_iterations`` branches that skip
+        unrelated entries (files + malformed iteration names) when
+        building the DEC-016 "available iterations" list.
+        """
+        skill_md = _write_skill(tmp_path)
+        # Real iteration present for the skill
+        _setup_iteration(tmp_path, 2)
+        # Non-dir child — should be skipped.
+        (tmp_path / ".clauditor" / "not-a-dir").write_text("x")
+        # Wrong prefix — should be skipped.
+        (tmp_path / ".clauditor" / "runs").mkdir()
+        # iteration-XX with non-integer suffix — should be skipped.
+        (tmp_path / ".clauditor" / "iteration-abc").mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--from-iteration", "99"])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        # Only the valid iteration 2 should be listed.
+        assert "Available iterations with this skill: 2" in err
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher wiring smoke test.
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherWiring:
+    def test_badge_subcommand_registered(self, capsys) -> None:
+        """``clauditor --help`` lists ``badge`` as an available subcommand."""
+        with pytest.raises(SystemExit):
+            main(["--help"])
+        out = capsys.readouterr().out
+        assert "badge" in out
+
+    def test_badge_help_renders_flags(self, capsys) -> None:
+        with pytest.raises(SystemExit):
+            main(["badge", "--help"])
+        out = capsys.readouterr().out
+        for flag in (
+            "--from-iteration",
+            "--output",
+            "--url-only",
+            "--force",
+            "--repo",
+            "--branch",
+            "--label",
+            "--style",
+            "--verbose",
+        ):
+            assert flag in out

--- a/tests/test_cli_badge.py
+++ b/tests/test_cli_badge.py
@@ -320,21 +320,59 @@ class TestCmdBadgeExplicitIterationMissing:
     def test_non_integer_from_iteration_exits_2(
         self, tmp_path: Path, monkeypatch, capsys
     ) -> None:
+        """``--from-iteration abc`` fails argparse ``_positive_int`` validation.
+
+        argparse raises ``SystemExit(2)`` directly with its own error
+        format; the SkillSpec load never happens (review pass 1, B-2
+        — validate before paying the load cost).
+        """
         skill_md = _write_skill(tmp_path)
         monkeypatch.chdir(tmp_path)
-        rc = main(["badge", str(skill_md), "--from-iteration", "abc"])
-        assert rc == 2
+        with pytest.raises(SystemExit) as excinfo:
+            main(["badge", str(skill_md), "--from-iteration", "abc"])
+        assert excinfo.value.code == 2
 
         err = capsys.readouterr().err
-        assert "--from-iteration must be a positive integer" in err
+        # argparse's own error message references the flag and the value.
+        assert "--from-iteration" in err
+        assert "'abc'" in err
 
     def test_zero_from_iteration_exits_2(
         self, tmp_path: Path, monkeypatch, capsys
     ) -> None:
+        """``--from-iteration 0`` also rejected by ``_positive_int``."""
         skill_md = _write_skill(tmp_path)
         monkeypatch.chdir(tmp_path)
-        rc = main(["badge", str(skill_md), "--from-iteration", "0"])
-        assert rc == 2
+        with pytest.raises(SystemExit) as excinfo:
+            main(["badge", str(skill_md), "--from-iteration", "0"])
+        assert excinfo.value.code == 2
+
+        err = capsys.readouterr().err
+        assert "--from-iteration" in err
+        assert "must be >= 1" in err
+
+    def test_url_only_with_missing_explicit_iteration_exits_1(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Precedence anchor: DEC-016 wins over ``--url-only`` (review pass
+        2, N2-2). An explicit ``--from-iteration N`` that does not exist
+        is an input error even in URL-only mode — the user asked for a
+        specific iteration and should be told it isn't there.
+        """
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--url-only",
+                "--from-iteration",
+                "9999",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "iteration 9999 not found" in err
 
 
 # ---------------------------------------------------------------------------
@@ -533,7 +571,8 @@ class TestCmdBadgeStyleValidation:
             (tmp_path / ".clauditor" / "badges" / "demo.json").read_text()
         )
         assert data["style"] == "flat"
-        assert data["cacheSeconds"] == "300"
+        # cacheSeconds is int-coerced per review pass 3, C3-1.
+        assert data["cacheSeconds"] == 300
 
     def test_control_char_rejects_exit_2(
         self, tmp_path: Path, monkeypatch, capsys
@@ -560,6 +599,142 @@ class TestCmdBadgeStyleValidation:
         assert rc == 2
         err = capsys.readouterr().err
         assert "length 600" in err
+
+    def test_value_with_embedded_equals(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``--style link=https://foo.com?x=y`` — value containing ``=``.
+
+        The ``split("=", 1)`` handling must preserve the second ``=``
+        in the value verbatim (review pass 2, N2-1).
+        """
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--style",
+                "link=https://foo.com?x=y",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(
+            (tmp_path / ".clauditor" / "badges" / "demo.json").read_text()
+        )
+        assert data["link"] == "https://foo.com?x=y"
+
+    def test_cache_seconds_coerced_to_int(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Review pass 3, C3-1: ``cacheSeconds`` is typed int per shields.io."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--style",
+                "cacheSeconds=300",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(
+            (tmp_path / ".clauditor" / "badges" / "demo.json").read_text()
+        )
+        # Native int in the JSON, not string "300".
+        assert data["cacheSeconds"] == 300
+        assert isinstance(data["cacheSeconds"], int)
+
+    def test_non_numeric_cache_seconds_exits_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Non-integer value for an int-typed style key rejects at parse."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--style",
+                "cacheSeconds=abc",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "cacheSeconds" in err
+        assert "integer" in err
+
+
+# ---------------------------------------------------------------------------
+# --label validation (review pass 1, B-3).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdBadgeLabelValidation:
+    """Reject --label values that break Markdown ``![alt](url)`` syntax."""
+
+    @pytest.mark.parametrize(
+        "bad_label",
+        [
+            "broken[label",
+            "broken]label",
+            "broken(label",
+            "broken)label",
+            "multi\nline",
+            "carriage\rreturn",
+        ],
+    )
+    def test_label_with_markdown_breaking_chars_exits_2(
+        self, tmp_path: Path, monkeypatch, capsys, bad_label: str
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(skill_md), "--label", bad_label])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--label" in err
+
+    def test_overlong_label_exits_2(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(skill_md), "--label", "x" * 600])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--label is too long" in err
+
+    @pytest.mark.parametrize("empty_label", ["", "   ", "\t"])
+    def test_empty_label_exits_2(
+        self, tmp_path: Path, monkeypatch, capsys, empty_label: str
+    ) -> None:
+        """Review pass 3, N3-2: empty/whitespace labels rejected.
+
+        Accessibility-hostile ``![](url)`` output is not what users
+        intended when they pass ``--label ""``.
+        """
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(skill_md), "--label", empty_label])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "must not be empty" in err
+
+    def test_label_with_spaces_and_unicode_accepted(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+        rc = main(["badge", str(skill_md), "--label", "My Skill — ✓"])
+        assert rc == 0
 
 
 # ---------------------------------------------------------------------------
@@ -617,11 +792,10 @@ class TestCmdBadgeUrlOnly:
             rc = main(["badge", str(skill_md), "--url-only"])
 
         assert rc == 0
-        out = capsys.readouterr().out
-        assert "myorg/myrepo/master" in out
+        captured = capsys.readouterr()
+        assert "myorg/myrepo/master" in captured.out
         # No placeholder warning when auto-detect succeeds.
-        err = capsys.readouterr().err
-        assert "placeholder" not in err
+        assert "placeholder" not in captured.err
 
     def test_auto_detect_slug_missing_uses_placeholder(
         self, tmp_path: Path, monkeypatch, capsys
@@ -795,6 +969,47 @@ class TestCmdBadgeZeroL1Assertions:
         assert data["color"] == "lightgrey"
         assert data["message"] == "no data"
 
+    def test_zero_assertions_with_url_only_does_not_mention_write(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Review pass 1, B-1: the DEC-007 "wrote lightgrey badge" warning
+        must NOT fire under ``--url-only`` (which prints a Markdown line
+        and does not write JSON). Otherwise stderr claims a write that
+        never happened.
+        """
+        skill_md = _write_skill(tmp_path)
+        iter_skill_dir = (
+            tmp_path / ".clauditor" / "iteration-1" / "demo"
+        )
+        iter_skill_dir.mkdir(parents=True)
+        (iter_skill_dir / "assertions.json").write_text(
+            json.dumps({"input_tokens": 0, "output_tokens": 0, "results": []})
+        )
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(
+            [
+                "badge",
+                str(skill_md),
+                "--url-only",
+                "--repo",
+                "u/r",
+                "--branch",
+                "main",
+            ]
+        )
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Markdown line printed to stdout.
+        assert "img.shields.io/endpoint" in captured.out
+        # No "wrote lightgrey" claim on stderr.
+        assert "wrote lightgrey" not in captured.err
+        assert "0 L1 assertions" not in captured.err
+        # JSON file NOT created.
+        assert not (
+            tmp_path / ".clauditor" / "badges" / "demo.json"
+        ).exists()
+
 
 # ---------------------------------------------------------------------------
 # Disk-write error path (exit 1).
@@ -824,6 +1039,42 @@ class TestCmdBadgeDiskWriteError:
         err = capsys.readouterr().err
         assert "could not write" in err
         assert "disk full" in err
+
+    def test_atomic_write_preserves_existing_on_failure(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Review pass 2, C2-3: failed write must NOT truncate existing badge.
+
+        The atomic tmp+rename pattern guarantees that a mid-write
+        OSError (disk full, EIO) leaves the existing target untouched.
+        A naive ``Path.write_text`` on the target would truncate it
+        at open-time and the failure would leave an empty file.
+        """
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        monkeypatch.chdir(tmp_path)
+
+        # Seed an existing badge file with known content.
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        original = '{"schemaVersion": 1, "message": "prior good badge"}\n'
+        target.write_text(original)
+
+        from unittest.mock import MagicMock
+
+        # Patch Path.write_text to fail — this fires on the tmp
+        # sibling, not on the target itself.
+        with patch(
+            "clauditor.cli.badge.Path.write_text",
+            MagicMock(side_effect=OSError("disk full")),
+        ):
+            rc = main(["badge", str(skill_md), "--force"])
+
+        assert rc == 1
+        # Target is still the original — NOT truncated to empty.
+        assert target.read_text() == original
+        # And no stray .tmp file left behind.
+        assert not list(target.parent.glob(".*.tmp"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -38,6 +38,13 @@ class TestGetRepoSlug:
             ("https://gitlab.com/group/sub/REPO", "group/sub/REPO"),
             ("git@gitlab.com:group/sub/REPO.git", "group/sub/REPO"),
             ("https://bitbucket.org/USER/REPO.git", "USER/REPO"),
+            # Review pass 3, C3-2: trailing slash survives .git strip.
+            ("https://github.com/USER/REPO.git/", "USER/REPO"),
+            ("https://github.com/USER/REPO/", "USER/REPO"),
+            # Explicit ssh:// scheme — docstring says SSH broadly.
+            ("ssh://git@github.com/USER/REPO.git", "USER/REPO"),
+            ("ssh://git@github.com/USER/REPO", "USER/REPO"),
+            ("git://github.com/USER/REPO", "USER/REPO"),
         ],
     )
     def test_parses_url_shapes(self, url: str, expected: str, tmp_path: Path) -> None:
@@ -46,6 +53,25 @@ class TestGetRepoSlug:
             return_value=_completed(stdout=f"{url}\n"),
         ):
             assert get_repo_slug(tmp_path) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Review pass 3, C3-2: single-component slugs are rejected.
+            "https://github.com/USER",
+            "https://github.com/USER/",
+            "git@github.com:USER",
+        ],
+    )
+    def test_rejects_single_component_slugs(
+        self, url: str, tmp_path: Path
+    ) -> None:
+        """A slug without a ``/`` cannot form a valid raw-content URL."""
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout=f"{url}\n"),
+        ):
+            assert get_repo_slug(tmp_path) is None
 
     def test_returns_none_when_git_not_installed(self, tmp_path: Path) -> None:
         with patch(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,217 @@
+"""Tests for :mod:`clauditor._git`.
+
+The module wraps ``git remote get-url origin`` and ``git symbolic-ref
+refs/remotes/origin/HEAD`` with pure helpers that never raise under
+documented error conditions. Tests patch ``subprocess.run`` at the
+module boundary so no real ``git`` process is invoked.
+
+Traces to DEC-002 and DEC-017 of ``plans/super/77-clauditor-badge.md``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clauditor._git import get_default_branch, get_repo_slug
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    """Build a ``CompletedProcess`` for patched ``subprocess.run``."""
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+class TestGetRepoSlug:
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("https://github.com/USER/REPO.git", "USER/REPO"),
+            ("https://github.com/USER/REPO", "USER/REPO"),
+            ("git@github.com:USER/REPO.git", "USER/REPO"),
+            ("git@github.com:USER/REPO", "USER/REPO"),
+            ("https://gitlab.com/group/sub/REPO.git", "group/sub/REPO"),
+            ("https://gitlab.com/group/sub/REPO", "group/sub/REPO"),
+            ("git@gitlab.com:group/sub/REPO.git", "group/sub/REPO"),
+            ("https://bitbucket.org/USER/REPO.git", "USER/REPO"),
+        ],
+    )
+    def test_parses_url_shapes(self, url: str, expected: str, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout=f"{url}\n"),
+        ):
+            assert get_repo_slug(tmp_path) == expected
+
+    def test_returns_none_when_git_not_installed(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run", side_effect=FileNotFoundError()
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_returns_none_when_not_a_repo(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=128,
+                stdout="",
+                stderr="fatal: not a git repository\n",
+            ),
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_returns_none_when_no_origin_remote(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=2,
+                stdout="",
+                stderr="error: No such remote 'origin'\n",
+            ),
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_returns_none_on_empty_output(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="\n"),
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_returns_none_on_unknown_url_shape(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="some-weird-protocol://whatever\n"),
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10),
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_returns_none_on_generic_subprocess_error(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            side_effect=subprocess.SubprocessError("boom"),
+        ):
+            assert get_repo_slug(tmp_path) is None
+
+    def test_passes_cwd_as_string(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="https://github.com/USER/REPO\n"),
+        ) as mock_run:
+            get_repo_slug(tmp_path)
+            assert mock_run.call_args.kwargs["cwd"] == str(tmp_path)
+
+    def test_never_raises_on_any_documented_error(self, tmp_path: Path) -> None:
+        """Smoke test: every documented error path returns ``None`` cleanly."""
+        for side in (
+            FileNotFoundError(),
+            subprocess.TimeoutExpired(cmd="git", timeout=10),
+            subprocess.SubprocessError("boom"),
+        ):
+            with patch("clauditor._git.subprocess.run", side_effect=side):
+                # Would raise if the helper is not defensive enough.
+                assert get_repo_slug(tmp_path) is None
+
+
+class TestGetDefaultBranch:
+    @pytest.mark.parametrize(
+        "output, expected",
+        [
+            ("refs/remotes/origin/main\n", "main"),
+            ("refs/remotes/origin/master\n", "master"),
+            ("refs/remotes/origin/dev\n", "dev"),
+            ("refs/remotes/origin/release-1.2\n", "release-1.2"),
+        ],
+    )
+    def test_parses_symbolic_ref_output(
+        self, output: str, expected: str, tmp_path: Path
+    ) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout=output),
+        ):
+            assert get_default_branch(tmp_path) == expected
+
+    def test_returns_none_when_git_not_installed(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run", side_effect=FileNotFoundError()
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_returns_none_when_no_origin_head(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="fatal: ref refs/remotes/origin/HEAD is not a symbolic ref\n",
+            ),
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_returns_none_on_unexpected_output(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="unexpected\n"),
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_returns_none_on_empty_output(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="\n"),
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_returns_none_on_prefix_only_output(self, tmp_path: Path) -> None:
+        """Output matches the prefix exactly with no trailing branch."""
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="refs/remotes/origin/\n"),
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10),
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_returns_none_on_generic_subprocess_error(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            side_effect=subprocess.SubprocessError("boom"),
+        ):
+            assert get_default_branch(tmp_path) is None
+
+    def test_passes_cwd_as_string(self, tmp_path: Path) -> None:
+        with patch(
+            "clauditor._git.subprocess.run",
+            return_value=_completed(stdout="refs/remotes/origin/main\n"),
+        ) as mock_run:
+            get_default_branch(tmp_path)
+            assert mock_run.call_args.kwargs["cwd"] == str(tmp_path)
+
+    def test_never_raises_on_any_documented_error(self, tmp_path: Path) -> None:
+        """Smoke test: every documented error path returns ``None`` cleanly."""
+        for side in (
+            FileNotFoundError(),
+            subprocess.TimeoutExpired(cmd="git", timeout=10),
+            subprocess.SubprocessError("boom"),
+        ):
+            with patch("clauditor._git.subprocess.run", side_effect=side):
+                assert get_default_branch(tmp_path) is None


### PR DESCRIPTION
## Summary

Super plan for [#77](https://github.com/wjduenow/clauditor/issues/77) — `clauditor badge` command that emits shields.io endpoint JSON from a skill's iteration sidecars.

- **Phase:** detailing (awaiting approval)
- **Stories:** 5 implementation stories + Quality Gate + Patterns & Memory
- **Decisions:** 27 captured (DEC-001 through DEC-027)

## Plan document

See [`plans/super/77-clauditor-badge.md`](plans/super/77-clauditor-badge.md) for the full plan.

### Story overview

| ID | Title | Deps |
|---|---|---|
| US-001 | Pure `compute_badge` + `Badge` dataclass family | none |
| US-002 | Git wrapper `_git.py` (`get_repo_slug`, `get_default_branch`) | none |
| US-003 | Sidecar discovery + `--url-only` URL builder | US-001 |
| US-004 | CLI command `cli/badge.py` + dispatcher wiring | US-001/002/003 |
| US-005 | Docs: `cli-reference.md#badge` + new `docs/badges.md` | US-004 |
| US-006 | Quality Gate — code-review x4 + CodeRabbit | all impl |
| US-007 | Patterns & Memory | US-006 |

### Key design points

- Pure core first (US-001): nested dataclasses with `to_endpoint_json()`; shields.io `schemaVersion` at top and our `clauditor.schema_version: 1` as first-key of the extension block.
- Git wrapper isolated (US-002) so tests patch one seam.
- Exit codes 0/1/2 (no LLM → non-LLM taxonomy applies).
- Two lightgrey paths (no-iteration, zero-L1) both write \"no data\" + warn + exit 0, but respect `--force`.
- Schema-drift guarded via in-test `to_json()` fixture generation.

## Next steps

- Review the plan in this PR.
- Approve to proceed to devolve (beads creation for Ralph).