### PR TITLE
#80: Tighten frontmatter validation for strict YAML bugs (plan)

### DIFF
--- a/.claude/rules/permissive-parser-strict-validator.md
+++ b/.claude/rules/permissive-parser-strict-validator.md
@@ -1,0 +1,238 @@
+# Rule: Permissive parser at the parse boundary, strict validator at the conformance layer
+
+When a module accepts user-authored text that will later be rendered
+by external tools (GitHub, CI validators, schema checkers, other
+parsers), split the load path into **two** layers:
+
+- **A permissive parser** that accepts the tolerated on-disk shape
+  and extracts a data structure. Its job is "get the data out of
+  the file without losing information". It returns a dict (or
+  dataclass) on success and raises on unrecoverable corruption.
+- **A strict validator** that runs AFTER the parser succeeds,
+  inspects the parsed dict AND the raw text where needed, and
+  emits diagnostics for every way the input would fail a stricter
+  downstream consumer. Its job is "prevent the user from shipping
+  a file that renders fine locally but breaks elsewhere."
+
+Do NOT fold strict correctness checks into the permissive parser.
+The two layers have different contracts: parsing is "can we read
+it?", validating is "should it exist in this shape?" — conflating
+them makes error messages worse and blocks legitimate partial-file
+workflows (e.g. diagnostic scripts, incremental edits, historical
+reads).
+
+## The pattern
+
+### Parser — permissive, minimal, single job
+
+```python
+# _frontmatter.py
+def parse_frontmatter(text: str) -> tuple[dict | None, str]:
+    """Read SKILL.md-style frontmatter; return (data, body).
+
+    Accepts the shape real SKILL.md files use today, not full YAML.
+    No strict-YAML-spec compliance: we tolerate unquoted scalars
+    with embedded punctuation, comma-separated strings in list
+    fields, etc. Downstream conformance checks catch shapes that
+    strict consumers would reject.
+    """
+    # ... 80 lines of dict-building ...
+```
+
+### Validator — strict, diagnostic-emitting, runs on parsed + raw
+
+```python
+# conformance.py
+def check_conformance(
+    skill_md_text: str, skill_path: Path
+) -> list[ConformanceIssue]:
+    """Run every agentskills.io spec rule against a SKILL.md.
+
+    Runs the permissive parser first; if it raises, we surface an
+    ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` issue and short-circuit.
+    Otherwise we run a chain of ``_check_*`` functions over the
+    parsed dict (and, for a handful of raw-text-only checks, the
+    original ``skill_md_text``).
+
+    Every check appends to the issue list in place. Never raises.
+    Returns the concatenated issue list.
+    """
+    issues: list[ConformanceIssue] = []
+    try:
+        parsed, body = parse_frontmatter(skill_md_text)
+    except ValueError as exc:
+        issues.append(
+            ConformanceIssue(
+                code="AGENTSKILLS_FRONTMATTER_INVALID_YAML",
+                severity="error",
+                message=f"Frontmatter YAML is malformed: {exc}",
+            )
+        )
+        return issues
+
+    # Raw-text-only checks run before the parsed-dict chain — they
+    # catch YAML ambiguities that the permissive parser happily
+    # accepts (e.g. unquoted space-colon-space inside scalars).
+    _check_unquoted_colon_in_scalar(skill_md_text, issues)
+
+    # Parsed-dict checks for every spec rule.
+    _check_name(parsed, skill_path, issues)
+    _check_description(parsed, issues)
+    _check_compatibility(parsed, issues)
+    # ... etc ...
+
+    return issues
+```
+
+## Why this shape
+
+- **Different contracts, different concerns.** The parser's
+  contract is "preserve every byte of user-authored information
+  into a Python object"; the validator's contract is "report every
+  way the input would fail a strict downstream consumer". A single
+  combined function would have to satisfy both contracts at once,
+  producing a confused error model where a failed strict check
+  looks indistinguishable from a failed parse.
+
+- **Permissive parsing enables diagnostic tooling.** Scripts that
+  want to peek at frontmatter for debugging, incremental editors
+  that want to preview partial content, and rescue tools that
+  salvage data from malformed files all benefit from a parser
+  that tolerates gray-area shapes. A strict parser raises on
+  anything ambiguous; a permissive one returns best-effort data
+  and lets the caller decide what to do. The clauditor use case:
+  `clauditor lint` runs the strict validator; other clauditor
+  commands that just want the frontmatter for non-validation
+  purposes run only the permissive parser.
+
+- **Strict validation is the right place for "what renders
+  downstream" checks.** The conformance layer knows about external
+  contracts (agentskills.io spec, GitHub's YAML renderer, Claude
+  Code's slash-command discovery) that are outside the parser's
+  scope. Piling them into the parser would bloat a module whose
+  whole point is minimalism. Keeping them in the validator lets
+  the parser stay small and the validator grow as external
+  contracts evolve.
+
+- **Error messages improve when concerns are split.** The parser's
+  errors describe structural corruption ("missing closing
+  delimiter"); the validator's errors describe semantic violations
+  ("line 4 has ': ' inside an unquoted value — strict parsers
+  reject this"). Each message can be precise because the layer
+  knows its own invariants. A combined layer would have to emit
+  messages that straddle both.
+
+- **The "permissive + strict" split scales to multiple strict
+  layers.** Today clauditor has one validator (`conformance.py`).
+  A future project might have two: one for the agentskills.io
+  spec, one for a registry-specific shape. They can both consume
+  the same permissive parser output without fighting over parse
+  behavior.
+
+- **Failure mode: strict checks in the permissive parser.** If
+  the parser starts raising on shapes the conformance layer
+  already flags, the failure mode downgrades from "surface every
+  issue at once" to "surface the first issue and stop". Users
+  fixing a file with multiple bugs have to iterate N times, one
+  bug per round-trip, instead of seeing all N at once.
+
+## What NOT to do
+
+- Do NOT add "strict YAML" checks to the permissive parser. The
+  parser's contract is minimalism; strictness belongs in the
+  validator.
+- Do NOT make the validator raise on issues — it must return a
+  list of `ConformanceIssue` so the caller can decide how to
+  surface them (stderr, structured JSON, etc.). See
+  `.claude/rules/pure-compute-vs-io-split.md`.
+- Do NOT duplicate validation logic across the two layers. If the
+  parser already rejects a shape (e.g. missing closing `---`),
+  the validator doesn't need a redundant check — let the
+  parser's `ValueError` flow through the validator's
+  `AGENTSKILLS_FRONTMATTER_INVALID_YAML` branch.
+- Do NOT make the validator raise to "promote" an issue. Return
+  it as an error-severity `ConformanceIssue` and let the CLI /
+  caller route to the right exit code.
+- Do NOT inline strict checks into permissive-parse code paths
+  just because they share a line-by-line walk. The walk is
+  cheap; two walks are still O(n) and the separation is worth
+  the tiny duplication.
+
+## Canonical implementation
+
+- Parser: `src/clauditor/_frontmatter.py::parse_frontmatter`. Explicit
+  minimalism: the module docstring enumerates the shapes it
+  supports. Raises `ValueError` on structural corruption; tolerates
+  ambiguous-but-readable shapes (unquoted scalars with embedded
+  punctuation, comma-separated list fields, etc.).
+- Validator: `src/clauditor/conformance.py::check_conformance`. 24+
+  `AGENTSKILLS_*` codes enforce the agentskills.io spec + Claude-
+  Code-specific invariants (parent-dir-name match, frontmatter
+  shape). Runs the parser first, short-circuits on `ValueError`,
+  then runs the `_check_*` chain over the parsed dict AND the raw
+  text for checks that need byte-level visibility (e.g.
+  `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR` walks the
+  raw text line-by-line because quote-awareness requires pre-
+  parse information).
+
+The #80 refactor is the latest reinforcement of this pattern: when
+a SKILL.md with unquoted `space-colon-space` in a scalar value
+shipped (GitHub's strict renderer rejected it but clauditor's
+parser didn't), the fix was a new `_check_*()` in the validator
+layer — NOT a new rejection in the parser. The parser stays
+permissive; the validator grows to match new external contracts.
+
+Traces to: DEC-001, DEC-002, DEC-004 of
+`plans/super/80-strict-frontmatter-yaml.md`.
+
+## Companion rules
+
+- `.claude/rules/pure-compute-vs-io-split.md` — the validator's
+  pure-compute contract (no I/O, never raises, returns a list).
+  The two rules compose: a validator that satisfies both is pure
+  and strict.
+- `.claude/rules/pre-llm-contract-hard-validate.md` — the general
+  "fail loudly at parse boundaries" shape, applied here at the
+  validator boundary (not the parser).
+- `.claude/rules/constant-with-type-info.md` — for validators
+  whose diagnostic codes need a central table. clauditor's
+  `conformance.py` declares codes inline rather than in a table
+  (convention established by the first 24 codes); new codes
+  should match that convention.
+
+## When this rule applies
+
+Any future work where:
+
+- A module accepts user-authored text or config (SKILL.md,
+  `eval.json`, a hand-written rubric, a regen-proposer output)
+  AND
+- That text will later be consumed by a stricter external
+  contract (a renderer, a registry, a CI validator) where errors
+  cost the user real time
+  AND
+- The permissive parse is useful on its own for diagnostic or
+  incremental workflows.
+
+Examples of future callers:
+
+- A rubric-criteria validator that runs stricter checks than the
+  spec loader.
+- A plugin-upload validator that enforces registry-specific
+  shapes beyond what `SkillSpec.from_file` requires.
+- A `clauditor propose-eval` regen pipeline that validates the
+  LLM's output against both the loader's contract AND the
+  downstream clauditor-pipeline contract.
+
+## When this rule does NOT apply
+
+- Internal-only data formats with no downstream consumers (a
+  debug dump, a transient cache). The strict validator layer has
+  no audience.
+- Loaders that genuinely cannot read the input without applying
+  the strict rule (e.g. a binary format where byte-level
+  structure is the validity contract). Separation is impossible.
+- Cases where the parser already IS the validator by design (e.g.
+  a protobuf-generated decoder). The split has no room to land.
+- One-off scripts with a single caller and no workflow implications.
+  The ceremony of two layers costs more than it saves.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,6 +77,8 @@ Non-LLM 0/1/2 taxonomy per `.claude/rules/llm-cli-exit-code-taxonomy.md`:
 
 The agentskills.io spec defines the frontmatter keys `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools`. Unknown keys normally trigger `AGENTSKILLS_FRONTMATTER_UNKNOWN_KEY` (warning). Two Claude Code extension keys are allowlisted and do NOT trigger the warning: `argument-hint` and `disable-model-invocation`. The allowlist is maintained by the maintainer-only `/review-agentskills-spec` skill, which periodically diffs Claude Code's published frontmatter documentation against the `KNOWN_CLAUDE_CODE_EXTENSION_KEYS` constant in `src/clauditor/conformance.py` (per DEC-009 and DEC-013 of `plans/super/71-agentskills-lint.md`).
 
+Unquoted `: ` (space-colon-space) inside a frontmatter scalar value triggers `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR` (error, exit 2) — strict YAML parsers (PyYAML, GitHub's renderer) treat such values as nested mappings while clauditor's permissive reader accepts them silently. Wrap the value in double quotes to silence it (per DEC-003 and DEC-007 of `plans/super/80-strict-frontmatter-yaml.md`).
+
 ### Soft-warn hook on every skill load
 
 Beyond the standalone `lint` command, `SkillSpec.from_file` calls `check_conformance` on every skill load and emits **warnings only** to stderr with the `clauditor.conformance:` prefix. Errors are silent at that seam — they surface when the user runs `clauditor lint`. The hook never blocks `from_file`; a skill that would fail `lint` today still loads for `validate`, `grade`, and downstream commands (per DEC-003).

--- a/plans/super/80-strict-frontmatter-yaml.md
+++ b/plans/super/80-strict-frontmatter-yaml.md
@@ -1,0 +1,587 @@
+# 80 — Tighten SKILL.md frontmatter validation to catch YAML bugs
+
+## Meta
+
+- **Ticket:** [#80](https://github.com/wjduenow/clauditor/issues/80)
+- **Phase:** detailing
+- **Sessions:** 1
+- **Last session:** 2026-04-22
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/80-strict-frontmatter-yaml`
+- **Branch:** `feature/80-strict-frontmatter-yaml`
+- **Base:** `dev`
+
+## Ticket summary
+
+PR #79 fixed a symptom: `.claude/skills/review-agentskills-spec/SKILL.md`
+had `compatibility: Requires ... Optional: the ...` — an unquoted
+`space-colon-space` sequence inside a plain scalar. GitHub's strict
+YAML parser rejected it (`mapping values are not allowed in this
+context at line 3 column 95`); clauditor's own `_frontmatter.py`
+parser accepted it silently.
+
+This ticket tightens `check_conformance` so that class of bug is
+caught by `clauditor lint` / the `SkillSpec.from_file` soft-warn hook
+before it lands in a file that won't render on GitHub.
+
+## Discovery
+
+### Committed-state findings (Codebase Scout)
+
+**`src/clauditor/_frontmatter.py`** — deliberately permissive YAML
+subset parser. `_split_key_value` uses `line.partition(":")` — it
+splits on the **first** colon only. So
+`compatibility: Requires ... Optional: the ...` is stored as a raw
+string; the embedded `: ` is never examined. Module docstring
+explicitly scopes it to "the shape real SKILL.md files use today,
+not full YAML".
+
+**`src/clauditor/conformance.py`** — 24+ existing `AGENTSKILLS_*`
+codes, all declared **inline** in `ConformanceIssue(code=..., severity=..., message=...)`
+constructor calls (not a central constant table).
+`AGENTSKILLS_FRONTMATTER_INVALID_YAML` already exists at ~lines
+219-233 and catches `ValueError` from `parse_frontmatter`, with
+newline sanitization in the message. After permissive-parse
+succeeds, other `_check_<field>` functions run per top-level key.
+
+**PyYAML dep status** — **NOT a runtime or dev dep.** `pyproject.toml`
+has `dependencies = []` and no PyYAML in dev deps or `uv.lock`. The
+"minimal hand-rolled YAML reader to avoid adding PyYAML as a runtime
+dependency" is an **explicit project convention** documented in
+`tests/test_bundled_skill.py`'s module docstring.
+
+**Test seams:**
+- `tests/test_frontmatter.py` — 18 cases; **no test for unquoted
+  space-colon-space plain scalars**.
+- `tests/test_conformance.py` — extensive coverage of existing
+  AGENTSKILLS_* codes; has negative tests for `INVALID_YAML` (missing
+  delimiter, colon-less line) but not for the unquoted-colon case.
+- `tests/test_bundled_{skill,review_skill}.py` — exercise
+  `check_conformance` indirectly via `SkillSpec.from_file`; 18 tests
+  for the review skill, 2 for the clauditor skill.
+
+**CLI surface** (`src/clauditor/cli/lint.py`):
+- exit 0 — no issues or warnings-only without `--strict`
+- exit 1 — parse/load failure OR `AGENTSKILLS_FRONTMATTER_INVALID_YAML`
+  (special case; overrides `--strict`)
+- exit 2 — any error-severity issue OR warnings with `--strict`
+
+**Soft-warn hook** (`SkillSpec.from_file`): only WARNINGS surface to
+stderr with the `clauditor.conformance: <CODE>: <message>` prefix.
+Errors stay silent at this seam — they surface when the user runs
+`clauditor lint`.
+
+**Regression fixture (pre-#79 file at commit `6b858b8`):**
+
+```yaml
+---
+name: review-agentskills-spec
+description: Review the current agentskills.io specification and ...
+compatibility: Requires network access to fetch https://agentskills.io/specification. Optional: the gh CLI for issue creation.
+metadata:
+  clauditor-version: "0.0.0-dev"
+disable-model-invocation: true
+allowed-tools: WebFetch, Read, Grep, Glob, Bash(gh issue create:*)
+---
+```
+
+The bug is the unquoted `Optional: ` on the `compatibility:` line.
+
+### Applicable rules (Convention Checker)
+
+| Rule | Applies | Constraint |
+| --- | --- | --- |
+| `pure-compute-vs-io-split.md` | yes | `check_conformance` stays pure: no I/O, no raise, returns `list[ConformanceIssue]`. |
+| `pre-llm-contract-hard-validate.md` | yes | Fail loudly at the parse boundary: any YAML that strict parsers reject must produce a user-visible issue. |
+| `llm-cli-exit-code-taxonomy.md` | yes | New error-severity issue routes to exit 2 (input validation), not 1 or 3. |
+| `plan-contradiction-stop.md` | yes | Standard Ralph hygiene; escalate if plan preconditions turn out false. |
+| `constant-with-type-info.md` | **no** — conformance.py uses inline code declarations, not a central table. Existing convention overrides. |
+
+### Key convention flip
+
+Initial ticket ranked Option A (PyYAML re-parse) as the strongest
+backstop. Discovery surfaces that **PyYAML is explicitly avoided by
+project convention** — the whole reason `_frontmatter.py` exists is
+to keep PyYAML off the dependency list. This flips the recommendation
+toward Option B (targeted regex, no new dep).
+
+Option C (both) would violate the convention for the PyYAML half
+with no marginal benefit Option B doesn't already provide for this
+bug class.
+
+## Scoping questions
+
+### Q1 — Option A/B/C after the dep-convention discovery?
+
+Ticket originally leaned toward A or C. Discovery makes B the
+aligned choice.
+
+- **A. PyYAML strict re-parse** — broad coverage of every strict-vs-
+  permissive divergence, but violates the "no PyYAML" convention.
+  Adds a runtime dep the project has explicitly avoided.
+- **B. Targeted check for unquoted `: ` inside plain scalars** —
+  no new dep, aligned with convention, catches the exact bug class
+  the ticket names, narrow coverage.
+- **C. Both** — all of A's cost for B's benefit.
+
+**Recommend B.** If future strict-vs-permissive bugs surface, we can
+add more targeted checks case-by-case. A PyYAML dep is a one-way
+door.
+
+### Q2 — Where does the new check live?
+
+- **A. In `conformance.py::check_conformance` as a new `_check_*()` function** — runs after the permissive parse succeeds, inspects the parsed dict + raw text, appends a new `AGENTSKILLS_FRONTMATTER_*` code if any top-level scalar value contains unquoted `: `.
+- **B. In `_frontmatter.py::parse_frontmatter` — parser becomes stricter** — the parser itself raises `ValueError`, which flows through the existing `AGENTSKILLS_FRONTMATTER_INVALID_YAML` code.
+
+**Recommend A.** Keeps the parser's permissive contract intact
+(documented by its module docstring); new behavior lives under a
+new conformance code so error messages can be specific and
+debuggable. Option B changes parser semantics, may break existing
+direct `parse_frontmatter` callers/tests, and blurs the "what does
+this code detect" mapping.
+
+### Q3 — New error code name and severity?
+
+- **A. `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR` / `error`** — specific, debuggable, exit 2 per `llm-cli-exit-code-taxonomy.md`.
+- **B. `AGENTSKILLS_FRONTMATTER_YAML_AMBIGUOUS_SCALAR` / `error`** — slightly broader name; might fit future related checks.
+- **C. Warning severity** — skill still loads for Claude Code, but file fails on GitHub. Warning would mean `clauditor lint` still exits 0.
+
+**Recommend A** for name (matches the existing specific-code
+convention — e.g. `NAME_CONSECUTIVE_HYPHENS`). **Recommend error**
+for severity — the file is de facto broken on GitHub; silent-
+warning would defeat the ticket's motivation.
+
+### Q4 — How strict should the regex pattern be?
+
+The check needs to reject `" Optional: the"` but accept `"https://foo"`
+(colon-slash, no space after colon). Draft pattern: for each top-
+level scalar value that came from an **unquoted** line, reject if
+`: ` (colon followed by space) appears anywhere in the value.
+
+Edge cases:
+- **Quoted values (`"..."` or `'...'`)**: the parser's `_strip_quotes`
+  runs before the check sees the value. Need to pass the check
+  ONLY unquoted values — requires a small change to
+  `_frontmatter.py` to expose "was this value quoted?" OR track
+  quoting in the new check by re-inspecting the raw text.
+- **Nested `metadata:` values**: same rule should apply. Less
+  common in practice but worth the consistency.
+- **The actual URL case `https://`**: `:/` not `: ` — passes the
+  check naturally.
+
+Options:
+
+- **A. Re-inspect raw text in the new check** — the check function
+  walks the raw frontmatter text directly (regex-match each
+  `key: value` line where the value isn't quote-wrapped), no
+  changes to `_frontmatter.py`.
+- **B. Extend `_frontmatter.py` to record quoted-vs-unquoted per value** — cleaner data flow but widens the parser's public surface.
+
+**Recommend A.** Zero changes to `_frontmatter.py`; the new check is
+self-contained. A one-line regex in conformance.py is simpler than
+a parser-level contract change.
+
+### Q5 — Scope the check to top-level scalars only, or include nested `metadata:` values?
+
+- **A. Top-level only** — matches where the #79 bug occurred; simpler.
+- **B. Top-level + nested `metadata:`** — consistency; trivial extra coverage.
+
+**Recommend B.** The regex is the same; the walk just visits one
+more level. Future nested-block bugs get caught for free.
+
+## Architecture review
+
+Targeted review for a small validator extension. Most axes n/a (no
+auth surface, no runtime-path change, no schema evolution). Material
+axes:
+
+| Area | Rating | Finding |
+| --- | --- | --- |
+| Regex correctness | concern → resolved in DEC-007 | False-positive / false-negative edges: URLs, quoted values, nested `metadata:`, comments. Algorithm codified below. |
+| Testing strategy | concern → resolved in DEC-006 | Three test classes enumerated: regression, quote awareness, nested scope. |
+| Existing skills | pass | Verified: `src/clauditor/skills/clauditor/SKILL.md` and post-#79 `.claude/skills/review-agentskills-spec/SKILL.md` both pass the new check. No breakage. |
+
+No blockers.
+
+## Refinement log
+
+### Decisions
+
+**DEC-001 — Option B (targeted regex, no PyYAML dep).**
+Discovery surfaced an explicit project convention ("minimal hand-
+rolled YAML reader to avoid adding PyYAML as a runtime dependency",
+documented in `tests/test_bundled_skill.py`). Adding PyYAML is a
+one-way door; a targeted check catches the exact bug class the
+ticket names without importing a heavy dep. Future strict-vs-
+permissive divergences can be handled one-at-a-time with additional
+targeted checks.
+
+**DEC-002 — New check lives in `conformance.py`, not `_frontmatter.py`.**
+`_frontmatter.py`'s module docstring explicitly scopes it to a
+permissive YAML subset; that contract is load-bearing for error-
+message stability and for downstream direct callers. The new
+behavior is a conformance concern (does this file render on
+GitHub?), not a parsing concern (can we read the dict?). Adding it
+to `conformance.py` keeps both contracts clean.
+
+**DEC-003 — Code name `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR`, severity `error`.**
+Name matches existing specific-code convention
+(e.g. `AGENTSKILLS_NAME_CONSECUTIVE_HYPHENS`). Severity `error`
+because the file fails to render on GitHub — a warning would let
+`clauditor lint` exit 0 on a de facto broken file, defeating the
+ticket's motivation. CLI exit routes to 2 per
+`.claude/rules/llm-cli-exit-code-taxonomy.md` (input validation
+failure).
+
+**DEC-004 — Raw-text inspection, no `_frontmatter.py` API widening.**
+The check walks the raw frontmatter text line-by-line rather than
+requiring `parse_frontmatter` to report quoted-vs-unquoted. Zero
+parser changes; the check is fully self-contained in
+`conformance.py`.
+
+**DEC-005 — Scope: top-level scalars + nested `metadata:` values.**
+The line-by-line walker naturally visits every key:value line
+regardless of nesting. A nested unquoted `: ` is exactly as
+problematic as a top-level one; the walk is free.
+
+**DEC-006 — Test coverage: three classes, explicit cases.**
+
+Each class lives in `tests/test_conformance.py` and uses
+`check_conformance(text, path)` directly (pure-compute, no
+`tmp_path` needed for most cases).
+
+- **`TestUnquotedColonInScalarDetection`**:
+  - `test_pre_79_fixture_flagged` — verbatim pre-#79 SKILL.md
+    content → expects one `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR`
+    error at the `compatibility:` line.
+  - `test_post_79_fixture_passes` — quoted compatibility value →
+    expects zero issues of the new code.
+  - `test_clauditor_bundled_skill_passes` — current
+    `src/clauditor/skills/clauditor/SKILL.md` → expects zero issues
+    of the new code.
+
+- **`TestQuoteAwareness`**:
+  - `test_double_quoted_value_with_colon_space_passes` —
+    `description: "Note: when X happens"` → no issue.
+  - `test_single_quoted_value_with_colon_space_passes` —
+    `description: 'Note: when X happens'` → no issue.
+  - `test_unquoted_value_with_colon_space_flagged` —
+    `description: Note: when X happens` → one issue.
+  - `test_url_in_unquoted_value_passes` —
+    `link: See https://example.com/page for details` → no issue
+    (colon-slash, no space after).
+  - `test_allowed_tools_colon_star_passes` —
+    `allowed-tools: Bash(gh issue create:*)` → no issue (colon-
+    star, no space after).
+
+- **`TestNestedMetadataScope`**:
+  - `test_nested_unquoted_value_with_colon_space_flagged` — a
+    `metadata:` child line with unquoted `: ` → one issue.
+  - `test_nested_quoted_value_with_colon_space_passes` — the
+    same child, quoted → no issue.
+
+**DEC-007 — Algorithm (raw-text walker).**
+
+```python
+def _check_unquoted_colon_in_scalar(
+    skill_md_text: str, issues: list[ConformanceIssue]
+) -> None:
+    """Reject unquoted ``: `` inside scalar values.
+
+    Walks the raw frontmatter text line-by-line. For each line that
+    looks like ``key: value``, extract the value portion, skip it if
+    empty or wrapped in matching quotes, otherwise flag the line if
+    ``": "`` appears anywhere in it.
+
+    Runs AFTER ``parse_frontmatter`` has already succeeded; the
+    existing ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` short-circuit
+    handles files that fail permissive parsing first.
+    """
+    # Extract the frontmatter block (between the two ``---`` markers).
+    # If no frontmatter, no-op.
+    lines = skill_md_text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return
+    try:
+        end_idx = next(
+            i for i, line in enumerate(lines[1:], start=1)
+            if line.strip() == "---"
+        )
+    except StopIteration:
+        return  # malformed — already caught by INVALID_YAML
+
+    for lineno, line in enumerate(lines[1:end_idx], start=2):
+        # 1-based line numbers in error messages (YAML convention,
+        # matches GitHub's "line 3 column 95" style).
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        value = value.lstrip()
+        if not value:
+            continue  # ``metadata:`` block header, no scalar to check
+        # Quote detection: first char determines quoting. The
+        # permissive parser already stripped matching quotes, but
+        # here we're inspecting raw text, so this is our own check.
+        if (value[0] == '"' and value.rstrip().endswith('"')) or \
+           (value[0] == "'" and value.rstrip().endswith("'")):
+            continue
+        if ": " in value:
+            issues.append(
+                ConformanceIssue(
+                    code="AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR",
+                    severity="error",
+                    message=(
+                        f"Frontmatter line {lineno} has ': ' inside "
+                        f"an unquoted value for key {key.strip()!r}: "
+                        f"strict YAML parsers (including GitHub's) "
+                        f"treat this as a nested mapping. Wrap the "
+                        f"value in double quotes."
+                    ),
+                )
+            )
+```
+
+Design notes:
+
+- **Runs after existing parse succeeds** — if `parse_frontmatter`
+  raises, the existing `AGENTSKILLS_FRONTMATTER_INVALID_YAML` fires
+  and `check_conformance` short-circuits before reaching this
+  check. No double-fire risk.
+- **Line numbers 1-based from the first YAML content line** — matches
+  YAML convention and the GitHub error format ("line 3 column 95")
+  so users can cross-reference.
+- **Quote detection is first-and-last char match** — avoids false
+  positives when a quote appears mid-string (e.g. `"foo" bar baz`
+  isn't a valid quoted scalar; we fall through to the `: ` check,
+  which is the conservative choice).
+- **Message names the key** — debuggability; user can Cmd-F to find
+  the offending line.
+- **Message recommends the fix** ("wrap in double quotes") — makes
+  the error self-serve.
+
+**DEC-008 — No CLI code changes.**
+The existing `clauditor lint` CLI already routes error-severity
+issues to exit code 2. The new code slots into that path with no
+special-casing. The only file that changes is `conformance.py`
+(and its tests).
+
+**DEC-009 — Documentation note in `docs/cli-reference.md`.**
+`docs/cli-reference.md` lists the `AGENTSKILLS_FRONTMATTER_INVALID_YAML`
+exit-1 special case. The new code does NOT need a special case
+(routes normally through error → exit 2). But the conformance
+section should mention the new code alongside existing codes for
+completeness. Small prose addition; no new table required.
+
+**DEC-010 — Scope guard.**
+No changes to:
+- `src/clauditor/_frontmatter.py` (public contract preserved).
+- `pyproject.toml` (no PyYAML, no other dep).
+- `src/clauditor/cli/lint.py` (existing exit code flow handles it).
+- `src/clauditor/spec.py::SkillSpec.from_file` (soft-warn hook
+  surfaces warnings only — errors stay silent at that seam, same
+  as all other error-severity codes).
+- Existing bundled skills' `SKILL.md` content (verified no breakage).
+
+### Session notes
+
+- **Dep convention discovery was load-bearing.** The ticket's initial
+  preference for Option A (PyYAML) would have violated an explicit,
+  documented project constraint. Discovery caught it. Codify in
+  US-004 if this generalizes to a "check the project's stated
+  convention before adopting a 'standard' approach" rule.
+- **Raw-text inspection vs parser-extension tradeoff (DEC-004).**
+  Keeping the walker self-contained in `conformance.py` is cheaper
+  this round. If a future ticket needs quote-awareness for a
+  different check, the parser-extension refactor becomes worth it;
+  not now.
+
+## Detailed breakdown
+
+### US-001 — Implement `_check_unquoted_colon_in_scalar` + tests + doc note
+
+**Description.** Add the new conformance check to `conformance.py`
+with TDD: write all 9 test cases from DEC-006 first, watch them fail
+against an empty `_check_unquoted_colon_in_scalar` stub, then
+implement the algorithm from DEC-007 and watch them pass. Also add
+a short doc note to `docs/cli-reference.md` listing the new code
+alongside the existing conformance codes. One atomic commit.
+
+**Traces to:** DEC-001 through DEC-010 (all).
+
+**Files.**
+
+- `src/clauditor/conformance.py` —
+  - Add `_check_unquoted_colon_in_scalar(skill_md_text, issues)` per
+    DEC-007. Place it alongside the other `_check_*` functions.
+  - Call it from `check_conformance` AFTER
+    `parse_frontmatter` succeeds (so the existing
+    `AGENTSKILLS_FRONTMATTER_INVALID_YAML` short-circuit wins for
+    files that fail permissive parsing). Exact call site: right
+    after `parsed, body = parse_frontmatter(skill_md_text)` and
+    before any other `_check_*` that inspects `parsed`. The new
+    check doesn't need `parsed` — it walks the raw text.
+- `tests/test_conformance.py` —
+  - `TestUnquotedColonInScalarDetection` (3 cases per DEC-006).
+    Pre-#79 fixture content is inline in the test (DEC-006 lists
+    it verbatim); don't read a file. Use the clauditor-skill
+    content from `git show HEAD:src/clauditor/skills/clauditor/SKILL.md`
+    inline, NOT via file I/O.
+  - `TestQuoteAwareness` (5 cases).
+  - `TestNestedMetadataScope` (2 cases).
+- `docs/cli-reference.md` — append a 1-2-sentence note to the
+  conformance-codes section mentioning
+  `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR` and what
+  triggers it. No new table or subsection — consistency with how
+  other codes are referenced.
+
+**Depends on:** none (first story).
+
+**Acceptance criteria.**
+
+- All 9 new test cases pass (see DEC-006 for the list).
+- Existing `tests/test_conformance.py` suite remains green.
+- `uv run ruff check src/ tests/` passes.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+  with ≥80% coverage.
+- `tests/test_bundled_review_skill.py` and
+  `tests/test_bundled_skill.py` still pass — both bundled skills
+  do not trigger the new check (DEC-006 has explicit positive
+  tests for this; they should validate in live pytest too).
+- `docs/cli-reference.md` has a grep-able mention of
+  `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR`.
+- Scope guard (DEC-010): `git diff` shows NO changes to
+  `src/clauditor/_frontmatter.py`, `pyproject.toml`,
+  `src/clauditor/cli/lint.py`, or `src/clauditor/spec.py`.
+
+**Done when:** one atomic commit with message like
+`#80: Add AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR check`,
+all acceptance criteria pass.
+
+**TDD:**
+
+Write these 9 tests FIRST, then implement. Each failure message
+should name the test and the expected issue code. Order in the
+TDD workflow:
+
+1. Write `TestUnquotedColonInScalarDetection::test_pre_79_fixture_flagged`
+   with the verbatim pre-#79 frontmatter inline. Expected:
+   `check_conformance(text, path)` returns at least one
+   `ConformanceIssue` with `code == "AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR"`
+   and `severity == "error"`.
+2. Write `test_post_79_fixture_passes` (quoted version). Expected:
+   zero issues of that code.
+3. Write `test_clauditor_bundled_skill_passes`. Expected: zero
+   issues of that code.
+4. Write `TestQuoteAwareness::test_double_quoted_value_with_colon_space_passes`.
+5. Write `test_single_quoted_value_with_colon_space_passes`.
+6. Write `test_unquoted_value_with_colon_space_flagged`.
+7. Write `test_url_in_unquoted_value_passes`.
+8. Write `test_allowed_tools_colon_star_passes`.
+9. Write `TestNestedMetadataScope::test_nested_unquoted_value_with_colon_space_flagged`
+   and `test_nested_quoted_value_with_colon_space_passes`.
+
+Stub `_check_unquoted_colon_in_scalar` to a no-op, run pytest, watch
+the 6 positive-flag tests fail and the 3 pass-through tests pass.
+
+Then implement per DEC-007. All 9 pass.
+
+---
+
+### US-002 — Quality Gate
+
+**Description.** Standard 4-pass code-review gate over the full
+changeset. No wheel-verification step this time (DEC-005 of the #75
+plan was specific to a packaging concern; #80 has no packaging
+surface). Focus passes on the algorithm's correctness edges
+(regex false-positive / false-negative behavior) and terminology
+consistency in the new doc note.
+
+**Traces to:** standard quality conventions; no DEC-### drive this
+directly.
+
+**Files.** None modified unless review surfaces real issues.
+
+**Depends on:** US-001.
+
+**Acceptance criteria.**
+
+- **4 code-review passes** via `code-reviewer` agent across the
+  full changeset (`dev..HEAD`). Fix real issues each pass. Note
+  false positives.
+- **CodeRabbit review** on the open PR. Address real findings.
+- **Ruff + pytest green:**
+  - `uv run ruff check src/ tests/`
+  - `uv run pytest --cov=clauditor --cov-report=term-missing`
+    passes at 80% gate.
+- **Explicit algorithm sanity check.** Read through
+  `_check_unquoted_colon_in_scalar` once post-implementation with
+  an eye on each DEC-007 design note:
+  - Does it correctly skip when no `---` frontmatter is present?
+  - Does it handle the no-closing-`---` case without raising
+    (fall-through to existing INVALID_YAML)?
+  - Are line numbers 1-based and consistent with YAML convention?
+- **No new runtime deps.** `uv.lock` should be unchanged unless
+  a test-only dep was added. Confirm with
+  `git diff 1083cc3..HEAD -- uv.lock pyproject.toml`.
+
+**Done when:** all passes complete, all real issues fixed, final
+pytest + ruff green.
+
+**TDD:** N/A — Quality Gate is verification.
+
+---
+
+### US-003 — Patterns & Memory
+
+**Description.** Capture anything learned from this refactor. Two
+candidate patterns stand out:
+
+1. **"Check project conventions before adopting a 'standard'
+   approach."** The ticket's initial lean toward PyYAML was
+   reasonable on general grounds but violated an explicit project
+   convention that was only discoverable by reading
+   `tests/test_bundled_skill.py`'s module docstring.
+   Generalizable lesson: when a ticket proposes a "standard" tool,
+   check the project for a documented reason to avoid it before
+   committing to the shape. Candidate rule:
+   `.claude/rules/check-dep-conventions-before-proposing.md` (or
+   fold as a section into an existing rules-maintenance doc).
+
+2. **"Permissive parser + strict validator at conformance layer"
+   as a recurring shape.** clauditor's `_frontmatter.py` is
+   deliberately permissive; `conformance.py` adds strict checks on
+   top. This refactor extends that pattern. If future tickets
+   want similar "tighten strictness without touching the parser"
+   work, there's now a cookbook.
+
+**Traces to:** closing-ceremony convention (always last story).
+
+**Files.**
+
+- `.claude/rules/` — add a new rule only if one of the above
+  patterns has concrete future callers on the horizon. Prefer
+  small focused rules over omnibus prose.
+- Memory — nothing obvious to add (the conventions codified in
+  this work already live in `.claude/rules/` and module
+  docstrings; no session-specific knowledge to persist).
+- Plan doc `Session notes` extended with the closeout outcome.
+
+**Depends on:** US-002 (Quality Gate).
+
+**Acceptance criteria.**
+
+- At most ONE new rule file added, if the "check dep conventions"
+  pattern is worth codifying. If in doubt, skip — rules without
+  concrete callers rot.
+- Plan doc updated with outcome notes.
+
+**Done when:** Memory/rules reflect anything durable; plan phase
+advances to `devolved`.
+
+**TDD:** N/A.
+
+## Beads manifest
+
+*(Phase 7 — filled on devolve.)*

--- a/plans/super/80-strict-frontmatter-yaml.md
+++ b/plans/super/80-strict-frontmatter-yaml.md
@@ -3,7 +3,7 @@
 ## Meta
 
 - **Ticket:** [#80](https://github.com/wjduenow/clauditor/issues/80)
-- **Phase:** devolved
+- **Phase:** closed
 - **Sessions:** 1
 - **Last session:** 2026-04-22
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/80-strict-frontmatter-yaml`
@@ -396,6 +396,43 @@ No changes to:
   this round. If a future ticket needs quote-awareness for a
   different check, the parser-extension refactor becomes worth it;
   not now.
+
+### Ralph closeout (2026-04-22)
+
+- **5 commits on `feature/80-strict-frontmatter-yaml`:**
+  - `9b72dc7` — super-plan doc
+  - `5506b1a` — devolve + beads manifest
+  - `83af1c9` — US-001 implementation (check + 10 tests + doc note)
+  - `15802ba` — Quality Gate pass 2 (backtick key format + multi-
+    line emit regression test)
+  - (US-003 commit pending at plan write time)
+- **Quality Gate result:** 4 passes, pass 2 found 2 actionable nits
+  (both fixed), passes 1/3/4 clean. Full suite **2024 passed / 1
+  skipped (live) / 0 failed**. ~98 % coverage. Ruff green. Scope
+  guard (DEC-010) satisfied: zero changes to `_frontmatter.py`,
+  `pyproject.toml`, `cli/lint.py`, `spec.py`, `uv.lock`. PyYAML
+  convention preserved.
+- **Durable pattern codified (US-003).**
+  `.claude/rules/permissive-parser-strict-validator.md` — first
+  explicit rule capturing the two-layer shape that `_frontmatter.py`
+  + `conformance.py` embody. Two canonical anchors (existing
+  architecture + this #80 extension), plus named future callers
+  (rubric validator, plugin-upload validator, regen validator).
+  The pattern was implicit in the codebase before this refactor;
+  now it's discoverable via `.claude/rules/` search.
+- **Dep-convention lesson (not codified as a separate rule).**
+  Discovery flipped the ticket's PyYAML preference after finding
+  the "no PyYAML" convention in `tests/test_bundled_skill.py`'s
+  module docstring. A "check project conventions before adopting
+  a standard approach" meta-rule was considered but skipped —
+  it's a super-plan Phase-1 concern rather than a code pattern,
+  and rules without concrete future callers rot. The lesson
+  lives in the `permissive-parser-strict-validator.md` rule's
+  "Why this shape" section implicitly (the pyproject.toml's
+  empty `dependencies = []` is load-bearing).
+- **CodeRabbit review:** will run automatically on PR #82 push if
+  the repo is integrated. Any real findings handled as follow-up
+  before merge.
 
 ## Detailed breakdown
 

--- a/plans/super/80-strict-frontmatter-yaml.md
+++ b/plans/super/80-strict-frontmatter-yaml.md
@@ -3,7 +3,7 @@
 ## Meta
 
 - **Ticket:** [#80](https://github.com/wjduenow/clauditor/issues/80)
-- **Phase:** detailing
+- **Phase:** devolved
 - **Sessions:** 1
 - **Last session:** 2026-04-22
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/80-strict-frontmatter-yaml`
@@ -584,4 +584,13 @@ advances to `devolved`.
 
 ## Beads manifest
 
-*(Phase 7 — filled on devolve.)*
+- **Epic:** `clauditor-7eb` — `#80: Tighten SKILL.md frontmatter
+  validation for strict YAML (epic)`
+- **Tasks:**
+  - `clauditor-7eb.1` — US-001 — Implement check + tests + doc note
+    (ready; no blockers)
+  - `clauditor-7eb.2` — US-002 — Quality Gate (blocked on `.1`)
+  - `clauditor-7eb.3` — US-003 — Patterns & Memory (blocked on `.2`)
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/80-strict-frontmatter-yaml`
+- **Branch:** `feature/80-strict-frontmatter-yaml`
+- **Plan PR:** https://github.com/wjduenow/clauditor/pull/82

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -247,6 +247,14 @@ def check_conformance(
         _check_body(body, issues)
         return issues
 
+    # Strict-YAML-ambiguity check runs AFTER the permissive parse
+    # succeeds. Rejects unquoted ``: `` (space-colon-space) inside
+    # scalar values — the exact YAML ambiguity class that caused #79.
+    # Walks the raw text directly; does not need ``parsed``. See
+    # DEC-001 through DEC-007 of
+    # ``plans/super/80-strict-frontmatter-yaml.md``.
+    _check_unquoted_colon_in_scalar(skill_md_text, issues)
+
     _check_name(parsed, skill_path, is_modern_layout, issues)
     _check_description(parsed, issues)
     _check_license(parsed, issues)
@@ -667,3 +675,77 @@ def _check_body(body: str, issues: list[ConformanceIssue]) -> None:
                 ),
             )
         )
+
+
+def _check_unquoted_colon_in_scalar(
+    skill_md_text: str, issues: list[ConformanceIssue]
+) -> None:
+    """Reject unquoted ``: `` (space-colon-space) inside scalar values.
+
+    Walks the raw frontmatter text line-by-line. For each line that
+    looks like ``key: value``, extract the value portion, skip it if
+    empty or wrapped in matching quotes, otherwise flag the line if
+    ``": "`` appears anywhere in the value.
+
+    Runs AFTER ``parse_frontmatter`` has already succeeded; the
+    existing ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` short-circuit
+    handles files that fail permissive parsing first.
+
+    This catches the YAML ambiguity class that caused #79: strict
+    parsers (PyYAML, GitHub's renderer) treat ``foo: bar: baz`` as a
+    nested mapping, while clauditor's permissive ``_frontmatter.py``
+    accepts it as a plain scalar. See DEC-007 of
+    ``plans/super/80-strict-frontmatter-yaml.md``.
+    """
+    # Extract the frontmatter block (between the two ``---`` markers).
+    # If no frontmatter, no-op.
+    lines = skill_md_text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return
+    try:
+        end_idx = next(
+            i for i, line in enumerate(lines[1:], start=1)
+            if line.strip() == "---"
+        )
+    except StopIteration:
+        # Malformed — already caught by INVALID_YAML.
+        return
+
+    for lineno, line in enumerate(lines[1:end_idx], start=2):
+        # 1-based line numbers in error messages (YAML convention,
+        # matches GitHub's "line 3 column 95" style).
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        value = value.lstrip()
+        if not value:
+            # ``metadata:`` block header — no scalar to check.
+            continue
+        # Quote detection: first-and-last char match. The permissive
+        # parser already stripped matching quotes, but here we're
+        # inspecting raw text, so this is our own check. Trailing
+        # whitespace after the quote is tolerated; a stray quote
+        # mid-string falls through to the ``": "`` check (conservative).
+        trimmed = value.rstrip()
+        if len(trimmed) >= 2 and (
+            (trimmed[0] == '"' and trimmed[-1] == '"')
+            or (trimmed[0] == "'" and trimmed[-1] == "'")
+        ):
+            continue
+        if ": " in value:
+            issues.append(
+                ConformanceIssue(
+                    code="AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR",
+                    severity="error",
+                    message=(
+                        f"Frontmatter line {lineno} has ': ' inside "
+                        f"an unquoted value for key {key.strip()!r}: "
+                        f"strict YAML parsers (including GitHub's) "
+                        f"treat this as a nested mapping. Wrap the "
+                        f"value in double quotes."
+                    ),
+                )
+            )

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -742,7 +742,7 @@ def _check_unquoted_colon_in_scalar(
                     severity="error",
                     message=(
                         f"Frontmatter line {lineno} has ': ' inside "
-                        f"an unquoted value for key {key.strip()!r}: "
+                        f"an unquoted value for key `{key.strip()}`: "
                         f"strict YAML parsers (including GitHub's) "
                         f"treat this as a nested mapping. Wrap the "
                         f"value in double quotes."

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -698,20 +698,36 @@ def _check_unquoted_colon_in_scalar(
     ``plans/super/80-strict-frontmatter-yaml.md``.
     """
     # Extract the frontmatter block (between the two ``---`` markers).
-    # If no frontmatter, no-op.
+    # Match parse_frontmatter's tolerance: allow leading blank lines
+    # before the opening delimiter. If no frontmatter at all, no-op.
     lines = skill_md_text.splitlines()
-    if not lines or lines[0].strip() != "---":
+    if not lines:
         return
+    opening_index = next(
+        (i for i, line in enumerate(lines) if line.strip()),
+        None,
+    )
+    if opening_index is None or lines[opening_index].strip() != "---":
+        return
+
     try:
         end_idx = next(
-            i for i, line in enumerate(lines[1:], start=1)
+            i
+            for i, line in enumerate(
+                lines[opening_index + 1 :], start=opening_index + 1
+            )
             if line.strip() == "---"
         )
     except StopIteration:
-        # Malformed — already caught by INVALID_YAML.
+        # Malformed — already caught by INVALID_YAML when called via
+        # check_conformance, but we guard defensively here for direct
+        # callers.
         return
 
-    for lineno, line in enumerate(lines[1:end_idx], start=2):
+    for lineno, line in enumerate(
+        lines[opening_index + 1 : end_idx],
+        start=opening_index + 2,
+    ):
         # 1-based line numbers in error messages (YAML convention,
         # matches GitHub's "line 3 column 95" style).
         stripped = line.lstrip()
@@ -724,18 +740,30 @@ def _check_unquoted_colon_in_scalar(
         if not value:
             # ``metadata:`` block header — no scalar to check.
             continue
-        # Quote detection: first-and-last char match. The permissive
-        # parser already stripped matching quotes, but here we're
-        # inspecting raw text, so this is our own check. Trailing
-        # whitespace after the quote is tolerated; a stray quote
-        # mid-string falls through to the ``": "`` check (conservative).
-        trimmed = value.rstrip()
-        if len(trimmed) >= 2 and (
-            (trimmed[0] == '"' and trimmed[-1] == '"')
-            or (trimmed[0] == "'" and trimmed[-1] == "'")
-        ):
-            continue
-        if ": " in value:
+
+        # Quote detection: if the value starts with a quote and has a
+        # matching close quote before the end, treat it as a valid
+        # quoted scalar. YAML allows an inline ``# ...`` comment after
+        # a closed quoted scalar, so we ignore anything after the
+        # close quote (this is what strict parsers do).
+        if value[0] in ('"', "'"):
+            quote_char = value[0]
+            close_idx = value.find(quote_char, 1)
+            if close_idx > 0:
+                continue
+
+        # Not a closed quoted scalar. Strip a trailing YAML inline
+        # comment (``#`` preceded by whitespace, outside quotes — we
+        # already handled the quoted-scalar case above) before the
+        # ``": "`` check, so ``foo # note: here`` doesn't false-flag
+        # on the colon-space inside the comment.
+        scan = value
+        for i in range(1, len(scan)):
+            if scan[i] == "#" and scan[i - 1].isspace():
+                scan = scan[:i].rstrip()
+                break
+
+        if ": " in scan:
             issues.append(
                 ConformanceIssue(
                     code="AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR",

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -984,3 +984,125 @@ class TestNestedMetadataScope:
         )
         issues = check_conformance(text, _modern_path())
         assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+
+class TestParserAcceptedEdgeCases:
+    """Edge cases that the permissive ``parse_frontmatter`` accepts:
+    leading blank lines before the opening ``---`` and quoted scalars
+    with trailing YAML inline comments. Surfaced by Copilot review on
+    PR #82."""
+
+    def test_leading_blank_lines_before_frontmatter_flagged(self):
+        # parse_frontmatter tolerates leading blank lines; the walker
+        # must too, or it silently skips the whole file. Line numbers
+        # are also offset accordingly.
+        text = (
+            "\n"
+            "\n"
+            "---\n"
+            "name: my-skill\n"
+            "description: Has bug: embedded here.\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, _UNQUOTED_COLON_CODE)
+        assert len(flagged) == 1
+        # Line 5 = 2 blanks + '---' + name line + description line.
+        assert "line 5" in flagged[0].message, flagged[0].message
+
+    def test_quoted_value_with_trailing_comment_passes(self):
+        # YAML allows an inline ``# ...`` comment after a closed
+        # quoted scalar. Strict parsers treat the ``: `` INSIDE the
+        # quoted portion as a literal part of the string, not a
+        # nested mapping indicator.
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            'description: "Note: example case" # trailing comment\n'
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+    def test_unquoted_value_with_trailing_comment_and_colon_space_flagged(
+        self,
+    ):
+        # Comment-stripping is a helper for the quote-awareness path;
+        # it must NOT suppress legitimate flagging of ``: `` in the
+        # unquoted portion of the value.
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: Has bug: embedded here # trailing comment\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, _UNQUOTED_COLON_CODE)
+        assert len(flagged) == 1
+
+    def test_unquoted_with_hash_no_colon_space_passes(self):
+        # An unquoted value that contains ``#`` but no ``: `` in the
+        # pre-comment portion should pass. Pins comment-stripping
+        # arithmetic: if the scanner's strip is too aggressive it
+        # might trim real content.
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: hello # world\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+
+class TestWalkerDefensiveGuards:
+    """Direct-call tests for defensive branches unreachable via the
+    normal ``check_conformance`` flow (where ``parse_frontmatter``
+    raises and ``AGENTSKILLS_FRONTMATTER_INVALID_YAML`` short-circuits
+    before the walker runs). These guards protect future direct
+    callers."""
+
+    def _call_walker(self, text: str) -> list:
+        """Invoke the walker directly, bypassing check_conformance."""
+        from clauditor.conformance import (  # noqa: PLC0415
+            _check_unquoted_colon_in_scalar,
+        )
+
+        issues: list = []
+        _check_unquoted_colon_in_scalar(text, issues)
+        return issues
+
+    def test_empty_input_noop(self):
+        assert self._call_walker("") == []
+
+    def test_no_frontmatter_delimiter_noop(self):
+        assert self._call_walker("just body, no frontmatter\n") == []
+
+    def test_only_blank_lines_noop(self):
+        assert self._call_walker("\n\n\n") == []
+
+    def test_missing_closing_delimiter_noop(self):
+        # Defensive guard: parse_frontmatter would have raised, but
+        # the walker tolerates this via StopIteration → return.
+        assert (
+            self._call_walker("---\nname: my-skill\ndescription: ok\n")
+            == []
+        )
+
+    def test_comment_line_inside_frontmatter_skipped(self):
+        # Comment-only lines are not scalars; the walker must skip
+        # them (covers the ``not stripped or startswith('#')`` guard).
+        issues = self._call_walker(
+            "---\nname: foo\n# a comment line\nbar: baz\n---\n"
+        )
+        # No ``: `` in scalar values — passes cleanly.
+        assert issues == []
+
+    def test_colonless_line_inside_frontmatter_skipped(self):
+        # Defensive guard: parse_frontmatter would reject this, but
+        # the walker's ``if ':' not in stripped: continue`` handles
+        # it gracefully if called directly.
+        issues = self._call_walker(
+            "---\nname: foo\ncolonless line\nbar: baz\n---\n"
+        )
+        assert issues == []

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -863,6 +863,26 @@ class TestUnquotedColonInScalarDetection:
             f"got issues={[(i.code, i.message) for i in issues]}"
         )
 
+    def test_two_offending_lines_emit_two_issues(self):
+        # Pin the "one issue per offending line" contract. Two unquoted
+        # space-colon-space sequences on distinct lines should both be
+        # flagged; a single emit with a multi-line summary would hide the
+        # second offense from a user fixing them one at a time.
+        text = (
+            "---\n"
+            "name: skill\n"
+            "description: First bug: embedded here.\n"
+            "compatibility: Second bug: also embedded.\n"
+            "---\n"
+            "\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path("skill"))
+        flagged = _by_code(issues, _UNQUOTED_COLON_CODE)
+        assert len(flagged) == 2, (
+            f"expected 2 {_UNQUOTED_COLON_CODE} issues (one per offending "
+            f"line), got {len(flagged)}: {[i.message for i in flagged]}"
+        )
+
 
 class TestQuoteAwareness:
     """Quote-detection edges: values wrapped in ``"..."`` / ``'...'``

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -778,3 +778,189 @@ class TestConformanceIssueInvariants:
                 assert "\r" not in issue.message, (
                     f"CR in message from {issue.code}: {issue.message!r}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR — #80 US-001
+# ---------------------------------------------------------------------------
+
+
+_UNQUOTED_COLON_CODE = "AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR"
+
+
+class TestUnquotedColonInScalarDetection:
+    """Regression + negative cases for the #80 strict-YAML check.
+
+    Tests per DEC-006 of ``plans/super/80-strict-frontmatter-yaml.md``.
+    The pre-#79 fixture is the exact content that caused GitHub's YAML
+    renderer to reject ``.claude/skills/review-agentskills-spec/SKILL.md``
+    with ``mapping values are not allowed in this context``.
+    """
+
+    def test_pre_79_fixture_flagged(self):
+        # Verbatim pre-#79 frontmatter (see plan Discovery section).
+        # The bug is the unquoted ``Optional: `` on the compatibility:
+        # line.
+        text = (
+            "---\n"
+            "name: review-agentskills-spec\n"
+            "description: Review the current agentskills.io specification "
+            "and open follow-up issues.\n"
+            "compatibility: Requires network access to fetch "
+            "https://agentskills.io/specification. Optional: the gh CLI "
+            "for issue creation.\n"
+            "metadata:\n"
+            '  clauditor-version: "0.0.0-dev"\n'
+            "disable-model-invocation: true\n"
+            "allowed-tools: WebFetch, Read, Grep, Glob, "
+            "Bash(gh issue create:*)\n"
+            "---\n"
+            "\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path("review-agentskills-spec"))
+        flagged = _by_code(issues, _UNQUOTED_COLON_CODE)
+        assert len(flagged) >= 1, (
+            f"expected at least one {_UNQUOTED_COLON_CODE} issue, got "
+            f"codes={_codes(issues)}"
+        )
+        assert all(i.severity == "error" for i in flagged)
+
+    def test_post_79_fixture_passes(self):
+        # Same content, with compatibility value wrapped in double quotes.
+        text = (
+            "---\n"
+            "name: review-agentskills-spec\n"
+            "description: Review the current agentskills.io specification "
+            "and open follow-up issues.\n"
+            'compatibility: "Requires network access to fetch '
+            "https://agentskills.io/specification. Optional: the gh CLI "
+            'for issue creation."\n'
+            "metadata:\n"
+            '  clauditor-version: "0.0.0-dev"\n'
+            "disable-model-invocation: true\n"
+            "allowed-tools: WebFetch, Read, Grep, Glob, "
+            "Bash(gh issue create:*)\n"
+            "---\n"
+            "\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path("review-agentskills-spec"))
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+    def test_clauditor_bundled_skill_passes(self):
+        # Read the bundled SKILL.md via the clauditor package path — the
+        # one exception to "no file I/O in tests" is that the bundled
+        # skill path is stable and this is the canonical regression guard
+        # that the new check does not break shipped skills.
+        import clauditor  # noqa: PLC0415
+
+        skill_path = (
+            Path(clauditor.__file__).parent / "skills" / "clauditor" / "SKILL.md"
+        )
+        text = skill_path.read_text(encoding="utf-8")
+        issues = check_conformance(text, skill_path)
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == [], (
+            "bundled clauditor SKILL.md must not trigger the new check; "
+            f"got issues={[(i.code, i.message) for i in issues]}"
+        )
+
+
+class TestQuoteAwareness:
+    """Quote-detection edges: values wrapped in ``"..."`` / ``'...'``
+    bypass the check; unquoted values containing ``: `` trigger it.
+
+    Also pins the URL and ``Bash(... create:*)`` patterns as non-triggers
+    because the colon is NOT followed by a space.
+    """
+
+    def test_double_quoted_value_with_colon_space_passes(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            'description: "Note: when X happens, do Y"\n'
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+    def test_single_quoted_value_with_colon_space_passes(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: 'Note: when X happens, do Y'\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+    def test_unquoted_value_with_colon_space_flagged(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: Note: when X happens, do Y\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, _UNQUOTED_COLON_CODE)
+        assert len(flagged) == 1
+        assert flagged[0].severity == "error"
+        # Message should name the offending key so the author can find it.
+        assert "description" in flagged[0].message
+
+    def test_url_in_unquoted_value_passes(self):
+        # Colon-slash, no space after colon → not ambiguous YAML.
+        # ``description`` is used so we're testing a known spec key.
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: See https://example.com/page for details\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+    def test_allowed_tools_colon_star_passes(self):
+        # Colon-star glob in a Bash tool spec is a legitimate value; the
+        # colon is NOT followed by a space, so no ambiguity.
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: A skill\n"
+            "allowed-tools: Bash(gh issue create:*)\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []
+
+
+class TestNestedMetadataScope:
+    """The walker visits nested ``metadata:`` child lines too (DEC-005).
+
+    Same rule applies at any indent: unquoted ``: `` inside a child
+    scalar is a bug even when the parent is the ``metadata`` block.
+    """
+
+    def test_nested_unquoted_value_with_colon_space_flagged(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: A skill\n"
+            "metadata:\n"
+            "  note: foo: bar baz\n"
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, _UNQUOTED_COLON_CODE)
+        assert len(flagged) == 1
+        assert flagged[0].severity == "error"
+
+    def test_nested_quoted_value_with_colon_space_passes(self):
+        text = (
+            "---\n"
+            "name: my-skill\n"
+            "description: A skill\n"
+            "metadata:\n"
+            '  note: "foo: bar baz"\n'
+            "---\n\nbody\n"
+        )
+        issues = check_conformance(text, _modern_path())
+        assert _by_code(issues, _UNQUOTED_COLON_CODE) == []


### PR DESCRIPTION
## Summary
Super plan for #80 — add `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR` to `check_conformance` so SKILL.md files with unquoted space-colon-space sequences get caught by `clauditor lint` before failing to render on GitHub. Follow-up to the #79 symptom fix.

**Phase:** closed (all 3 stories implemented + Quality Gate complete + Copilot findings addressed; ready for review)
**Stories:** 1 implementation + Quality Gate + Patterns & Memory = **3 total**, all closed in beads epic `clauditor-7eb`
**Decisions:** **10 decisions** captured

## Key decisions
- **DEC-001** — **Option B (targeted regex), not PyYAML.** Discovery surfaced an explicit project convention (documented in `tests/test_bundled_skill.py`: "hand-rolled YAML reader to avoid adding PyYAML as a runtime dependency"). Initial ticket preference was flipped.
- **DEC-002** — New check lives in `conformance.py`, not `_frontmatter.py`. Keeps the permissive-parser contract intact.
- **DEC-003** — Code `AGENTSKILLS_FRONTMATTER_UNQUOTED_COLON_IN_SCALAR`, severity `error`. Routes to exit 2.
- **DEC-004** — Raw-text inspection in the new check; no `_frontmatter.py` API widening.
- **DEC-005** — Scope includes top-level + nested `metadata:` values.
- **DEC-007** — Full ~40-line walker algorithm drafted inline in the plan.

## Plan document
See `plans/super/80-strict-frontmatter-yaml.md` for the full plan.

## Stories
| # | Title | Depends on |
| --- | --- | --- |
| **US-001** | Implement check + 10 TDD tests + doc note (atomic commit) | — |
| **US-002** | Quality Gate (4× review + CodeRabbit + validation) | US-001 |
| **US-003** | Patterns & Memory — new rule `permissive-parser-strict-validator.md` | US-002 |

## Implementation status
- ✅ All 3 stories implemented
- ✅ 4-pass internal code review (pass 2 actionable, others clean)
- ✅ Copilot review on this PR addressed: leading-blank-lines handling, quoted-value-with-trailing-comment false positive, test-gap coverage, plan phase alignment
- ✅ CodeRabbit local review surfaced 2 findings, both out of scope (in files already shipped via #75/#71)
- ✅ 2034 tests pass, **100% coverage on `conformance.py`** (5 defensive branches now covered via direct-call tests), 98.05% overall
- ✅ DEC-010 scope guard satisfied: zero changes to `_frontmatter.py`, `pyproject.toml`, `cli/lint.py`, `spec.py`, `uv.lock`

## Next steps
- Review and merge

Closes #80.
