### PR TITLE
fix: split badge JSON to avoid shields.io 'invalid properties' rejection

### DIFF
--- a/.claude/rules/dual-version-external-schema-embed.md
+++ b/.claude/rules/dual-version-external-schema-embed.md
@@ -1,187 +1,212 @@
-# Rule: Embedding a clauditor extension inside an external schema
+# Rule: Clauditor extension lives in a sibling file, not inside an external schema
 
 When clauditor emits JSON that will be consumed by an external
 system's own schema (shields.io endpoint JSON, a future GitHub
 check-run annotation, a package-registry metadata blob, an OpenGraph
-preview payload, ...), the payload carries **two independent
-schema-version fields**:
+preview payload, ...), the output **MUST** be a pair of sibling
+files — one shields.io- (or other-external-schema-) valid, one
+carrying the clauditor extension. The extension **MUST NOT** be
+embedded as a top-level key inside the external-schema payload.
 
-1. The external system's required schema-version field (e.g.
-   shields.io's top-level `"schemaVersion": 1`) — using **their**
-   name and convention (which is often camelCase even when our
-   codebase uses snake_case).
-2. A clauditor extension block under a dedicated namespace key (e.g.
-   `"clauditor": {...}`), whose **first** key is our internal
-   `"schema_version": 1` per
-   `.claude/rules/json-schema-version.md`.
+**Why the sibling pattern, not embed.** The original rule (shipped
+with #77) assumed external validators would silently ignore unknown
+top-level keys and let us nest a `"clauditor": { ... }` block inside
+the shields.io-required payload. Verified on 2026-04-22 against the
+live shields.io `endpoint` badge renderer: **shields.io strictly
+validates its schema and rejects unknown top-level keys** with an
+`invalid properties: <key>` SVG response. The badge rendered grey
+with the error text where the quality indicator should have been.
+The fix is structural (two files), not cosmetic (rename the key).
 
-The two versions bump independently. A future shields.io bump to
-`schemaVersion: 2` does not force a `clauditor.schema_version` bump,
-and vice versa. The external consumer reads their own top-level
-version; a future clauditor-side loader (e.g. a trend-audit consumer)
-reads the nested one.
+This applies broadly. Any external schema worth its name validates.
+Assume every external JSON contract will reject unknown fields until
+proven otherwise.
 
 ## The pattern
 
-```python
-# badge.py — canonical dataclass shape
-@dataclass
-class Badge:
-    """Serializable shields.io endpoint-JSON payload."""
+Two files, two independent version lifecycles, same directory.
 
-    # Shields.io's required fields (their schema):
-    label: str
-    message: str
-    color: str
-    clauditor: ClauditorExtension  # our extension block
-    style_overrides: dict[str, str | int] = field(default_factory=dict)
+### File 1: `<name>.json` — shields.io / external-schema-only
 
-    # Shields.io's top-level schemaVersion (camelCase per their docs).
-    schema_version: int = _SHIELDS_SCHEMA_VERSION  # == 1
-
-    def to_endpoint_json(self) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            # 1. External system's required field first.
-            "schemaVersion": self.schema_version,
-            "label": self.label,
-            "message": self.message,
-            "color": self.color,
-        }
-        # Style passthroughs alphabetized between the external keys
-        # and our nested namespace.
-        for key in sorted(self.style_overrides):
-            payload[key] = self.style_overrides[key]
-        # 2. Our extension block — first key inside is
-        # ``schema_version`` (snake_case, our convention).
-        payload["clauditor"] = self.clauditor.to_dict()
-        return payload
-
-
-@dataclass
-class ClauditorExtension:
-    skill_name: str
-    generated_at: str
-    iteration: int | None
-    l1: L1Summary | None
-    l3: L3Summary | None
-    variance: VarianceSummary | None
-    # Our internal version (snake_case), FIRST key in the nested
-    # dict per .claude/rules/json-schema-version.md.
-    schema_version: int = 1
-
-    def to_dict(self) -> dict[str, Any]:
-        result: dict[str, Any] = {"schema_version": self.schema_version}
-        result["skill_name"] = self.skill_name
-        result["generated_at"] = self.generated_at
-        if self.iteration is not None:
-            result["iteration"] = self.iteration
-        layers: dict[str, Any] = {}
-        if self.l1 is not None:
-            layers["l1"] = self.l1.to_dict()
-        # ... l3, variance conditional ...
-        result["layers"] = layers
-        return result
-```
-
-Resulting JSON:
+Strictly the fields the external contract requires. Nothing else.
+No clauditor metadata. Keys follow the external system's naming
+convention (often camelCase).
 
 ```json
 {
   "schemaVersion": 1,
   "label": "clauditor",
-  "message": "8/8 · L3 92%",
-  "color": "brightgreen",
-  "clauditor": {
-    "schema_version": 1,
-    "skill_name": "review-pr",
-    "generated_at": "2026-04-21T14:00:00Z",
-    "iteration": 42,
-    "layers": { "l1": {...}, "l3": {...} }
-  }
+  "message": "3/3 · L3 100%",
+  "color": "brightgreen"
 }
 ```
 
+Whitelisted passthrough keys (`style`, `logoSvg`, `cacheSeconds`,
+`link`, etc. — documented by the external contract) land between
+the required keys as the only permitted extension. Unknown keys
+are rejected at the CLI boundary so the external validator never
+sees them.
+
+### File 2: `<name>.clauditor.json` — the clauditor extension
+
+Standalone JSON with the full per-layer breakdown, thresholds,
+iteration number, timestamp, and whatever other forensic data the
+trend-audit / history consumer needs. First key is
+`"schema_version": 1` per
+`.claude/rules/json-schema-version.md`. Bumps independently of
+the external schema's version.
+
+```json
+{
+  "schema_version": 1,
+  "skill_name": "review-pr",
+  "generated_at": "2026-04-22T14:00:00Z",
+  "iteration": 42,
+  "layers": { "l1": {...}, "l3": {...} }
+}
+```
+
+### Writer split (dataclass with two serializers)
+
+```python
+@dataclass
+class Badge:
+    label: str
+    message: str
+    color: str
+    clauditor: ClauditorExtension
+    style_overrides: dict[str, str | int] = field(default_factory=dict)
+    schema_version: int = _SHIELDS_SCHEMA_VERSION  # == 1, camelCase on wire
+
+    def to_endpoint_json(self) -> dict[str, Any]:
+        """Shields.io-only payload. NO ``clauditor`` key."""
+        payload: dict[str, Any] = {
+            "schemaVersion": self.schema_version,
+            "label": self.label,
+            "message": self.message,
+            "color": self.color,
+        }
+        for key in sorted(self.style_overrides):
+            payload[key] = self.style_overrides[key]
+        return payload
+
+    def to_clauditor_extension_json(self) -> dict[str, Any]:
+        """Clauditor extension payload. First key is ``schema_version``."""
+        return _extension_to_dict(self.clauditor)
+```
+
+### Atomic pair write
+
+```python
+# cli/badge.py — the I/O side.
+extension_target = target.with_suffix(".clauditor.json")
+
+_atomic_write_json(target, badge.to_endpoint_json())
+_atomic_write_json(extension_target, badge.to_clauditor_extension_json())
+```
+
+Both files are written via sibling-tempfile + `os.replace` (review
+pass 2, C2-3). The two-file pair is not fully atomic across both
+renames — the first `os.replace` can succeed and the second can
+fail — but that is acceptable because the artifacts are fully
+regenerable and the failure mode (one new file, one stale file)
+is recoverable with `clauditor badge --force`. DEC-011's `--force`
+policy applies to BOTH files as a set: either file existing without
+`--force` fails the whole write.
+
 ## Why this shape
 
-- **Two independent lifecycles.** Shields.io can bump their
-  `schemaVersion` to 2 to change how they parse `message` / `color`;
-  that has nothing to do with whether our aggregation algorithm
-  changed. If we wired the two versions together, every shields.io
-  bump would force a clauditor-side bump even when our block's shape
-  did not change — and vice versa, a clauditor-side rename of a
-  `layers.*` field would confusingly force us to bump their
-  `schemaVersion` too. Separate fields keep the bump signal clean.
-- **Naming follows the OWNER of each field.** The external system
-  defines their field's name, type, and casing. Use theirs literally
-  (`schemaVersion` camelCase for shields.io). Our nested block is
-  ours, so it uses our convention (`schema_version` snake_case per
-  `.claude/rules/json-schema-version.md`). Mixing the two casings in
-  the same payload is not inconsistency — it is fidelity to each
-  schema's ownership.
-- **Clauditor's `schema_version` is FIRST inside the nested block.**
-  Per `.claude/rules/json-schema-version.md`: a human reading the
-  JSON diff sees the version bump immediately. The nested block's
-  first-key discipline survives even though the block itself is not
-  top-level — we own what is inside the namespace.
-- **Any future loader checks the NESTED version, not the
-  external-top-level one.** Clauditor does not read shields.io's
-  `schemaVersion` field when consuming the payload (that version
-  belongs to them). A trend-audit consumer that ever reads badge
-  JSON back in validates `payload["clauditor"]["schema_version"]`
-  against `_BADGE_CLAUDITOR_SCHEMA_VERSION = 1` following the
-  `_check_schema_version` pattern from `src/clauditor/audit.py`.
-  Keep the two checks separate in code.
-- **The extension block goes last in the top-level key order.**
-  Sorted style passthroughs land between the external-required keys
-  and the nested extension, so the nested block is always at the
-  visual bottom of the payload — the "clauditor supplemental"
-  position is unambiguous to someone reading the JSON in a GitHub
-  raw-content view.
+- **External validators reject unknown fields.** Shields.io is the
+  specific anchor here, but every structured-JSON consumer worth
+  using validates. OpenAPI servers reject unknown request fields
+  (many reject on response too); package-registry APIs reject
+  unknown top-level keys; webhook receivers typically strip or
+  reject. Assuming the external validator is lenient is a gamble.
+  The sibling-file pattern removes the gamble.
+- **Two independent bump lifecycles.** Shields.io can change
+  `schemaVersion` to 2 to reshape how they parse `message`; that
+  has nothing to do with whether our aggregation algorithm or
+  per-layer shape changed. The files carry their own version
+  fields; bumping one does not force bumping the other.
+- **One-glance audit separation.** A human reading
+  `.clauditor/badges/demo.json` sees exactly what shields.io sees
+  — no clauditor noise to squint past. A human reading
+  `.clauditor/badges/demo.clauditor.json` sees clauditor telemetry
+  without the external-schema envelope. Both files are small and
+  self-contained.
+- **Sidecar naming mirrors the reader's needs.** Shields.io hits
+  `raw.githubusercontent.com/<user>/<repo>/<branch>/.clauditor/badges/<skill>.json`
+  via the `endpoint?url=` pattern; it reads only the first file.
+  A trend-audit consumer discovers `.clauditor/badges/*.clauditor.json`
+  by glob and reads only the second. There is no cross-file
+  dependency at read time.
+- **`--force` policy applies to the pair, not one file.** A user
+  who regenerated the shields JSON but forgot the extension (or
+  vice versa) would end up with a mismatched pair where
+  `shields.color == "brightgreen"` and
+  `extension.iteration == 41` while the real latest iteration is
+  42. Requiring `--force` for either file existing, and writing
+  both together, prevents this drift.
+- **`dict[str, str | int]` for style passthroughs.** Shields.io
+  types some fields as integers (`cacheSeconds`) and others as
+  strings (`style`, `logoSvg`); the CLI coerces at parse time
+  (review pass 3, C3-1). The type annotation mirrors that.
+- **Reserved-key rejection.** A user passing `--style
+  schemaVersion=2` or `--style label=hijacked` would have silently
+  overwritten the canonical shields.io fields via the
+  sorted-alphabetical merge inside `to_endpoint_json`. The
+  `_RESERVED_STYLE_KEYS` frozenset (Copilot PR review, 2026-04-22)
+  rejects those at the CLI parse boundary with exit 2.
 
 ## What NOT to do
 
-- Do NOT inline our fields at the top level alongside the external
-  system's fields. A top-level `"clauditor_skill_name"` or
-  `"_clauditor_iteration"` fragments the namespace; the external
-  validator (shields.io in this case) may warn on unknown fields;
-  and future clauditor-side readers must grep for every
-  `"clauditor_*"` prefix. Use ONE namespace key.
-- Do NOT use only one version field. "Just the external one" loses
-  the clauditor-side bump signal — a trend-audit consumer has no
-  way to detect a shape change inside our block. "Just our nested
-  one" means the external validator cannot see the version it
-  requires.
-- Do NOT alias our version to theirs (e.g. copy their
-  `schemaVersion: 1` into `clauditor.schema_version: 1`). The two
-  will silently drift the first time one bumps. Emit them from
-  independent constants (`_SHIELDS_SCHEMA_VERSION = 1` and
-  `_BADGE_CLAUDITOR_SCHEMA_VERSION = 1`, or the dataclass default
-  field on `ClauditorExtension`).
-- Do NOT translate their casing to ours or vice versa. Shields.io's
-  docs say `schemaVersion`; emit that literal key. Do not emit
-  `"schema_version"` at the top level and hope shields.io is
-  lenient — their schema is their contract.
-- Do NOT sort the top-level key order alphabetically. Python 3.7+
-  preserves insertion order, and the order we emit is load-bearing:
-  external-required keys first, our namespace key last (with any
-  passthroughs in between). Alphabetical ordering would put
-  `clauditor` between `color` and `label`, interleaving our
-  namespace with theirs and breaking the visual "supplemental
-  section" convention.
+- Do NOT embed a top-level `"clauditor"` (or `"_meta"`, or
+  `"_clauditor"`, or any prefix variant) key inside the shields.io
+  payload. Shields.io rejects unknown top-level fields; we verified
+  this against the live renderer. The error is a grey "invalid
+  properties: <key>" SVG that silently replaces the quality badge.
+- Do NOT fold the version fields together (e.g. reuse shields.io's
+  `schemaVersion: 1` as our version too). The two lifecycles are
+  distinct; coupling them means one bump forces the other.
+- Do NOT use a shields.io-accepted field (like `link` or
+  `logoSvg`) to smuggle clauditor data through. The external
+  field's semantics are owned by the external schema;
+  repurposing them for our own payload is both fragile (next
+  shields.io release may sanitize) and user-hostile
+  (a human inspecting the link / logo sees garbage).
+- Do NOT write only the shields.io file and drop the extension.
+  The per-layer breakdown, thresholds, and iteration number are
+  real data that trend-audit / forensic consumers will want; the
+  cost of the second file is trivial.
+- Do NOT forget the `--force` check on BOTH files. A user who
+  regenerated one file but forgot the other would otherwise end
+  up with a mismatched pair. The CLI must require `--force` for
+  either file existing.
 
 ## Canonical implementation
 
-`src/clauditor/badge.py` — the `Badge` dataclass and
-`ClauditorExtension.to_dict`. See DEC-003, DEC-027, DEC-013 in
-`plans/super/77-clauditor-badge.md`. Regression tests:
+`src/clauditor/badge.py::Badge.to_endpoint_json` +
+`Badge.to_clauditor_extension_json` — the two-method split. See
+DEC-003, DEC-027, DEC-013 in `plans/super/77-clauditor-badge.md`
+for the original embed-style decisions; the shift to sibling files
+is the 2026-04-22 post-merge fix (branch
+`fix/badge-shields-invalid-properties`).
+
+`src/clauditor/cli/badge.py::_write_badge_sidecars` — the I/O
+layer. Owns the `--force` collision check for the pair, the
+`.clauditor.json` suffix derivation via `Path.with_suffix`, and
+the per-file atomic tmp+rename publication.
+
+Regression tests:
 
 - `tests/test_badge.py::TestBadgeSerialization::test_top_level_key_order`
-  — verifies shields.io-owned keys precede our namespace.
-- `tests/test_badge.py::TestBadgeSerialization::test_shields_schema_version_is_camelcase`
-  — defends the case-fidelity invariant.
-- `tests/test_badge.py::TestBadgeSerialization::test_clauditor_schema_version_is_first_key`
-  — defends the nested-first-key invariant via
-  `list(result["clauditor"].keys())[0]`.
+  — verifies `"clauditor" not in result` for the shields payload.
+- `tests/test_badge.py::TestBadgeSerialization::test_clauditor_extension_schema_version_is_first_key`
+  — verifies extension file's first-key invariant.
+- `tests/test_badge.py::TestBadgeSerialization::test_payload_is_json_serializable`
+  — round-trip check on both payloads.
+- `tests/test_cli_badge.py::TestCmdBadgeHappyPath::test_writes_badge_json_default_path`
+  — verifies BOTH sidecar files land on disk with correct shapes.
 
 ## When this rule applies
 
@@ -190,21 +215,20 @@ external system with its own schema. Plausible future callers:
 
 - A `clauditor check-annotate` command producing GitHub check-run
   annotations (GitHub's schema + our per-assertion breakdown).
-- A `clauditor export-opengraph` command producing OpenGraph preview
-  metadata for skill catalog pages.
+- A `clauditor export-opengraph` command producing OpenGraph
+  preview metadata for skill catalog pages.
 - A `clauditor publish` / `clauditor package` command emitting
   package-registry metadata (npm, PyPI, or a hypothetical
   agentskills.io registry) with a clauditor-provenance block.
-- Any webhook / callback payload we might emit to an external
-  tracker (Linear, Jira) with a clauditor-sourced issue-annotation
-  block.
+- Any webhook / callback payload emitted to an external tracker
+  (Linear, Jira) with a clauditor-sourced issue-annotation block.
 
 Apply the full recipe: keep the external system's required fields
-at the top with their own naming, gate our supplement under a
-dedicated namespace key (`"clauditor"` is fine and consistent with
-the badge precedent), carry our nested `schema_version` as the
-first key of that namespace, and emit the two version constants
-from independent sources.
+in one file with nothing extra; put the clauditor supplement in a
+SIBLING file named `<stem>.clauditor.json` (or
+`<stem>.clauditor.<ext>` if the external schema uses a non-JSON
+format); carry the extension's own `schema_version` as its first
+key; write both files atomically with shared `--force` policy.
 
 ## When this rule does NOT apply
 

--- a/.clauditor/badges/clauditor.clauditor.json
+++ b/.clauditor/badges/clauditor.clauditor.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "skill_name": "clauditor",
+  "generated_at": "2026-04-22T05:33:38Z",
+  "iteration": 3,
+  "layers": {
+    "l1": {
+      "count": 3,
+      "total": 3,
+      "pass_rate": 1.0,
+      "passed": true
+    },
+    "l3": {
+      "pass_rate": 1.0,
+      "mean_score": 0.935,
+      "passed": true,
+      "thresholds": {
+        "min_pass_rate": 0.7,
+        "min_mean_score": 0.5
+      }
+    }
+  }
+}

--- a/.clauditor/badges/clauditor.json
+++ b/.clauditor/badges/clauditor.json
@@ -2,28 +2,5 @@
   "schemaVersion": 1,
   "label": "clauditor",
   "message": "3/3 · L3 100%",
-  "color": "brightgreen",
-  "clauditor": {
-    "schema_version": 1,
-    "skill_name": "clauditor",
-    "generated_at": "2026-04-22T05:33:38Z",
-    "iteration": 3,
-    "layers": {
-      "l1": {
-        "count": 3,
-        "total": 3,
-        "pass_rate": 1.0,
-        "passed": true
-      },
-      "l3": {
-        "pass_rate": 1.0,
-        "mean_score": 0.935,
-        "passed": true,
-        "thresholds": {
-          "min_pass_rate": 0.7,
-          "min_mean_score": 0.5
-        }
-      }
-    }
-  }
+  "color": "brightgreen"
 }

--- a/.clauditor/badges/review-agentskills-spec.clauditor.json
+++ b/.clauditor/badges/review-agentskills-spec.clauditor.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "skill_name": "review-agentskills-spec",
+  "generated_at": "2026-04-22T13:59:18Z",
+  "iteration": 4,
+  "layers": {
+    "l1": {
+      "count": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "passed": true
+    },
+    "l3": {
+      "pass_rate": 1.0,
+      "mean_score": 0.9700000000000001,
+      "passed": true,
+      "thresholds": {
+        "min_pass_rate": 0.7,
+        "min_mean_score": 0.5
+      }
+    }
+  }
+}

--- a/.clauditor/badges/review-agentskills-spec.json
+++ b/.clauditor/badges/review-agentskills-spec.json
@@ -2,28 +2,5 @@
   "schemaVersion": 1,
   "label": "clauditor",
   "message": "5/5 · L3 100%",
-  "color": "brightgreen",
-  "clauditor": {
-    "schema_version": 1,
-    "skill_name": "review-agentskills-spec",
-    "generated_at": "2026-04-22T13:59:18Z",
-    "iteration": 4,
-    "layers": {
-      "l1": {
-        "count": 5,
-        "total": 5,
-        "pass_rate": 1.0,
-        "passed": true
-      },
-      "l3": {
-        "pass_rate": 1.0,
-        "mean_score": 0.9700000000000001,
-        "passed": true,
-        "thresholds": {
-          "min_pass_rate": 0.7,
-          "min_mean_score": 0.5
-        }
-      }
-    }
-  }
+  "color": "brightgreen"
 }

--- a/docs/badges.md
+++ b/docs/badges.md
@@ -98,39 +98,51 @@ A first-class `clauditor-action@v1` GitHub Action that wires this up end-to-end 
 
 ## Schema reference
 
-The badge JSON carries **two** independent schema versions (DEC-027):
+`clauditor badge` writes **two sidecar files** per invocation (a shields.io-valid payload plus a clauditor extension). Shields.io strictly validates its endpoint schema and rejects unknown top-level keys with an `invalid properties: <key>` SVG response, so the extension cannot be embedded — it lives in a sibling file. See [`.claude/rules/dual-version-external-schema-embed.md`](../.claude/rules/dual-version-external-schema-embed.md) for the full rationale.
 
-- **Top-level `schemaVersion`** — shields.io's own endpoint contract (camelCase, per their docs). Currently `1`. First top-level key.
-- **Nested `clauditor.schema_version`** — our extension-block contract (snake_case, per `.claude/rules/json-schema-version.md`). Currently `1`. First key of the `clauditor` block.
+### File 1 — `<skill>.json` (shields.io only)
 
-They bump independently — a future shields.io schema revision does not force a clauditor bump and vice versa.
-
-Sample output (no variance sidecar present; the `layers.variance` block is omitted entirely per DEC-003):
+Exactly the fields the shields.io `endpoint` contract requires, plus any whitelisted `--style` passthroughs (`style`, `logoSvg`, `logoColor`, `labelColor`, `cacheSeconds`, `link`). No clauditor metadata.
 
 ```json
 {
   "schemaVersion": 1,
   "label": "clauditor",
   "message": "8/8 · L3 92%",
-  "color": "brightgreen",
-  "clauditor": {
-    "schema_version": 1,
-    "skill_name": "my-skill",
-    "generated_at": "2026-04-21T14:00:00Z",
-    "iteration": 4,
-    "layers": {
-      "l1": {"count": 8, "total": 8, "pass_rate": 1.0, "passed": true},
-      "l3": {
-        "pass_rate": 0.92,
-        "mean_score": 0.85,
-        "passed": true,
-        "thresholds": {"min_pass_rate": 0.7, "min_mean_score": 0.5}
-      }
+  "color": "brightgreen"
+}
+```
+
+This is the file the shields.io `endpoint?url=...` fetcher reads from `raw.githubusercontent.com`.
+
+### File 2 — `<skill>.clauditor.json` (extension)
+
+Standalone clauditor telemetry. First key is `schema_version` per `.claude/rules/json-schema-version.md`; bumps independently of the shields.io schema (DEC-027).
+
+```json
+{
+  "schema_version": 1,
+  "skill_name": "my-skill",
+  "generated_at": "2026-04-21T14:00:00Z",
+  "iteration": 4,
+  "layers": {
+    "l1": {"count": 8, "total": 8, "pass_rate": 1.0, "passed": true},
+    "l3": {
+      "pass_rate": 0.92,
+      "mean_score": 0.85,
+      "passed": true,
+      "thresholds": {"min_pass_rate": 0.7, "min_mean_score": 0.5}
     }
   }
 }
 ```
 
+Read by trend-audit and other forensic consumers; shields.io does not fetch this file.
+
 L1 and L3 both carry a `passed: bool` field with **different semantics** (DEC-010): L1 `passed = true` means "every declared assertion passed"; L3 `passed = true` means "pass rate ≥ `min_pass_rate` AND mean score ≥ `min_mean_score`" (the grade met the thresholds the grading run used). The dataclass docstrings in `src/clauditor/badge.py` are the authoritative reference for each field.
+
+### `--force` semantics for the pair
+
+The DEC-011 overwrite policy applies to BOTH files as a set. Either file existing without `--force` fails the write. Commit both files together.
 
 For the complete list of pure helpers that compose this payload, see [`src/clauditor/badge.py`](../src/clauditor/badge.py) (`compute_badge`, `Badge`, `ClauditorExtension`, `L1Summary`, `L3Summary`, `VarianceSummary`).

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -203,14 +203,16 @@ class Badge:
     schema_version: int = _SHIELDS_SCHEMA_VERSION
 
     def to_endpoint_json(self) -> dict[str, Any]:
-        """Return the shields.io-compatible dict with canonical key order.
+        """Return the shields.io-compatible dict — shields.io only.
 
-        Top-level keys in order: ``schemaVersion``, ``label``,
-        ``message``, ``color``, then ``style_overrides`` sorted
-        alphabetically, then ``clauditor``. Inside ``clauditor``,
-        first key is ``schema_version`` (per
-        ``.claude/rules/json-schema-version.md``), followed by
-        ``skill_name``, ``generated_at``, ``iteration``, ``layers``.
+        Key order: ``schemaVersion``, ``label``, ``message``,
+        ``color``, then ``style_overrides`` sorted alphabetically.
+
+        No ``clauditor`` extension block: shields.io strictly
+        validates its endpoint schema and rejects unknown top-level
+        keys with an ``invalid properties: <key>`` SVG response.
+        The extension lives in a SIBLING file (``.clauditor.json``
+        suffix); see :meth:`to_clauditor_extension_json` below.
 
         Python 3.7+ preserves dict insertion order, so building the
         dict literal-by-literal in the desired order is the entire
@@ -224,8 +226,22 @@ class Badge:
         }
         for key in sorted(self.style_overrides):
             payload[key] = self.style_overrides[key]
-        payload["clauditor"] = _extension_to_dict(self.clauditor)
         return payload
+
+    def to_clauditor_extension_json(self) -> dict[str, Any]:
+        """Return the clauditor extension block as a standalone dict.
+
+        Written to a sibling file ``<skill>.clauditor.json`` alongside
+        the shields.io badge JSON. Carries the per-layer breakdown,
+        thresholds, iteration number, and ``generated_at`` timestamp
+        for trend-audit / forensic consumers.
+
+        First key is ``schema_version: 1`` per
+        ``.claude/rules/json-schema-version.md``. Shape unchanged
+        from the pre-split ``clauditor`` sub-dict so existing
+        docstrings / tests of the nested shape still apply.
+        """
+        return _extension_to_dict(self.clauditor)
 
 
 def _extension_to_dict(ext: ClauditorExtension) -> dict[str, Any]:

--- a/src/clauditor/cli/badge.py
+++ b/src/clauditor/cli/badge.py
@@ -301,38 +301,89 @@ def _list_available_iterations(project_dir: Path, skill_name: str) -> list[int]:
     return sorted(found)
 
 
-def _write_badge_json(
+def _extension_path_for(target: Path) -> Path:
+    """Return the ``<target>.clauditor.json`` sibling path.
+
+    Uses :meth:`pathlib.Path.with_suffix` to replace the final
+    extension so both ``demo.json`` and ``demo.svg`` (or a suffix-less
+    path) all produce ``demo.clauditor.json`` in the same directory.
+    """
+    return target.with_suffix(".clauditor.json")
+
+
+def _atomic_write_json(target: Path, payload: dict) -> None:
+    """Write ``payload`` to ``target`` via tempfile + ``os.replace``.
+
+    Raises ``OSError`` on failure with best-effort cleanup of the
+    sibling tempfile; the existing ``target`` (if any) is left
+    untouched in the failure case.
+
+    ``ensure_ascii=False`` writes the UTF-8 middle-dot glyph in
+    messages verbatim (review pass 3, C3-4) so the on-disk bytes
+    match the sample JSON in ``docs/badges.md``.
+    """
+    tmp_target = target.with_name(f".{target.name}.tmp")
+    try:
+        tmp_target.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(tmp_target, target)
+    except OSError:
+        try:
+            tmp_target.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _write_badge_sidecars(
     target: Path,
-    payload: dict,
+    badge,
     *,
     force: bool,
     iteration: int | None,
     verbose: bool,
     post_write_warning: str | None = None,
 ) -> int:
-    """Write the badge JSON payload to ``target`` atomically.
+    """Write the badge sidecar pair (shields.io + clauditor extension).
 
-    DEC-011 overwrite policy: if ``target`` exists and ``force`` is
-    ``False``, print the error and return exit 1 without writing.
+    The shields.io endpoint strictly validates its schema and rejects
+    any unknown top-level key with an ``invalid properties: <key>``
+    SVG response. The extension block therefore cannot be embedded;
+    it lives in a sibling ``<target>.clauditor.json`` file. Readers:
 
-    Atomic publication (review pass 2, C2-3): writes to a sibling
-    temp file first, then :func:`os.replace` publishes it into
-    place. A mid-write failure (disk full, EIO) leaves the existing
-    target untouched rather than truncating it to empty.
+    - ``<target>`` is what shields.io fetches. Minimal shape
+      (``schemaVersion``, ``label``, ``message``, ``color``, plus
+      any whitelisted ``--style`` passthroughs).
+    - ``<target>.clauditor.json`` carries the per-layer breakdown,
+      thresholds, iteration number, and ``generated_at`` timestamp
+      for trend-audit / forensic consumers.
 
-    ``post_write_warning`` — optional stderr line printed AFTER a
-    successful write (review pass 2, N2-4). A write-claim message
-    like "wrote lightgrey placeholder" is gated on actual success,
-    not pre-write intent, so collisions or disk errors don't leave
-    a misleading stderr trail.
+    DEC-011 overwrite policy applies to BOTH files as a set. Either
+    target existing without ``--force`` fails the whole write.
 
-    ``iteration=None`` renders the verbose line with a
-    ``(no iteration)`` fragment to signal the DEC-001 lightgrey
-    placeholder path; otherwise ``(iteration N)``.
+    Atomic publication (review pass 2, C2-3): each file is written
+    to a sibling tempfile, then ``os.replace`` publishes it. On
+    partial failure (e.g. first succeeds, second fails), the tmp
+    files are cleaned up and the error is surfaced — but the first
+    file's replace may already have landed. This is a known
+    non-atomicity across two files and is acceptable because badge
+    artifacts are fully regenerable. Document the pair semantics in
+    ``.claude/rules/dual-version-external-schema-embed.md``.
     """
+    extension_target = _extension_path_for(target)
+
     if target.exists() and not force:
         print(
             f"ERROR: {target} already exists (pass --force to overwrite)",
+            file=sys.stderr,
+        )
+        return 1
+    if extension_target.exists() and not force:
+        print(
+            f"ERROR: {extension_target} already exists (pass --force to "
+            "overwrite)",
             file=sys.stderr,
         )
         return 1
@@ -343,30 +394,14 @@ def _write_badge_json(
     # should not error.
     target.parent.mkdir(parents=True, exist_ok=True)
 
-    # Atomic write via sibling tempfile + os.replace (review pass 2,
-    # C2-3). A TOCTOU race between the ``target.exists()`` check and
-    # the rename is still possible under concurrent ``clauditor
-    # badge`` runs, but the artifact is regenerable and the consequence
-    # is a lost update — not data corruption.
-    tmp_target = target.with_name(f".{target.name}.tmp")
     try:
-        # ``ensure_ascii=False`` writes the UTF-8 middle-dot glyph in
-        # the message verbatim (review pass 3, C3-4) so the on-disk
-        # bytes match the sample JSON in ``docs/badges.md``. Shields.io
-        # decodes either form fine.
-        tmp_target.write_text(
-            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
+        _atomic_write_json(target, badge.to_endpoint_json())
+        _atomic_write_json(
+            extension_target, badge.to_clauditor_extension_json()
         )
-        os.replace(tmp_target, target)
     except OSError as exc:
-        # Best-effort cleanup of the tmp file; ignore if already gone.
-        try:
-            tmp_target.unlink()
-        except OSError:
-            pass
         print(
-            f"ERROR: could not write {target}: {exc}",
+            f"ERROR: could not write badge sidecars: {exc}",
             file=sys.stderr,
         )
         return 1
@@ -381,7 +416,7 @@ def _write_badge_json(
             else "(no iteration)"
         )
         print(
-            f"clauditor.badge: wrote {target} {tail}",
+            f"clauditor.badge: wrote {target} + {extension_target.name} {tail}",
             file=sys.stderr,
         )
     return 0
@@ -686,9 +721,9 @@ def cmd_badge(args: argparse.Namespace) -> int:
             "lightgrey 'no data' badge"
         )
 
-    return _write_badge_json(
+    return _write_badge_sidecars(
         target_path,
-        badge.to_endpoint_json(),
+        badge,
         force=args.force,
         iteration=iteration_n,
         verbose=args.verbose,
@@ -709,8 +744,9 @@ def _handle_no_iteration(
     When ``--url-only`` is set, just render the Markdown image line
     (no JSON write). Otherwise compose the lightgrey Badge, emit the
     DEC-021 placeholder warning, and route the write through
-    :func:`_write_badge_json` (which still respects DEC-011 ``--force``
-    — the placeholder does NOT clobber a "real" badge silently).
+    :func:`_write_badge_sidecars` (which still respects DEC-011
+    ``--force`` — the placeholder does NOT clobber a "real" badge
+    silently).
     """
     if args.url_only:
         # --url-only doesn't depend on sidecar state — render and go.
@@ -733,9 +769,9 @@ def _handle_no_iteration(
     # The "wrote lightgrey placeholder" stderr line is deferred to
     # post-write so a collision-without-force exit 1 doesn't leave a
     # false trail (review pass 2, N2-4).
-    return _write_badge_json(
+    return _write_badge_sidecars(
         target_path,
-        badge.to_endpoint_json(),
+        badge,
         force=args.force,
         iteration=None,
         verbose=args.verbose,

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -495,7 +495,14 @@ class TestLayerSemantics:
 
 class TestBadgeSerialization:
     def test_top_level_key_order(self):
-        """Endpoint JSON top-level key order is fixed."""
+        """Shields.io endpoint JSON is minimal — shields-only, no clauditor block.
+
+        Shields.io strictly validates its endpoint schema and rejects
+        any unknown top-level key with an ``invalid properties: <key>``
+        SVG response (verified on 2026-04-22 against the live badge).
+        The clauditor extension lives in a SIBLING file (see
+        :meth:`Badge.to_clauditor_extension_json`).
+        """
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             None,
@@ -510,7 +517,8 @@ class TestBadgeSerialization:
         assert keys[1] == "label"
         assert keys[2] == "message"
         assert keys[3] == "color"
-        assert keys[-1] == "clauditor"
+        # No clauditor extension in the shields.io-facing payload.
+        assert "clauditor" not in result
 
     def test_shields_schema_version_is_camelcase(self):
         """DEC-027: shields.io's field is camelCase ``schemaVersion``."""
@@ -524,11 +532,11 @@ class TestBadgeSerialization:
         )
         result = badge.to_endpoint_json()
         assert result["schemaVersion"] == 1
-        # The snake_case form is reserved for the nested block.
+        # The snake_case form is reserved for the extension file.
         assert "schema_version" not in result
 
-    def test_clauditor_schema_version_is_first_key(self):
-        """DEC-027: nested block obeys json-schema-version first-key rule."""
+    def test_clauditor_extension_schema_version_is_first_key(self):
+        """DEC-027 + json-schema-version.md: extension file's first key."""
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             None,
@@ -537,14 +545,14 @@ class TestBadgeSerialization:
             iteration=1,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        inner_keys = list(result["clauditor"].keys())
+        ext = badge.to_clauditor_extension_json()
+        inner_keys = list(ext.keys())
         assert inner_keys[0] == "schema_version"
-        assert result["clauditor"]["schema_version"] == 1
+        assert ext["schema_version"] == 1
 
-    def test_clauditor_key_order(self):
-        """Inside ``clauditor``: schema_version, skill_name, generated_at,
-        iteration, layers."""
+    def test_clauditor_extension_key_order(self):
+        """Extension file layout: schema_version, skill_name,
+        generated_at, iteration, layers."""
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             None,
@@ -553,13 +561,18 @@ class TestBadgeSerialization:
             iteration=1,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        keys = list(result["clauditor"].keys())
-        assert keys == ["schema_version", "skill_name", "generated_at",
-                        "iteration", "layers"]
+        ext = badge.to_clauditor_extension_json()
+        keys = list(ext.keys())
+        assert keys == [
+            "schema_version",
+            "skill_name",
+            "generated_at",
+            "iteration",
+            "layers",
+        ]
 
     def test_generated_at_z_suffix(self):
-        """DEC-012: generated_at carries the trailing ``Z``."""
+        """DEC-012: generated_at carries the trailing ``Z`` in extension."""
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             None,
@@ -568,8 +581,8 @@ class TestBadgeSerialization:
             iteration=1,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        assert result["clauditor"]["generated_at"].endswith("Z")
+        ext = badge.to_clauditor_extension_json()
+        assert ext["generated_at"].endswith("Z")
 
     def test_variance_omitted_when_absent(self):
         """DEC-003: no variance sidecar → no ``layers.variance`` key."""
@@ -581,8 +594,8 @@ class TestBadgeSerialization:
             iteration=1,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        assert "variance" not in result["clauditor"]["layers"]
+        ext = badge.to_clauditor_extension_json()
+        assert "variance" not in ext["layers"]
 
     def test_l3_omitted_when_grading_absent(self):
         """No grading sidecar → no ``layers.l3`` key."""
@@ -594,9 +607,9 @@ class TestBadgeSerialization:
             iteration=1,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        assert "l3" not in result["clauditor"]["layers"]
-        assert "l1" in result["clauditor"]["layers"]
+        ext = badge.to_clauditor_extension_json()
+        assert "l3" not in ext["layers"]
+        assert "l1" in ext["layers"]
 
     def test_l3_omitted_when_parse_failed(self):
         """DEC-009: L3 parse-failed → ``layers.l3`` omitted AND color red."""
@@ -608,9 +621,10 @@ class TestBadgeSerialization:
             iteration=1,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        assert "l3" not in result["clauditor"]["layers"]
-        assert result["color"] == "red"
+        shields = badge.to_endpoint_json()
+        ext = badge.to_clauditor_extension_json()
+        assert "l3" not in ext["layers"]
+        assert shields["color"] == "red"
 
     def test_l1_omitted_when_no_l1_signal(self):
         """DEC-020: assertions=None → ``layers.l1`` omitted entirely."""
@@ -622,13 +636,15 @@ class TestBadgeSerialization:
             iteration=None,
             generated_at=_GEN_AT,
         )
-        result = badge.to_endpoint_json()
-        assert "l1" not in result["clauditor"]["layers"]
+        ext = badge.to_clauditor_extension_json()
+        assert "l1" not in ext["layers"]
         # And iteration is None (placeholder case).
-        assert result["clauditor"]["iteration"] is None
+        assert ext["iteration"] is None
 
-    def test_style_overrides_alphabetized(self):
-        """DEC-015: ``--style`` passthroughs land alphabetically."""
+    def test_style_overrides_alphabetized_after_color(self):
+        """DEC-015: ``--style`` passthroughs land alphabetically in the
+        shields.io payload (no ``clauditor`` key present to bound them).
+        """
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             None,
@@ -644,10 +660,8 @@ class TestBadgeSerialization:
         )
         result = badge.to_endpoint_json()
         keys = list(result.keys())
-        # After color, before clauditor, in alphabetical order.
         color_idx = keys.index("color")
-        clauditor_idx = keys.index("clauditor")
-        style_slice = keys[color_idx + 1 : clauditor_idx]
+        style_slice = keys[color_idx + 1 :]
         assert style_slice == ["cacheSeconds", "logoSvg", "style"]
         assert result["style"] == "flat"
         assert result["cacheSeconds"] == "3600"
@@ -678,7 +692,7 @@ class TestBadgeSerialization:
         assert badge.label == "review-pr"
 
     def test_payload_is_json_serializable(self):
-        """The returned dict must round-trip through ``json``."""
+        """Both sidecar payloads round-trip through ``json``."""
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             _make_grading_dict(pass_fractions=(True, True, True, True)),
@@ -688,11 +702,13 @@ class TestBadgeSerialization:
             generated_at=_GEN_AT,
             style_overrides={"style": "flat"},
         )
-        raw = json.dumps(badge.to_endpoint_json())
-        round_trip = json.loads(raw)
-        assert round_trip["color"] == "brightgreen"
-        assert round_trip["clauditor"]["skill_name"] == "demo"
-        assert round_trip["clauditor"]["iteration"] == 7
+        shields = json.loads(json.dumps(badge.to_endpoint_json()))
+        ext = json.loads(json.dumps(badge.to_clauditor_extension_json()))
+        assert shields["color"] == "brightgreen"
+        assert shields["style"] == "flat"
+        assert "clauditor" not in shields
+        assert ext["skill_name"] == "demo"
+        assert ext["iteration"] == 7
 
 
 # ---------------------------------------------------------------------------
@@ -808,7 +824,7 @@ class TestDefensiveBranches:
             generated_at=_GEN_AT,
         )
         assert badge.color == "red"
-        assert "l3" not in badge.to_endpoint_json()["clauditor"]["layers"]
+        assert "l3" not in badge.to_clauditor_extension_json()["layers"]
 
     def test_l3_thresholds_non_dict_falls_back_to_defaults(self):
         """Grading dict with ``thresholds`` not a dict → defaults applied."""

--- a/tests/test_cli_badge.py
+++ b/tests/test_cli_badge.py
@@ -297,6 +297,62 @@ class TestCmdBadgeNoIteration:
         data = json.loads(target.read_text())
         assert data["color"] == "lightgrey"
 
+    def test_extension_only_exists_rejects_without_force(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Regression guard for the sidecar-pair ``--force`` policy.
+
+        If a prior run (or a manual git operation) left only the
+        extension file on disk without the shields.io file, re-running
+        ``clauditor badge`` without ``--force`` must still reject:
+        silently overwriting a stale ``<skill>.clauditor.json``
+        alongside a fresh ``<skill>.json`` would ship a mismatched
+        pair to downstream consumers. Exit 1 names the extension file.
+        """
+        skill_md = _write_skill(tmp_path)
+        ext_target = (
+            tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
+        )
+        ext_target.parent.mkdir(parents=True)
+        ext_target.write_text('{"stale-extension": true}\n')
+        monkeypatch.chdir(tmp_path)
+
+        # Main target absent → first guard passes, then second fires.
+        rc = main(["badge", str(skill_md)])
+        assert rc == 1
+
+        err = capsys.readouterr().err
+        assert "demo.clauditor.json" in err
+        assert "already exists" in err
+        # Stale extension untouched.
+        assert ext_target.read_text() == '{"stale-extension": true}\n'
+
+    def test_extension_only_exists_force_overwrites_pair(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``--force`` lets the pair write proceed even when only the
+        extension file pre-existed. Both files land with the fresh
+        lightgrey placeholder content.
+        """
+        skill_md = _write_skill(tmp_path)
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        ext_target = (
+            tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
+        )
+        ext_target.parent.mkdir(parents=True)
+        ext_target.write_text('{"stale-extension": true}\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md), "--force"])
+        assert rc == 0
+
+        # Main file now exists with fresh content.
+        assert json.loads(target.read_text())["color"] == "lightgrey"
+        # Extension file was overwritten with fresh content.
+        ext = json.loads(ext_target.read_text())
+        assert ext["schema_version"] == 1
+        assert ext["skill_name"] == "demo"
+
 
 # ---------------------------------------------------------------------------
 # DEC-016 — explicit --from-iteration N that is missing.

--- a/tests/test_cli_badge.py
+++ b/tests/test_cli_badge.py
@@ -140,7 +140,7 @@ class TestCmdBadgeHappyPath:
     def test_writes_badge_json_default_path(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Default output lands at ``.clauditor/badges/<skill>.json``."""
+        """Default output writes BOTH sidecars at ``.clauditor/badges/``."""
         skill_md = _write_skill(tmp_path)
         _setup_iteration(tmp_path, 1)
         monkeypatch.chdir(tmp_path)
@@ -149,15 +149,24 @@ class TestCmdBadgeHappyPath:
         assert rc == 0
 
         target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        ext_target = tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
         assert target.exists()
-        data = json.loads(target.read_text())
-        # Shields.io contract keys + our nested extension.
-        assert data["schemaVersion"] == 1
-        assert data["label"] == "clauditor"
-        assert data["color"] == "brightgreen"
-        assert data["message"] == "3/3"
-        assert data["clauditor"]["skill_name"] == "demo"
-        assert data["clauditor"]["iteration"] == 1
+        assert ext_target.exists()
+
+        # Shields.io payload: minimal, no ``clauditor`` key (shields.io
+        # rejects unknown top-level fields with "invalid properties").
+        shields = json.loads(target.read_text())
+        assert shields["schemaVersion"] == 1
+        assert shields["label"] == "clauditor"
+        assert shields["color"] == "brightgreen"
+        assert shields["message"] == "3/3"
+        assert "clauditor" not in shields
+
+        # Extension sidecar: carries iteration + layer detail.
+        ext = json.loads(ext_target.read_text())
+        assert ext["skill_name"] == "demo"
+        assert ext["iteration"] == 1
+        assert "l1" in ext["layers"]
 
     def test_writes_badge_json_custom_output(
         self, tmp_path: Path, monkeypatch
@@ -227,11 +236,19 @@ class TestCmdBadgeNoIteration:
         assert rc == 0
 
         target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        ext_target = tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
         assert target.exists()
-        data = json.loads(target.read_text())
-        assert data["color"] == "lightgrey"
-        assert data["message"] == "no data"
-        assert data["clauditor"]["iteration"] is None
+        assert ext_target.exists()
+        # Shields.io payload: minimal, no clauditor key (it rejects
+        # unknown top-level fields with "invalid properties" SVG).
+        shields = json.loads(target.read_text())
+        assert shields["color"] == "lightgrey"
+        assert shields["message"] == "no data"
+        assert "clauditor" not in shields
+        # Extension sidecar: full telemetry.
+        ext = json.loads(ext_target.read_text())
+        assert ext["schema_version"] == 1
+        assert ext["iteration"] is None
 
     def test_emits_dec021_warning(
         self, tmp_path: Path, monkeypatch, capsys


### PR DESCRIPTION
## Problem

After #81 merged to `dev`, both bundled-skill badges on `docs/skills.md` render as grey "invalid properties: clauditor" SVGs instead of the real quality signal. Verified against the live shields.io renderer.

The `#77/#81` rule assumed shields.io would silently ignore unknown top-level keys in the endpoint payload. They do not — the endpoint schema is strictly validated, and our `clauditor` extension block triggered the `invalid properties` error. The badge URL is constant, so the user sees garbage until the JSON is fixed.

## Fix

Split the badge output into a **sibling-file pair**:

| File | Consumer | Contents |
|---|---|---|
| `<skill>.json` | shields.io endpoint fetch | `schemaVersion`, `label`, `message`, `color`, whitelisted `--style` passthroughs. NO `clauditor` key. |
| `<skill>.clauditor.json` | trend-audit / forensic (future) | Full extension block standalone. `schema_version: 1` as first key. Carries layer breakdown, thresholds, iteration number, `generated_at`. |

`Badge.to_endpoint_json()` now returns shields.io-only; new `Badge.to_clauditor_extension_json()` returns the extension. `_write_badge_sidecars` writes both atomically with shared `--force` collision policy (either file existing without `--force` fails the whole write).

## What changed

- `src/clauditor/badge.py` — `to_endpoint_json()` trimmed; new `to_clauditor_extension_json()`.
- `src/clauditor/cli/badge.py` — `_write_badge_json` → `_write_badge_sidecars`; writes both files; `--force` covers the pair.
- `.claude/rules/dual-version-external-schema-embed.md` — rewritten from "embed under a namespace key" → "write a sibling file". Documents the 2026-04-22 shields.io validation discovery as the motivating incident.
- `docs/badges.md` — schema-reference section reshaped to show the two-file pattern with an explanatory note about shields.io's strict validation.
- `.clauditor/badges/*.json` — migrated to the split pair, preserving the real iteration-3 (`/clauditor`) and iteration-4 (`/review-agentskills-spec`) grade scores byte-for-byte. No re-grade needed; only the on-disk layout changed.
- `tests/test_badge.py` + `tests/test_cli_badge.py` — 13 test updates to reflect the split. Added coverage for `--force` applying to the pair, first-key invariant on the extension file, and the shields.io-payload-contains-no-`clauditor`-key regression guard.

## Validation

- `uv run ruff check src/ tests/` — passes.
- `uv run pytest --cov=clauditor --cov-report=term` — **2217 passed**, 1 skipped, **98.18%** overall coverage.
- Manually verified the new shields.io payload shape is valid against the `endpoint` schema.