### PR TITLE
fix(grader): retry once on parse failure + surface line/col/tail (#94)

### DIFF
--- a/scripts/repro_cli_truncation.py
+++ b/scripts/repro_cli_truncation.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Reproduce CLI transport truncation for clauditor#94.
+
+Calls :func:`clauditor.runner._invoke_claude_cli` directly with a prompt
+engineered to elicit a long structured-JSON response (similar to a
+grader verdict). Runs N times, records whether each response parses as
+JSON, captures the final ``result`` message's ``stop_reason`` and token
+counts, and dumps full ``raw_messages`` to a log dir on any truncation.
+
+Usage::
+
+    uv run python scripts/repro_cli_truncation.py --runs 20
+    uv run python scripts/repro_cli_truncation.py --log-dir ./trunc-logs
+
+Exits 0 regardless of truncation outcome — the goal is to gather
+evidence, not gate CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+# The investigation prompt: asks for a long, structured JSON response
+# that mimics the shape of a real L3 grading response. Longer evidence
+# strings + more criteria push output size toward the observed
+# truncation boundary (~700-1000 tokens).
+INVESTIGATION_PROMPT = """You are grading a skill output against 5 criteria. Return ONLY a JSON array with this exact shape (no prose before or after):
+
+[
+  {"criterion": "<criterion text>", "passed": true|false, "evidence": "<2-3 sentences quoting specific passages that justify the verdict>"},
+  ...
+]
+
+Here are the 5 criteria. Invent plausible skill output in your head and grade against each one. Write evidence strings that are at least 200 characters each, quoting specific (imagined) passages from the output.
+
+1. Does the output include a complete project overview with at least 3 paragraphs covering architecture, dependencies, and deployment considerations?
+2. Does the output provide working code examples for every public API endpoint documented, including request/response schemas and error cases?
+3. Does the output identify at least 4 distinct failure modes and explain the mitigation strategy for each, with concrete detection criteria?
+4. Does the output recommend a specific versioning strategy (semver, calver, or custom) with justification based on the project's release cadence?
+5. Does the output conclude with a prioritized list of follow-up tasks, each tagged with effort estimate (S/M/L) and a brief rationale?
+
+Return ONLY the JSON array. No preamble, no markdown fences, no trailing prose."""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=10, help="Number of runs (default: 10)")
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=Path("./trunc-logs"),
+        help="Where to write raw_messages dumps for truncated runs",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Override model (e.g. 'sonnet', 'opus'). Defaults to CLI default.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Per-invocation timeout in seconds (default: 300)",
+    )
+    args = parser.parse_args()
+
+    from clauditor.runner import _invoke_claude_cli, env_without_api_key
+    import os
+
+    args.log_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Running {args.runs} CLI invocations against truncation-prone prompt...")
+    print(f"Log dir for truncations: {args.log_dir}")
+    print(f"Model: {args.model or '(CLI default)'}")
+    print()
+
+    results: list[dict] = []
+    for i in range(args.runs):
+        start = time.monotonic()
+        invoke = _invoke_claude_cli(
+            INVESTIGATION_PROMPT,
+            cwd=None,
+            env=env_without_api_key(os.environ),
+            timeout=args.timeout,
+            claude_bin="claude",
+            model=args.model,
+        )
+        duration = time.monotonic() - start
+
+        # Extract the final result message's stop_reason + usage.
+        stop_reason = None
+        result_msg = None
+        for msg in invoke.raw_messages:
+            if msg.get("type") == "result":
+                result_msg = msg
+                # stop_reason might live under `message` (SDK-style) or
+                # be flat on the result — probe both.
+                stop_reason = (
+                    msg.get("stop_reason")
+                    or (msg.get("message") or {}).get("stop_reason")
+                )
+                break
+
+        # Try to parse the output as JSON to detect truncation.
+        output = invoke.output.strip()
+        # Strip markdown fences defensively (grader prompts get them too).
+        if output.startswith("```"):
+            lines = output.splitlines()
+            output = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+        parse_error: str | None = None
+        parsed_ok = False
+        try:
+            data = json.loads(output)
+            parsed_ok = isinstance(data, list) and len(data) >= 1
+        except json.JSONDecodeError as exc:
+            parse_error = f"{type(exc).__name__}: {exc.msg} at line {exc.lineno} col {exc.colno}"
+
+        output_tail = output[-200:] if len(output) > 200 else output
+        record = {
+            "run": i,
+            "duration_s": round(duration, 2),
+            "exit_code": invoke.exit_code,
+            "output_len": len(invoke.output),
+            "input_tokens": invoke.input_tokens,
+            "output_tokens": invoke.output_tokens,
+            "stop_reason": stop_reason,
+            "parsed_ok": parsed_ok,
+            "parse_error": parse_error,
+            "output_tail": output_tail,
+            "error": invoke.error,
+        }
+        results.append(record)
+
+        status = "OK " if parsed_ok else "FAIL"
+        print(
+            f"  run {i:2d}: {status} "
+            f"exit={invoke.exit_code} "
+            f"tokens={invoke.output_tokens:>4d} "
+            f"stop={stop_reason!r:<20s} "
+            f"dur={duration:.1f}s"
+            + (f"  [{parse_error}]" if parse_error else "")
+        )
+
+        # On truncation, dump full raw_messages for inspection.
+        if not parsed_ok:
+            dump_path = args.log_dir / f"run-{i:02d}-raw.json"
+            dump_path.write_text(
+                json.dumps(
+                    {
+                        "summary": record,
+                        "output_full": invoke.output,
+                        "raw_messages": invoke.raw_messages,
+                        "stream_events": invoke.stream_events,
+                    },
+                    indent=2,
+                )
+            )
+            print(f"         -> dumped raw_messages to {dump_path}")
+
+    # Summary.
+    print()
+    print("=" * 60)
+    ok = sum(1 for r in results if r["parsed_ok"])
+    fail = args.runs - ok
+    print(f"Summary: {ok}/{args.runs} parsed OK, {fail}/{args.runs} failed")
+    if fail > 0:
+        fail_stops = sorted({r["stop_reason"] for r in results if not r["parsed_ok"]}, key=str)
+        fail_tokens = [r["output_tokens"] for r in results if not r["parsed_ok"]]
+        ok_tokens = [r["output_tokens"] for r in results if r["parsed_ok"]]
+        print(f"Failed stop_reasons: {fail_stops}")
+        print(f"Failed output_tokens: {fail_tokens}")
+        print(f"Passed output_tokens: {ok_tokens}")
+
+    # Always write the full summary JSON for post-hoc analysis.
+    summary_path = args.log_dir / "summary.json"
+    summary_path.write_text(json.dumps(results, indent=2))
+    print(f"Full summary: {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -380,11 +380,20 @@ class ExtractionParseError:
 
     ``kind`` is one of:
 
-    - ``"json"`` — the response body could not be parsed as JSON.
+    - ``"json"`` — the response body could not be parsed as JSON (or
+      was empty after fence-stripping). Retry-worthy: transient model
+      decode failure.
+    - ``"shape"`` — the response parsed as valid JSON but with the
+      wrong top-level type (e.g. a list/string/number where a
+      section-keyed dict was expected). NOT retry-worthy: model-
+      protocol bug. Gated separately from ``"json"`` so
+      :func:`_extract_call_with_retry` can treat decode-vs-shape
+      failures differently (clauditor-6cf / #94 Copilot feedback).
     - ``"flat_list"`` — a spec-declared section came back as a flat list
       instead of the expected tier-grouped dict. ``section`` names the
       offending section; ``raw`` carries the full parsed response so the
       CLI layer can attach it to its ``grader:parse:<section>`` assertion.
+      NOT retry-worthy: model-protocol bug.
     """
 
     kind: str
@@ -493,13 +502,16 @@ def parse_extraction_response(
     # The prompt asks for a top-level JSON object keyed by section name.
     # A misbehaving model can return a bare list/string/number — iterating
     # ``.items()`` on that would raise AttributeError mid-parse. Fail
-    # explicitly with a structured parse error instead.
+    # explicitly with a structured parse error instead. ``kind="shape"``
+    # (not ``"json"``) so :func:`_extract_call_with_retry` does not
+    # retry — a response that decodes as valid JSON but with the wrong
+    # top-level type is a model-protocol bug, not a transient hiccup.
     if not isinstance(raw, dict):
         return ExtractionParseResult(
             extracted=ExtractedOutput(),
             parse_errors=[
                 ExtractionParseError(
-                    kind="json",
+                    kind="shape",
                     message=(
                         f"Expected JSON object at top level, got "
                         f"{type(raw).__name__}: {text[:200]}"
@@ -754,7 +766,13 @@ def build_extraction_report_from_text(
         )
 
     parse = parse_extraction_response(response_text, eval_spec)
-    if any(err.kind == "json" for err in parse.parse_errors):
+    # Short-circuit to empty-results on both "json" (decode) and
+    # "shape" (wrong top-level type) — neither leaves us with a
+    # usable ``ExtractedOutput.sections`` to grade. Flat-list
+    # section failures proceed into ``build_extraction_report``
+    # so the per-field schema check still attaches to the other
+    # sections.
+    if any(err.kind in ("json", "shape") for err in parse.parse_errors):
         return ExtractionReport(
             skill_name=skill_name,
             model=model,
@@ -788,8 +806,10 @@ async def _extract_call_with_retry(
 
     Returns ``(response_text, source, input_tokens, output_tokens)`` — the
     final attempt's response text, the transport source, and cumulative
-    token counts across attempts. One retry on JSON decode failure per
-    clauditor-6cf / #94; no retry on flat-list / shape failures, which
+    token counts across attempts. One retry on ``kind == "json"`` (true
+    decode failures + empty-after-fence-strip) per clauditor-6cf / #94;
+    no retry on ``kind == "shape"`` (valid JSON, wrong top-level type)
+    or ``kind == "flat_list"`` (section tiering missing) — both
     indicate a model-protocol bug rather than a transient hiccup.
     """
     from clauditor._anthropic import call_anthropic

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -14,6 +14,13 @@ from clauditor.assertions import AssertionResult, AssertionSet
 from clauditor.formats import get_format
 from clauditor.schemas import EvalSpec
 
+# Grader-orchestrator parse retry (clauditor-6cf / #94). See module
+# docstring of :mod:`clauditor.quality_grader` for the rationale and
+# distinction from transport-layer retries; mirrored here so the L2
+# extract_and_grade / extract_and_report paths inherit the same
+# recovery shape as L3 grade_quality / blind_compare.
+_GRADER_PARSE_RETRY_LIMIT = 2
+
 
 @dataclass
 class ExtractedEntry:
@@ -422,6 +429,25 @@ def _strip_markdown_fence(text: str) -> str:
     return text
 
 
+def describe_json_parse_failure(
+    text: str, exc: json.JSONDecodeError
+) -> str:
+    """Format a grader-response JSON parse failure for operator eyes.
+
+    Includes the decoder's message, position, response length, and a
+    short tail of the bytes so a reader can distinguish malformed-JSON
+    (tail looks like ``]`` / ``}``) from true truncation (tail is
+    mid-content). Used by both :mod:`clauditor.grader` and
+    :mod:`clauditor.quality_grader`. See bead ``clauditor-6cf`` / #94.
+    """
+    tail = text[-120:] if len(text) > 120 else text
+    return (
+        f"Failed to parse grader response as JSON: {exc.msg} "
+        f"at line {exc.lineno} col {exc.colno}. "
+        f"Response was {len(text)} chars; ends with: {tail!r}"
+    )
+
+
 def parse_extraction_response(
     text: str, eval_spec: EvalSpec
 ) -> ExtractionParseResult:
@@ -437,14 +463,26 @@ def parse_extraction_response(
     json_str = _strip_markdown_fence(text)
     try:
         raw = json.loads(json_str.strip())
-    except (json.JSONDecodeError, IndexError):
+    except json.JSONDecodeError as exc:
+        return ExtractionParseResult(
+            extracted=ExtractedOutput(),
+            parse_errors=[
+                ExtractionParseError(
+                    kind="json",
+                    message=describe_json_parse_failure(text, exc),
+                    evidence=text[:200],
+                )
+            ],
+        )
+    except IndexError:
         return ExtractionParseResult(
             extracted=ExtractedOutput(),
             parse_errors=[
                 ExtractionParseError(
                     kind="json",
                     message=(
-                        f"Failed to parse grader response as JSON: "
+                        f"Failed to parse grader response as JSON "
+                        f"(empty or truncated after fence strip): "
                         f"{text[:200]}"
                     ),
                     evidence=text[:200],
@@ -738,6 +776,58 @@ def build_extraction_report_from_text(
     )
 
 
+async def _extract_call_with_retry(
+    prompt: str,
+    eval_spec: EvalSpec,
+    *,
+    model: str,
+    transport: str,
+    ctx: str,
+) -> tuple[str, str, int, int]:
+    """Issue the extraction Anthropic call with parse retry.
+
+    Returns ``(response_text, source, input_tokens, output_tokens)`` — the
+    final attempt's response text, the transport source, and cumulative
+    token counts across attempts. One retry on JSON decode failure per
+    clauditor-6cf / #94; no retry on flat-list / shape failures, which
+    indicate a model-protocol bug rather than a transient hiccup.
+    """
+    from clauditor._anthropic import call_anthropic
+    from clauditor.quality_grader import _emit_parse_retry_notice
+
+    total_input = 0
+    total_output = 0
+    last_text = ""
+    last_source = "api"
+    for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
+        api_result = await call_anthropic(
+            prompt, model=model, max_tokens=4096, transport=transport
+        )
+        total_input += api_result.input_tokens
+        total_output += api_result.output_tokens
+        last_source = api_result.source
+        last_text = (
+            api_result.text_blocks[0] if api_result.text_blocks else ""
+        )
+        if not last_text:
+            # Empty response — retry-worthy.
+            if attempt < _GRADER_PARSE_RETRY_LIMIT - 1:
+                _emit_parse_retry_notice(
+                    ctx, attempt + 2, _GRADER_PARSE_RETRY_LIMIT
+                )
+                continue
+            break
+        parse = parse_extraction_response(last_text, eval_spec)
+        has_json_error = any(err.kind == "json" for err in parse.parse_errors)
+        if not has_json_error:
+            break
+        if attempt < _GRADER_PARSE_RETRY_LIMIT - 1:
+            _emit_parse_retry_notice(
+                ctx, attempt + 2, _GRADER_PARSE_RETRY_LIMIT
+            )
+    return last_text, last_source, total_input, total_output
+
+
 async def extract_and_grade(
     output: str,
     eval_spec: EvalSpec,
@@ -746,22 +836,23 @@ async def extract_and_grade(
 ) -> AssertionSet:
     """Layer 2: Extract structured data with Haiku, then validate against schema.
 
-    Thin async wrapper: builds a prompt, issues one Anthropic call, parses
-    the response, and returns an :class:`AssertionSet`. All verdict logic
+    Thin async wrapper: builds a prompt, issues up to
+    :data:`_GRADER_PARSE_RETRY_LIMIT` Anthropic calls (one retry on
+    malformed-JSON response — see clauditor-6cf / #94), parses the
+    response, and returns an :class:`AssertionSet`. All verdict logic
     lives in the pure helpers :func:`build_extraction_prompt`,
     :func:`parse_extraction_response`, :func:`grade_extraction`, and
     :func:`build_extraction_assertion_set`.
 
     Requires the 'grader' extra: pip install clauditor[grader]
     """
-    from clauditor._anthropic import call_anthropic
-
     prompt = build_extraction_prompt(eval_spec, output)
-    api_result = await call_anthropic(
-        prompt, model=model, max_tokens=4096, transport=transport
-    )
-    response_text = (
-        api_result.text_blocks[0] if api_result.text_blocks else ""
+    response_text, _source, input_tokens, output_tokens = (
+        await _extract_call_with_retry(
+            prompt, eval_spec,
+            model=model, transport=transport,
+            ctx="extract_and_grade",
+        )
     )
     # Note: AssertionSet does not carry transport_source — extract_and_grade's
     # sidecar (``assertions.json``) is unaffected by US-006. The transport
@@ -770,8 +861,8 @@ async def extract_and_grade(
     return build_extraction_assertion_set(
         response_text,
         eval_spec,
-        input_tokens=api_result.input_tokens,
-        output_tokens=api_result.output_tokens,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
     )
 
 
@@ -785,8 +876,10 @@ async def extract_and_report(
 ) -> ExtractionReport:
     """Layer 2 wrapper that returns a field-id-keyed :class:`ExtractionReport`.
 
-    Thin async wrapper: builds a prompt, issues one Anthropic call, parses
-    the response, and aggregates an :class:`ExtractionReport`. All verdict
+    Thin async wrapper: builds a prompt, issues up to
+    :data:`_GRADER_PARSE_RETRY_LIMIT` Anthropic calls (one retry on
+    malformed-JSON response — see clauditor-6cf / #94), parses the
+    response, and aggregates an :class:`ExtractionReport`. All verdict
     logic lives in the pure helpers :func:`build_extraction_prompt`,
     :func:`parse_extraction_response`, :func:`build_extraction_report`, and
     :func:`build_extraction_report_from_text`.
@@ -794,21 +887,20 @@ async def extract_and_report(
     Used by ``cmd_grade`` (US-003) to persist per-field extraction results to
     ``iteration-N/<skill>/extraction.json``.
     """
-    from clauditor._anthropic import call_anthropic
-
     prompt = build_extraction_prompt(eval_spec, output)
-    api_result = await call_anthropic(
-        prompt, model=model, max_tokens=4096, transport=transport
-    )
-    response_text = (
-        api_result.text_blocks[0] if api_result.text_blocks else ""
+    response_text, source, input_tokens, output_tokens = (
+        await _extract_call_with_retry(
+            prompt, eval_spec,
+            model=model, transport=transport,
+            ctx="extract_and_report",
+        )
     )
     return build_extraction_report_from_text(
         response_text,
         eval_spec,
         skill_name=skill_name,
         model=model,
-        input_tokens=api_result.input_tokens,
-        output_tokens=api_result.output_tokens,
-        transport_source=api_result.source,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        transport_source=source,
     )

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -483,21 +483,6 @@ def parse_extraction_response(
                 )
             ],
         )
-    except IndexError:
-        return ExtractionParseResult(
-            extracted=ExtractedOutput(),
-            parse_errors=[
-                ExtractionParseError(
-                    kind="json",
-                    message=(
-                        f"Failed to parse grader response as JSON "
-                        f"(empty or truncated after fence strip): "
-                        f"{text[:200]}"
-                    ),
-                    evidence=text[:200],
-                )
-            ],
-        )
 
     # The prompt asks for a top-level JSON object keyed by section name.
     # A misbehaving model can return a bare list/string/number — iterating

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -333,11 +333,6 @@ def _parse_blind_response_verbose(
         data = json.loads(json_str.strip())
     except json.JSONDecodeError as exc:
         return None, describe_json_parse_failure(text, exc)
-    except IndexError:
-        return None, (
-            "Failed to parse blind judge response as JSON "
-            f"(empty after fence strip): response was {len(text)} chars"
-        )
 
     if not isinstance(data, dict):
         return None, None
@@ -865,11 +860,6 @@ def _parse_grading_response_verbose(
         data = json.loads(json_str.strip())
     except json.JSONDecodeError as exc:
         return [], describe_json_parse_failure(text, exc)
-    except IndexError:
-        return [], (
-            "Failed to parse grader response as JSON "
-            f"(empty after fence strip): response was {len(text)} chars"
-        )
 
     if not isinstance(data, list):
         return [], None

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -1119,17 +1119,33 @@ async def grade_quality(
             api_result.text_blocks[0] if api_result.text_blocks else ""
         )
         # Decide retry based on the parse outcome, not the final
-        # GradingReport — alignment failures raise ValueError below
-        # and must NOT be retried. Pass-through on success; retry on
-        # JSON / shape / empty-text failures when attempts remain.
+        # GradingReport. Mirrors :func:`_call_blind_side_with_retry` so
+        # the L3 grader has consistent retry semantics across
+        # grade_quality and blind_compare:
+        # - Alignment failure (ValueError): NOT retry-worthy — the
+        #   judge returned a structurally valid but positionally-
+        #   misaligned result set; a retry won't fix a prompt-design
+        #   bug. Let ``build_grading_report`` classify it.
+        # - True decode failure (``parse_error is not None``): retry-
+        #   worthy — transient model hiccup.
+        # - Empty response (``last_response_text == ""``): retry-
+        #   worthy — transient; the model may just have dropped the
+        #   text block.
+        # - Shape failure (valid JSON but top-level not a list:
+        #   ``parse_error is None`` and ``results == []`` and
+        #   ``last_response_text != ""``): NOT retry-worthy — model-
+        #   protocol bug, same rationale as blind_compare and
+        #   ``_extract_call_with_retry``.
         try:
-            results, _ = _parse_grading_response_verbose(
+            results, parse_error = _parse_grading_response_verbose(
                 last_response_text, eval_spec.grading_criteria
             )
         except ValueError:
             break  # alignment failure — let build_grading_report classify
-        if last_response_text and results:
+        if results:
             break  # success
+        if last_response_text and parse_error is None:
+            break  # shape failure — model-protocol bug, not transient
         if attempt < _GRADER_PARSE_RETRY_LIMIT - 1:
             _emit_parse_retry_notice(
                 "grade_quality", attempt + 2, _GRADER_PARSE_RETRY_LIMIT

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -10,6 +10,7 @@ import datetime
 import json
 import math
 import random
+import sys
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
@@ -25,6 +26,18 @@ DEFAULT_GRADING_MODEL = "claude-sonnet-4-6"
 # Indirection so tests can patch blind_compare timing without affecting
 # the asyncio event loop's own time.monotonic() calls.
 _monotonic = time.monotonic
+
+# Grader-orchestrator parse retry (clauditor-6cf / #94). The model
+# occasionally emits malformed JSON (unescaped quotes in evidence
+# strings, incomplete structures) at ~5% rate; one retry with the same
+# prompt catches the transient hiccup without a structural schema
+# change. This is distinct from :func:`clauditor._anthropic.call_anthropic`'s
+# retry ladder — that ladder handles transport-layer errors
+# (rate-limit, 5xx); this retry handles output-quality errors
+# (malformed JSON) that pass the transport contract but fail the
+# grader's parse. Retries are NOT triggered on alignment failures —
+# those indicate a prompt-design bug, not a model hiccup.
+_GRADER_PARSE_RETRY_LIMIT = 2
 
 
 @dataclass
@@ -293,14 +306,20 @@ def build_blind_prompt(
     )
 
 
-def parse_blind_response(text: str) -> dict | None:
-    """Parse the judge's JSON response for blind A/B comparison.
+def _parse_blind_response_verbose(
+    text: str,
+) -> tuple[dict | None, str | None]:
+    """Same contract as :func:`parse_blind_response` plus a parse-error
+    description for retry / diagnostics.
 
-    Pure function (no I/O). Mirrors :func:`parse_grading_response` style —
-    tries raw JSON first, then falls back to stripping markdown fences.
-    Returns ``None`` on malformed input; :func:`blind_compare` handles
-    graceful failure.
+    Returns ``(data, None)`` on success, ``(None, description)`` on JSON
+    decode failure (with line/col + response tail), and ``(None, None)``
+    on shape failure (top-level not a dict, or missing required keys) —
+    shape failures indicate a model-protocol bug, not a transient
+    hiccup, so retry is unlikely to help.
     """
+    from clauditor.grader import describe_json_parse_failure
+
     json_str = text
     if "```" in json_str:
         if "```json" in json_str:
@@ -312,15 +331,33 @@ def parse_blind_response(text: str) -> dict | None:
 
     try:
         data = json.loads(json_str.strip())
-    except (json.JSONDecodeError, IndexError):
-        return None
+    except json.JSONDecodeError as exc:
+        return None, describe_json_parse_failure(text, exc)
+    except IndexError:
+        return None, (
+            "Failed to parse blind judge response as JSON "
+            f"(empty after fence strip): response was {len(text)} chars"
+        )
 
     if not isinstance(data, dict):
-        return None
+        return None, None
     required = ("preference", "score_1", "score_2", "confidence", "reasoning")
     if not all(key in data for key in required):
-        return None
-    return data
+        return None, None
+    return data, None
+
+
+def parse_blind_response(text: str) -> dict | None:
+    """Parse the judge's JSON response for blind A/B comparison.
+
+    Pure function (no I/O). Mirrors :func:`parse_grading_response` style —
+    tries raw JSON first, then falls back to stripping markdown fences.
+    Returns ``None`` on malformed input; :func:`blind_compare` handles
+    graceful failure.
+
+    Thin wrapper around :func:`_parse_blind_response_verbose`.
+    """
+    return _parse_blind_response_verbose(text)[0]
 
 
 # Legacy alias — the helper was private pre-US-005. Keep so existing
@@ -539,6 +576,55 @@ def _build_blind_prompt_for_mapping(
     return build_blind_prompt(user_prompt, slot_1, slot_2, rubric_hint)
 
 
+async def _call_blind_side_with_retry(
+    prompt: str,
+    *,
+    model: str,
+    transport: str,
+    side_label: str,
+) -> tuple[dict | None, str, str, int, int]:
+    """Run one side of a blind-compare judge with parse retry.
+
+    Returns ``(parsed, text, source, input_tokens, output_tokens)`` — the
+    parsed verdict dict (or ``None`` on shape failure), the final
+    attempt's response text, the transport source, and the cumulative
+    token counts across attempts. One retry on JSON decode failure per
+    clauditor-6cf / #94; no retry on shape failure (missing required
+    keys) since that indicates a model-protocol bug.
+    """
+    from clauditor._anthropic import call_anthropic
+
+    total_input = 0
+    total_output = 0
+    last_text = ""
+    last_source = "api"
+    parsed: dict | None = None
+    for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
+        r = await call_anthropic(
+            prompt, model=model, max_tokens=2048, transport=transport
+        )
+        total_input += r.input_tokens
+        total_output += r.output_tokens
+        last_source = r.source
+        last_text = r.text_blocks[0] if r.text_blocks else ""
+        parsed, parse_err = _parse_blind_response_verbose(last_text)
+        if parsed is not None:
+            break
+        # Retry only on decode failures (parse_err populated). Shape
+        # failures (parse_err is None, parsed is None) mean the model
+        # returned valid JSON but missing required keys — not a
+        # transient hiccup.
+        if parse_err is None:
+            break
+        if attempt < _GRADER_PARSE_RETRY_LIMIT - 1:
+            _emit_parse_retry_notice(
+                f"blind_compare.{side_label}",
+                attempt + 2,
+                _GRADER_PARSE_RETRY_LIMIT,
+            )
+    return parsed, last_text, last_source, total_input, total_output
+
+
 async def blind_compare(
     user_prompt: str,
     output_a: str,
@@ -558,40 +644,42 @@ async def blind_compare(
     disagreement on the winner yields ``preference="tie"`` with
     ``position_agreement=False``.
 
+    Each side retries once on JSON decode failure (clauditor-6cf / #94).
+    Retries fire independently: if side 1 parses on the first attempt
+    but side 2 needs a retry, only side 2 is re-invoked.
+
     Requires the 'grader' extra: pip install clauditor[grader]
     """
     import asyncio as _asyncio
 
-    from clauditor._anthropic import call_anthropic
     _validate_blind_inputs(user_prompt, output_a, output_b)
     m1, m2 = _pick_blind_mappings(rng)
     args = (user_prompt, output_a, output_b, rubric_hint)
     p1 = _build_blind_prompt_for_mapping(m1, *args)
     p2 = _build_blind_prompt_for_mapping(m2, *args)
     start = _monotonic()
-    r1, r2 = await _asyncio.gather(
-        call_anthropic(p1, model=model, max_tokens=2048, transport=transport),
-        call_anthropic(p2, model=model, max_tokens=2048, transport=transport),
+    side1, side2 = await _asyncio.gather(
+        _call_blind_side_with_retry(
+            p1, model=model, transport=transport, side_label="side1"
+        ),
+        _call_blind_side_with_retry(
+            p2, model=model, transport=transport, side_label="side2"
+        ),
     )
     duration = _monotonic() - start
-    # Pre-refactor semantics: take the FIRST text block only so downstream
-    # parsers see the same string they did before ``_extract_result``
-    # started joining blocks.
-    t1 = r1.text_blocks[0] if r1.text_blocks else ""
-    t2 = r2.text_blocks[0] if r2.text_blocks else ""
+    parsed1, t1, src1, in1, out1 = side1
+    parsed2, t2, src2, in2, out2 = side2
     # DEC-018: transport_source reflects the underlying Anthropic call(s).
     # When the two parallel judges disagree (API + CLI — unlikely but
     # possible in an ``auto`` fallback race), stamp ``"mixed"`` so the
     # audit trail surfaces that the report isn't purely one transport.
-    transport_source = (
-        r1.source if r1.source == r2.source else "mixed"
-    )
+    transport_source = src1 if src1 == src2 else "mixed"
     return combine_blind_results(
-        parsed1=parse_blind_response(t1), parsed2=parse_blind_response(t2),
+        parsed1=parsed1, parsed2=parsed2,
         text1=t1, text2=t2,
         run1_mapping=m1, run2_mapping=m2, model=model,
-        input_tokens=r1.input_tokens + r2.input_tokens,
-        output_tokens=r1.output_tokens + r2.output_tokens,
+        input_tokens=in1 + in2,
+        output_tokens=out1 + out2,
         duration_seconds=duration,
         transport_source=transport_source,
     )
@@ -741,20 +829,26 @@ def _criterion_id(entry: object) -> str:
     return ""
 
 
-def parse_grading_response(
+def _parse_grading_response_verbose(
     text: str, criteria: list
-) -> list[GradingResult]:
-    """Parse a JSON grading response into GradingResult objects.
+) -> tuple[list[GradingResult], str | None]:
+    """Same contract as :func:`parse_grading_response` plus a parse-error
+    description for retry / diagnostics.
 
-    Handles both raw JSON and markdown-wrapped JSON (```json...```).
-    Returns an empty list on parse failure.
+    Returns ``(results, None)`` on success and ``([], description)`` when
+    ``json.loads`` fails — the description includes the decoder's
+    position + a tail of the response so a reader can tell malformed
+    JSON from true truncation (see
+    :func:`clauditor.grader.describe_json_parse_failure`).
+    Returns ``([], None)`` when the top-level value is not a list, so
+    the caller's "no results" branch still fires for shape errors.
 
-    Hard-fails with :class:`ValueError` when the judge returns a result
-    set that does not positionally align with ``criteria`` by expected
-    text — the stable-id assignment is positional (DEC-001 / #25), so
-    a reordered, dropped, or extra result would silently mis-label the
-    audit history. FIX-10: mismatch must be surfaced, not swallowed.
+    Alignment failures still raise :class:`ValueError` — the judge
+    returned a structurally valid but positionally-misaligned result
+    set, which indicates a prompt-design bug (not a transient model
+    hiccup) and should not be retried.
     """
+    from clauditor.grader import describe_json_parse_failure
     from clauditor.schemas import criterion_text
 
     json_str = text
@@ -769,11 +863,16 @@ def parse_grading_response(
 
     try:
         data = json.loads(json_str.strip())
-    except (json.JSONDecodeError, IndexError):
-        return []
+    except json.JSONDecodeError as exc:
+        return [], describe_json_parse_failure(text, exc)
+    except IndexError:
+        return [], (
+            "Failed to parse grader response as JSON "
+            f"(empty after fence strip): response was {len(text)} chars"
+        )
 
     if not isinstance(data, list):
-        return []
+        return [], None
 
     # FIX-10: validate alignment before positional zip. Only filter out
     # non-dict entries up front so length comparisons mean what we think.
@@ -823,7 +922,28 @@ def parse_grading_response(
             )
         )
 
-    return results
+    return results, None
+
+
+def parse_grading_response(
+    text: str, criteria: list
+) -> list[GradingResult]:
+    """Parse a JSON grading response into GradingResult objects.
+
+    Handles both raw JSON and markdown-wrapped JSON (```json...```).
+    Returns an empty list on parse failure.
+
+    Hard-fails with :class:`ValueError` when the judge returns a result
+    set that does not positionally align with ``criteria`` by expected
+    text — the stable-id assignment is positional (DEC-001 / #25), so
+    a reordered, dropped, or extra result would silently mis-label the
+    audit history. FIX-10: mismatch must be surfaced, not swallowed.
+
+    Thin wrapper around :func:`_parse_grading_response_verbose` — the
+    verbose variant exposes a parse-error description for retry /
+    diagnostic use by :func:`build_grading_report`.
+    """
+    return _parse_grading_response_verbose(text, criteria)[0]
 
 
 def _grading_failure_report(
@@ -906,7 +1026,7 @@ def build_grading_report(
             **common,
         )
     try:
-        results = parse_grading_response(
+        results, parse_error = _parse_grading_response_verbose(
             response_text, eval_spec.grading_criteria
         )
     except ValueError as exc:
@@ -917,10 +1037,15 @@ def build_grading_report(
             **common,
         )
     if not results:
+        reasoning = parse_error or (
+            "Grader response parsed as JSON but top-level value was not "
+            f"an array (expected list of criterion verdicts); response "
+            f"was {len(response_text)} chars"
+        )
         return _grading_failure_report(
             eval_spec,
             evidence=response_text[:200],
-            reasoning="Failed to parse grader response as JSON",
+            reasoning=reasoning,
             **common,
         )
     return GradingReport(
@@ -936,6 +1061,22 @@ def build_grading_report(
     )
 
 
+def _emit_parse_retry_notice(ctx: str, attempt: int, total: int) -> None:
+    """Write a one-line stderr notice when a grader call is being retried
+    due to a parse failure (clauditor-6cf / #94).
+
+    Kept separate from the transport-layer stderr notices emitted by
+    :mod:`clauditor._anthropic` so operators can distinguish
+    "retrying because the transport hiccuped" from "retrying because
+    the model emitted bad JSON".
+    """
+    print(
+        f"clauditor.{ctx}: grader response did not parse; "
+        f"retrying ({attempt}/{total})",
+        file=sys.stderr,
+    )
+
+
 async def grade_quality(
     output: str,
     eval_spec: EvalSpec,
@@ -945,10 +1086,15 @@ async def grade_quality(
 ) -> GradingReport:
     """Layer 3: Grade skill output against rubric criteria using an LLM.
 
-    Thin async wrapper: builds a prompt, issues one Anthropic call, parses
-    the response, and returns a :class:`GradingReport`. All heavy lifting
-    lives in the pure helpers :func:`build_grading_prompt` and
-    :func:`parse_grading_response`.
+    Thin async wrapper: builds a prompt, issues up to
+    :data:`_GRADER_PARSE_RETRY_LIMIT` Anthropic calls (one retry on
+    malformed-JSON response — see clauditor-6cf / #94), parses the
+    response, and returns a :class:`GradingReport`. Token counts and
+    duration accumulate across attempts. Retry is NOT triggered on
+    alignment failures (prompt-design bug, not a transient hiccup).
+
+    All heavy lifting lives in the pure helpers
+    :func:`build_grading_prompt` and :func:`parse_grading_response`.
 
     Requires the 'grader' extra: pip install clauditor[grader]
     """
@@ -958,23 +1104,47 @@ async def grade_quality(
     prompt = build_grading_prompt(eval_spec, output)
 
     start = _monotonic()
-    api_result = await call_anthropic(
-        prompt, model=model, max_tokens=4096, transport=transport
-    )
-    duration = _monotonic() - start
+    total_input_tokens = 0
+    total_output_tokens = 0
+    last_response_text = ""
+    last_source = "api"
+    for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
+        api_result = await call_anthropic(
+            prompt, model=model, max_tokens=4096, transport=transport
+        )
+        total_input_tokens += api_result.input_tokens
+        total_output_tokens += api_result.output_tokens
+        last_source = api_result.source
+        last_response_text = (
+            api_result.text_blocks[0] if api_result.text_blocks else ""
+        )
+        # Decide retry based on the parse outcome, not the final
+        # GradingReport — alignment failures raise ValueError below
+        # and must NOT be retried. Pass-through on success; retry on
+        # JSON / shape / empty-text failures when attempts remain.
+        try:
+            results, _ = _parse_grading_response_verbose(
+                last_response_text, eval_spec.grading_criteria
+            )
+        except ValueError:
+            break  # alignment failure — let build_grading_report classify
+        if last_response_text and results:
+            break  # success
+        if attempt < _GRADER_PARSE_RETRY_LIMIT - 1:
+            _emit_parse_retry_notice(
+                "grade_quality", attempt + 2, _GRADER_PARSE_RETRY_LIMIT
+            )
 
-    response_text = (
-        api_result.text_blocks[0] if api_result.text_blocks else ""
-    )
+    duration = _monotonic() - start
     return build_grading_report(
-        response_text,
+        last_response_text,
         eval_spec,
         model=model,
         thresholds=thresholds,
         duration=duration,
-        input_tokens=api_result.input_tokens,
-        output_tokens=api_result.output_tokens,
-        transport_source=api_result.source,
+        input_tokens=total_input_tokens,
+        output_tokens=total_output_tokens,
+        transport_source=last_source,
     )
 
 

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1221,13 +1221,23 @@ class TestExtractAndReportEmptyResponse:
             ],
         )
 
-        fake_response = MagicMock()
-        fake_response.content = []
-        fake_response.usage.input_tokens = 10
-        fake_response.usage.output_tokens = 3
+        # Parse retry (clauditor-6cf / #94): empty content triggers one
+        # retry. Provide 2 empty responses; the final report should
+        # still carry the "no text blocks" parse error and sum tokens
+        # across attempts.
+        empty_a = MagicMock()
+        empty_a.content = []
+        empty_a.usage.input_tokens = 10
+        empty_a.usage.output_tokens = 3
+        empty_b = MagicMock()
+        empty_b.content = []
+        empty_b.usage.input_tokens = 11
+        empty_b.usage.output_tokens = 4
 
         fake_client = MagicMock()
-        fake_client.messages.create = AsyncMock(return_value=fake_response)
+        fake_client.messages.create = AsyncMock(
+            side_effect=[empty_a, empty_b]
+        )
 
         with patch(
             "anthropic.AsyncAnthropic", return_value=fake_client
@@ -1239,8 +1249,8 @@ class TestExtractAndReportEmptyResponse:
         assert report.parse_errors
         assert "no text blocks" in report.parse_errors[0]
         assert report.results == []
-        assert report.input_tokens == 10
-        assert report.output_tokens == 3
+        assert report.input_tokens == 21
+        assert report.output_tokens == 7
 
     @pytest.mark.asyncio
     async def test_extract_and_grade_handles_empty_content(self) -> None:
@@ -1282,6 +1292,119 @@ class TestExtractAndReportEmptyResponse:
         assert result.results
         assert result.results[0].name == "grader:parse"
         assert "no text blocks" in result.results[0].message
+
+
+class TestExtractAndReportParseRetry:
+    """Parse retry (clauditor-6cf / #94): L2 orchestrators retry once on
+    JSON decode failure. Parallel to
+    :class:`tests.test_quality_grader.TestGradeQuality`'s retry tests."""
+
+    def _minimal_spec(self) -> EvalSpec:
+        return EvalSpec(
+            skill_name="s",
+            sections=[
+                SectionRequirement(
+                    name="Venues",
+                    tiers=[
+                        TierRequirement(
+                            label="primary",
+                            fields=[
+                                FieldRequirement(
+                                    name="venue_name", id="v1"
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_retries_on_malformed_json(self, capsys):
+        from clauditor.grader import extract_and_report
+
+        spec = self._minimal_spec()
+        good_payload = {
+            "Venues": {"primary": [{"venue_name": "A"}]}
+        }
+        bad = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        bad.content = [MagicMock(type="text", text="definitely not json")]
+        good = MagicMock(usage=MagicMock(input_tokens=100, output_tokens=50))
+        good.content = [
+            MagicMock(type="text", text=json.dumps(good_payload))
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=[bad, good])
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await extract_and_report("out", spec, skill_name="s")
+        # Retry succeeded → parse_errors empty, tokens accumulated.
+        assert report.parse_errors == []
+        assert report.input_tokens == 110
+        assert report.output_tokens == 55
+        # Stderr records the retry.
+        captured = capsys.readouterr()
+        assert "extract_and_report" in captured.err
+        assert "retrying" in captured.err.lower()
+
+    @pytest.mark.asyncio
+    async def test_extract_and_grade_retries_on_malformed_json(self, capsys):
+        from clauditor.grader import extract_and_grade
+
+        spec = self._minimal_spec()
+        good_payload = {
+            "Venues": {"primary": [{"venue_name": "A"}]}
+        }
+        bad = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        bad.content = [MagicMock(type="text", text="oh no not json")]
+        good = MagicMock(usage=MagicMock(input_tokens=100, output_tokens=50))
+        good.content = [
+            MagicMock(type="text", text=json.dumps(good_payload))
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=[bad, good])
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            result = await extract_and_grade("out", spec)
+        # Retry succeeded → no grader:parse failure assertion.
+        assert not any(r.name == "grader:parse" for r in result.results)
+        assert result.input_tokens == 110
+        assert result.output_tokens == 55
+        captured = capsys.readouterr()
+        assert "extract_and_grade" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_no_retry_on_success(self):
+        from clauditor.grader import extract_and_report
+
+        spec = self._minimal_spec()
+        good_payload = {"Venues": {"primary": [{"venue_name": "A"}]}}
+        good = MagicMock(usage=MagicMock(input_tokens=100, output_tokens=50))
+        good.content = [
+            MagicMock(type="text", text=json.dumps(good_payload))
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=good)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            await extract_and_report("out", spec, skill_name="s")
+        assert mock_client.messages.create.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_both_attempts_fail(self):
+        from clauditor.grader import extract_and_report
+
+        spec = self._minimal_spec()
+        bad_a = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        bad_a.content = [MagicMock(type="text", text="junk")]
+        bad_b = MagicMock(usage=MagicMock(input_tokens=11, output_tokens=6))
+        bad_b.content = [MagicMock(type="text", text="still junk")]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=[bad_a, bad_b])
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await extract_and_report("out", spec, skill_name="s")
+        assert report.parse_errors
+        # C: the detailed error message (line/col/ends-with) propagates.
+        assert any("at line" in err for err in report.parse_errors)
+        assert report.input_tokens == 21
+        assert report.output_tokens == 11
 
 
 class TestExtractAndReportHappyPath:
@@ -1723,6 +1846,60 @@ class TestStripMarkdownFence:
         # Only a single ``` with no closing partner: fallback to input.
         text = 'hello ``` world'
         assert _strip_markdown_fence(text) == text
+
+
+class TestDescribeJsonParseFailure:
+    """Pure helper: grader JSON parse failure → operator-readable string.
+
+    C (clauditor-6cf / #94): this is the shared error-description helper
+    used by both ``clauditor.grader`` and ``clauditor.quality_grader``.
+    """
+
+    def test_includes_decoder_position_and_length(self):
+        from clauditor.grader import describe_json_parse_failure
+
+        text = '{"broken": '  # trailing
+        try:
+            json.loads(text)
+        except json.JSONDecodeError as exc:
+            msg = describe_json_parse_failure(text, exc)
+        assert "at line" in msg
+        assert "col" in msg
+        assert f"{len(text)} chars" in msg
+        assert "ends with" in msg
+
+    def test_tail_visible_for_malformed_but_complete(self):
+        """The tail should expose the final bytes so a reader can tell
+        malformed-JSON (tail is ``]`` / ``}``) from true truncation
+        (tail is mid-content)."""
+        from clauditor.grader import describe_json_parse_failure
+
+        # JSON array closed but with unescaped interior quote — the
+        # tail must include the closing bracket so the reader knows
+        # this wasn't truncated.
+        text = '[{"k":"v with "bad" quote"}]'
+        try:
+            json.loads(text)
+        except json.JSONDecodeError as exc:
+            msg = describe_json_parse_failure(text, exc)
+        assert "]" in msg  # closing bracket surfaces in tail
+
+    def test_tail_truncated_for_long_responses(self):
+        """Long responses should only show a trailing window, not the
+        whole text, so the error stays one line of readable output."""
+        from clauditor.grader import describe_json_parse_failure
+
+        # 2KB of whitespace followed by broken JSON.
+        filler = " " * 2000
+        text = filler + "{"
+        try:
+            json.loads(text)
+        except json.JSONDecodeError as exc:
+            msg = describe_json_parse_failure(text, exc)
+        # The full text's length is recorded …
+        assert f"{len(text)} chars" in msg
+        # … but the rendered message itself is not 2KB long.
+        assert len(msg) < 500
 
 
 class TestBuildExtractionPromptWithOutput:

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1388,6 +1388,29 @@ class TestExtractAndReportParseRetry:
         assert mock_client.messages.create.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_extract_and_report_no_retry_on_shape_failure(self):
+        """Parse retry (clauditor-6cf / #94, Copilot feedback on PR #98):
+        a response that decodes as valid JSON but with the wrong top-
+        level type (list/string/number instead of section-keyed dict)
+        is tagged ``kind="shape"`` and must NOT be retried. Mirrors
+        ``grade_quality``'s shape-vs-decode split."""
+        from clauditor.grader import extract_and_report
+
+        spec = self._minimal_spec()
+        # Valid JSON, but a bare list where a dict was expected.
+        resp = MagicMock(usage=MagicMock(input_tokens=50, output_tokens=10))
+        resp.content = [MagicMock(type="text", text='["not", "a", "dict"]')]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=resp)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await extract_and_report("out", spec, skill_name="s")
+        assert mock_client.messages.create.await_count == 1
+        assert report.parse_errors
+        assert any(
+            "top level" in err.lower() for err in report.parse_errors
+        )
+
+    @pytest.mark.asyncio
     async def test_extract_and_report_both_attempts_fail(self):
         from clauditor.grader import extract_and_report
 
@@ -2028,13 +2051,19 @@ class TestParseExtractionResponse:
         structured parse error, not crash with AttributeError on
         ``raw.items()``. Guards against a misbehaving grader that
         returns a bare list/string/number/bool/null.
+
+        ``kind == "shape"`` (not ``"json"``) so
+        :func:`_extract_call_with_retry` does not retry — the response
+        decoded cleanly; the top-level type is wrong, which is a
+        model-protocol bug (clauditor-6cf / #94 Copilot feedback on
+        PR #98).
         """
         spec = _make_spec()
         result = parse_extraction_response(payload, spec)
         assert not result.success
         assert len(result.parse_errors) == 1
         err = result.parse_errors[0]
-        assert err.kind == "json"
+        assert err.kind == "shape"
         assert "Expected JSON object at top level" in err.message
         assert err.evidence == payload[:200]
 

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -2093,6 +2093,42 @@ class TestBlindCompare:
         assert report.position_agreement is False
         assert "run-2" in report.reasoning
 
+    @pytest.mark.asyncio
+    async def test_blind_compare_no_retry_on_shape_failure(self):
+        """Parse retry (clauditor-6cf / #94, Copilot feedback on PR #98):
+        a blind judge response that is valid JSON but missing required
+        keys (shape failure) must NOT be retried — covers the
+        ``_call_blind_side_with_retry`` ``parse_err is None`` break
+        branch. Mirrors ``grade_quality``'s shape-vs-decode split."""
+        # Valid JSON dict, but missing required fields (no "preference").
+        shape_bad = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        shape_bad.content = [
+            MagicMock(type="text", text='{"wrong": "keys"}')
+        ]
+        ok = _blind_response("1", confidence=0.8, score_1=0.9, score_2=0.3)
+
+        async def dispatcher(**kwargs):
+            prompt = kwargs["messages"][0]["content"]
+            r1_block = prompt.split("<response_1>", 1)[1].split(
+                "</response_1>", 1
+            )[0]
+            # Seed 1, run-1 "ab->12": a-text in response_1 slot → shape_bad.
+            if "a-text" in r1_block:
+                return shape_bad
+            return ok
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=dispatcher)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await blind_compare(
+                "q", "a-text", "b-text", rng=random.Random(1)
+            )
+        # Shape failure must NOT retry — exactly 2 calls total (one per
+        # side, no retry on side1 despite its shape failure).
+        assert mock_client.messages.create.await_count == 2
+        # Run-1 side failed shape, run-2 parsed — partial-parse path.
+        assert report.position_agreement is False
+
 
 class TestParseBlindResponse:
     def _full(self, **overrides):

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -961,6 +961,112 @@ class TestGradeQuality:
         assert report.input_tokens == 500
         assert report.output_tokens == 200
 
+    @pytest.mark.asyncio
+    async def test_grade_quality_retries_on_malformed_json(self, capsys):
+        """Parse retry (clauditor-6cf / #94): first call returns malformed
+        JSON, second returns valid JSON → final report is the passing
+        verdict, tokens sum across both attempts, stderr records the
+        retry."""
+        spec = _make_spec()
+        good_data = [
+            {
+                "criterion": criterion_text(c), "passed": True,
+                "score": 0.9, "evidence": "e", "reasoning": "r",
+            }
+            for c in spec.grading_criteria
+        ]
+        bad = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        bad.content = [MagicMock(type="text", text="not json at all")]
+        good = MagicMock(usage=MagicMock(input_tokens=100, output_tokens=50))
+        good.content = [
+            MagicMock(type="text", text=json.dumps(good_data))
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=[bad, good])
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await grade_quality("output", spec)
+        assert report.passed is True
+        assert len(report.results) == 3
+        # Tokens accumulated across both attempts.
+        assert report.input_tokens == 110
+        assert report.output_tokens == 55
+        # Stderr recorded the retry.
+        captured = capsys.readouterr()
+        assert "grade_quality" in captured.err
+        assert "retrying" in captured.err.lower()
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_no_retry_on_success(self):
+        """Parse retry (clauditor-6cf / #94): a clean first response must
+        NOT trigger a retry — only one API call is made."""
+        spec = _make_spec()
+        good_data = [
+            {
+                "criterion": criterion_text(c), "passed": True,
+                "score": 0.9, "evidence": "e", "reasoning": "r",
+            }
+            for c in spec.grading_criteria
+        ]
+        good = MagicMock(usage=MagicMock(input_tokens=100, output_tokens=50))
+        good.content = [
+            MagicMock(type="text", text=json.dumps(good_data))
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=good)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            await grade_quality("output", spec)
+        assert mock_client.messages.create.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_does_not_retry_on_alignment_failure(self):
+        """Parse retry (clauditor-6cf / #94): alignment failures (wrong
+        number of results) indicate a prompt-design bug and must NOT be
+        retried. Regression guard so we don't waste API calls on a
+        non-transient failure."""
+        spec = _make_spec()  # 3 criteria
+        # Only 1 result returned — raises ValueError in the verbose
+        # parser, which the orchestrator treats as "don't retry".
+        data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True, "score": 0.9,
+                "evidence": "e", "reasoning": "r",
+            }
+        ]
+        resp = MagicMock(usage=MagicMock(input_tokens=50, output_tokens=10))
+        resp.content = [MagicMock(type="text", text=json.dumps(data))]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=resp)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await grade_quality("output", spec)
+        # Exactly one API call despite the failure.
+        assert mock_client.messages.create.await_count == 1
+        assert report.results[0].criterion == "parse_response"
+        assert "misalignment" in report.results[0].reasoning.lower()
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_both_attempts_fail(self):
+        """Parse retry (clauditor-6cf / #94): both attempts return
+        malformed JSON → final failure report with cumulative tokens
+        and the detailed parse-error reasoning from C."""
+        spec = _make_spec()
+        bad_a = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        bad_a.content = [MagicMock(type="text", text="not json")]
+        bad_b = MagicMock(usage=MagicMock(input_tokens=11, output_tokens=6))
+        bad_b.content = [MagicMock(type="text", text="still not")]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=[bad_a, bad_b])
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await grade_quality("output", spec)
+        assert report.passed is False
+        assert report.results[0].criterion == "parse_response"
+        assert report.input_tokens == 21
+        assert report.output_tokens == 11
+        # C: reasoning carries the JSONDecodeError details from the
+        # LAST attempt, not a generic "Failed to parse" message.
+        assert "at line" in report.results[0].reasoning
+        assert "ends with" in report.results[0].reasoning
+
 
 def _make_grading_report(
     passed: bool, mean_score: float = 0.9, pass_rate: float = 1.0
@@ -1673,12 +1779,20 @@ class TestBlindCompare:
 
     @pytest.mark.asyncio
     async def test_blind_compare_malformed_json_returns_graceful_tie(self):
-        bad1 = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
-        bad1.content = [MagicMock(type="text", text="not json at all")]
-        bad2 = MagicMock(usage=MagicMock(input_tokens=12, output_tokens=7))
-        bad2.content = [MagicMock(type="text", text="also not json")]
+        # Parse-retry (clauditor-6cf / #94): each side retries once on
+        # JSON decode failure, so 4 bad responses total (2 per side).
+        bad1a = MagicMock(usage=MagicMock(input_tokens=10, output_tokens=5))
+        bad1a.content = [MagicMock(type="text", text="not json at all")]
+        bad1b = MagicMock(usage=MagicMock(input_tokens=11, output_tokens=6))
+        bad1b.content = [MagicMock(type="text", text="still not json")]
+        bad2a = MagicMock(usage=MagicMock(input_tokens=12, output_tokens=7))
+        bad2a.content = [MagicMock(type="text", text="also not json")]
+        bad2b = MagicMock(usage=MagicMock(input_tokens=13, output_tokens=8))
+        bad2b.content = [MagicMock(type="text", text="nope still bad")]
         mock_client = AsyncMock()
-        mock_client.messages.create = AsyncMock(side_effect=[bad1, bad2])
+        mock_client.messages.create = AsyncMock(
+            side_effect=[bad1a, bad2a, bad1b, bad2b]
+        )
         with patch(
             "anthropic.AsyncAnthropic",
             return_value=mock_client,
@@ -1694,10 +1808,11 @@ class TestBlindCompare:
         assert (
             "parse" in report.reasoning.lower()
             or "not json at all" in report.reasoning
+            or "nope still bad" in report.reasoning
         )
-        # Tokens still populated from both calls (sums exactly)
-        assert report.input_tokens == 22
-        assert report.output_tokens == 12
+        # Tokens accumulate across both sides and both retry attempts.
+        assert report.input_tokens == 10 + 11 + 12 + 13
+        assert report.output_tokens == 5 + 6 + 7 + 8
 
     @pytest.mark.asyncio
     async def test_blind_compare_seeded_rng_is_deterministic(self):
@@ -1802,15 +1917,22 @@ class TestBlindCompare:
     @pytest.mark.asyncio
     async def test_blind_compare_partial_parse_failure_keeps_good_run(self):
         # Seed 1 → run-1 "ab->12"; judge says "1" → a wins in run-1.
-        # Run-2 returns garbage → cannot verify position agreement.
+        # Run-2 returns garbage twice → parse retry exhausts; cannot
+        # verify position agreement. See clauditor-6cf / #94.
         good = _blind_response(
             "1", confidence=0.9, score_1=0.85, score_2=0.3,
             input_tokens=100, output_tokens=40,
         )
-        bad = MagicMock(usage=MagicMock(input_tokens=20, output_tokens=10))
-        bad.content = [MagicMock(type="text", text="garbage not json")]
+        bad_a = MagicMock(usage=MagicMock(input_tokens=20, output_tokens=10))
+        bad_a.content = [MagicMock(type="text", text="garbage not json")]
+        bad_b = MagicMock(usage=MagicMock(input_tokens=21, output_tokens=11))
+        bad_b.content = [MagicMock(type="text", text="garbage not json v2")]
         mock_client = AsyncMock()
-        mock_client.messages.create = AsyncMock(side_effect=[good, bad])
+        # Order: side1 attempt 1 (good), side2 attempt 1 (bad_a),
+        # side2 attempt 2 (bad_b). Side1 parsed so no retry.
+        mock_client.messages.create = AsyncMock(
+            side_effect=[good, bad_a, bad_b]
+        )
         with patch(
             "anthropic.AsyncAnthropic",
             return_value=mock_client,
@@ -1825,24 +1947,42 @@ class TestBlindCompare:
         assert report.confidence == pytest.approx(0.9)
         assert "parse" in report.reasoning.lower()
         assert "run-1" in report.reasoning
-        assert report.input_tokens == 120
-        assert report.output_tokens == 50
+        assert report.input_tokens == 100 + 20 + 21
+        assert report.output_tokens == 40 + 10 + 11
 
     @pytest.mark.asyncio
     async def test_blind_compare_partial_parse_run1_bad_keeps_run2(self):
         # Symmetric to test_blind_compare_partial_parse_failure_keeps_good_run:
-        # run-1 is garbage, run-2 parses. Verdict must come from run-2 and
-        # the reasoning must credit run-2 (not "run-1"). Regression test for
-        # the hardcoded-run-number bug flagged by CodeRabbit.
-        bad = MagicMock(usage=MagicMock(input_tokens=20, output_tokens=10))
-        bad.content = [MagicMock(type="text", text="garbage not json")]
+        # run-1 is garbage (twice, retry exhausted), run-2 parses.
+        # Verdict must come from run-2 and the reasoning must credit
+        # run-2 (not "run-1"). Regression test for the hardcoded-run-
+        # number bug flagged by CodeRabbit. Parse retry behavior tracked
+        # in clauditor-6cf / #94.
+        #
+        # Use a prompt-content dispatcher: under seed 1, run-1's
+        # mapping places a-text in <response_1>; run-2's mapping
+        # places b-text in <response_1>. Route by this marker so the
+        # test is independent of asyncio scheduling order.
+        bad_a = MagicMock(usage=MagicMock(input_tokens=20, output_tokens=10))
+        bad_a.content = [MagicMock(type="text", text="garbage not json")]
         # Seed 1 → run-2 "ab->21"; judge says "2" → a wins in original space.
         good = _blind_response(
             "2", confidence=0.8, score_1=0.4, score_2=0.85,
             input_tokens=100, output_tokens=40,
         )
+
+        async def dispatcher(**kwargs):
+            prompt = kwargs["messages"][0]["content"]
+            # run-1 mapping under seed 1 places a-text in response_1.
+            r1_block = prompt.split("<response_1>", 1)[1].split(
+                "</response_1>", 1
+            )[0]
+            if "a-text" in r1_block:
+                return bad_a  # run-1: always garbage
+            return good  # run-2: parses cleanly
+
         mock_client = AsyncMock()
-        mock_client.messages.create = AsyncMock(side_effect=[bad, good])
+        mock_client.messages.create = AsyncMock(side_effect=dispatcher)
         with patch(
             "anthropic.AsyncAnthropic",
             return_value=mock_client,
@@ -1900,11 +2040,26 @@ class TestBlindCompare:
     async def test_blind_compare_empty_content_response(self):
         # Covers the text_of() branch where response.content is empty —
         # the function returns "", which then fails JSON parse → graceful tie.
+        # Parse retry (clauditor-6cf / #94): run-1 side retries after the
+        # empty response; run-2 side parses cleanly on first attempt.
+        # Route responses by prompt content to avoid asyncio-scheduling
+        # fragility.
         empty = MagicMock(usage=MagicMock(input_tokens=5, output_tokens=2))
         empty.content = []
         ok = _blind_response("1", confidence=0.8, score_1=0.9, score_2=0.3)
+
+        async def dispatcher(**kwargs):
+            prompt = kwargs["messages"][0]["content"]
+            r1_block = prompt.split("<response_1>", 1)[1].split(
+                "</response_1>", 1
+            )[0]
+            # Seed 1, run-1 "ab->12": a-text in response_1 slot → empty.
+            if "a-text" in r1_block:
+                return empty
+            return ok
+
         mock_client = AsyncMock()
-        mock_client.messages.create = AsyncMock(side_effect=[empty, ok])
+        mock_client.messages.create = AsyncMock(side_effect=dispatcher)
         with patch(
             "anthropic.AsyncAnthropic",
             return_value=mock_client,
@@ -2310,6 +2465,42 @@ class TestBuildGradingReport:
         )
         assert report.results[0].criterion == "parse_response"
         assert "misalignment" in report.results[0].reasoning
+
+    def test_unparseable_json_surfaces_line_col_and_tail(self):
+        """C (clauditor-6cf / #94): a malformed-JSON response produces a
+        failure report whose reasoning includes the decoder's line/col
+        position AND a tail of the bytes, so an operator can tell
+        malformed-JSON (tail looks like ``]``) from true truncation
+        (tail is mid-content). Regression guard against reverting to
+        the generic "Failed to parse grader response as JSON" string."""
+        spec = _make_spec()
+        # Real-world failure pattern from the #94 repro: unescaped
+        # double-quote inside an evidence string. The JSON array is
+        # closed (ends with "]") so the tail should make that visible.
+        bad_text = (
+            '[{"criterion":"c","passed":true,"score":1.0,'
+            '"evidence":"outer "inner" quote","reasoning":"r"}]'
+        )
+        report = build_grading_report(
+            bad_text,
+            spec,
+            model="m",
+            thresholds=GradeThresholds(),
+            duration=0.0,
+            input_tokens=1,
+            output_tokens=1,
+        )
+        reasoning = report.results[0].reasoning
+        assert report.results[0].criterion == "parse_response"
+        assert "Failed to parse" in reasoning
+        assert "at line" in reasoning
+        assert "col" in reasoning
+        # Tail is rendered so the reader can distinguish truncation
+        # from malformed-but-complete JSON.
+        assert "ends with" in reasoning
+        # The closing bracket should be visible in the tail — proof the
+        # response was NOT truncated.
+        assert "]" in reasoning
 
     def test_unparseable_json_yields_failure_report(self):
         spec = _make_spec()

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1045,6 +1045,28 @@ class TestGradeQuality:
         assert "misalignment" in report.results[0].reasoning.lower()
 
     @pytest.mark.asyncio
+    async def test_grade_quality_does_not_retry_on_shape_failure(self):
+        """Parse retry (clauditor-6cf / #94, Copilot feedback on PR #98):
+        a response that is valid JSON but has the wrong top-level type
+        (e.g. a dict where a list was expected) is a model-protocol bug,
+        not a transient hiccup — must NOT be retried. Mirrors
+        ``_call_blind_side_with_retry``'s shape-vs-decode split."""
+        spec = _make_spec()
+        # Valid JSON, top-level dict instead of list → verbose parser
+        # returns ``([], None)`` (shape failure, no decode error).
+        resp = MagicMock(usage=MagicMock(input_tokens=50, output_tokens=10))
+        resp.content = [
+            MagicMock(type="text", text='{"not": "a list"}')
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=resp)
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
+            report = await grade_quality("output", spec)
+        # Exactly one API call — shape failure must not retry.
+        assert mock_client.messages.create.await_count == 1
+        assert report.results[0].criterion == "parse_response"
+
+    @pytest.mark.asyncio
     async def test_grade_quality_both_attempts_fail(self):
         """Parse retry (clauditor-6cf / #94): both attempts return
         malformed JSON → final failure report with cumulative tokens


### PR DESCRIPTION
Closes #94.

## Summary

- **B — Orchestrator-level parse retry**: one retry on malformed grader JSON across `grade_quality`, `blind_compare` (per-side), `extract_and_grade`, and `extract_and_report`. Distinct from the transport-layer retry ladder in `_anthropic.py` — this one handles output-quality failures (bad JSON), not transport errors. Alignment failures are NOT retried (prompt-design bug, not transient).
- **C — Detailed parse-error surfacing**: new `describe_json_parse_failure(text, exc)` helper produces `"Failed to parse grader response as JSON: <msg> at line N col M. Response was K chars; ends with: '...<tail>'"` so operators can tell malformed-JSON (tail closes with `]`) from true truncation (tail mid-content).

Expected failure rate: ~5% → ~0.25% with retry; remaining tail diagnosable from the improved message.

## Investigation context

20-run sweep via new `scripts/repro_cli_truncation.py` caught 1/20 failures at 1082 output tokens with `stop_reason="end_turn"` — **not** a max-token cap. Root cause was an unescaped `"` in an evidence string. The original #94 report of "cut off mid-string" is likely the same class of bug (json.loads bails at the bad byte, giving a truncation-like symptom). Full investigation notes in bead `clauditor-6cf`.

## Test plan

- [x] `uv run pytest tests/test_grader.py tests/test_quality_grader.py -q` — 269 pass (257 existing + 12 new)
- [x] `uv run pytest --cov=clauditor -q` — 2481 pass, 1 pre-existing unrelated failure on a temp research doc
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Soak: run `clauditor grade` on a grader-prone skill (e.g. release-manager) across a handful of iterations; observe retry notice on stderr when the grader hiccups, confirm final reports are clean.

## New tests

- `TestDescribeJsonParseFailure` (3 tests) — pure helper asserts line/col/length/tail visible; tail truncated for long responses
- `TestExtractAndReportParseRetry` (4 tests) — retry-on-malformed / no-retry-on-success / both-fail with cumulative tokens
- `TestGradeQuality` (4 new retry tests) — retries, no retry on alignment failure, stderr notice, both-fail detailed reasoning
- `TestBuildGradingReport` — new C test asserting `at line`/`col`/`ends with` + closing bracket visible

## Notes

- Four existing blind-compare tests updated to account for retry semantics. Two switched to a prompt-content dispatcher (instead of `side_effect=[...]` list) since `asyncio.gather` scheduling is not strict FIFO with `AsyncMock`.
- `parse_grading_response` / `parse_blind_response` public signatures are unchanged — internal verbose variants carry the error string for retry + surfacing use.
- `scripts/repro_cli_truncation.py` is local-only, not run by CI. Parallels `scripts/bench_cli_transport.py`.