### PR TITLE
fix(suggest): derive skill_name via canonical helper (#100)

### DIFF
--- a/src/clauditor/cli/suggest.py
+++ b/src/clauditor/cli/suggest.py
@@ -10,7 +10,7 @@ from clauditor._anthropic import (
     AnthropicAuthMissingError,
     check_any_auth_available,
 )
-from clauditor.paths import resolve_clauditor_dir
+from clauditor.paths import derive_skill_name, resolve_clauditor_dir
 from clauditor.suggest import (
     NoPriorGradeError,
     load_suggest_input,
@@ -111,7 +111,18 @@ async def _cmd_suggest_impl(args: argparse.Namespace) -> int:
     if not skill_path.exists():
         print(f"Error: skill file not found: {skill_path}", file=sys.stderr)
         return 1
-    skill_name = skill_path.stem
+    # Route identity derivation through the canonical helper per
+    # ``.claude/rules/skill-identity-from-frontmatter.md``. ``skill_path.stem``
+    # returns the literal "SKILL" for the modern ``<dir>/SKILL.md`` layout,
+    # which misdirects the iteration path below; ``derive_skill_name``
+    # consults frontmatter ``name:`` first, then falls back to
+    # layout-aware filesystem derivation.
+    try:
+        skill_md_text = skill_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"Error: could not read skill file {skill_path}: {exc}", file=sys.stderr)
+        return 1
+    skill_name = derive_skill_name(skill_path, skill_md_text)
     clauditor_dir = resolve_clauditor_dir()
 
     try:

--- a/src/clauditor/cli/suggest.py
+++ b/src/clauditor/cli/suggest.py
@@ -132,6 +132,11 @@ async def _cmd_suggest_impl(args: argparse.Namespace) -> int:
             with_transcripts=args.with_transcripts,
             from_iteration=args.from_iteration,
             skill_md_path=skill_path,
+            # Thread the text we already read for ``derive_skill_name``
+            # so the loader skips its second read. Eliminates the tiny
+            # TOCTOU window where the file could change between the two
+            # reads.
+            skill_md_text=skill_md_text,
         )
     except NoPriorGradeError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/src/clauditor/suggest.py
+++ b/src/clauditor/suggest.py
@@ -334,6 +334,7 @@ def load_suggest_input(
     clauditor_dir: Path,
     *,
     skill_md_path: Path,
+    skill_md_text: str | None = None,
     with_transcripts: bool = False,
     from_iteration: int | None = None,
 ) -> SuggestInput:
@@ -343,6 +344,15 @@ def load_suggest_input(
     from the user-facing skill name and for short-circuiting on the
     DEC-008 row 2 "no failing signals" path. This loader returns a
     valid (possibly empty) :class:`SuggestInput` either way.
+
+    ``skill_md_text`` is an optional pre-read copy of ``skill_md_path``.
+    When the CLI already read the file (e.g. to run ``derive_skill_name``
+    against the frontmatter per #100), it can pass the text through to
+    avoid a second disk read and eliminate the tiny TOCTOU window
+    between the two reads. When ``None``, the loader reads from disk.
+    CRLF normalization is performed here either way so every caller
+    lands on the canonical LF substrate downstream anchor validation,
+    sequential apply, and unified-diff rendering depend on.
     """
     iteration, skill_dir = find_latest_grading(
         clauditor_dir, skill, from_iteration=from_iteration
@@ -356,17 +366,18 @@ def load_suggest_input(
         _load_transcript_events(skill_dir) if with_transcripts else None
     )
 
+    if skill_md_text is None:
+        skill_md_text = skill_md_path.read_text(encoding="utf-8")
+
     return SuggestInput(
         skill_name=skill,
         source_iteration=iteration,
         source_grading_path=_repo_relative(clauditor_dir, grading_path),
-        # Normalize CRLF → LF at load so downstream anchor validation,
-        # sequential apply, and unified-diff rendering all agree on the
-        # canonical LF substrate. Sonnet's replacement strings will be
-        # LF-only regardless of the source file's line endings.
-        skill_md_text=skill_md_path.read_text(encoding="utf-8")
-        .replace("\r\n", "\n")
-        .replace("\r", "\n"),
+        # Normalize CRLF → LF so downstream anchor validation, sequential
+        # apply, and unified-diff rendering all agree on the canonical
+        # LF substrate. Sonnet's replacement strings will be LF-only
+        # regardless of the source file's line endings.
+        skill_md_text=skill_md_text.replace("\r\n", "\n").replace("\r", "\n"),
         failing_assertions=failing_assertions,
         failing_grading_criteria=failing_grading_criteria,
         output_slices=output_slices,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5441,6 +5441,46 @@ class TestCmdSuggest:
         assert len(jsons) == 1
         assert len(diffs) == 1
 
+    def test_modern_layout_locates_iteration_by_parent_dir_name(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Regression for #100: modern-layout ``<dir>/SKILL.md`` must
+        derive ``skill_name`` from the parent dir (or frontmatter
+        ``name:``), not from ``skill_path.stem`` which returns the
+        literal ``"SKILL"``. Pre-fix this test errored with
+        "no iteration under ... contains SKILL/grading.json"."""
+        (tmp_path / ".git").mkdir()
+        skill_dir_src = tmp_path / ".claude" / "skills" / "my-skill"
+        skill_dir_src.mkdir(parents=True)
+        skill_md = skill_dir_src / "SKILL.md"
+        skill_md.write_text(
+            "---\n"
+            "name: my-skill\n"
+            "description: does things\n"
+            "---\n"
+            "\n"
+            "# My Skill\n"
+            "\n"
+            "This skill does things.\n"
+        )
+        iteration_dir = tmp_path / ".clauditor" / "iteration-1" / "my-skill"
+        self._write_grading_json(iteration_dir, all_pass=False)
+        self._write_failing_assertions(iteration_dir)
+        monkeypatch.chdir(tmp_path)
+
+        report = self._fake_report()
+        with patch(
+            "clauditor.cli.suggest.propose_edits",
+            new=AsyncMock(return_value=report),
+        ):
+            rc = main(["suggest", ".claude/skills/my-skill/SKILL.md"])
+
+        err = capsys.readouterr().err
+        assert "SKILL/grading.json" not in err, (
+            f"suggest used literal SKILL stem as skill_name: {err!r}"
+        )
+        assert rc == 0, f"expected exit 0, got {rc}; stderr={err!r}"
+
     def test_json_flag_prints_sidecar_json_to_stdout(
         self, tmp_path, monkeypatch, capsys
     ):


### PR DESCRIPTION
## Summary

- Route \`clauditor suggest\`'s \`skill_name\` derivation through \`clauditor.paths.derive_skill_name\` per \`.claude/rules/skill-identity-from-frontmatter.md\`.
- \`skill_path.stem\` returned the literal \`\"SKILL\"\` for every modern-layout skill (\`<dir>/SKILL.md\`), so suggest looked for \`.clauditor/iteration-N/SKILL/grading.json\` and emitted a misleading \"Run 'clauditor grade ...' first\" error even after a successful grade.
- Adds a regression test that stages a modern-layout skill with frontmatter \`name:\`, seeds a failing \`iteration-1/<name>/\` run, and asserts suggest locates the iteration (reproduces #100 exactly when reverted).

Closes #100.

## Test plan

- [x] \`uv run pytest tests/test_cli.py::TestCmdSuggest\` — 16/16 pass (including new regression).
- [x] Reverted the \`suggest.py\` fix and confirmed the new test fails with the exact observed error substring (\`SKILL/grading.json\`).
- [x] \`uv run pytest --cov=clauditor\` — 2472 passed, 1 skipped, coverage 98.31% (above the 80% gate).
- [x] \`uv run ruff check src/ tests/\` — clean.