### PR TITLE
fix(trend): drop trailing sparkline to keep stdout pipe-clean (#106)

### DIFF
--- a/src/clauditor/cli/trend.py
+++ b/src/clauditor/cli/trend.py
@@ -23,7 +23,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``trend`` subparser."""
     p_trend = subparsers.add_parser(
         "trend",
-        help="Print a trend line (TSV + ASCII sparkline) from grade history",
+        help="Print a trend line (TSV) from grade history",
     )
     p_trend.add_argument("skill_name", help="Skill name to trend")
     p_trend_group = p_trend.add_mutually_exclusive_group(required=True)
@@ -55,7 +55,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def cmd_trend(args: argparse.Namespace) -> int:
-    """Render a trend line (TSV + ASCII sparkline) for a skill metric."""
+    """Render a trend line (TSV) for a skill metric."""
     records = history.read_records(skill=args.skill_name)
     if not records:
         print(
@@ -126,5 +126,4 @@ def cmd_trend(args: argparse.Namespace) -> int:
 
     for ts, v in zip(timestamps, values):
         print(f"{ts}\t{v}")
-    print(history.sparkline(values))
     return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3907,7 +3907,7 @@ class TestTimeoutFlag:
 
     def test_run_timeout_default_none_preserves_fallback(self):
         """run (no --timeout) → SkillRunner.run(timeout=None), so the runner's
-        self.timeout default of 180s kicks in."""
+        self.timeout default of 300s kicks in."""
         mock_runner = MagicMock()
         mock_runner.run.return_value = make_skill_result(
             output="skill output", skill_name="my-skill",
@@ -4352,14 +4352,12 @@ class TestCmdTrend:
         out = capsys.readouterr().out
         assert "0.5" in out
         assert "0.7" in out
-        # Sparkline line present (non-empty last line)
+        # stdout ends with the last data row's newline — every non-empty
+        # line must be a TSV data row (#106).
         lines = [ln for ln in out.splitlines() if ln]
         assert lines
-        # Sparkline should use only glyphs from SPARK_GLYPHS
-        from clauditor.history import SPARK_GLYPHS
-
-        spark = lines[-1]
-        assert all(c in SPARK_GLYPHS for c in spark)
+        for ln in lines:
+            assert "\t" in ln, f"non-data trailing line on stdout: {ln!r}"
 
     def test_metric_in_metrics_dict(self, tmp_path, monkeypatch, capsys):
         monkeypatch.chdir(tmp_path)
@@ -4385,6 +4383,28 @@ class TestCmdTrend:
         assert rc == 1
         err = capsys.readouterr().err
         assert "no history" in err.lower() or "no records" in err.lower()
+
+    def test_stdout_ends_with_last_data_row_no_sparkline_artifact(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Regression for #106: stdout must end with the last data row's
+        newline — no trailing sparkline/artifact line. Users piping the
+        output to awk/jq otherwise get a non-parseable trailing line."""
+        monkeypatch.chdir(tmp_path)
+        self._seed(tmp_path / ".clauditor" / "history.jsonl", n=2)
+
+        rc = main(["trend", "test-skill", "--metric", "pass_rate"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if ln]
+        assert len(lines) == 2, (
+            f"expected only data rows, got {len(lines)} lines: {lines!r}"
+        )
+        for ln in lines:
+            assert "\t" in ln, (
+                f"non-TSV trailing line on stdout: {ln!r} — "
+                "sparkline/artifact regression"
+            )
 
     def test_last_n_truncates(self, tmp_path, monkeypatch, capsys):
         monkeypatch.chdir(tmp_path)
@@ -4572,12 +4592,8 @@ class TestCmdTrendDottedPath:
         assert "500" in out
         assert "600" in out
         assert "700" in out
-        # Sparkline line present
-        from clauditor.history import SPARK_GLYPHS
-
-        spark = out.splitlines()[-1]
-        assert spark
-        assert all(c in SPARK_GLYPHS for c in spark)
+        # stdout ends with the last data row — no trailing artifact (#106).
+        assert "\t" in out.splitlines()[-1]
 
 
 class TestCmdTrendListMetrics:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3907,7 +3907,7 @@ class TestTimeoutFlag:
 
     def test_run_timeout_default_none_preserves_fallback(self):
         """run (no --timeout) → SkillRunner.run(timeout=None), so the runner's
-        self.timeout default of 300s kicks in."""
+        self.timeout default of 180s kicks in."""
         mock_runner = MagicMock()
         mock_runner.run.return_value = make_skill_result(
             output="skill output", skill_name="my-skill",


### PR DESCRIPTION
Closes #106.

## Summary
- `clauditor trend` was emitting a trailing sparkline line (e.g. `_#` / `#_` for 2-point series), breaking downstream `| awk` / `| jq` consumers with a non-parseable tail line.
- Drop the `history.sparkline(values)` print from `cmd_trend` so stdout ends with the last TSV data row. The `history.sparkline()` helper itself stays — still unit-tested in `tests/test_history.py` and available if a future opt-in flag wants to resurrect it.
- Update the subparser help string to drop the "ASCII sparkline" phrasing.

## Tests
- `TestCmdTrend.test_happy_path` and `TestCmdTrendDottedPath.test_dotted_nested_metric` now assert every non-empty stdout line is a TSV data row (no glyph trailer).
- New regression guard `TestCmdTrend.test_stdout_ends_with_last_data_row_no_sparkline_artifact` directly pins the acceptance criterion from #106.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/test_cli.py::TestCmdTrend tests/test_cli.py::TestCmdTrendCommandFilter tests/test_cli.py::TestCmdTrendDottedPath tests/test_cli.py::TestCmdTrendListMetrics tests/test_history.py --no-cov` — 56 passed
- [x] Full suite — 2530 passed, 1 pre-existing unrelated failure in `tests/test_docs_examples.py` (verified present on dev)