### PR TITLE
feat(skill): add clauditor suggest step to bundled /clauditor workflow (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Edits under `.claude/skills/clauditor/` are [hot-reloaded](https://code.claude.c
 
 ## Using /clauditor in Claude Code
 
-Invoke the slash command with a skill path — Claude locates the eval spec, runs L1, and asks before spending tokens on L3; if no sibling `<skill>.eval.json` exists, Claude offers `clauditor propose-eval` as an LLM-assisted bootstrap (with a cost-free `--dry-run` preview) before grading.
+Invoke the slash command with a skill path — Claude locates the eval spec, runs L1, and asks before spending tokens on L3; if no sibling `<skill>.eval.json` exists, Claude offers `clauditor propose-eval` as an LLM-assisted bootstrap (with a cost-free `--dry-run` preview) before grading. If L3 reports failing criteria, Claude offers `clauditor suggest` to propose a unified diff of SKILL.md edits motivated by the specific failing criterion ids.
 
 ```text
 /clauditor .claude/commands/my-skill.md

--- a/docs/skill-usage.md
+++ b/docs/skill-usage.md
@@ -45,8 +45,16 @@ skill to evaluate.
    reports failing assertion ids.
 4. If L1 passes, asks before running L3 grading (`clauditor grade`) —
    costs Sonnet tokens, writes a full `grading.json` sidecar.
-5. Summarizes: which layers ran, pass/fail counts, sidecar paths you
-   can open for details.
+5. If L3 reports failing criteria, asks before running
+   `clauditor suggest` — proposes a unified diff of SKILL.md edits
+   motivated by the failing criterion ids. Writes `<skill>-<timestamp>.diff`
+   and `<skill>-<timestamp>.json` under `.clauditor/suggestions/`.
+   Shows you the diff plus `motivated_by` + `confidence` from the
+   sidecar; does not auto-apply — review, `git apply` (or hand-edit),
+   then re-run `validate` / `grade` to measure the score delta.
+6. Summarizes: which layers ran, pass/fail counts, sidecar paths
+   (including the suggest diff path if it ran) you can open for
+   details.
 
 **When to use `/clauditor` vs. the CLI directly:**
 

--- a/docs/skill-usage.md
+++ b/docs/skill-usage.md
@@ -47,11 +47,14 @@ skill to evaluate.
    costs Sonnet tokens, writes a full `grading.json` sidecar.
 5. If L3 reports failing criteria, asks before running
    `clauditor suggest` — proposes a unified diff of SKILL.md edits
-   motivated by the failing criterion ids. Writes `<skill>-<timestamp>.diff`
-   and `<skill>-<timestamp>.json` under `.clauditor/suggestions/`.
-   Shows you the diff plus `motivated_by` + `confidence` from the
-   sidecar; does not auto-apply — review, `git apply` (or hand-edit),
-   then re-run `validate` / `grade` to measure the score delta.
+   motivated by the failing criterion ids. Writes
+   `<skill-name>-<timestamp>.diff` and `<skill-name>-<timestamp>.json`
+   under `.clauditor/suggestions/` (`<skill-name>` is the skill's
+   derived identity — frontmatter `name:` or parent-directory name,
+   not the file stem). Shows you the diff plus `motivated_by` +
+   `confidence` from the sidecar; does not auto-apply — review,
+   `git apply` (or hand-edit), then re-run `validate` / `grade` to
+   measure the score delta.
 6. Summarizes: which layers ran, pass/fail counts, sidecar paths
    (including the suggest diff path if it ran) you can open for
    details.

--- a/src/clauditor/skills/clauditor/SKILL.md
+++ b/src/clauditor/skills/clauditor/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   clauditor-version: "0.0.0-dev"
 argument-hint: "[skill-path]"
 disable-model-invocation: true
-allowed-tools: Bash(clauditor *), Bash(clauditor propose-eval *), Bash(uv run clauditor *)
+allowed-tools: Bash(clauditor *), Bash(clauditor propose-eval *), Bash(clauditor suggest *), Bash(uv run clauditor *)
 ---
 
 # /clauditor — Validate and grade a Claude Code skill
@@ -90,11 +90,30 @@ entry point before running validate/grade.
    Report the overall `pass_rate`, any failing criterion ids, and the
    path to the sidecar for follow-up.
 
-6. **Report concisely.** Surface:
+6. **If L3 reports failing criteria, offer `clauditor suggest`.** Ask
+   the user to confirm — this costs Sonnet tokens. `suggest` reads
+   the grade's `grading.json` and proposes a unified diff of SKILL.md
+   edits motivated by the failing criterion ids.
+
+   ```bash
+   uv run clauditor suggest <skill-path>
+   ```
+
+   Writes `<skill>-<timestamp>.diff` and `<skill>-<timestamp>.json`
+   under `.clauditor/suggestions/`. Show the user the diff plus the
+   `motivated_by` criterion ids and `confidence` from the JSON
+   sidecar. Do NOT auto-apply — let the user `git apply` the diff
+   (or hand-edit) and re-run `validate` / `grade` to measure the
+   score delta. See `docs/cli-reference.md#suggest` for the full
+   flag reference.
+
+7. **Report concisely.** Surface:
    - Which layers ran (L1 / L2 / L3)
    - Pass/fail counts per layer
    - Sidecar paths the user can open to inspect full results
-   - One-line next step (re-run, inspect transcript, tighten rubric)
+   - If `suggest` ran: the diff path + motivated-by ids
+   - One-line next step (re-run, inspect transcript, tighten rubric,
+     apply the suggested diff)
 
 ## Common errors
 
@@ -105,3 +124,6 @@ entry point before running validate/grade.
   criterion needs a unique string `id`. Edit the spec and re-run.
 - **`no project root found`** — `clauditor` expects to run inside a
   project with `.git/` or `.claude/`. Use `--project-dir` or `cd` first.
+- **`no iteration under ... contains <skill>/grading.json`** —
+  `clauditor suggest` requires a prior `clauditor grade` run. Run
+  Step 5 first, then retry.

--- a/src/clauditor/skills/clauditor/SKILL.md
+++ b/src/clauditor/skills/clauditor/SKILL.md
@@ -99,13 +99,15 @@ entry point before running validate/grade.
    uv run clauditor suggest <skill-path>
    ```
 
-   Writes `<skill>-<timestamp>.diff` and `<skill>-<timestamp>.json`
-   under `.clauditor/suggestions/`. Show the user the diff plus the
-   `motivated_by` criterion ids and `confidence` from the JSON
-   sidecar. Do NOT auto-apply — let the user `git apply` the diff
-   (or hand-edit) and re-run `validate` / `grade` to measure the
-   score delta. See `docs/cli-reference.md#suggest` for the full
-   flag reference.
+   Writes `<skill-name>-<timestamp>.diff` and
+   `<skill-name>-<timestamp>.json` under `.clauditor/suggestions/`,
+   where `<skill-name>` is the skill's derived identity (frontmatter
+   `name:` or parent-directory name, NOT the file stem). Show the
+   user the diff plus the `motivated_by` criterion ids and
+   `confidence` from the JSON sidecar. Do NOT auto-apply — let the
+   user `git apply` the diff (or hand-edit) and re-run `validate` /
+   `grade` to measure the score delta. See `docs/cli-reference.md`
+   for the full flag reference.
 
 7. **Report concisely.** Surface:
    - Which layers ran (L1 / L2 / L3)
@@ -124,6 +126,6 @@ entry point before running validate/grade.
   criterion needs a unique string `id`. Edit the spec and re-run.
 - **`no project root found`** — `clauditor` expects to run inside a
   project with `.git/` or `.claude/`. Use `--project-dir` or `cd` first.
-- **`no iteration under ... contains <skill>/grading.json`** —
+- **`no iteration under ... contains <skill-name>/grading.json`** —
   `clauditor suggest` requires a prior `clauditor grade` run. Run
   Step 5 first, then retry.

--- a/tests/test_bundled_skill.py
+++ b/tests/test_bundled_skill.py
@@ -219,6 +219,20 @@ class TestSkillMdBody:
             "(DEC-007 regression guard)"
         )
 
+    def test_body_mentions_suggest(
+        self, frontmatter_and_body: tuple[dict, str]
+    ) -> None:
+        # Regression guard per
+        # .claude/rules/bundled-skill-docs-sync.md: the bundled SKILL.md
+        # body must reference `clauditor suggest` so the closing half of
+        # the workflow (propose SKILL.md edits from failing L3
+        # criteria) does not silently disappear on a future edit.
+        _, body = frontmatter_and_body
+        assert "clauditor suggest" in body, (
+            "bundled SKILL.md body must mention 'clauditor suggest' "
+            "(bundled-skill-docs-sync regression guard)"
+        )
+
 
 class TestBundledSkillViaSpec:
     def test_bundled_skill_loads_via_skillspec(self) -> None:


### PR DESCRIPTION
## Summary

- Adds a new Step 6 to the bundled `/clauditor` slash-command workflow that offers `clauditor suggest` when L3 grading reports failing criteria, surfacing the closing half of the grader-to-improvement loop where users actually encounter it.
- Keeps the triangle sync contract from `.claude/rules/bundled-skill-docs-sync.md`: SKILL.md workflow edit + `docs/skill-usage.md` narrative summary + `README.md` "Using /clauditor in Claude Code" teaser, all moved in lockstep.
- Adds a `test_body_mentions_suggest` regression guard to `tests/test_bundled_skill.py`, mirroring the existing `test_body_mentions_propose_eval` pattern.

Partial implementation of #109. The README dedicated section, `docs/skill-usage.md` worked walkthrough with sidecar JSON, and `docs/cli-reference.md` `## suggest` section are still open for separate follow-ups.

## Files changed

| File | Change |
|------|--------|
| `src/clauditor/skills/clauditor/SKILL.md` | `allowed-tools` gains `Bash(clauditor suggest *)`; new Step 6 (suggest); prior Step 6 renumbered to 7; common-error added for missing grading.json |
| `docs/skill-usage.md` | Narrative item 5 added for suggest; prior 5 renumbered to 6 |
| `README.md` | "Using /clauditor in Claude Code" teaser extended by one sentence |
| `tests/test_bundled_skill.py` | New `test_body_mentions_suggest` regression guard |

## Motivation

Surfaced during pre-PyPI burn-in round 2 (2026-04-24). After fixing #100 (`suggest` now works end-to-end on modern-layout skills), running `suggest` against the `find-restaurants` L3 failure produced a clean, motivated unified diff in 24 seconds via subscription transport — exactly the kind of closing-loop workflow the slash command should walk users through. But the bundled SKILL.md had zero mentions of `suggest`, so users invoking `/clauditor` would never discover it was available.

This PR wires suggest into the guided flow without changing any of the fixed steps (propose-eval, validate, grade).

## Per the rules

- `.claude/rules/bundled-skill-docs-sync.md` — triangle sync between SKILL.md, skill-usage.md, and README.md. Handled.
- `.claude/rules/readme-promotion-recipe.md` — README teaser remains a D2 lean teaser; one-sentence extension, no new code block, heading text unchanged.
- `.claude/rules/pre-llm-contract-hard-validate.md` — the suggest tool already enforces the anchor-safety invariant the new Step 6 relies on; no new contract added.

## Test plan

- [x] `uv run pytest tests/test_bundled_skill.py` — 16 passed in 0.05s (including the new regression guard).
- [ ] CI runs the full suite.
- [ ] Reviewer: inspect the Step 6 body for tone/voice match with Steps 3-5.
- [ ] Reviewer: confirm the README teaser stays inside the ~165-line budget (teaser grew by 1 sentence, other sections untouched).

## Notes for reviewers

- `allowed-tools` line uses the wildcard-plus-explicit entry pattern (DEC-001 of `plans/super/54-teach-propose-eval-workflow.md`). `Bash(clauditor *)` already covers `clauditor suggest`, but the explicit entry matches the pre-existing `Bash(clauditor propose-eval *)` convention.
- `docs/temp/medium-closing-the-loop.md` (gitignored) is a companion Medium draft using the `find-restaurants` run as a worked example. Not included in this PR but informed the narrative framing.
- The body-length cap (`BODY_MAX_LINES = 500`) is well under; bundled SKILL.md body is now ~105 lines.