### PR TITLE
docs(#109): surface clauditor suggest across README + reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Auditor for AgentSkills.io skills and Claude Integrations. Catches when your ski
 <details>
 <summary>Contents</summary>
 
-[Install](#install) · [Why clauditor?](#why-clauditor) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
+[Install](#install) · [Why clauditor?](#why-clauditor) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [Suggest](#llm-assisted-skill-improvement-clauditor-suggest) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
 
 </details>
 
@@ -100,6 +100,20 @@ L1 catches shape regressions for free, L2 uses Haiku to validate structured fiel
 ```
 
 Full reference: [docs/layers.md](https://github.com/wjduenow/clauditor/blob/dev/docs/layers.md).
+
+## LLM-assisted skill improvement (`clauditor suggest`)
+
+When `clauditor grade` returns failing L3 criteria, `clauditor suggest` reads that iteration's `grading.json`, asks Sonnet to propose minimal SKILL.md edits keyed to the failing criterion ids, and writes a unified diff plus a JSON sidecar with `motivated_by`, `anchor`, `confidence`, and per-edit rationale. Every proposal is hard-validated so its `anchor` appears exactly once in the target SKILL.md before anything lands on disk — no silent drift, no blind patches.
+
+```bash
+clauditor grade .claude/skills/my-skill/SKILL.md      # produces grading.json
+clauditor suggest .claude/skills/my-skill/SKILL.md    # reads latest grading.json
+# → unified diff on stdout; sidecar at .clauditor/suggestions/my-skill-<ts>.{diff,json}
+```
+
+Review, `git apply` (or hand-edit), then re-run `clauditor grade` to measure the score delta. The sidecar is stable (`schema_version: 1`) for downstream tooling.
+
+**Covered in the full reference:** traceability via `motivated_by`, the anchor-safety contract, sidecar field-by-field reference, `--from-iteration`, `--with-transcripts`, `--model`, `--json`, and the full worked walkthrough. Full reference: [docs/skill-usage.md#proposing-skill-improvements](https://github.com/wjduenow/clauditor/blob/dev/docs/skill-usage.md#proposing-skill-improvements).
 
 ## CLI Reference
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -224,6 +224,78 @@ Captured skill output is scrubbed through `clauditor.transcripts.redact` before 
 - `clauditor propose-eval` fills in an `eval.json` for a skill whose **SKILL.md already exists**. It does not write a skill stub and does not regenerate SKILL.md.
 - `clauditor capture <skill> -- "args"` produces the captured run that `propose-eval` reads as grounding context. Capturing before `propose-eval` typically lifts the quality of the generated spec (the proposer sees what real output looks like).
 
+## suggest
+
+LLM-assisted skill improvement. `clauditor suggest <skill.md>` reads the latest `.clauditor/iteration-N/<skill>/grading.json`, asks Sonnet to propose minimal SKILL.md edits keyed to the failing L3 criteria (and any failing L1 assertions captured in the same iteration), hard-validates every proposal's `anchor` as a once-only substring of the current SKILL.md, and writes a unified diff plus a JSON sidecar under `.clauditor/suggestions/`. Use it to close the loop from "grader produced a verdict" to "tool produced an applicable, motivated, anchor-validated edit proposal."
+
+Requires authentication: `ANTHROPIC_API_KEY` for API transport, or an authenticated `claude` CLI for CLI transport. See [Authentication and API Keys](#authentication-and-api-keys).
+
+### Why `suggest` exists
+
+Three guarantees you can't get from a hand-written or free-form-LLM patch:
+
+- **Traceability** — every proposed edit carries `motivated_by: [criterion_id, ...]`, tying the SKILL.md change back to the specific grader signals that motivated it. The proposer rejects at parse time any `motivated_by` id that does not appear in the input's failing-signal lists.
+- **Anchor safety** — each `edit_proposal.anchor` is validated to appear **exactly once** in the on-disk SKILL.md (sequentially, so later edits see the mutated buffer earlier edits produced). Any failure aborts the run before writing either file; no partial diffs, no blind replacement.
+- **Structured output** — diff + JSON sidecar with `motivated_by`, `anchor`, `replacement`, `rationale`, `confidence`, model/timestamp, `source_iteration`, and `schema_version: 1` for downstream tooling consumers.
+
+### Required inputs
+
+- `<skill_md>` (positional) — path to the SKILL.md file. The command reads the latest iteration under `.clauditor/` that contains `<skill>/grading.json` (skill identity is derived from the SKILL.md via the canonical `derive_skill_name` helper — frontmatter `name:` first, parent-directory name as fallback).
+
+### Flags
+
+| Flag | Purpose |
+| ---- | ------- |
+| `--from-iteration N` | Override latest-iteration discovery. Loads the grade run from `.clauditor/iteration-N/<skill>/grading.json` (N must be a positive integer). |
+| `--with-transcripts` | Include per-run stream-json transcripts in the proposer prompt. Increases token spend; useful when grading-only signals are ambiguous about the failure mode. |
+| `--model MODEL` | Override the proposer model (default: `claude-sonnet-4-6`). |
+| `--json` | Print the full `SuggestReport` JSON envelope to stdout instead of the unified diff. The sidecar file is still written regardless. |
+| `-v, --verbose` | Log bundle size, token counts, duration, and sidecar paths to stderr. |
+| `--transport {api,cli,auto}` | Route the Anthropic call through the HTTP SDK (`api`), the `claude -p` subprocess (`cli`), or the default auto-resolution (`auto` — picks CLI when available). Precedence: this flag > `CLAUDITOR_TRANSPORT` env > `EvalSpec.transport` > default `auto`. Full reference: [docs/transport-architecture.md](transport-architecture.md). |
+
+### Examples
+
+```bash
+# Basic use — reads the latest iteration's grading.json, writes diff + sidecar.
+clauditor suggest .claude/skills/my-skill/SKILL.md
+
+# Preview in CI-friendly JSON form (sidecar still written on disk).
+clauditor suggest .claude/skills/my-skill/SKILL.md --json
+
+# Target an older iteration explicitly.
+clauditor suggest .claude/skills/my-skill/SKILL.md --from-iteration 3
+
+# Include transcripts for more context when grading-only signals are thin.
+clauditor suggest .claude/skills/my-skill/SKILL.md --with-transcripts
+
+# Apply a proposed diff.
+git apply .clauditor/suggestions/my-skill-<timestamp>.diff
+```
+
+### Sidecar layout
+
+Each invocation that reaches the write step produces two sibling files under `.clauditor/suggestions/`:
+
+- `<skill>-<timestamp>.diff` — a unified diff you can feed to `git apply` (or hand-edit).
+- `<skill>-<timestamp>.json` — the structured `SuggestReport` envelope with `schema_version: 1` as the first key. Fields: `skill_name`, `model`, `generated_at` (UTC ISO), `source_iteration`, `source_grading_path`, `input_tokens`, `output_tokens`, `duration_seconds`, `summary_rationale`, `edit_proposals` (list of `{id, anchor, replacement, rationale, confidence, motivated_by, applies_to_file}`), `validation_errors`, `parse_error`, `api_error`.
+
+Timestamps are microsecond-precision UTC (`%Y%m%dT%H%M%S%fZ`); two invocations in the same microsecond would collide (acceptable for v1).
+
+### Exit codes
+
+Mirrors the DEC-008 contract in `src/clauditor/cli/suggest.py`:
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success — diff (or `--json` envelope) printed to stdout, sidecar written to `.clauditor/suggestions/`. Also `0` when the latest iteration has zero failing signals: Sonnet is NOT called, a stderr note is printed, no sidecar is written (DEC-008 row 2). |
+| `1` | Load-time or parse-layer failure: no prior `grading.json` under `.clauditor/`, unreadable SKILL.md, unparseable proposer response, OS error writing the sidecar. No sidecar is written for these branches. |
+| `2` | Anchor-validation failure — one or more proposals named an `anchor` that does not appear exactly once in the current SKILL.md. Errors printed on stderr, no sidecar written. Also `2` when no usable authentication is available (neither `ANTHROPIC_API_KEY` nor an authenticated `claude` CLI). |
+| `3` | Anthropic API error — auth failure, rate-limit exhaustion, connection error, or any non-retriable SDK error surfaced by `clauditor._anthropic.call_anthropic`. No sidecar written. |
+
+### Relationship to `grade`
+
+`clauditor grade` is the prerequisite: `suggest` has no standalone mode and no LLM call if no failing signals exist in the discovered iteration. If no `grading.json` exists under `.clauditor/`, the command exits 1 with a hint to run `clauditor grade` first. The bundled `/clauditor` slash command wires this handoff automatically — see [docs/skill-usage.md#proposing-skill-improvements](skill-usage.md#proposing-skill-improvements) for the full walkthrough.
+
 ## badge
 
 Generate a [shields.io](https://shields.io)-compatible endpoint JSON from a skill's latest iteration sidecars. `clauditor badge <skill.md>` reads the most recent `.clauditor/iteration-N/<skill>/assertions.json` (L1) and, when present, `grading.json` (L3) / `variance.json`, classifies color and message per the project's rules, and writes the result to `.clauditor/badges/<skill>.json` (or a path passed to `--output`). Point any shields.io endpoint URL at the raw JSON and the rendered SVG updates whenever the JSON changes.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -288,7 +288,7 @@ Mirrors the DEC-008 contract in `src/clauditor/cli/suggest.py`:
 | Code | Meaning |
 | ---- | ------- |
 | `0` | Success — diff (or `--json` envelope) printed to stdout, sidecar written to `.clauditor/suggestions/`. Also `0` when the latest iteration has zero failing signals: Sonnet is NOT called, a stderr note is printed, no sidecar is written (DEC-008 row 2). |
-| `1` | Load-time or parse-layer failure: no prior `grading.json` under `.clauditor/`, unreadable SKILL.md, unparseable proposer response, OS error writing the sidecar. No sidecar is written for these branches. |
+| `1` | Load-time or parse-layer failure: no prior `grading.json` under `.clauditor/`, unreadable SKILL.md, unparseable proposer response, or OS error while writing the sidecar. For the load/parse branches no sidecar is written; for OS write failures, partial sidecar artifacts may remain if one sidecar file (JSON or diff) was written before the error occurred (`write_sidecar` writes the two sibling files sequentially, not atomically). |
 | `2` | Anchor-validation failure — one or more proposals named an `anchor` that does not appear exactly once in the current SKILL.md. Errors printed on stderr, no sidecar written. Also `2` when no usable authentication is available (neither `ANTHROPIC_API_KEY` nor an authenticated `claude` CLI). |
 | `3` | Anthropic API error — auth failure, rate-limit exhaustion, connection error, or any non-retriable SDK error surfaced by `clauditor._anthropic.call_anthropic`. No sidecar written. |
 

--- a/docs/skill-usage.md
+++ b/docs/skill-usage.md
@@ -71,3 +71,104 @@ skill to evaluate.
 The full skill playbook lives at
 [`src/clauditor/skills/clauditor/SKILL.md`](../src/clauditor/skills/clauditor/SKILL.md)
 (what Claude reads when the slash command fires).
+
+## Proposing skill improvements
+
+When `clauditor grade` returns failing L3 criteria, you have a
+grading.json that names exactly which criteria missed and why.
+`clauditor suggest` closes the loop: it reads that grading.json,
+asks Sonnet to propose minimal SKILL.md edits keyed to the failing
+criterion ids, and writes a unified diff plus a JSON sidecar so you
+can review before anything lands in your SKILL.md.
+
+**The loop:**
+
+```bash
+clauditor grade    .claude/skills/my-skill/SKILL.md   # 1. produces grading.json (L3 failures)
+clauditor suggest  .claude/skills/my-skill/SKILL.md   # 2. proposes SKILL.md edits
+# review the diff…
+git apply .clauditor/suggestions/my-skill-<timestamp>.diff   # 3. apply (or hand-edit)
+clauditor grade    .claude/skills/my-skill/SKILL.md   # 4. re-grade to measure delta
+```
+
+The command reads the **latest** iteration that contains a
+`<skill>/grading.json`; pass `--from-iteration N` to target an
+older run explicitly.
+
+**Sidecar shape (`.clauditor/suggestions/<skill>-<timestamp>.json`):**
+
+```json
+{
+  "schema_version": 1,
+  "skill_name": "my-skill",
+  "model": "claude-sonnet-4-6",
+  "generated_at": "2026-04-24T18:03:22.451820Z",
+  "source_iteration": 7,
+  "source_grading_path": ".clauditor/iteration-7/my-skill/grading.json",
+  "input_tokens": 4812,
+  "output_tokens": 311,
+  "duration_seconds": 9.42,
+  "summary_rationale": "Three edits address the 'distance_ok' criterion by tightening the distance constraint in the Scope section.",
+  "edit_proposals": [
+    {
+      "id": "edit-1",
+      "anchor": "Return the five closest venues.",
+      "replacement": "Return up to five venues within the specified radius; prefer closer results and omit any venue beyond the radius.",
+      "rationale": "Adds an explicit radius constraint so the skill stops returning out-of-range results.",
+      "confidence": 0.82,
+      "motivated_by": ["distance_ok"],
+      "applies_to_file": "SKILL.md"
+    }
+  ],
+  "validation_errors": [],
+  "parse_error": null,
+  "api_error": null
+}
+```
+
+**What each field buys you:**
+
+- `motivated_by` — list of failing criterion / assertion ids that
+  drove the edit. Traces every proposed change back to a concrete
+  grader signal; if no failing signal exists for an id, the
+  proposer is rejected at parse time.
+- `anchor` — a verbatim substring of the current SKILL.md that
+  must appear **exactly once**, hard-validated before the sidecar
+  is written. A too-short anchor that matches multiple places or a
+  hallucinated anchor that matches nothing fails the whole run
+  with exit 2 — no partial diff, no silent drift.
+- `replacement` — the exact text to swap in at the anchor site.
+- `confidence` — proposer's self-reported `[0, 1]` confidence.
+  Surface low-confidence edits to the user first; do not auto-apply.
+- `rationale` / `summary_rationale` — per-edit and run-wide
+  explanation. Use them in commit messages.
+- `schema_version` — `1`, first key by convention so downstream
+  tooling can pin on it without scanning the whole payload.
+
+**Safety rails:**
+
+- Anchor exactly-once invariant — every `edit_proposal.anchor` is
+  validated against the on-disk SKILL.md *sequentially* (edits
+  apply in order, and a later edit's anchor must still resolve
+  uniquely after earlier edits apply). Any failure aborts the run
+  before writing either file.
+- No auto-apply — the command writes a diff and a sidecar; it
+  never mutates your SKILL.md. You review, then `git apply` (or
+  hand-edit).
+- Traceability — because every edit carries `motivated_by`, you
+  can tie a specific SKILL.md change back to the failing grader
+  signal that motivated it, weeks or months later.
+
+**Common failure modes:**
+
+- `no iteration under .clauditor/ contains <skill>/grading.json` —
+  run `clauditor grade` first.
+- `anchor not found in SKILL.md` / `anchor appears N times (must be
+  exactly once)` — the proposer hallucinated or picked a non-unique
+  anchor. Re-run; the command is idempotent. Persistent failures
+  can indicate SKILL.md text drifted between the grade run and the
+  suggest run.
+- Exit 3 — Anthropic API error (auth, rate limit, 5xx). No sidecar
+  written; retry once the upstream issue clears.
+
+Full flag reference: [`cli-reference.md#suggest`](cli-reference.md#suggest).


### PR DESCRIPTION
Closes #109 (the remaining three acceptance items PR #111 deferred).

## Summary

- README: new `## LLM-assisted skill improvement (clauditor suggest)` D3-rich teaser between `## Three Layers of Validation` and `## CLI Reference` — paragraph + 3-line invocation block + covered-in-full-reference list + link to the worked walkthrough. Contents TOC updated with a `[Suggest]` anchor. Follows `.claude/rules/readme-promotion-recipe.md`.
- docs/skill-usage.md: new `## Proposing skill improvements` section with the full grade → suggest → apply → re-grade loop, an annotated sidecar JSON sample (motivated_by, anchor, confidence, rationale, schema_version), the three safety rails (exactly-once anchor validation, no auto-apply, traceability), and common failure modes.
- docs/cli-reference.md: new `## suggest` section between `## propose-eval` and `## badge`, mirroring the propose-eval shape (preamble, auth pointer, required inputs, flags table, examples, sidecar layout, exit-code table, relationship-to-grade). Full flag matrix + DEC-008 exit-code contract.

## Scope notes

- The bundled `/clauditor` SKILL.md workflow and the `tests/test_bundled_skill.py::test_body_mentions_suggest` regression guard were landed in #111 — not touched here.
- Additive docs only: the parallel-update triangle from `.claude/rules/bundled-skill-docs-sync.md` does not fire (no SKILL.md `## Workflow` step change in this PR).

## Test plan

- [x] `uv run ruff check src/ tests/` → all checks pass
- [x] `uv run pytest --no-cov` → 2514 passed, 1 skipped
- [ ] Spot-check the README section renders cleanly on github.com
- [ ] Spot-check the `[Suggest]` TOC anchor resolves to the new H2
- [ ] Spot-check the skill-usage.md `#proposing-skill-improvements` link from README resolves
- [ ] Spot-check the cli-reference.md `#suggest` anchor resolves from the skill-usage.md "Full flag reference" link