### PR TITLE
feat(runner): label apiKeySource telemetry lines with call subject (#107)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -289,6 +289,8 @@ Four skill-invoking commands share two flags that control the `claude -p` subpro
 
 When `claude -p` emits an `apiKeySource` value on its stream-json `init` event, the runner captures it on `SkillResult.api_key_source` and prints one stderr info line of the form `clauditor.runner: apiKeySource=<value>`. Values are labels (`"ANTHROPIC_API_KEY"`, `"claude.ai"`, `"none"`), not secrets. Older `claude` builds that omit the field leave `api_key_source` at `None` and suppress the stderr line — absence is the signal. See [`docs/stream-json-schema.md`](stream-json-schema.md#type-system) for the parser contract.
 
+Under `--transport cli`, each grader subprocess call also emits its own `apiKeySource` line. To distinguish them, the line carries a `(<subject>)` suffix naming the internal LLM call — e.g. `clauditor.runner: apiKeySource=none (L2 extraction)` and `clauditor.runner: apiKeySource=none (L3 grading)` for a `grade` run with tiered sections. Known subjects today: `L2 extraction`, `L3 grading`, `L3 blind compare side1` / `L3 blind compare side2`, `triggers judge`, `suggest proposer`, `propose-eval`. Skill-run subprocesses emit the line without a suffix.
+
 ```bash
 # Force subscription auth, raise the watchdog to ten minutes.
 clauditor grade .claude/commands/deep-research.md --no-api-key --timeout 600

--- a/docs/stream-json-schema.md
+++ b/docs/stream-json-schema.md
@@ -58,7 +58,13 @@ is parsed for its `apiKeySource` field (when present).
   that case `api_key_source` stays `None` and no stderr line is
   emitted (absence is the signal, per DEC-012 of
   `plans/super/64-runner-auth-timeout.md`). Subsequent `system/init`
-  messages are ignored — first init wins, per DEC-015.
+  messages are ignored — first init wins, per DEC-015. When the
+  caller threads a `subject` through `call_anthropic` (grader call
+  sites — L2 extraction, L3 grading, L3 blind compare side1/side2,
+  triggers judge, suggest proposer, propose-eval) the stderr line
+  gains a ` (<subject>)` suffix so operators can attribute
+  multi-subprocess runs (e.g. `grade --transport cli`) to specific
+  internal LLM calls (issue #107).
 
 All `system/*` messages (every subtype) are appended to
 `raw_messages` and `stream_events` for downstream tooling

--- a/src/clauditor/_anthropic.py
+++ b/src/clauditor/_anthropic.py
@@ -636,6 +636,7 @@ async def call_anthropic(
     model: str,
     max_tokens: int = 4096,
     transport: Literal["api", "cli", "auto"] = "auto",
+    subject: str | None = None,
 ) -> AnthropicResult:
     """Issue a single-turn user prompt against ``model`` with retries.
 
@@ -660,6 +661,14 @@ async def call_anthropic(
               binary is on PATH, else API (DEC-001 subscription-first).
               The first ``auto → cli`` resolution per Python process
               emits a one-shot stderr announcement (DEC-019).
+        subject: Optional call-site label threaded to the CLI transport
+            for :func:`clauditor.runner._invoke_claude_cli`'s
+            ``apiKeySource`` telemetry line. When set, the CLI branch
+            emits ``clauditor.runner: apiKeySource=<val> (<subject>)``
+            so operators can attribute each line to a specific internal
+            LLM call (e.g. ``"L2 extraction"``, ``"L3 grading"``). See
+            issue #107. Ignored by the SDK transport (no telemetry
+            line is emitted there).
     """
     resolved, from_auto = _resolve_transport(transport)
 
@@ -674,7 +683,7 @@ async def call_anthropic(
 
     if resolved == "cli":
         return await _call_via_claude_cli(
-            prompt, model=model, max_tokens=max_tokens
+            prompt, model=model, max_tokens=max_tokens, subject=subject
         )
     return await _call_via_sdk(prompt, model=model, max_tokens=max_tokens)
 
@@ -824,6 +833,7 @@ async def _call_via_claude_cli(
     *,
     model: str,
     max_tokens: int,  # noqa: ARG001 — CLI does not take max_tokens.
+    subject: str | None = None,
 ) -> AnthropicResult:
     """CLI (subprocess) transport branch.
 
@@ -877,6 +887,7 @@ async def _call_via_claude_cli(
             claude_bin="claude",
             model=model,
             allow_hang_heuristic=False,
+            subject=subject,
         )
         duration = _monotonic() - start
 

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -804,7 +804,11 @@ async def _extract_call_with_retry(
     last_source = "api"
     for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
         api_result = await call_anthropic(
-            prompt, model=model, max_tokens=4096, transport=transport
+            prompt,
+            model=model,
+            max_tokens=4096,
+            transport=transport,
+            subject="L2 extraction",
         )
         total_input += api_result.input_tokens
         total_output += api_result.output_tokens

--- a/src/clauditor/propose_eval.py
+++ b/src/clauditor/propose_eval.py
@@ -749,7 +749,11 @@ async def _single_propose_attempt(
 
     try:
         result = await call_anthropic(
-            prompt, model=model, max_tokens=max_tokens, transport=transport
+            prompt,
+            model=model,
+            max_tokens=max_tokens,
+            transport=transport,
+            subject="propose-eval",
         )
     except Exception as exc:  # noqa: BLE001 — never raise out of propose_eval
         return _AttemptResult(

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -596,7 +596,11 @@ async def _call_blind_side_with_retry(
     parsed: dict | None = None
     for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
         r = await call_anthropic(
-            prompt, model=model, max_tokens=2048, transport=transport
+            prompt,
+            model=model,
+            max_tokens=2048,
+            transport=transport,
+            subject=f"L3 blind compare {side_label}",
         )
         total_input += r.input_tokens
         total_output += r.output_tokens
@@ -1100,7 +1104,11 @@ async def grade_quality(
     last_source = "api"
     for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
         api_result = await call_anthropic(
-            prompt, model=model, max_tokens=4096, transport=transport
+            prompt,
+            model=model,
+            max_tokens=4096,
+            transport=transport,
+            subject="L3 grading",
         )
         total_input_tokens += api_result.input_tokens
         total_output_tokens += api_result.output_tokens

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -740,9 +740,21 @@ def _invoke_claude_cli(
         # proposer) append ``" (<subject>)"`` so operators running
         # ``grade --transport cli`` can attribute each line to a
         # specific internal LLM call instead of seeing identical
-        # lines from multiple grader subprocesses.
+        # lines from multiple grader subprocesses. Sanitize any
+        # embedded newlines / carriage returns and cap the length so
+        # a hostile or buggy caller cannot break the "one line per
+        # run" invariant that log-scraping tools rely on.
         if api_key_source is not None:
-            suffix = f" ({subject})" if subject else ""
+            sanitized_subject = None
+            if subject:
+                sanitized_subject = (
+                    subject.replace("\r", " ").replace("\n", " ").strip()
+                )
+                if sanitized_subject:
+                    sanitized_subject = sanitized_subject[:200]
+            suffix = (
+                f" ({sanitized_subject})" if sanitized_subject else ""
+            )
             print(
                 f"clauditor.runner: apiKeySource={api_key_source}{suffix}",
                 file=sys.stderr,

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -450,6 +450,7 @@ def _invoke_claude_cli(
     claude_bin: str,
     model: str | None = None,
     allow_hang_heuristic: bool = True,
+    subject: str | None = None,
 ) -> InvokeResult:
     """Run ``claude -p <prompt>`` with stream-json output and parse the NDJSON.
 
@@ -733,9 +734,17 @@ def _invoke_claude_cli(
         # line) — absence is the signal. Values are labels
         # (``ANTHROPIC_API_KEY``, ``claude.ai``, ``none``), not
         # secrets, so printing them is safe.
+        #
+        # Issue #107: when ``subject`` is provided (callers like the
+        # L2 extraction grader, the L3 grading judge, the suggest
+        # proposer) append ``" (<subject>)"`` so operators running
+        # ``grade --transport cli`` can attribute each line to a
+        # specific internal LLM call instead of seeing identical
+        # lines from multiple grader subprocesses.
         if api_key_source is not None:
+            suffix = f" ({subject})" if subject else ""
             print(
-                f"clauditor.runner: apiKeySource={api_key_source}",
+                f"clauditor.runner: apiKeySource={api_key_source}{suffix}",
                 file=sys.stderr,
             )
 

--- a/src/clauditor/suggest.py
+++ b/src/clauditor/suggest.py
@@ -996,7 +996,11 @@ async def propose_edits(
 
     try:
         result = await call_anthropic(
-            prompt, model=model, max_tokens=max_tokens, transport=transport
+            prompt,
+            model=model,
+            max_tokens=max_tokens,
+            transport=transport,
+            subject="suggest proposer",
         )
     except Exception as exc:  # noqa: BLE001 — never raise out of propose_edits
         return _empty_report(api_error=f"anthropic API error: {exc!r}")

--- a/src/clauditor/triggers.py
+++ b/src/clauditor/triggers.py
@@ -192,7 +192,11 @@ async def classify_query(
 
     try:
         result = await call_anthropic(
-            prompt, model=model, max_tokens=1024, transport=transport
+            prompt,
+            model=model,
+            max_tokens=1024,
+            transport=transport,
+            subject="triggers judge",
         )
     except AnthropicHelperError as exc:
         # Graceful degradation: a single API failure (auth, 5xx

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -1258,6 +1258,70 @@ class TestCallViaClaudeCli:
         msg = str(exc_info.value)
         assert secret_leak not in msg
 
+    @pytest.mark.asyncio
+    async def test_subject_labels_stderr_apikeysource_line(
+        self, capsys
+    ) -> None:
+        """Issue #107: ``subject=`` threads through to the CLI's
+        ``apiKeySource`` stderr line so operators running
+        ``grade --transport cli`` can attribute each telemetry line to a
+        specific internal LLM call (e.g. L2 extraction vs L3 grading).
+        """
+        from tests.conftest import make_fake_skill_stream
+
+        fake = make_fake_skill_stream(
+            "ok",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "none",
+            },
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            await call_anthropic(
+                "p",
+                model="m",
+                transport="cli",
+                subject="L2 extraction",
+            )
+        captured = capsys.readouterr()
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        assert len(matching) == 1, captured.err
+        assert (
+            matching[0]
+            == "clauditor.runner: apiKeySource=none (L2 extraction)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subject_none_preserves_unlabeled_stderr_line(
+        self, capsys
+    ) -> None:
+        """Issue #107 acceptance criterion 4: existing format unchanged
+        when ``subject`` is not threaded through."""
+        from tests.conftest import make_fake_skill_stream
+
+        fake = make_fake_skill_stream(
+            "ok",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "none",
+            },
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            await call_anthropic("p", model="m", transport="cli")
+        captured = capsys.readouterr()
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        assert matching == ["clauditor.runner: apiKeySource=none"]
+
 
 class TestAnthropicResultFields:
     """Cover :attr:`AnthropicResult.source` and :attr:`duration_seconds`.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2560,6 +2560,80 @@ class TestApiKeySourceParsing:
         ]
         assert matching == ["clauditor.runner: apiKeySource=none"]
 
+    def test_stderr_line_sanitizes_subject_newlines_and_length(self, capsys):
+        # Copilot PR #114 review: ``subject`` is free-form, so a
+        # caller that accidentally passes a multi-line string or an
+        # unbounded value must not break the "one line per run"
+        # invariant that log scrapers rely on. Sanitization replaces
+        # CR/LF with spaces, strips, and caps at 200 chars.
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "none",
+            },
+        )
+        hostile = "  L2\nextraction\rwith   " + ("x" * 500) + "  "
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            _invoke_claude_cli(
+                "prompt",
+                cwd=None,
+                env=None,
+                timeout=180,
+                claude_bin="claude",
+                subject=hostile,
+            )
+        captured = capsys.readouterr()
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        # One line only — embedded \n did not split the output.
+        assert len(matching) == 1, captured.err
+        line = matching[0]
+        assert "\n" not in line and "\r" not in line
+        # Leading/trailing whitespace stripped; CR/LF replaced with spaces.
+        expected_prefix = (
+            "clauditor.runner: apiKeySource=none (L2 extraction with "
+        )
+        assert line.startswith(expected_prefix)
+        # 200-char cap applied to the sanitized subject body.
+        start = line.index("(") + 1
+        end = line.rindex(")")
+        assert end - start <= 200
+
+    def test_stderr_line_omits_suffix_when_subject_whitespace_only(
+        self, capsys
+    ):
+        # A whitespace-only subject strips to empty and must not emit
+        # a trailing ``()`` suffix — degrade to the unlabeled format.
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "none",
+            },
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            _invoke_claude_cli(
+                "prompt",
+                cwd=None,
+                env=None,
+                timeout=180,
+                claude_bin="claude",
+                subject="   \n\r ",
+            )
+        captured = capsys.readouterr()
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        assert matching == ["clauditor.runner: apiKeySource=none"]
+
     def test_stderr_line_suppressed_when_init_missing_field(self, capsys):
         # init present but apiKeySource absent → no stderr line (DEC-012).
         fake = make_fake_skill_stream(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2498,6 +2498,68 @@ class TestApiKeySourceParsing:
         captured = capsys.readouterr()
         assert "apiKeySource=" not in captured.err
 
+    def test_stderr_line_appends_subject_suffix(self, capsys):
+        # Issue #107: when the caller threads a ``subject`` label
+        # through ``_invoke_claude_cli`` (as grader call sites do via
+        # ``call_anthropic``), the stderr info line gains a
+        # ``" (<subject>)"`` suffix so operators can attribute each
+        # line to a specific internal LLM call.
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "none",
+            },
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            _invoke_claude_cli(
+                "prompt",
+                cwd=None,
+                env=None,
+                timeout=180,
+                claude_bin="claude",
+                subject="L2 extraction",
+            )
+        captured = capsys.readouterr()
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        assert len(matching) == 1, captured.err
+        assert (
+            matching[0]
+            == "clauditor.runner: apiKeySource=none (L2 extraction)"
+        )
+
+    def test_stderr_line_omits_suffix_when_subject_none(self, capsys):
+        # Issue #107 acceptance criterion 4: no regression in the
+        # existing format when ``subject`` is not threaded through.
+        fake = make_fake_skill_stream(
+            "hello",
+            init_message={
+                "type": "system",
+                "subtype": "init",
+                "apiKeySource": "none",
+            },
+        )
+        with patch("clauditor.runner.subprocess.Popen", return_value=fake):
+            _invoke_claude_cli(
+                "prompt",
+                cwd=None,
+                env=None,
+                timeout=180,
+                claude_bin="claude",
+            )
+        captured = capsys.readouterr()
+        matching = [
+            line
+            for line in captured.err.splitlines()
+            if "apiKeySource=" in line
+        ]
+        assert matching == ["clauditor.runner: apiKeySource=none"]
+
     def test_stderr_line_suppressed_when_init_missing_field(self, capsys):
         # init present but apiKeySource absent → no stderr line (DEC-012).
         fake = make_fake_skill_stream(


### PR DESCRIPTION
Closes #107.

## Summary
- Thread an optional `subject` kwarg through `call_anthropic` → `_call_via_claude_cli` → `_invoke_claude_cli` so each grader subprocess under `--transport cli` emits a distinguishable stderr line.
- When `subject` is set, the stderr line becomes `clauditor.runner: apiKeySource=<val> (<subject>)`; otherwise it stays `clauditor.runner: apiKeySource=<val>` (no regression).
- Six grader call sites labeled: `L2 extraction`, `L3 grading`, `L3 blind compare side1` / `side2`, `triggers judge`, `suggest proposer`, `propose-eval`. Skill-run subprocesses stay unlabeled.
- Docs updated in `docs/cli-reference.md` and `docs/stream-json-schema.md`.

## Before
```
clauditor.runner: apiKeySource=none
clauditor.runner: apiKeySource=none
Quality Grade: ...
```

## After
```
clauditor.runner: apiKeySource=none (L2 extraction)
clauditor.runner: apiKeySource=none (L3 grading)
Quality Grade: ...
```

## Acceptance criteria (from issue)
- [x] `grade --transport cli` produces two distinguishable telemetry lines (one per internal LLM call).
- [x] Labels identify the layer/call site so future failures can be attributed.
- [x] `extract` and `suggest` (single `call_anthropic` each) emit a single labeled line with the same shape.
- [x] No regression in the existing `apiKeySource` format; the label is an additive suffix.

## Test plan
- [x] `uv run ruff check src/ tests/` — passes.
- [x] `uv run pytest --cov=clauditor -q` — 2517 passed, 98.40% coverage.
- [x] New tests in `tests/test_runner.py::TestApiKeySourceParsing` cover both the labeled and unlabeled stderr paths.
- [x] New tests in `tests/test_anthropic.py::TestCallViaClaudeCli` cover the end-to-end `call_anthropic(subject=...)` plumbing.