### PR TITLE
docs: rebrand site homepage to "Agent Skills"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # clauditor
 
-Auditor for AgentSkills.io skills and Claude Integrations. Catches when your skill produces the wrong shape, not just the wrong answer — layered evaluation from free deterministic assertions through LLM-graded quality rubrics.
+Automated quality checks for [Agent Skills](https://agentskills.io). Catches when your skill produces the wrong shape, not just the wrong answer — layered evaluation from free deterministic assertions through LLM-graded quality rubrics.
 
 ## Install
 
@@ -17,7 +17,7 @@ Layer 1 (deterministic assertions) works without an `ANTHROPIC_API_KEY`. Layers 
 - [CLI Reference](cli-reference.md) — every subcommand, flag, and exit code
 - [Eval Spec Format](eval-spec-reference.md) — complete `.eval.json` schema
 - [Pytest Integration](pytest-plugin.md) — fixtures and options
-- [Using /clauditor](skill-usage.md) — the bundled Claude Code skill
+- [Using /clauditor](skill-usage.md) — the bundled Agent Skill
 
 ## Source
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: clauditor
-site_description: Auditor for AgentSkills.io skills and Claude Integrations
+site_description: Automated quality checks for Agent Skills (agentskills.io)
 site_url: https://wjduenow.github.io/clauditor/
 repo_url: https://github.com/wjduenow/clauditor
 repo_name: wjduenow/clauditor


### PR DESCRIPTION
## Summary
- Mirror the README's "Agent Skills" framing (PR #120) on the published docs site at https://wjduenow.github.io/clauditor/.
- Update `docs/index.md` tagline + the bundled-skill link wording.
- Update `mkdocs.yml` `site_description` so the `<meta name="description">` tag on every page also matches.

The README change in #120 only affected the GitHub repo landing page — the MkDocs site renders `docs/index.md`, not `README.md`. Verified locally with `mkdocs build` that `site/index.html` now contains the new tagline.

## Test plan
- [ ] CI green (lint, validate-skill, tests)
- [ ] After merge, confirm https://wjduenow.github.io/clauditor/ shows "Automated quality checks for Agent Skills." in the homepage opening line (cache may take ~10 min)