### PR TITLE
docs: enable mermaid diagram rendering in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,13 @@ theme:
 exclude_docs: |
   temp/
 
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
 nav:
   - Home: index.md
   - Quick Start: quick-start.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.0.dev4"
+version = "0.1.0.dev5"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Add the `pymdownx.superfences` mermaid `custom_fence` to `mkdocs.yml`. Material 9 sees this and lazy-loads mermaid.js at runtime when a page contains a `<pre class="mermaid">` block.
- Existing mermaid block in `docs/layers.md` will now render as a real diagram instead of a plain code-fence on https://wjduenow.github.io/clauditor/layers/.

## Test plan
- [ ] CI green
- [ ] After merge + redeploy, https://wjduenow.github.io/clauditor/layers/ shows the rendered flowchart (eval.json → L1/L2/L3 → assertions/extraction/grading sidecars)