### PR TITLE
docs: source the site homepage from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Automated quality checks for [Agent Skills](https://agentskills.io). A skill is a reusable instruction file (`SKILL.md`) that tells Claude how to do a task. clauditor answers three questions about every run: **Did it run?** **Did it return the right structure?** **Was the answer actually good?** First two checks cost pennies and run in CI; the third is for release gates.
 
-<details>
+<details markdown="1">
 <summary>Contents</summary>
 
 [Why clauditor?](#why-clauditor) · [Install](#install) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [Suggest](#llm-assisted-skill-improvement-clauditor-suggest) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Skill compatibility](#skill-compatibility) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
@@ -38,7 +38,7 @@ clauditor --version
 
 Layer 1 works without any LLM credentials. Layers 2 & 3 and `propose-eval` need either an Anthropic API key (`ANTHROPIC_API_KEY`) or the `claude` CLI installed and signed in to a Claude Pro/Max subscription — see [Authentication](#authentication-and-api-keys).
 
-<details>
+<details markdown="1">
 <summary>Installing from source (for contributors)</summary>
 
 ```bash
@@ -87,7 +87,7 @@ If you use [Claude Code](https://claude.com/claude-code) interactively, you can 
 
 From your project root, `uv run clauditor setup` creates a symlink at `.claude/skills/clauditor` pointing at the bundled Claude Code skill; `pip install --upgrade clauditor` then picks up skill updates automatically. Restart Claude Code once if `.claude/skills/` did not exist before.
 
-<details><summary>Flags and details</summary>
+<details markdown="1"><summary>Flags and details</summary>
 
 - `--unlink` — remove the `/clauditor` symlink. Refuses symlinks not pointing at the installed clauditor package, so it won't touch user-authored skills.
 - `--force` — overwrite an existing file or symlink at `.claude/skills/clauditor`.
@@ -211,7 +211,7 @@ Optional blocks (`input_files`, `output_files`, `variance`, `trigger_tests`) add
 
 **Covered in the full reference:** the full eval-spec JSON shape, `input_files` staging rules, `output_file` / `output_files` capture, and the `format` validation DSL (`phone_us`, `url`, `domain`, … or inline regex). Full reference: [docs/eval-spec-reference.md](https://github.com/wjduenow/clauditor/blob/dev/docs/eval-spec-reference.md).
 
-<details><summary>Alignment with agentskills.io</summary>
+<details markdown="1"><summary>Alignment with agentskills.io</summary>
 
 clauditor implements (and extends) the workflow at [agentskills.io/skill-creation/evaluating-skills](https://agentskills.io/skill-creation/evaluating-skills):
 
@@ -235,10 +235,10 @@ Note: `--no-api-key` only affects the subprocess; the six LLM-mediated commands 
 clauditor works for most skills out of the box. A few patterns need a workaround or aren't supported yet:
 
 - **Skills with parallel sub-tasks** (the `Task(run_in_background=true)` pattern): pass `--sync-tasks` to force them to run sequentially. Output capture works correctly, but the *async behavior itself* (race conditions, late-arriving results) is not tested — you're evaluating a slightly different execution model than what ships.
-- **Skills that ask the user mid-run** (e.g. `AskUserQuestion` to clarify intent): not supported directly — clauditor runs skills non-interactively, so the question never gets an answer and the run hangs. The fix is usually to take all parameters in the initial prompt; see the worked before/after example and the `not_contains AskUserQuestion` regression assertion in [`docs/skill-usage.md#recipe-skills-that-ask-the-user-mid-run`](docs/skill-usage.md#recipe-skills-that-ask-the-user-mid-run), with [`examples/.claude/commands/example-skill.eval.json`](examples/.claude/commands/example-skill.eval.json) as the canonical anchor.
+- **Skills that ask the user mid-run** (e.g. `AskUserQuestion` to clarify intent): not supported directly — clauditor runs skills non-interactively, so the question never gets an answer and the run hangs. The fix is usually to take all parameters in the initial prompt; see the worked before/after example and the `not_contains AskUserQuestion` regression assertion in [`docs/skill-usage.md#recipe-skills-that-ask-the-user-mid-run`](docs/skill-usage.md#recipe-skills-that-ask-the-user-mid-run), with [`examples/.claude/skills/find-kid-activities/SKILL.eval.json`](examples/.claude/skills/find-kid-activities/SKILL.eval.json) as the canonical anchor.
 - **Skills whose correctness depends on async timing**: cannot be tested accurately yet. Blocked on an upstream Claude Code feature.
 
-<details>
+<details markdown="1">
 <summary>Technical detail and upstream tracking</summary>
 
 clauditor invokes skills through `claude -p` (non-interactive print mode), which is a strict subset of the interactive Claude Code runtime. **Works**: sequential `Task` calls, parallel tool calls in the parent turn, every standard tool (`WebSearch`, `WebFetch`, `Bash`, `Read`, `Write`, `Edit`). **Works with `--sync-tasks`**: skills using `Task(run_in_background=true)` — the flag sets `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in the subprocess env, resolving the [#97](https://github.com/wjduenow/clauditor/issues/97) output-truncation case. **Loud failure today**: skills whose correctness depends on true async semantics — blocked on upstream Claude Code gaining headless background-task polling, tracked in [anthropics/claude-code#52917](https://github.com/anthropics/claude-code/issues/52917) and catalogued in [`docs/adr/transport-research-103.md`](docs/adr/transport-research-103.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,4 @@
-# clauditor
-
-Automated quality checks for [Agent Skills](https://agentskills.io). Catches when your skill produces the wrong shape, not just the wrong answer — layered evaluation from free deterministic assertions through LLM-graded quality rubrics.
-
-## Install
-
-```bash
-pip install clauditor-eval
-```
-
-Layer 1 (deterministic assertions) works without an `ANTHROPIC_API_KEY`. Layers 2 & 3 and `propose-eval` require an `ANTHROPIC_API_KEY` or an authenticated `claude` CLI.
-
-## Quick links
-
-- [Quick Start](quick-start.md) — from zero to a passing eval in minutes
-- [Three Layers](layers.md) — how L1 / L2 / L3 fit together
-- [CLI Reference](cli-reference.md) — every subcommand, flag, and exit code
-- [Eval Spec Format](eval-spec-reference.md) — complete `.eval.json` schema
-- [Pytest Integration](pytest-plugin.md) — fixtures and options
-- [Using /clauditor](skill-usage.md) — the bundled Agent Skill
-
-## Source
-
-[github.com/wjduenow/clauditor](https://github.com/wjduenow/clauditor)
+{%
+  include-markdown "../README.md"
+  rewrite-relative-urls=true
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,12 @@ theme:
 exclude_docs: |
   temp/
 
+plugins:
+  - search
+  - include-markdown
+
 markdown_extensions:
+  - md_in_html
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,4 +94,5 @@ dev = [
     "ruff>=0.4.0",
     "anthropic>=0.40.0",
     "mkdocs-material>=9.0",
+    "mkdocs-include-markdown-plugin>=6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508 },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -181,6 +190,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "anthropic" },
+    { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -199,6 +209,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=6.0" },
     { name = "mkdocs-material", specifier = ">=9.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -633,6 +644,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555 },
+]
+
+[[package]]
+name = "mkdocs-include-markdown-plugin"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2d/bdf1aee3f4f7b34148b0f62298b62f03415160cb2707f09503c99a0a7cd5/mkdocs_include_markdown_plugin-7.2.2.tar.gz", hash = "sha256:f052ccb741eccf498116b826c1d78a2d761c56747372594709441cee0963fbc9", size = 25415 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/a5/f6b2f0aa805dbda52f6265e9aff1450c8643195442facf29d475bdeba15d/mkdocs_include_markdown_plugin-7.2.2-py3-none-any.whl", hash = "sha256:f2ec4487cf32d3e33ca528f9366f20fb9280ded9c8d1630eb2bbda244962dcd1", size = 29528 },
 ]
 
 [[package]]
@@ -1126,4 +1150,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854 },
 ]


### PR DESCRIPTION
## Summary
- Make `README.md` the single source of truth for both the GitHub repo landing page AND the published docs-site homepage at https://wjduenow.github.io/clauditor/.
- `docs/index.md` is reduced to one `include-markdown` directive that pulls `../README.md` and rewrites repo-relative links (`docs/quick-start.md` -> `quick-start/`, etc.) for the published site.
- Enable `md_in_html` and add `markdown="1"` to the 5 `<details>` blocks in the README so their inner markdown parses correctly under MkDocs (fixes the "raw markdown showing inside Contents disclosure" issue).
- Fix a stale README pointer to the pre-#120 example path.

## Followups (out of scope)
- The README still has some absolute `https://github.com/.../blob/dev/docs/X.md` links. They work, but they could be made relative for the docs-site experience. Not blocking.

## Test plan
- [ ] CI green (lint, validate-skill, tests, docs deploy)
- [ ] After merge + redeploy, https://wjduenow.github.io/clauditor/ shows the README content (badges, Contents disclosure expanded properly, all sections)
- [ ] Internal anchors like https://wjduenow.github.io/clauditor/#why-clauditor resolve
- [ ] Doc nav tabs (Quick Start, CLI Reference, etc.) still work