### PR TITLE
feat(release-manager): pre-check TestPyPI for version conflict

### DIFF
--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -5,7 +5,7 @@ compatibility: "Requires: uv, gh CLI, git. Must be run from the clauditor repo r
 metadata:
   clauditor-version: "0.0.0-dev"
 disable-model-invocation: true
-allowed-tools: Bash(git *), Bash(gh *), Bash(uv *), Bash(uvx *), Bash(grep *), Bash(cat *), Bash(sleep *), Bash(pip *), Read, Edit
+allowed-tools: Bash(git *), Bash(gh *), Bash(uv *), Bash(uvx *), Bash(grep *), Bash(cat *), Bash(sleep *), Bash(pip *), Bash(curl *), Read, Edit
 ---
 
 # /release-manager — Cut a clauditor-eval release
@@ -57,8 +57,19 @@ Then continue to "Determine version" (on all-PASS) or STOP with the failing chec
 Read `pyproject.toml` and extract the current version.
 
 **For a test release:** version must have a pre-release suffix (`.devN`, `aN`, `bN`, `rcN`).
-If the current version is already a pre-release (e.g. `0.1.0.dev3`), use it as-is.
+If the current version is already a pre-release (e.g. `0.1.0.dev3`), use it as the candidate.
 If it is a clean version (e.g. `0.1.0`), stop and tell the user to bump to a dev version first.
+
+Then check TestPyPI to make sure the candidate has not already been published — TestPyPI rejects re-uploads of the same version, and discovering this after the GitHub release tag is pushed is painful:
+
+```bash
+candidate=$(grep '^version' pyproject.toml | cut -d'"' -f2)
+if curl -sf "https://test.pypi.org/pypi/clauditor-eval/${candidate}/json" >/dev/null; then
+  echo "Version ${candidate} already on TestPyPI — bump required"
+fi
+```
+
+If the candidate already exists on TestPyPI, propose the next `.devN` bump (e.g. `0.1.0.dev5` → `0.1.0.dev6`) and ask the user to confirm. On confirmation, edit `pyproject.toml` to set `version = "{next_dev_version}"` and re-run the TestPyPI check against the new candidate (in case that one was also published). If the candidate does **not** exist on TestPyPI, use it as-is — no edit needed.
 
 **For a full release:** strip the pre-release suffix from the current version.
 If the current version is already clean (e.g. `0.1.0`), use it as-is.


### PR DESCRIPTION
## Summary

Closes #125.

The `/release-manager` test workflow currently uses `pyproject.toml`'s version as-is. If that version already shipped to TestPyPI, the publish workflow fails *after* the GitHub release tag has been pushed — exactly the failure mode hit during the `v0.1.0.dev5` cut.

This PR adds a TestPyPI existence check inside the `Determine version` section. The skill now:

1. Pulls the candidate version from `pyproject.toml`.
2. Queries `https://test.pypi.org/pypi/clauditor-eval/{candidate}/json` via `curl -sf`.
3. On hit, proposes the next `.devN` bump and asks the user to confirm.
4. On confirm, edits `pyproject.toml` and re-checks (in case the next one was also published).

The pre-existing "Step 2 — Commit if version changed" already handles the case where `pyproject.toml` was edited, so no further wiring was needed.

`Bash(curl *)` was added to `allowed-tools`.

## Test plan

- [x] `clauditor lint` passes (only the pre-existing experimental-tools warning).
- [x] `pytest` passes.
- [ ] Next test release dry-runs the new check (verify hit + miss paths against TestPyPI).