### PR TITLE
chore: release 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.0.dev6"
+version = "0.1.0"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "clauditor-eval"
-version = "0.1.0.dev6"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Cuts the first stable release of clauditor-eval to PyPI: **0.1.0**
- Bumps `pyproject.toml` and refreshes `uv.lock`

## Test plan
- [x] Pre-flight tests pass on `main` after fast-forward (2595 passed, 98.44% coverage)
- [x] `uv build` produces `clauditor_eval-0.1.0-py3-none-any.whl` and `clauditor_eval-0.1.0.tar.gz`
- [x] `uvx twine check dist/*` PASSED on both artifacts
- [ ] After merge: tag `v0.1.0` on `main` HEAD, create GitHub release (no `--prerelease`), publish workflow uploads to PyPI