### PR TITLE
fix(conformance): address agentskills.io spec drift (#129)

### DIFF
--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -703,16 +703,15 @@ _NON_LOCAL_REF_PREFIX_RE: re.Pattern[str] = re.compile(
 )
 
 
-def _reference_depth(target: str) -> int:
-    """Return the directory-hop depth of a local reference target.
+def _normalize_ref_target(target: str) -> str:
+    """Strip the syntactic noise that does not affect a path's depth.
 
-    ``0`` means same-directory (e.g. ``foo.md``); ``1`` means one
-    subdirectory deep (e.g. ``refs/foo.md``); ``2+`` means deeper.
-    Returns ``-1`` as a sentinel when the target escapes the skill
-    directory via ``..``.
-
-    Strips a leading ``./`` and trailing ``#anchor`` / ``?query``
-    components before counting.
+    Removes trailing ``#anchor`` / ``?query`` components and any
+    leading ``./`` segments so that ``./foo/bar.md``,
+    ``foo/bar.md``, and ``foo/bar.md#sec`` collapse to the same
+    canonical form. Used by both depth calculation and the
+    de-duplication ``seen`` set so syntactic variants of the same
+    underlying file produce one warning, not three.
     """
     for sep in ("#", "?"):
         idx = target.find(sep)
@@ -720,7 +719,20 @@ def _reference_depth(target: str) -> int:
             target = target[:idx]
     while target.startswith("./"):
         target = target[2:]
-    parts = target.split("/")
+    return target
+
+
+def _reference_depth(normalized: str) -> int:
+    """Return the directory-hop depth of an already-normalized target.
+
+    ``0`` means same-directory (e.g. ``foo.md``); ``1`` means one
+    subdirectory deep (e.g. ``refs/foo.md``); ``2+`` means deeper.
+    Returns ``-1`` as a sentinel when the target escapes the skill
+    directory via ``..``.
+
+    Caller is expected to have run :func:`_normalize_ref_target` first.
+    """
+    parts = normalized.split("/")
     if any(p == ".." for p in parts):
         return -1
     # Number of directory hops = total segments minus the filename.
@@ -772,9 +784,13 @@ def _check_reference_depth(
             continue
         for match in _MD_INLINE_LINK_RE.finditer(line):
             _maybe_flag_reference(match.group(1), seen, issues)
-
-    for match in _MD_REF_DEF_RE.finditer(body):
-        _maybe_flag_reference(match.group(1), seen, issues)
+        # Reference-style definitions are scanned per-line (not once
+        # over the whole body) so the fence skip applies — a
+        # ``[label]: a/b/c.md`` line inside a ``\`\`\`...\`\`\`` block
+        # is treated as example syntax, not a real definition.
+        ref_match = _MD_REF_DEF_RE.match(line)
+        if ref_match:
+            _maybe_flag_reference(ref_match.group(1), seen, issues)
 
 
 def _maybe_flag_reference(
@@ -784,12 +800,16 @@ def _maybe_flag_reference(
 ) -> None:
     if not target or _NON_LOCAL_REF_PREFIX_RE.match(target):
         return
-    depth = _reference_depth(target)
+    normalized = _normalize_ref_target(target)
+    depth = _reference_depth(normalized)
     if 0 <= depth <= 1:
         return
-    if target in seen:
+    # De-dup on the normalized form so syntactic variants of the
+    # same underlying file (``./a/b/c.md``, ``a/b/c.md``,
+    # ``a/b/c.md#sec``) produce one warning, not three.
+    if normalized in seen:
         return
-    seen.add(target)
+    seen.add(normalized)
     if depth == -1:
         message = (
             f"SKILL.md references `{target}` which escapes the skill "

--- a/src/clauditor/conformance.py
+++ b/src/clauditor/conformance.py
@@ -263,6 +263,7 @@ def check_conformance(
     _check_allowed_tools(parsed, issues)
     _check_unknown_keys(parsed, issues)
     _check_body(body, issues)
+    _check_reference_depth(body, issues)
 
     return issues
 
@@ -498,7 +499,8 @@ def _check_license(parsed: dict, issues: list[ConformanceIssue]) -> None:
                 severity="error",
                 message=(
                     "Frontmatter `license` is empty; omit the key or "
-                    "provide a non-empty SPDX identifier."
+                    "provide a non-empty license name or path to a "
+                    "bundled license file."
                 ),
             )
         )
@@ -675,6 +677,140 @@ def _check_body(body: str, issues: list[ConformanceIssue]) -> None:
                 ),
             )
         )
+
+
+# Markdown link / image targets. Captures the URL/path portion of an
+# inline ``[text](target)`` or ``![alt](target)``, stopping at the first
+# whitespace or close-paren so an optional ``"title"`` after the target
+# does not contaminate the capture.
+_MD_INLINE_LINK_RE: re.Pattern[str] = re.compile(
+    r"!?\[[^\]]*\]\(\s*([^\s\)]+)"
+)
+
+# Reference-style link definitions: ``[label]: target [optional title]``.
+# Anchored to line start so it does not match the usage form
+# ``[text][label]`` elsewhere in the line.
+_MD_REF_DEF_RE: re.Pattern[str] = re.compile(
+    r"^\s{0,3}\[[^\]]+\]:\s*(\S+)",
+    re.MULTILINE,
+)
+
+# Targets that are NOT local file references: any URL scheme
+# (``http:``, ``mailto:``, ``ftp:``, ``data:``, …), absolute paths
+# (``/foo``), and pure anchors (``#section``). Schemes follow RFC 3986.
+_NON_LOCAL_REF_PREFIX_RE: re.Pattern[str] = re.compile(
+    r"^(?:[a-zA-Z][a-zA-Z0-9+.-]*:|#|/)"
+)
+
+
+def _reference_depth(target: str) -> int:
+    """Return the directory-hop depth of a local reference target.
+
+    ``0`` means same-directory (e.g. ``foo.md``); ``1`` means one
+    subdirectory deep (e.g. ``refs/foo.md``); ``2+`` means deeper.
+    Returns ``-1`` as a sentinel when the target escapes the skill
+    directory via ``..``.
+
+    Strips a leading ``./`` and trailing ``#anchor`` / ``?query``
+    components before counting.
+    """
+    for sep in ("#", "?"):
+        idx = target.find(sep)
+        if idx != -1:
+            target = target[:idx]
+    while target.startswith("./"):
+        target = target[2:]
+    parts = target.split("/")
+    if any(p == ".." for p in parts):
+        return -1
+    # Number of directory hops = total segments minus the filename.
+    return max(0, len(parts) - 1)
+
+
+def _check_reference_depth(
+    body: str, issues: list[ConformanceIssue]
+) -> None:
+    """Flag Markdown references more than one directory deep.
+
+    Walks the body line by line, scanning for inline link / image
+    targets and reference-style link definitions. Skips fenced code
+    blocks (triple-backtick and triple-tilde) so example link
+    syntax inside code does not produce false positives. Targets with
+    URL schemes, absolute paths, and pure anchors are not local file
+    references and are skipped.
+
+    A target is considered "one level deep" when it lives in the same
+    directory as SKILL.md (``foo.md``) or in an immediate subdirectory
+    (``refs/foo.md``). Two or more directory hops (``a/b/c.md``) and
+    parent-escaping references (``../foo.md``) are flagged with
+    ``AGENTSKILLS_REFERENCE_DEPTH_TOO_DEEP`` (severity warning).
+
+    Per-target de-duplication: each unique target produces at most one
+    issue, even if referenced multiple times.
+    """
+    if body == "":
+        return
+
+    seen: set[str] = set()
+    in_fence = False
+    fence_marker = ""
+
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if in_fence:
+            if stripped.startswith(fence_marker):
+                in_fence = False
+                fence_marker = ""
+            continue
+        if stripped.startswith("```"):
+            in_fence = True
+            fence_marker = "```"
+            continue
+        if stripped.startswith("~~~"):
+            in_fence = True
+            fence_marker = "~~~"
+            continue
+        for match in _MD_INLINE_LINK_RE.finditer(line):
+            _maybe_flag_reference(match.group(1), seen, issues)
+
+    for match in _MD_REF_DEF_RE.finditer(body):
+        _maybe_flag_reference(match.group(1), seen, issues)
+
+
+def _maybe_flag_reference(
+    target: str,
+    seen: set[str],
+    issues: list[ConformanceIssue],
+) -> None:
+    if not target or _NON_LOCAL_REF_PREFIX_RE.match(target):
+        return
+    depth = _reference_depth(target)
+    if 0 <= depth <= 1:
+        return
+    if target in seen:
+        return
+    seen.add(target)
+    if depth == -1:
+        message = (
+            f"SKILL.md references `{target}` which escapes the skill "
+            f"directory via `..`; the agentskills.io specification "
+            f"recommends keeping file references one level deep from "
+            f"SKILL.md."
+        )
+    else:
+        message = (
+            f"SKILL.md references `{target}` which is {depth} "
+            f"directories deep; the agentskills.io specification "
+            f"recommends keeping file references one level deep from "
+            f"SKILL.md (avoid deeply nested reference chains)."
+        )
+    issues.append(
+        ConformanceIssue(
+            code="AGENTSKILLS_REFERENCE_DEPTH_TOO_DEEP",
+            severity="warning",
+            message=message,
+        )
+    )
 
 
 def _check_unquoted_colon_in_scalar(

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1282,3 +1282,27 @@ class TestReferenceDepth:
         text = _build_skill(body=body)
         issues = check_conformance(text, _modern_path())
         assert self._CODE not in _codes(issues)
+
+    def test_dedup_collapses_syntactic_variants(self):
+        # ``./a/b/c.md``, ``a/b/c.md``, and ``a/b/c.md#sec`` all
+        # resolve to the same underlying file — produce one warning.
+        body = (
+            "[a](./a/b/c.md) and [b](a/b/c.md) and [c](a/b/c.md#sec).\n"
+        )
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, self._CODE)
+        assert len(flagged) == 1
+
+    def test_ref_def_inside_fenced_code_block_ignored(self):
+        # Reference-style link definitions inside a fenced block are
+        # example syntax, not real definitions — must not be flagged.
+        body = (
+            "Example of a ref-style link:\n"
+            "```markdown\n"
+            "[label]: deep/nested/page.md\n"
+            "```\n"
+        )
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1106,3 +1106,179 @@ class TestWalkerDefensiveGuards:
             "---\nname: foo\ncolonless line\nbar: baz\n---\n"
         )
         assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# Reference-depth validation
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceDepth:
+    """Validate ``AGENTSKILLS_REFERENCE_DEPTH_TOO_DEEP`` checks.
+
+    The agentskills.io spec recommends keeping file references one
+    level deep from SKILL.md. Same-directory and one-subdirectory
+    references are accepted; two or more directory hops and parent
+    escapes are flagged with severity warning.
+    """
+
+    _CODE = "AGENTSKILLS_REFERENCE_DEPTH_TOO_DEEP"
+
+    def test_sibling_reference_accepted(self):
+        body = "See [details](reference.md) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_one_subdirectory_accepted(self):
+        body = "See [details](references/api.md) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_dot_slash_prefix_does_not_inflate_depth(self):
+        body = "See [details](./refs/api.md) and [other](./sibling.md).\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_two_subdirectories_flagged(self):
+        body = "See [details](references/api/v2.md) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE in _codes(issues)
+        issue = _by_code(issues, self._CODE)[0]
+        assert issue.severity == "warning"
+        assert "references/api/v2.md" in issue.message
+        assert "2 directories deep" in issue.message
+
+    def test_three_subdirectories_flagged(self):
+        body = "Deep: [x](a/b/c/file.md).\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        issue = _by_code(issues, self._CODE)[0]
+        assert "3 directories deep" in issue.message
+
+    def test_parent_escape_flagged(self):
+        body = "See [up](../shared/util.md) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE in _codes(issues)
+        issue = _by_code(issues, self._CODE)[0]
+        assert "escapes the skill directory" in issue.message
+        assert "`..`" in issue.message
+
+    def test_parent_escape_in_middle_flagged(self):
+        body = "See [up](sub/../../other.md) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE in _codes(issues)
+
+    def test_image_target_flagged(self):
+        body = "![diagram](img/sub/diagram.png)\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE in _codes(issues)
+
+    def test_reference_style_definition_flagged(self):
+        body = "See [the docs][docs].\n\n[docs]: refs/sub/page.md\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE in _codes(issues)
+        issue = _by_code(issues, self._CODE)[0]
+        assert "refs/sub/page.md" in issue.message
+
+    def test_external_url_skipped(self):
+        body = (
+            "Visit [home](https://example.com/a/b/c) and "
+            "[mail](mailto:foo@example.com) and "
+            "[ftp](ftp://files.example.com/x/y/z).\n"
+        )
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_anchor_only_skipped(self):
+        body = "See [section](#deep-section) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_absolute_path_skipped(self):
+        body = "See [system](/etc/foo/bar) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_anchor_suffix_stripped_before_depth(self):
+        # ``refs/api.md#section`` is depth 1, not depth 2.
+        body = "See [details](refs/api.md#section) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_query_suffix_stripped_before_depth(self):
+        body = "See [details](refs/api.md?ver=2) for more.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_link_inside_fenced_code_block_ignored(self):
+        body = (
+            "Here is a code example:\n"
+            "```\n"
+            "[doc](a/b/c/d.md)\n"
+            "```\n"
+            "End.\n"
+        )
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_link_inside_tilde_fence_ignored(self):
+        body = (
+            "Example:\n"
+            "~~~\n"
+            "[doc](a/b/c/d.md)\n"
+            "~~~\n"
+        )
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_duplicate_target_only_flagged_once(self):
+        body = (
+            "First [a](deep/nested/page.md). "
+            "Second [b](deep/nested/page.md). "
+            "Third [c](deep/nested/page.md).\n"
+        )
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, self._CODE)
+        assert len(flagged) == 1
+
+    def test_distinct_deep_targets_each_flagged(self):
+        body = "[a](x/y/z.md) and [b](p/q/r.md).\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        flagged = _by_code(issues, self._CODE)
+        assert len(flagged) == 2
+
+    def test_link_with_title_target_extracted(self):
+        body = '[doc](deep/nested/page.md "Title goes here")\n'
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE in _codes(issues)
+        issue = _by_code(issues, self._CODE)[0]
+        assert "deep/nested/page.md" in issue.message
+
+    def test_empty_body_silent(self):
+        text = _build_skill(body="")
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)
+
+    def test_body_without_links_silent(self):
+        body = "Just some prose, no links here.\n"
+        text = _build_skill(body=body)
+        issues = check_conformance(text, _modern_path())
+        assert self._CODE not in _codes(issues)


### PR DESCRIPTION
## Summary

Closes #129. Two deltas detected against the 2026-04-24 fetch of [agentskills.io/specification](https://agentskills.io/specification):

- **`AGENTSKILLS_LICENSE_EMPTY` message phrasing**: previously suggested a "non-empty SPDX identifier", which mislead authors who legitimately want free-form license text. Replaced with "non-empty license name or path to a bundled license file" to match the spec's wording. No behavior change.
- **`AGENTSKILLS_REFERENCE_DEPTH_TOO_DEEP` (new check, severity `warning`)**: scans Markdown link / image targets and reference-style definitions in the SKILL.md body for paths more than one directory deep, plus parent escapes (`..`). Same-directory and one-subdirectory references stay silent (lenient interpretation per the spec's "one level deep from SKILL.md" wording). Skips fenced code blocks, URL schemes, anchors, and absolute paths. Per-target de-dupe so a target referenced N times produces one warning.

## Test plan

- [x] `uv run pytest tests/test_conformance.py` — 21 new `TestReferenceDepth` cases + existing license assertions pass
- [x] `uv run pytest tests/test_bundled_skill.py` — bundled SKILL.md still conforms (no new warnings)
- [x] `uv run pytest --cov=clauditor` — 2614 passed, `conformance.py` at 100% coverage
- [x] `uv run ruff check src/ tests/` — clean