### PR TITLE
docs: cut 0.1.0 changelog section, wire into mkdocs nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ contain breaking changes without a deprecation shim; see the
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **How this is maintained.** Day-to-day work goes under `[Unreleased]`; on
+> release, those entries are promoted under a new version header dated with
+> the release day. The `/release-manager` skill uses the version section as
+> the GitHub Release body via `gh release create --notes-file`, so this file
+> is the single source of truth for human-facing release notes.
+
 ## [Unreleased]
+
+## [0.1.0] - 2026-04-25
+
+First stable release on PyPI: <https://pypi.org/project/clauditor-eval/0.1.0/>.
 
 ### Breaking changes
 
@@ -220,3 +230,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the codified recipe.
 - Bundled `/clauditor` Claude Code slash command installable via
   `clauditor setup`.
+
+[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,4 @@
+{%
+  include-markdown "../CHANGELOG.md"
+  rewrite-relative-urls=true
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,3 +49,4 @@ nav:
   - Badges: badges.md
   - Architecture: architecture.md
   - Stream JSON: stream-json-schema.md
+  - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- Promotes the existing `[Unreleased]` content to a `[0.1.0] - 2026-04-25` section with the matching PyPI URL
- Adds reference links at the bottom for `[Unreleased]` (compare-to-HEAD) and `[0.1.0]` (release tag)
- Adds a "How this is maintained" note tying the file to the `/release-manager` skill (next PR will wire `--notes-file` into the skill)
- Wires CHANGELOG.md into the docs site as a Changelog page via `include-markdown` so the root file stays the single source of truth

## Test plan
- [x] `[Unreleased]` is empty and `[0.1.0]` carries the prior content
- [x] Reference links resolve (compare and tag URLs)
- [ ] After merge: confirm the docs-site `Changelog` nav entry renders
- [ ] Future release: `/release-manager` Step 5 uses `--notes-file` against the new section