### PR TITLE
chore: release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-26
+
 ### Added
 
 - **`AGENTSKILLS_REFERENCE_DEPTH_TOO_DEEP` conformance warning (#129) —
@@ -264,5 +266,6 @@ First stable release on PyPI: <https://pypi.org/project/clauditor-eval/0.1.0/>.
 - Bundled `/clauditor` Claude Code slash command installable via
   `clauditor setup`.
 
-[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.1
 [0.1.0]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.1.dev0"
+version = "0.1.1"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "clauditor-eval"
-version = "0.1.1.dev0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Cuts v0.1.1 to PyPI. Pre-flight tests pass (2623 passed, 98.45% cov); `uv build` + `uvx twine check` PASSED on both wheel and sdist. CHANGELOG promoted from `[Unreleased]` to `[0.1.1] - 2026-04-26`.