### PR TITLE
chore: begin 0.1.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.1"
+version = "0.1.2.dev0"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "clauditor-eval"
-version = "0.1.1"
+version = "0.1.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps version to 0.1.2.dev0 after the v0.1.1 release.