### PR TITLE
#150: skill identity to prompt resolver (plan)

### DIFF
--- a/.claude/rules/harness-protocol-shape.md
+++ b/.claude/rules/harness-protocol-shape.md
@@ -3,9 +3,13 @@
 When adding a new harness implementation (Codex per #149, future raw-API
 agent loop, etc.), conform to the `Harness` protocol surface defined in
 `src/clauditor/_harnesses/__init__.py`. The protocol is **structurally
-typed** (no `@runtime_checkable` decorator; no inheritance pressure) so a
-harness is "in" the moment it provides three members with matching
-signatures.
+typed** and decorated `@runtime_checkable`, so `isinstance(obj, Harness)`
+works as a duck-typed drift-guard — but `runtime_checkable` only checks
+member presence, not signature shape; sibling tests in
+`tests/test_runner.py::TestHarnessProtocol` use `inspect.signature` to
+lock the parameter set. A harness is "in" the moment it provides four
+members (`name`, `invoke`, `strip_auth_keys`, `build_prompt`) with
+matching signatures.
 
 ## The pattern
 
@@ -47,15 +51,31 @@ class MyHarness:
         # Return a NEW dict with your harness's auth env vars removed.
         # Pure, non-mutating per non-mutating-scrub.md.
         ...
+
+    def build_prompt(
+        self,
+        skill_name: str,
+        args: str,
+        *,
+        system_prompt: str | None,
+    ) -> str:
+        # Compose the wire-shape prompt this harness's ``invoke``
+        # expects. Pure compute (no I/O, no global state) per
+        # pure-compute-vs-io-split.md. Each harness owns its own
+        # rendering — Claude Code uses ``"/{skill_name} {args}"``;
+        # raw-API harnesses embed ``system_prompt`` in a structured
+        # message body. Harnesses with no notion of a separate system
+        # prompt MUST still accept and ignore the kwarg.
+        ...
 ```
 
 ## Rationale
 
-Three members keep the protocol minimal: identity (`name`), the work
-itself (`invoke`), and a non-mutating env scrub (`strip_auth_keys`).
-Construction parameters are entirely per-harness — they don't appear on
-the protocol surface — so harness-specific knobs cannot leak into
-cross-harness code.
+Four members keep the protocol minimal: identity (`name`), the work
+itself (`invoke`), a non-mutating env scrub (`strip_auth_keys`), and the
+pure prompt composer (`build_prompt`). Construction parameters are
+entirely per-harness — they don't appear on the protocol surface — so
+harness-specific knobs cannot leak into cross-harness code.
 
 ### Why `name: ClassVar[str]`
 
@@ -102,20 +122,79 @@ hidden system prompts) populate `harness_metadata` with their own keys.
 sidecars can surface harness-specific observability without bumping a
 schema version.
 
+### Why `build_prompt` is on the protocol (not a free function)
+
+Each harness's wire-shape is structurally different: Claude Code consumes
+`"/{skill_name} {args}"` slash-commands resolved by `claude -p`; future
+Codex / raw-API harnesses prepend `system_prompt` and append `args` as
+distinct message-body components. Putting `build_prompt` on the protocol
+lets every harness own its own rendering without forcing
+`SkillRunner.run` to branch on harness type. Per US-001 of issue #150,
+the method is **pure compute** — no file I/O, no global state — so
+auto-derive of `system_prompt` from `SKILL.md` body lives one layer up
+in `SkillSpec.run` (which wraps read/parse failures in a `RuntimeError`
+naming the skill + path with `__cause__` chained, per
+`.claude/rules/pure-compute-vs-io-split.md`).
+
+### Why `system_prompt` on `build_prompt` is keyword-only
+
+Per US-001 of issue #150, `system_prompt` is a positional-swap risk
+against `args` (both are strings; transposing them silently sends the
+wrong text to the LLM). Marking it keyword-only after `*` makes the
+mistake unrepresentable: `harness.build_prompt("foo", "bar", "baz")`
+would `TypeError` instead of binding `"baz"` to `system_prompt`.
+Harnesses with no notion of a separate system prompt
+(`ClaudeCodeHarness`) MUST still accept and ignore the kwarg — analogous
+to how all harnesses accept `model` on `invoke` even if they pin a
+fixed value internally.
+
 ## Canonical implementations
 
 - `src/clauditor/_harnesses/_claude_code.py::ClaudeCodeHarness` — the
   primary implementation; subprocess + stream-json parser.
-- `src/clauditor/_harnesses/_mock.py::MockHarness` — minimal test
-  helper; records every `invoke(...)` call, returns a configurable
+  `build_prompt` returns `f"/{skill_name}"` when `args == ""`, else
+  `f"/{skill_name} {args}"`; ignores `system_prompt`.
+- `src/clauditor/_harnesses/_mock.py::MockHarness` — production-grade
+  protocol implementation (NOT just a test fake). Records every
+  `invoke(...)` and `build_prompt(...)` call on `invoke_calls` and
+  `build_prompt_calls` respectively, returns a configurable
   `InvokeResult`. Use for `SkillRunner(harness=MockHarness(...))` in
-  unit tests when you don't want to mock subprocess.
+  unit tests when you don't want to mock subprocess. **Because
+  `MockHarness` is a real protocol implementation, every protocol
+  addition MUST update it in the same PR** — otherwise `isinstance(mock,
+  Harness)` silently breaks for any test that relied on it.
+
+## Adding a new protocol member — checklist
+
+When extending the protocol with a new member (`build_prompt` from #150
+is the first such extension since the protocol was extracted in #148):
+
+1. Define the member on `Harness` in `src/clauditor/_harnesses/__init__.py`
+   with a clear docstring noting purity and per-harness ownership.
+2. Implement on **every** existing harness in the same PR — including
+   `MockHarness` (it is production-grade, not a test fake; see canonical
+   implementations above). A skipped implementation silently breaks
+   `isinstance(harness, Harness)` for any caller relying on the
+   `runtime_checkable` drift-guard.
+3. Keep I/O at a higher layer. If the new member needs a side-effectful
+   resolver (e.g. `build_prompt`'s `system_prompt` auto-derive), put the
+   I/O in `SkillSpec.run` (or its analogue) and pass the resolved value
+   into the pure protocol method, per
+   `.claude/rules/pure-compute-vs-io-split.md`.
+4. Update the count in this rule's opening paragraph and rationale
+   header. The signature drift between rule prose and protocol code is
+   real footgun; keeping the count current is the cheap audit signal.
+5. Add a signature-locking test in
+   `tests/test_runner.py::TestHarnessProtocol` using `inspect.signature`
+   to assert the parameter set, kinds (positional vs keyword-only), and
+   return annotation. Keyword-only parameters are particularly
+   sensitive — `runtime_checkable` does not enforce them.
 
 ## Adding a new harness — checklist
 
 1. Create `src/clauditor/_harnesses/_<name>.py` (private module
    convention — leading underscore).
-2. Define the class with the three protocol members. Match parameter
+2. Define the class with the four protocol members. Match parameter
    names and types exactly.
 3. Construct an `InvokeResult` populated with semantic-equivalent
    fields (`output`, `exit_code`, `duration_seconds`, `error`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`EvalSpec.system_prompt: str | None = None` field (#150).** Mirrors
+  `user_prompt`'s shape and validation: optional at load time, when set
+  must be a non-empty, non-whitespace string (`EvalSpec.from_file`
+  rejects empty strings, whitespace-only strings, and non-string
+  values). When unset, clauditor auto-derives the system prompt from
+  the `SKILL.md` body (post-frontmatter, via `parse_frontmatter`) at
+  `SkillSpec.run` time. Explicit `EvalSpec.system_prompt` wins over
+  the auto-derived `SKILL.md` body. Auto-derive failures (missing
+  file, malformed frontmatter) raise a `RuntimeError` naming the
+  skill and path. Frontmatter `system_prompt:` keys inside `SKILL.md`
+  are NOT supported (DEC-003) — the body is the auto-derive source.
+  See [`docs/eval-spec-reference.md#system-prompt`](docs/eval-spec-reference.md#system-prompt).
+- **`Harness.build_prompt(skill_name, args, *, system_prompt) -> str`
+  protocol method (#150).** Third member of the cross-harness
+  `Harness` protocol (alongside `invoke` and `strip_auth_keys`). Each
+  harness owns its identity-to-prompt strategy: `ClaudeCodeHarness`
+  keeps the slash-command synthesis (`f"/{skill_name} {args}"`, or
+  `f"/{skill_name}"` when args is empty) and ignores `system_prompt`
+  because the `claude -p` CLI has no separate system-prompt channel;
+  `MockHarness` records `(skill_name, args, system_prompt)` on
+  `build_prompt_calls` for test assertions and returns a deterministic
+  stub that surfaces all three inputs. The forthcoming `CodexHarness`
+  (#149) will consume `system_prompt` as the system message. See
+  [`docs/architecture.md#3-harness-protocol`](docs/architecture.md#3-harness-protocol).
+- **`SkillRunner.run(..., system_prompt=...)` keyword-only kwarg
+  (#150).** Threads the resolved `system_prompt` from `SkillSpec.run`
+  to the harness's `build_prompt`. Keyword-only and placed last so it
+  cannot collide positionally with the existing `cwd` / `env` /
+  `timeout` kwargs. `SkillSpec.run` resolves the effective value once
+  (explicit `EvalSpec.system_prompt` > auto-derived `SKILL.md` body)
+  and threads the resolved string through this kwarg.
+
 ## [0.1.1] - 2026-04-26
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,3 +157,51 @@ flowchart LR
 - **L3** always runs (if `grading_criteria` defined — required for `grade`)
 - All three layers receive the **same skill output text** and evaluate independently
 - Results are combined into the final report; the overall pass/fail is driven by L3's `pass_rate` against the configured threshold (default 70%)
+
+---
+
+## 3. Harness Protocol
+
+`clauditor.runner.SkillRunner` is harness-agnostic — it delegates the
+actual LLM-CLI subprocess to a `Harness` implementation that satisfies
+the structural protocol defined in
+`src/clauditor/_harnesses/__init__.py`. The protocol has three
+members: `invoke(prompt, *, cwd, env, timeout, model, subject)` for
+the subprocess + parse loop, `strip_auth_keys(env)` for harness-specific
+auth-env scrubbing, and **`build_prompt(skill_name, args, *,
+system_prompt) -> str`** (introduced in #150) which composes the wire
+prompt each harness's `invoke` expects. Each harness owns its
+identity-to-prompt strategy; the runner never assembles a slash command
+or message body itself.
+
+Shipping implementations:
+
+- **`ClaudeCodeHarness.build_prompt`** — returns
+  `f"/{skill_name} {args}"`, or `f"/{skill_name}"` when `args` is the
+  empty string. Ignores `system_prompt` because the `claude -p` CLI
+  has no separate system-prompt channel (skill identity carries the
+  body via the slash command).
+- **`MockHarness.build_prompt`** — appends
+  `{"skill_name", "args", "system_prompt"}` to `build_prompt_calls` so
+  unit tests can assert against the triple, then returns a deterministic
+  string of the form `"[mock]<system_prompt or ''>|/<skill_name>
+  <args>"` (trailing whitespace stripped). The returned string surfaces
+  all three inputs so a test can assert on the rendered prompt without
+  inspecting the call list.
+- **Future: `CodexHarness.build_prompt` (#149)** — will prepend
+  `system_prompt` as the system message and append `args` as the user
+  message, matching the OpenAI-style structured-message wire format.
+  This is the motivating use case for the `system_prompt` kwarg living
+  on the cross-harness protocol surface.
+
+**Resolution flow.** `SkillSpec.run` resolves the effective
+`system_prompt` once at the spec layer (explicit `EvalSpec.system_prompt`
+> auto-derived `SKILL.md` body — see
+[`docs/eval-spec-reference.md#system-prompt`](eval-spec-reference.md#system-prompt))
+and threads the resolved string through to the harness via the new
+keyword-only `system_prompt` kwarg on `SkillRunner.run(...)`. The kwarg
+is keyword-only and placed last so callers cannot accidentally swap it
+positionally with the existing `cwd` / `env` / `timeout` kwargs.
+Harnesses that have no notion of a separate system prompt (currently
+`ClaudeCodeHarness`) MUST still accept and ignore the kwarg —
+analogous to how all harnesses accept `model` on `invoke`.

--- a/docs/eval-spec-reference.md
+++ b/docs/eval-spec-reference.md
@@ -273,6 +273,70 @@ A few `EvalSpec` fields tune specific code paths and are safe to omit:
   before enabling this field — evaluating sync is not equivalent to
   evaluating async.**
 
+## System Prompt
+
+`EvalSpec.system_prompt` (string, default `null`) is the prompt body
+sent to harnesses that consume a separate system-prompt channel. The
+shipping `ClaudeCodeHarness` ignores it (the `claude -p` CLI has no
+analogue — slash-command identity carries the skill body), but the
+forthcoming `CodexHarness` (#149) will prepend it before the user
+message. It is part of the cross-harness `Harness.build_prompt`
+contract introduced in #150 so a single `EvalSpec` shape feeds every
+harness identically.
+
+**Two-level precedence.** clauditor resolves the effective
+`system_prompt` once per run:
+
+1. **Explicit `EvalSpec.system_prompt`** (set in `eval.json`) wins.
+2. **Auto-derived `SKILL.md` body** — when the field is `null` or
+   omitted, clauditor reads the skill file referenced by `SkillSpec`,
+   strips the YAML frontmatter via `parse_frontmatter`, and uses the
+   remaining body as the system prompt.
+
+There is no third fallback. The empty-string body case threads through
+verbatim — a `SKILL.md` with frontmatter but no body resolves to `""`,
+not `None`, so a misconfigured skill surfaces clearly downstream
+rather than silently masking a missing prompt.
+
+**Validation rules.** When set, `system_prompt` must be a non-empty,
+non-whitespace string. The loader raises `ValueError` at
+`EvalSpec.from_file` time on any of: non-string value, empty string
+(`""`), or a string that strips to empty (whitespace-only). Mirrors
+`user_prompt`'s validation shape exactly.
+
+Frontmatter `system_prompt:` keys inside `SKILL.md` are NOT supported
+(DEC-003 of #150). The body of `SKILL.md` is the auto-derive source;
+authors who need a value distinct from the body must set it explicitly
+in `eval.json`.
+
+**Auto-derive failure mode.** If the auto-derive path is taken (no
+explicit `system_prompt` in the eval spec) and the skill file is
+missing, unreadable, or has malformed frontmatter, `SkillSpec.run`
+raises `RuntimeError` naming both the skill identity and the
+resolved skill path. The underlying `FileNotFoundError` / `OSError` /
+`ValueError` chains through `__cause__` for debug. This is a hard
+failure — not a warning — because every grader code path needs a
+deterministic system prompt for cross-run comparability.
+
+**Example — explicit override in eval.json:**
+
+```json
+{
+  "skill_name": "find-kid-activities",
+  "test_args": "\"Cupertino, CA\" --ages 4-6 --count 5",
+  "system_prompt": "You are a careful local-events researcher. Prefer primary sources (venue websites, official park pages) over aggregators. When confidence is low, say so explicitly.",
+  "assertions": [
+    {"id": "no_error", "type": "not_contains", "needle": "Error"}
+  ]
+}
+```
+
+When omitted, `clauditor` derives the same prompt from the body of
+`find-kid-activities/SKILL.md` automatically — the explicit field is
+only needed when the eval-time prompt should diverge from the shipped
+skill body (e.g. tightening rubric framing for a CI grader without
+editing `SKILL.md`).
+
 ## Schema history
 
 **Issue #67 — per-type assertion keys.** Assertion dicts previously

--- a/plans/super/150-prompt-resolver.md
+++ b/plans/super/150-prompt-resolver.md
@@ -10,6 +10,7 @@
 - **Sessions:** 1
 - **Last session:** 2026-04-29
 - **Total decisions:** 13
+- **PR URL:** https://github.com/wjduenow/clauditor/pull/158
 
 ---
 

--- a/plans/super/150-prompt-resolver.md
+++ b/plans/super/150-prompt-resolver.md
@@ -6,12 +6,13 @@
 - **Branch:** `feature/150-prompt-resolver`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/150-prompt-resolver`
 - **Base branch:** `dev`
-- **Phase:** `devolved`
+- **Phase:** `complete`
 - **Sessions:** 1
 - **Last session:** 2026-04-29
 - **Total decisions:** 13
 - **PR URL:** https://github.com/wjduenow/clauditor/pull/158
-- **Beads epic:** `clauditor-dnr`
+- **Beads epic:** `clauditor-dnr` (closed)
+- **Status:** All 7 stories merged on `feature/150-prompt-resolver`. CI green. Awaiting merge to `dev`.
 
 ---
 

--- a/plans/super/150-prompt-resolver.md
+++ b/plans/super/150-prompt-resolver.md
@@ -1,0 +1,410 @@
+# Super Plan: #150 — Multi-harness: skill identity to prompt resolver (`EvalSpec.system_prompt`)
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/150
+- **Parent epic:** https://github.com/wjduenow/clauditor/issues/143 (Multi-provider / multi-harness, Epic B)
+- **Branch:** `feature/150-prompt-resolver`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/150-prompt-resolver`
+- **Base branch:** `dev`
+- **Phase:** `published`
+- **Sessions:** 1
+- **Last session:** 2026-04-29
+- **Total decisions:** 13
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Decouple skill *identity* from skill *invocation strategy*. Today `SkillRunner.run` synthesizes `f"/{skill_name} {args}"` inline (`runner.py:280–282`) — that string is a slash command, which only Claude Code's CLI understands. Codex (under `exec`) and raw API harnesses have no slash-command discovery. Three changes:
+
+1. Add `EvalSpec.system_prompt: str | None = None` field with load-time validation (mirrors existing `user_prompt` from #39).
+2. Auto-derive `system_prompt` when unset by reading the resolved skill's `SKILL.md` body (frontmatter parsed off, body returned as-is).
+3. Add `Harness.build_prompt(skill_name, args, system_prompt) → str` to the protocol so each harness owns its strategy:
+   - `ClaudeCodeHarness.build_prompt` → existing `f"/{skill_name} {args}"` synthesis (ignores `system_prompt`).
+   - Future `CodexHarness.build_prompt` (#149) → prepend `system_prompt` body, append `args` as user query.
+4. `SkillSpec.run` resolves `system_prompt` once and threads it through to the harness.
+
+**Why:** Prerequisite for #149 (CodexHarness). Today's slash-command synthesis is Claude-Code-specific and inlined at the seam where the harness boundary should be. Without this resolver, any non-slash-command harness has to either re-implement the synthesis or hack around it.
+
+**Who benefits:** clauditor maintainers (unblocks #149), and downstream eval authors who want one `EvalSpec` to run across `{ClaudeCode, Codex, raw-API}` harness combinations.
+
+**Done when (from ticket):**
+1. A `SKILL.md` skill runs under Claude unchanged (back-compat).
+2. The same skill, with `EvalSpec.system_prompt` auto-derived, runs under Codex producing comparable output.
+3. An eval spec with explicit `system_prompt` overrides auto-derivation.
+4. Tests cover both back-compat (Claude path) and the Codex path.
+
+**Out of scope (explicit):**
+- Generating an `AGENTS.md` from `SKILL.md` (Codex auto-loads `AGENTS.md` from cwd; the `system_prompt` path is the explicit alternative).
+- LLM-assisted prompt rewriting per harness.
+- Actual `CodexHarness` implementation lives in #149.
+- New CLI flags (deferred to #151).
+
+**Dependencies:** Blocked by #148 (`Harness` protocol — already MERGED via PR #157). Blocks #149 (Codex needs the prompt resolver).
+
+### Codebase Findings
+
+#### Current `Harness` protocol (post-#148)
+
+`src/clauditor/_harnesses/__init__.py:1–79`
+
+```python
+@runtime_checkable
+class Harness(Protocol):
+    name: ClassVar[str]
+    def invoke(self, prompt: str, *, cwd, env, timeout, model=None, subject=None) -> InvokeResult: ...
+    def strip_auth_keys(self, env: dict[str, str]) -> dict[str, str]: ...
+```
+
+The protocol takes a fully-synthesized `prompt: str` and is transport-agnostic. `build_prompt` will be a new third method.
+
+#### Inline slash-command synthesis (the seam to extract)
+
+`src/clauditor/runner.py:280–282` (inside `SkillRunner.run`):
+
+```python
+prompt = f"/{skill_name}"
+if args:
+    prompt += f" {args}"
+```
+
+Then passed to `_invoke()` → `harness.invoke()` (line 393–398). Two internal callers:
+- `SkillRunner.run` (above)
+- `call_anthropic` at `_anthropic.py:881–882` via `asyncio.to_thread(_invoke_claude_cli, ...)` — Claude-only path; **does not need `build_prompt` plumbing** (it's a grader-side call, not skill-runner side).
+
+#### `EvalSpec` definition
+
+`src/clauditor/schemas.py:237–300` (fields) and `:301–775` (`from_dict` / `from_file` validation).
+
+Existing `user_prompt: str | None = None` field (DEC-001 of #39's plan) is the **template we follow**:
+
+```python
+# field declaration (line ~252)
+user_prompt: str | None = None
+
+# from_dict validation (lines 636–643)
+user_prompt = data.get("user_prompt")
+if user_prompt is not None:
+    if not isinstance(user_prompt, str) or not user_prompt.strip():
+        raise ValueError(
+            f"EvalSpec(skill_name={skill_name!r}): user_prompt "
+            f"must be a non-empty, non-whitespace string, "
+            f"got {user_prompt!r}"
+        )
+```
+
+#### Frontmatter parser
+
+`src/clauditor/_frontmatter.py:1–182`
+
+```python
+def parse_frontmatter(text: str) -> tuple[dict | None, str]:
+    """Return ``(parsed_frontmatter_dict, body_text)``."""
+```
+
+Returns the post-frontmatter body verbatim as the second tuple element. Auto-derive == call `parse_frontmatter(skill_md_text)` and use `body`. **No changes needed to `_frontmatter.py`.**
+
+#### `SkillSpec.run` flow
+
+`src/clauditor/spec.py:124–229`
+
+The auto-derive insertion point is between the existing resolution steps (~line 162, after `allow_hang_heuristic` is computed) and the call to `self.runner.run(...)` at line 193. The runner's `run()` will gain a `system_prompt: str | None = None` kwarg.
+
+#### No existing `ResolvedSkill` dataclass
+
+Frontmatter is parsed inline at call sites (e.g., `paths.py:125–140`). Re-reading SKILL.md once per run is acceptable for a first pass; caching can land later if profiling demands it.
+
+#### Test landscape
+
+- `tests/test_runner.py` (155 KB) — runner tests.
+- `tests/test_spec.py` (41 KB) — `SkillSpec` and `EvalSpec` tests.
+- `tests/conftest.py` — `make_fake_skill_stream` factory (lines 77–130), `_eval_spec_factory` (lines 398–427), `build_eval_spec(**overrides)` (lines 563–580). The `user_prompt` test patterns there give us the template for `system_prompt` tests.
+
+### Convention Constraints (from `.claude/rules/`)
+
+These rules apply to #150's design. Each will become a validation criterion at the Phase 4 rules-compliance gate.
+
+- **harness-protocol-shape** — `build_prompt` belongs on the `Harness` protocol; harnesses own their strategy. Don't inline harness-specific logic outside the protocol.
+- **skill-identity-from-frontmatter** — frontmatter is the identity source; body is content. The auto-derive treats body as the prompt content; frontmatter stays untouched.
+- **eval-spec-stable-ids** — `system_prompt` is a top-level scalar; if any sub-field structure is added later, each sub-entry must carry stable `id`s. Out of scope here.
+- **pre-llm-contract-hard-validate** — validate `system_prompt` (non-empty, non-whitespace) at `EvalSpec.from_dict` time, not at runtime. Mirror `user_prompt`.
+- **permissive-parser-strict-validator** — accept absent/None permissively; validate strictly when present.
+- **path-validation** — does not currently apply (we are not accepting `@file:` references). If we later allow `system_prompt: "@file:./prompt.md"`, this rule kicks in.
+- **non-mutating-scrub** — any normalization (trim trailing whitespace) must return a new string; never mutate the spec in place.
+- **pure-compute-vs-io-split** — `build_prompt` is pure (string in, string out). File I/O for auto-derive lives outside the protocol method, in `SkillSpec.run`.
+- **centralized-sdk-call** — N/A here; `build_prompt` does not call any SDK.
+- **dual-version-external-schema-embed** — if `EvalSpec` ever exports to an external registry, `system_prompt` participates in schema versioning. Out of scope here.
+- **json-schema-version** — if sidecars (e.g., `extraction.json`, `grading.json`) ever record the resolved `system_prompt`, bump `schema_version`. Out of scope unless a story explicitly adds it.
+
+### Project Documentation Touch Points
+
+- **`docs/eval-spec-reference.md`** — needs a new "System Prompt" section (auto-derive + override precedence).
+- **`docs/architecture.md`** — needs the `Harness.build_prompt` protocol addition documented.
+- **`README.md`** — light review only.
+
+### Proposed Scope (initial)
+
+1. New `EvalSpec.system_prompt: str | None = None` field + non-empty-string validation in `from_dict`.
+2. `Harness.build_prompt(skill_name, args, system_prompt) → str` added to the protocol.
+3. `ClaudeCodeHarness.build_prompt` returns `f"/{skill_name} {args}"` (ignores `system_prompt`).
+4. `SkillRunner.run` accepts `system_prompt` kwarg, calls `self.harness.build_prompt(...)` instead of inline synthesis at lines 280–282.
+5. `SkillSpec.run` resolves `effective_system_prompt`: explicit > auto-derived from SKILL.md body. Threads to `runner.run`.
+6. A test-only `_StringPromptHarness` (or extend `MockHarness`) that exercises the `system_prompt` path so we don't ship a dormant code path waiting for #149.
+7. Tests: back-compat (Claude path unchanged), explicit override path, auto-derive path, validation failure path.
+8. Doc updates: `docs/eval-spec-reference.md` + `docs/architecture.md` snippets.
+
+---
+
+## Scoping Questions (resolved)
+
+- **DEC-001 — `build_prompt` call site (Q1=A):** Called inside `SkillRunner.run`. Replace inline synthesis at `runner.py:280–282` with `prompt = self.harness.build_prompt(skill_name, args, system_prompt)`. Public `run()` gains `system_prompt: str | None = None` kwarg. **Rationale:** keeps the seam at the boundary the protocol was designed for; `SkillSpec.run` only owns *resolution*, not synthesis.
+- **DEC-002 — Auto-derive caching (Q2=A):** Read + parse `SKILL.md` inside `SkillSpec.run` every invocation. **Rationale:** one extra read per run is negligible (skills are small markdown files); avoids new state on `SkillSpec` and avoids a `ResolvedSkill` refactor that would touch many sites.
+- **DEC-003 — Frontmatter override (Q3=A):** Two-level precedence only. `EvalSpec.system_prompt` (explicit) wins; otherwise auto-derive from `SKILL.md` body. No frontmatter `system_prompt:` key. **Rationale:** keep the surface minimal; if frontmatter override is wanted later, it's a localized addition to the resolver.
+- **DEC-004 — ClaudeCodeHarness with explicit `system_prompt` (Q4=A):** Silent ignore. `ClaudeCodeHarness.build_prompt` returns `f"/{skill_name} {args}"` regardless of the `system_prompt` arg. **Rationale:** matches ticket text; cross-harness specs should run without per-harness friction.
+- **DEC-005 — Future-harness test coverage (Q5=A):** Add a test-only `_StringPromptHarness` (or extend the existing test fake) that uses `system_prompt` as the prompt body, so the protocol shape is exercised end-to-end before #149 ships. **Rationale:** prevents shipping a dormant code path; gives #149 a known-good reference.
+
+---
+
+## Architecture Review
+
+| Area | Rating | Summary |
+|---|---|---|
+| Security | **pass** | Inputs are trusted developer files (SKILL.md, eval.json). No new traversal surface. Existing `SKILL_NAME_RE` guard at `paths.py` is defense-in-depth. Optional: length cap on `system_prompt` to prevent accidental memory bloat. |
+| Performance | **pass** | Measured: ~0.013 ms read+parse for a 6.5 KB SKILL.md. Per-run overhead ~0.001% relative to subprocess startup. Variance worst case (5 sequential runs) totals ~0.065 ms. DEC-002 (re-read per run) is fine. |
+| API + Data Model | **concern** | (1) `build_prompt` should be keyword-only on `system_prompt` to match the codebase style for optional kwargs. (2) `MockHarness` already exists at `_harnesses/_mock.py` and **must** gain `build_prompt` — otherwise it stops satisfying the runtime-checkable protocol. (3) Kwarg order in `runner.run` for `system_prompt` is up for review. (4) Whether `SkillResult` should record the resolved `system_prompt` for audit/replay is open. (5) `EvalSpec` has no `schema_version`; sidecars do not embed `EvalSpec`. No version bumps. |
+| Observability | **concern** | (1) When `SkillSpec.run` auto-derives, missing/unreadable `SKILL.md` raises an unwrapped `FileNotFoundError`/`ValueError`; should be wrapped with a friendly stderr message. (2) Should we emit a one-line stderr "system_prompt source = explicit-eval-spec | auto-derived-from-body | not-set" tag (label only, not content)? Useful for cross-harness debugging once #149 lands. |
+| Testing | **pass** | Mature infrastructure exists: `test_schemas.py:1418–1756` has the `user_prompt` validation suite that we mirror; `tmp_skill_file` fixture in `conftest.py:432–485` writes modern-layout `.claude/skills/<n>/SKILL.md`; `MockHarness` at `_harnesses/_mock.py` is the harness fake. `TestHarnessProtocol` (`test_runner.py:165–226`) is a structural-conformance drift-guard we'll need to update for `build_prompt`. ~100 LoC of new tests across 4 files. Coverage gate (`--cov-fail-under=80`) will pass. |
+
+### Key concerns (carry into refinement)
+
+- **C-API-1 — Keyword-only `system_prompt` on `build_prompt`?** Ticket text shows positional ordering. Codebase style for optional kwargs is keyword-only (e.g., `invoke`'s `model`, `subject`).
+- **C-API-2 — `MockHarness` is a real implementation, not just a test toy.** It lives at `src/clauditor/_harnesses/_mock.py` and is referenced from production code (per the API+Data Model report). Adding `build_prompt` to the protocol requires implementing it on `MockHarness` *in this PR* — non-negotiable.
+- **C-API-3 — `SkillResult` audit field.** Should the resolved `system_prompt` be recorded on `SkillResult` so an audit log can reconstruct the exact request? Ticket is silent.
+- **C-API-4 — Kwarg position of `system_prompt` in `runner.run`.** Place it last (after `allow_hang_heuristic`) or grouped with prompt-related fields? Existing call sites all use kwargs, so no positional breakage.
+- **C-OBS-1 — Wrap auto-derive errors.** When SKILL.md is missing or has malformed frontmatter, surface a user-friendly error that names the skill, instead of a raw stack trace.
+- **C-OBS-2 — Source-label stderr log.** Emit `"clauditor: system_prompt source = <label>"` to stderr, label-only, no content. Helps debug cross-harness specs.
+- **C-SEC-1 — Length cap on `system_prompt`.** Optional defensive measure (e.g., reject > 100 KB at `from_dict` time). Ticket doesn't require it; cheap to add.
+
+No blockers. All concerns are decisions to make before story breakdown.
+
+---
+
+## Refinement Log
+
+- **DEC-006 — `build_prompt` parameter style (Q6=A):** Keyword-only on `system_prompt`. Final shape: `def build_prompt(self, skill_name: str, args: str, *, system_prompt: str | None) -> str`. **Why:** matches codebase convention for optional kwargs (e.g., `invoke`'s `model`, `subject`); call sites become self-documenting.
+- **DEC-007 — `SkillResult` audit field (Q7=A):** Do not add. Recording the resolved `system_prompt` on `SkillResult` is deferred to #154 (per-iteration harness context sidecar). **Why:** keeps #150 focused on resolution; sidecar/audit shape belongs to its own ticket.
+- **DEC-008 — `runner.run` kwarg position (Q8=A):** `system_prompt` lands last, after `allow_hang_heuristic`. **Why:** stable anchor for existing test mocks; "new optional kwargs go at the end" is consistent with prior changes here.
+- **DEC-009 — Auto-derive error handling (Q9=A):** Wrap and re-raise. When `SkillSpec.run` auto-derives and the read or `parse_frontmatter` fails, raise `RuntimeError(f"clauditor.spec: failed to auto-derive system_prompt for skill {skill_name!r} from {skill_path}: {orig}")` with the original exception chained via `from`. **Why:** raw `FileNotFoundError`/`ValueError` deep in `_frontmatter` doesn't tell the user which skill/path is broken.
+- **DEC-010 — Stderr source-label log (Q10=B):** No log emitted in #150. **Why:** silent today; cheap to add later if cross-harness debugging (#149) shows it would help.
+- **DEC-011 — `system_prompt` length cap (Q11=B):** No cap. **Why:** ticket doesn't require it; trust developer input; can add defensively later.
+- **DEC-012 — `MockHarness` must implement `build_prompt`:** Non-negotiable. `MockHarness` lives in `src/clauditor/_harnesses/_mock.py` and is referenced from production code, so the protocol addition forces an implementation here. The `MockHarness.build_prompt` records the inputs (so tests can assert what was passed) and returns a deterministic concatenation that includes `system_prompt` when present (so the e2e tests for the future Codex path can verify threading).
+- **DEC-013 — `TestHarnessProtocol` drift-guard updated:** `tests/test_runner.py:165–226` enforces structural conformance to the protocol via `inspect.signature`. The drift-guard must be updated to expect the new `build_prompt` member, including a signature check for `(skill_name: str, args: str, *, system_prompt: str | None) -> str`.
+
+---
+
+## Detailed Breakdown
+
+### Validation command (used as AC suffix on every implementation story)
+
+```bash
+uv run ruff check . && uv run pytest --cov-fail-under=80
+```
+
+---
+
+### US-001 — Add `build_prompt` to `Harness` protocol; implement on `ClaudeCodeHarness` and `MockHarness`
+
+**Description:** Extend the `Harness` protocol with a pure prompt-builder method that lets each harness own its identity-to-prompt strategy. Implement it on the two existing harnesses (`ClaudeCodeHarness` keeps slash-command synthesis; `MockHarness` records inputs and returns a deterministic concatenation). Update the drift-guard test to expect the new member.
+
+**Traces to:** DEC-001, DEC-004, DEC-006, DEC-012, DEC-013.
+
+**Files:**
+- `src/clauditor/_harnesses/__init__.py` — add `build_prompt(self, skill_name: str, args: str, *, system_prompt: str | None) -> str` to the `Harness` Protocol.
+- `src/clauditor/_harnesses/_claude_code.py` — implement `build_prompt`: returns `f"/{skill_name}"` when `args == ""`, else `f"/{skill_name} {args}"`. Ignores `system_prompt`.
+- `src/clauditor/_harnesses/_mock.py` — implement `build_prompt`: record `(skill_name, args, system_prompt)` on a list (`build_prompt_calls`) and return a deterministic string that includes `system_prompt` when present (e.g., `f"[mock]{system_prompt or ''}|/{skill_name} {args}".rstrip()`). The recorded calls are what tests assert against.
+- `tests/test_runner.py` — update `TestHarnessProtocol` (lines 165–226) to require `build_prompt` and check its signature via `inspect.signature`.
+
+**TDD:**
+- `test_claude_code_harness_build_prompt_with_args_and_no_system_prompt` — `("foo", "bar baz", system_prompt=None)` → `"/foo bar baz"`.
+- `test_claude_code_harness_build_prompt_no_args` — `("foo", "", system_prompt=None)` → `"/foo"`.
+- `test_claude_code_harness_build_prompt_ignores_system_prompt` — `("foo", "", system_prompt="anything")` → `"/foo"`.
+- `test_mock_harness_build_prompt_records_call` — `MockHarness.build_prompt("foo", "bar", system_prompt="hello")` appends to `build_prompt_calls` and the recorded entry contains all three values.
+- `test_harness_protocol_includes_build_prompt` — drift-guard asserts the method exists and has the keyword-only `system_prompt` parameter typed `str | None`, return type `str`.
+
+**Acceptance criteria:**
+- All five TDD tests pass.
+- Existing `TestHarnessProtocol` continues to pass (with the updated expectation).
+- `uv run ruff check . && uv run pytest --cov-fail-under=80` is green.
+
+**Done when:** Protocol exposes `build_prompt`; both shipping harnesses implement it; drift-guard is updated; tests pass.
+
+**Depends on:** none.
+
+---
+
+### US-002 — Add `EvalSpec.system_prompt` field with load-time validation
+
+**Description:** Add an optional `system_prompt: str | None = None` field to `EvalSpec`, mirroring the existing `user_prompt` field's shape and validation. Place it adjacent to `user_prompt` for grouping. Mirror the existing `user_prompt` test suite for the validation paths.
+
+**Traces to:** DEC-003 (no frontmatter override path on `EvalSpec`), DEC-011 (no length cap).
+
+**Files:**
+- `src/clauditor/schemas.py` — add `system_prompt: str | None = None` to the `EvalSpec` dataclass field list immediately after `user_prompt` (~line 252). Add validation in `from_dict` immediately after the `user_prompt` validation block (~line 644): same `isinstance(str) and strip()` check, same error-message style. Add a corresponding entry in `to_dict` (omit when `None`, emit when set), parallel to how `user_prompt` is serialized.
+- `tests/test_schemas.py` — mirror the `user_prompt` validation suite (lines 1418–1756) for `system_prompt`.
+
+**TDD:**
+- `test_from_file_loads_system_prompt` — eval.json with `"system_prompt": "you are helpful"` round-trips into the dataclass.
+- `test_from_file_system_prompt_absent_defaults_to_none` — eval.json without the key produces `system_prompt is None`.
+- `test_from_file_system_prompt_empty_string_rejected` — `"system_prompt": ""` raises `ValueError` with skill name in message.
+- `test_from_file_system_prompt_whitespace_only_rejected` — `"system_prompt": "   "` raises.
+- `test_from_file_system_prompt_non_string_rejected` — `"system_prompt": 42` raises.
+- `test_to_dict_omits_system_prompt_when_unset` — round-trip an `EvalSpec` with `system_prompt=None`; the output dict has no `system_prompt` key.
+- `test_to_dict_emits_system_prompt_when_set` — round-trip with `system_prompt="hi"`; output dict has the field.
+- Extend `make_eval_spec` / `build_eval_spec` factories in `conftest.py` to accept a `system_prompt` kwarg.
+
+**Acceptance criteria:**
+- All seven TDD tests pass.
+- The factories accept `system_prompt`.
+- `uv run ruff check . && uv run pytest --cov-fail-under=80` is green.
+
+**Done when:** `EvalSpec` carries `system_prompt`; loader validates it; serializer round-trips it; tests cover absent/valid/empty/whitespace/non-string.
+
+**Depends on:** none.
+
+---
+
+### US-003 — Wire `system_prompt` through `SkillRunner.run` via `harness.build_prompt`
+
+**Description:** Replace the inline `f"/{skill_name} {args}"` synthesis at `runner.py:280–282` with a call to `self.harness.build_prompt(...)`. Add `system_prompt: str | None = None` as the last keyword argument on `SkillRunner.run` (after `allow_hang_heuristic`). Thread it to `_invoke` only as far as needed to call `build_prompt` — it does not need to land on `InvokeResult`.
+
+**Traces to:** DEC-001, DEC-007, DEC-008.
+
+**Files:**
+- `src/clauditor/runner.py` — `SkillRunner.run` (line 247): add `system_prompt: str | None = None` as last kwarg. Replace lines 280–282 with `prompt = self.harness.build_prompt(skill_name, args, system_prompt=system_prompt)`. Audit `_invoke` to ensure it still passes `prompt` through unchanged.
+- `tests/test_runner.py` — add tests that assert `build_prompt` is called with the right args and that `system_prompt` propagates from `runner.run` kwargs.
+
+**TDD:**
+- `test_runner_run_calls_harness_build_prompt_with_args` — `MockHarness` records the call when `runner.run("foo", "bar")` is invoked; assert `("foo", "bar", system_prompt=None)`.
+- `test_runner_run_threads_system_prompt_kwarg_to_build_prompt` — `runner.run("foo", "bar", system_prompt="hello")` records `("foo", "bar", system_prompt="hello")`.
+- `test_runner_run_passes_built_prompt_to_invoke` — assert the prompt string returned by `MockHarness.build_prompt` is what reaches `MockHarness.invoke`.
+- `test_runner_run_back_compat_no_system_prompt_kwarg` — call `runner.run("foo", "bar")` with no `system_prompt`; ClaudeCodeHarness path produces `"/foo bar"` exactly (back-compat).
+
+**Acceptance criteria:**
+- Four TDD tests pass.
+- All existing `runner.run` tests pass without modification (back-compat).
+- `uv run ruff check . && uv run pytest --cov-fail-under=80` is green.
+
+**Done when:** Runner uses `build_prompt`; the `system_prompt` kwarg threads cleanly; back-compat is proven.
+
+**Depends on:** US-001 (needs `build_prompt` on the protocol and `MockHarness`).
+
+---
+
+### US-004 — Resolve and thread `system_prompt` in `SkillSpec.run` (auto-derive + explicit override + friendly errors)
+
+**Description:** In `SkillSpec.run`, compute `effective_system_prompt`: explicit (`self.eval_spec.system_prompt`) wins; otherwise read `self.skill_path` and use the body returned by `_frontmatter.parse_frontmatter` as the auto-derived value. Pass `system_prompt=effective_system_prompt` to `self.runner.run(...)`. Wrap read/parse failures with a `RuntimeError` that names the skill and path, chained from the original.
+
+**Traces to:** DEC-002, DEC-003, DEC-009.
+
+**Files:**
+- `src/clauditor/spec.py` — in `SkillSpec.run` (~line 162, after `allow_hang_heuristic` resolution and before the `self.runner.run(...)` call at ~line 193): add the resolution block. Wrap the file read + `parse_frontmatter` call in a `try/except (FileNotFoundError, OSError, ValueError)` and re-raise a `RuntimeError(f"clauditor.spec: failed to auto-derive system_prompt for skill {self.skill_name!r} from {self.skill_path}: {exc}") from exc`.
+- `tests/test_spec.py` — e2e tests using `tmp_skill_file` fixture (`conftest.py:432–485`) and `MockHarness`.
+
+**TDD:**
+- `test_skill_spec_run_auto_derives_system_prompt_from_body` — write a `SKILL.md` with frontmatter and a body; construct `SkillSpec` with no explicit `system_prompt`; call `run("args")`; assert `MockHarness.build_prompt_calls[-1].system_prompt` equals the body string.
+- `test_skill_spec_run_explicit_eval_spec_system_prompt_wins` — `SKILL.md` has body "BODY"; `EvalSpec.system_prompt = "EXPLICIT"`; assert recorded call uses `"EXPLICIT"`.
+- `test_skill_spec_run_no_system_prompt_when_eval_spec_explicitly_empty_body` — `SKILL.md` body is empty (frontmatter only); auto-derive yields empty string; the empty-body case threads through as `""` (allowed; falsy values do not trigger fallback). *(Documents the edge case rather than masking it.)*
+- `test_skill_spec_run_missing_skill_md_raises_friendly_error` — `skill_path` points at a non-existent file; assert `RuntimeError` is raised with `skill_name` and the path in the message; assert `__cause__` is a `FileNotFoundError`.
+- `test_skill_spec_run_malformed_frontmatter_raises_friendly_error` — write a `SKILL.md` with broken frontmatter (`---` opening with no closing); assert `RuntimeError` with skill name and path; `__cause__` is a `ValueError`.
+
+**Acceptance criteria:**
+- Five TDD tests pass.
+- Existing `SkillSpec.run` integration tests continue to pass (back-compat under `ClaudeCodeHarness` is preserved because the resolved `system_prompt` is ignored on that path).
+- `uv run ruff check . && uv run pytest --cov-fail-under=80` is green.
+
+**Done when:** `SkillSpec.run` resolves `system_prompt` correctly under all three branches (explicit, auto-derive, error); friendly error wrapping is in place.
+
+**Depends on:** US-002 (needs the field), US-003 (needs the runner kwarg).
+
+---
+
+### US-005 — Documentation updates
+
+**Description:** Document the new `system_prompt` field, its precedence, and the auto-derive behavior in user-facing docs. Document the protocol addition in architecture docs.
+
+**Traces to:** DEC-001, DEC-002, DEC-003, DEC-004.
+
+**Files:**
+- `docs/eval-spec-reference.md` — add a "System Prompt" subsection covering: (1) what it is, (2) the two-level precedence (explicit > auto-derived from `SKILL.md` body), (3) the validation rules (non-empty, non-whitespace string when set), (4) which harnesses use it (Codex via #149) vs ignore it (ClaudeCode).
+- `docs/architecture.md` — add a paragraph documenting `Harness.build_prompt` as the third protocol member, with a one-line description of each shipping implementation's strategy.
+- `CHANGELOG.md` — under `[Unreleased]`, add a bullet under "Added" for `EvalSpec.system_prompt` and `Harness.build_prompt`.
+
+**Acceptance criteria:**
+- All three docs updated.
+- `uv run ruff check . && uv run pytest --cov-fail-under=80` is green.
+
+**Done when:** Reference docs explain the field; architecture doc explains the protocol; changelog records the addition.
+
+**Depends on:** US-001, US-002, US-003, US-004.
+
+---
+
+### US-006 — Quality Gate (code review × 4 + CodeRabbit)
+
+**Description:** Run an in-process code reviewer four times across the full diff for #150 (everything since branch base `dev`). Fix every real bug surfaced on each pass. Run CodeRabbit if available. Validation must pass after all fixes.
+
+**Acceptance criteria:**
+- Four code-review passes complete.
+- All real bugs flagged on each pass are fixed (with rationale recorded for any flag rejected as a false positive).
+- CodeRabbit pass complete (or noted as unavailable).
+- `uv run ruff check . && uv run pytest --cov-fail-under=80` is green after all fixes.
+
+**Done when:** Four passes done, fixes committed, validation green.
+
+**Depends on:** US-001, US-002, US-003, US-004, US-005.
+
+---
+
+### US-007 — Patterns & Memory (priority 99)
+
+**Description:** Distill any reusable patterns from #150 into `.claude/rules/` and update relevant memory. Likely candidates if patterns surface during implementation:
+- A rule on "prompt-resolver lives in `SkillSpec`, harness owns the synthesis" — refines `harness-protocol-shape`.
+- A note on `MockHarness` being production-grade (not just a test fake) — informs future protocol additions.
+
+If no new patterns emerge, this story explicitly records "no new rules" and verifies existing rules still apply.
+
+**Acceptance criteria:**
+- Walk through `.claude/rules/` and update `harness-protocol-shape` if needed.
+- Update memory if any user/feedback-level patterns emerged.
+- Document the empty case explicitly if nothing new.
+
+**Done when:** Rules audit done, decisions recorded.
+
+**Depends on:** US-006.
+
+---
+
+### Story dependency graph
+
+```
+US-001 ─┬─> US-003 ──┐
+US-002 ─┴─> US-004 ──┴─> US-005 ──> US-006 ──> US-007
+```
+
+### Rules-compliance gate (validation)
+
+- ✅ `harness-protocol-shape` — `build_prompt` is added on the protocol; harnesses own their strategy. (US-001)
+- ✅ `pure-compute-vs-io-split` — `build_prompt` is pure; file I/O for auto-derive lives in `SkillSpec.run`, not in the protocol method. (US-001, US-004)
+- ✅ `pre-llm-contract-hard-validate` — `system_prompt` validated at `EvalSpec.from_dict` time. (US-002)
+- ✅ `permissive-parser-strict-validator` — `None` accepted permissively; non-empty-string strict when present. (US-002)
+- ✅ `non-mutating-scrub` — no normalization mutates the spec; `system_prompt` is stored as-given. (US-002)
+- ✅ `centralized-sdk-call` — `build_prompt` does not call any SDK. (US-001)
+- ✅ `skill-identity-from-frontmatter` — frontmatter is identity; body is content; auto-derive uses body, not identity. (US-004)
+
+---
+
+## Beads Manifest
+
+*(Phase 7)*

--- a/plans/super/150-prompt-resolver.md
+++ b/plans/super/150-prompt-resolver.md
@@ -6,11 +6,12 @@
 - **Branch:** `feature/150-prompt-resolver`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/150-prompt-resolver`
 - **Base branch:** `dev`
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **Sessions:** 1
 - **Last session:** 2026-04-29
 - **Total decisions:** 13
 - **PR URL:** https://github.com/wjduenow/clauditor/pull/158
+- **Beads epic:** `clauditor-dnr`
 
 ---
 
@@ -408,4 +409,25 @@ US-002 ─┴─> US-004 ──┴─> US-005 ──> US-006 ──> US-007
 
 ## Beads Manifest
 
-*(Phase 7)*
+- **Epic:** `clauditor-dnr` — #150: skill identity to prompt resolver (EvalSpec.system_prompt)
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/150-prompt-resolver`
+- **Branch:** `feature/150-prompt-resolver`
+- **PR:** https://github.com/wjduenow/clauditor/pull/158
+
+### Tasks
+
+| ID | Story | Priority | Blocked by |
+|---|---|---|---|
+| `clauditor-dnr.1` | US-001 — Add `build_prompt` to `Harness` protocol; implement on `ClaudeCodeHarness` and `MockHarness` | P1 | — |
+| `clauditor-dnr.2` | US-002 — Add `EvalSpec.system_prompt` field + validation | P1 | — |
+| `clauditor-dnr.3` | US-003 — Wire `system_prompt` through `SkillRunner.run` via `harness.build_prompt` | P1 | `.1` |
+| `clauditor-dnr.4` | US-004 — Resolve and thread `system_prompt` in `SkillSpec.run` (auto-derive + override + friendly errors) | P1 | `.2`, `.3` |
+| `clauditor-dnr.5` | US-005 — Documentation updates | P2 | `.1`, `.2`, `.3`, `.4` |
+| `clauditor-dnr.6` | US-006 — Quality Gate (code review × 4 + CodeRabbit) | P2 | `.1`, `.2`, `.3`, `.4`, `.5` |
+| `clauditor-dnr.7` | US-007 — Patterns & Memory | P3 | `.6` |
+
+### Next steps
+
+1. Run Ralph: `/ralph-run`
+2. Monitor: `bd list --status=in_progress` (or `bd ready` to see what's claimable)
+3. When done: `/closeout`

--- a/src/clauditor/_harnesses/__init__.py
+++ b/src/clauditor/_harnesses/__init__.py
@@ -77,3 +77,28 @@ class Harness(Protocol):
         Claude Code) and scrubs them; non-auth env vars are preserved.
         """
         ...
+
+    def build_prompt(
+        self,
+        skill_name: str,
+        args: str,
+        *,
+        system_prompt: str | None,
+    ) -> str:
+        """Compose the prompt string this harness's ``invoke`` expects.
+
+        Pure compute (no I/O, no global state) per
+        ``.claude/rules/pure-compute-vs-io-split.md``. Each harness owns
+        the wire-shape for how a skill invocation is rendered into a
+        single prompt string: Claude Code uses slash-style commands
+        (``"/foo bar"``) understood by the ``claude -p`` CLI; future
+        raw-API harnesses may instead embed ``args`` plus an explicit
+        ``system_prompt`` in a structured message body.
+
+        ``system_prompt`` is keyword-only (per US-001 of issue #150) so
+        callers cannot accidentally swap it positionally with ``args``.
+        Harnesses that have no notion of a separate system prompt (e.g.
+        ``ClaudeCodeHarness``) MUST still accept and ignore the kwarg —
+        analogous to how all harnesses accept ``model`` on ``invoke``.
+        """
+        ...

--- a/src/clauditor/_harnesses/_claude_code.py
+++ b/src/clauditor/_harnesses/_claude_code.py
@@ -391,6 +391,29 @@ class ClaudeCodeHarness:
         """
         return env_without_api_key(env)
 
+    def build_prompt(
+        self,
+        skill_name: str,
+        args: str,
+        *,
+        system_prompt: str | None,
+    ) -> str:
+        """Render a Claude-Code slash-style invocation.
+
+        Returns ``"/{skill_name}"`` when ``args`` is empty, otherwise
+        ``"/{skill_name} {args}"``. ``system_prompt`` is part of the
+        cross-harness :class:`Harness.build_prompt` contract but has no
+        analogue on the ``claude -p`` CLI surface, so it is intentionally
+        ignored here (US-001 of issue #150). Future raw-API harnesses
+        will consume it.
+
+        Pure compute (no I/O) per
+        ``.claude/rules/pure-compute-vs-io-split.md``.
+        """
+        if args == "":
+            return f"/{skill_name}"
+        return f"/{skill_name} {args}"
+
     def invoke(
         self,
         prompt: str,

--- a/src/clauditor/_harnesses/_mock.py
+++ b/src/clauditor/_harnesses/_mock.py
@@ -44,6 +44,10 @@ class MockHarness:
         )
     )
     invoke_calls: list[dict[str, Any]] = field(default_factory=list)
+    # Records every :meth:`build_prompt` call so unit tests can assert
+    # against it (US-001 of issue #150). Each entry is a dict with keys
+    # ``skill_name``, ``args``, ``system_prompt``.
+    build_prompt_calls: list[dict[str, Any]] = field(default_factory=list)
 
     def invoke(
         self,
@@ -76,3 +80,28 @@ class MockHarness:
         copy per ``.claude/rules/non-mutating-scrub.md``.
         """
         return dict(env)
+
+    def build_prompt(
+        self,
+        skill_name: str,
+        args: str,
+        *,
+        system_prompt: str | None,
+    ) -> str:
+        """Record the call and return a deterministic stub prompt.
+
+        Appends ``{"skill_name": ..., "args": ..., "system_prompt": ...}``
+        to :attr:`build_prompt_calls` so unit tests can assert against the
+        triple. Returns ``f"[mock]{system_prompt or ''}|/{skill_name}
+        {args}".rstrip()`` — a deterministic shape that surfaces all
+        three inputs (so a test can also assert on the returned string),
+        with trailing whitespace stripped when ``args`` is empty.
+        """
+        self.build_prompt_calls.append(
+            {
+                "skill_name": skill_name,
+                "args": args,
+                "system_prompt": system_prompt,
+            }
+        )
+        return f"[mock]{system_prompt or ''}|/{skill_name} {args}".rstrip()

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -253,6 +253,7 @@ class SkillRunner:
         env: dict[str, str] | None = None,
         timeout: int | None = None,
         allow_hang_heuristic: bool = True,
+        system_prompt: str | None = None,
     ) -> SkillResult:
         """Run a skill and capture its output.
 
@@ -273,13 +274,20 @@ class SkillRunner:
                 heuristic (DEC-005). Threaded here from
                 ``EvalSpec.allow_hang_heuristic`` so authors can opt out
                 when the heuristic is wrong for a particular skill.
+            system_prompt: Optional system prompt forwarded to
+                :meth:`Harness.build_prompt` (US-003 of issue #150).
+                Harnesses that have no notion of a separate system prompt
+                (``ClaudeCodeHarness``) ignore the kwarg; future raw-API
+                harnesses will embed it in a structured message body.
+                Placed LAST per DEC-008 of #150 — a stable anchor for
+                existing test mocks that bind earlier kwargs positionally.
 
         Returns:
             SkillResult with captured output
         """
-        prompt = f"/{skill_name}"
-        if args:
-            prompt += f" {args}"
+        prompt = self.harness.build_prompt(
+            skill_name, args, system_prompt=system_prompt
+        )
         return self._invoke(
             prompt=prompt,
             skill_name=skill_name,

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -249,6 +249,7 @@ class EvalSpec:
     # the skill-runner CLI arg string. Optional at load time, but required
     # by the blind-compare helper when that code path is used.
     user_prompt: str | None = None
+    system_prompt: str | None = None
     input_files: list[str] = field(default_factory=list)  # Resolved absolute paths
     assertions: list[dict] = field(default_factory=list)  # Layer 1 checks
     sections: list[SectionRequirement] = field(default_factory=list)  # Layer 2 schema
@@ -642,6 +643,15 @@ class EvalSpec:
                     f"got {user_prompt!r}"
                 )
 
+        system_prompt = data.get("system_prompt")
+        if system_prompt is not None:
+            if not isinstance(system_prompt, str) or not system_prompt.strip():
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): system_prompt "
+                    f"must be a non-empty, non-whitespace string, "
+                    f"got {system_prompt!r}"
+                )
+
         # DEC-005: optional per-eval escape hatch for the
         # interactive-hang heuristic. Absent → default True (back-compat).
         # Present → must be a real bool (reject "false", 0, None, etc.)
@@ -758,6 +768,7 @@ class EvalSpec:
             description=data.get("description", ""),
             test_args=data.get("test_args", ""),
             user_prompt=user_prompt,
+            system_prompt=system_prompt,
             input_files=resolved_input_files,
             assertions=data.get("assertions", []),
             sections=sections,
@@ -783,6 +794,11 @@ class EvalSpec:
             **(
                 {"user_prompt": self.user_prompt}
                 if self.user_prompt is not None
+                else {}
+            ),
+            **(
+                {"system_prompt": self.system_prompt}
+                if self.system_prompt is not None
                 else {}
             ),
             "input_files": self.input_files,

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -9,6 +9,7 @@ import glob
 import sys
 from pathlib import Path
 
+from clauditor._frontmatter import parse_frontmatter
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.conformance import check_conformance, format_issue_line
 from clauditor.paths import derive_project_dir, derive_skill_name
@@ -190,6 +191,33 @@ class SkillSpec:
         effective_env = env_override
         if effective_sync_tasks:
             effective_env = env_with_sync_tasks(effective_env)
+
+        # US-004 of issue #150: resolve the effective system_prompt.
+        # Explicit ``EvalSpec.system_prompt`` wins; otherwise auto-derive
+        # from the skill file body (post-frontmatter). Wrap I/O failures
+        # (missing file, malformed frontmatter, permission errors) as a
+        # friendly RuntimeError that names the skill and path; the
+        # original exception chains through ``__cause__`` for debug.
+        # The empty-string body case threads through verbatim — we do
+        # NOT fall back to None, so misconfigured skills surface clearly
+        # rather than silently masking the missing prompt.
+        effective_system_prompt = (
+            self.eval_spec.system_prompt
+            if (self.eval_spec is not None and self.eval_spec.system_prompt is not None)
+            else None
+        )
+        if effective_system_prompt is None:
+            try:
+                skill_text = self.skill_path.read_text(encoding="utf-8")
+                _meta, body = parse_frontmatter(skill_text)
+                effective_system_prompt = body
+            except (FileNotFoundError, OSError, ValueError) as exc:
+                raise RuntimeError(
+                    f"clauditor.spec: failed to auto-derive system_prompt "
+                    f"for skill {self.skill_name!r} from {self.skill_path}: "
+                    f"{exc}"
+                ) from exc
+
         result = self.runner.run(
             self.skill_name,
             run_args,
@@ -197,6 +225,7 @@ class SkillSpec:
             allow_hang_heuristic=allow_hang_heuristic,
             timeout=effective_timeout,
             env=effective_env,
+            system_prompt=effective_system_prompt,
         )
 
         # Read output from files if eval spec specifies file-based output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,7 +402,7 @@ def make_eval_spec():
             spec = make_eval_spec(skill_name="my-skill")
     """
 
-    def _factory(**overrides) -> EvalSpec:
+    def _factory(system_prompt: str | None = None, **overrides) -> EvalSpec:
         defaults = {
             "skill_name": "test-skill",
             "description": "A test eval spec",
@@ -422,6 +422,7 @@ def make_eval_spec():
             "grading_model": "claude-sonnet-4-6",
             "trigger_tests": None,
             "variance": None,
+            "system_prompt": system_prompt,
         }
         defaults.update(overrides)
         return EvalSpec(**defaults)
@@ -560,7 +561,9 @@ def make_skill_result(
     )
 
 
-def build_eval_spec(**overrides) -> EvalSpec:
+def build_eval_spec(
+    system_prompt: str | None = None, **overrides
+) -> EvalSpec:
     """Minimal EvalSpec with sensible defaults for CLI tests.
 
     Accepts any EvalSpec field as keyword overrides.
@@ -575,6 +578,7 @@ def build_eval_spec(**overrides) -> EvalSpec:
         grading_model="claude-sonnet-4-6",
         trigger_tests=None,
         variance=None,
+        system_prompt=system_prompt,
     )
     defaults.update(overrides)
     return EvalSpec(**defaults)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -167,14 +167,14 @@ class TestHarnessProtocol:
 
     The protocol lives in ``clauditor._harnesses`` and is the seam future
     harnesses (Codex per #149) will satisfy. This test confirms the
-    public shape: ``name`` ClassVar plus ``invoke`` and
-    ``strip_auth_keys`` methods. Per DEC-008, ``allow_hang_heuristic``
+    public shape: ``name`` ClassVar plus ``invoke``, ``strip_auth_keys``,
+    and ``build_prompt`` methods. Per DEC-008, ``allow_hang_heuristic``
     is intentionally NOT on ``invoke`` — it's a Claude-Code-specific
     knob configured at harness construction time (US-004).
     """
 
     def test_stub_satisfies_harness_protocol(self):
-        """A class with the three protocol members is structurally a
+        """A class with the four protocol members is structurally a
         ``Harness``. Verified at runtime via ``isinstance`` (the protocol
         is ``@runtime_checkable``) and at signature level via
         ``inspect.signature`` so adding a new required parameter to
@@ -206,6 +206,15 @@ class TestHarnessProtocol:
             def strip_auth_keys(self, env: dict[str, str]) -> dict[str, str]:
                 return dict(env)
 
+            def build_prompt(
+                self,
+                skill_name: str,
+                args: str,
+                *,
+                system_prompt: str | None,
+            ) -> str:
+                return f"/{skill_name}"
+
         stub = StubHarness()
 
         # Runtime member-presence check (the protocol is @runtime_checkable).
@@ -222,6 +231,36 @@ class TestHarnessProtocol:
         missing = protocol_params - stub_params
         assert not missing, (
             f"StubHarness.invoke missing protocol parameters: {missing}"
+        )
+
+    def test_harness_protocol_includes_build_prompt(self):
+        """Drift-guard for ``Harness.build_prompt`` (US-001 of #150).
+
+        Locks: (1) the method exists on the protocol; (2) ``system_prompt``
+        is keyword-only; (3) the return annotation is ``str``. A signature
+        change that drops keyword-only or changes the return type fails
+        this test.
+        """
+        import inspect
+
+        from clauditor._harnesses import Harness
+
+        assert hasattr(Harness, "build_prompt"), (
+            "Harness protocol missing build_prompt"
+        )
+        sig = inspect.signature(Harness.build_prompt)
+        params = sig.parameters
+        assert "system_prompt" in params, (
+            "Harness.build_prompt missing system_prompt parameter"
+        )
+        assert params["system_prompt"].kind is inspect.Parameter.KEYWORD_ONLY, (
+            "Harness.build_prompt.system_prompt must be keyword-only"
+        )
+        assert params["system_prompt"].annotation == "str | None", (
+            "Harness.build_prompt.system_prompt must be annotated 'str | None'"
+        )
+        assert sig.return_annotation == "str", (
+            "Harness.build_prompt return annotation must be 'str'"
         )
 
 
@@ -665,6 +704,56 @@ class TestHarnessStripAuthKeys:
         # Returns a new dict (mutation-safe per Harness protocol contract).
         scrubbed["FOO"] = "mutated"
         assert env["FOO"] == "bar"
+
+
+class TestHarnessBuildPrompt:
+    """Direct coverage of ``Harness.build_prompt`` on both implementers.
+
+    Pinned by US-001 of issue #150: the prompt-builder is a pure helper
+    (no I/O) per ``.claude/rules/pure-compute-vs-io-split.md``. Locks:
+    (1) ``ClaudeCodeHarness`` returns slash-style commands and ignores
+    ``system_prompt``; (2) ``MockHarness`` records every call on
+    ``build_prompt_calls`` for test assertions.
+    """
+
+    def test_claude_code_harness_build_prompt_with_args_and_no_system_prompt(self):
+        """Args present → ``"/{skill_name} {args}"``; ``system_prompt`` ignored."""
+        result = ClaudeCodeHarness().build_prompt("foo", "bar baz", system_prompt=None)
+        assert result == "/foo bar baz"
+
+    def test_claude_code_harness_build_prompt_no_args(self):
+        """Empty args → ``"/{skill_name}"`` with no trailing space."""
+        result = ClaudeCodeHarness().build_prompt("foo", "", system_prompt=None)
+        assert result == "/foo"
+
+    def test_claude_code_harness_build_prompt_ignores_system_prompt(self):
+        """``system_prompt`` does not appear in the Claude Code slash command."""
+        result = ClaudeCodeHarness().build_prompt("foo", "", system_prompt="anything")
+        assert result == "/foo"
+
+    def test_mock_harness_build_prompt_records_call(self):
+        """``MockHarness.build_prompt`` records ``(skill_name, args, system_prompt)``
+        on ``build_prompt_calls`` so unit tests can assert against it."""
+        from clauditor._harnesses._mock import MockHarness
+
+        mock = MockHarness()
+        returned = mock.build_prompt("foo", "bar", system_prompt="hello")
+        assert len(mock.build_prompt_calls) == 1
+        entry = mock.build_prompt_calls[0]
+        # Recorded entry must contain all three values; structure is the
+        # mock's choice (dict or tuple) so long as the values are present.
+        if isinstance(entry, dict):
+            assert entry["skill_name"] == "foo"
+            assert entry["args"] == "bar"
+            assert entry["system_prompt"] == "hello"
+        else:
+            assert "foo" in entry
+            assert "bar" in entry
+            assert "hello" in entry
+        # And the returned string is deterministic enough to surface
+        # ``system_prompt`` when present.
+        assert "hello" in returned
+        assert "foo" in returned
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -613,7 +613,9 @@ class TestSkillRunnerHarnessSubstitution:
 
     def test_skill_runner_records_invoke_call_args(self):
         """The mock records prompt/cwd/env/timeout exactly as the runner
-        forwards them to :meth:`Harness.invoke`."""
+        forwards them to :meth:`Harness.invoke`. Per US-003 of issue #150
+        the prompt is the string returned by ``MockHarness.build_prompt``,
+        which has its own deterministic shape (``"[mock]|/foo arg"``)."""
         from pathlib import Path
 
         from clauditor._harnesses._mock import MockHarness
@@ -625,7 +627,7 @@ class TestSkillRunnerHarnessSubstitution:
 
         assert len(mock.invoke_calls) == 1
         call = mock.invoke_calls[0]
-        assert call["prompt"] == "/foo arg"
+        assert call["prompt"] == "[mock]|/foo arg"
         assert call["cwd"] == Path("/tmp")
         assert call["env"] is None
         assert call["timeout"] == 99
@@ -754,6 +756,81 @@ class TestHarnessBuildPrompt:
         # ``system_prompt`` when present.
         assert "hello" in returned
         assert "foo" in returned
+
+
+class TestSkillRunnerRunBuildsPromptViaHarness:
+    """US-003 of issue #150: ``SkillRunner.run`` composes its prompt via
+    ``self.harness.build_prompt(...)`` rather than synthesizing the slash
+    string inline. The ``system_prompt`` kwarg threads from
+    :meth:`SkillRunner.run` through to ``build_prompt`` (see DEC-008 for
+    why it is the LAST keyword argument on ``run``).
+    """
+
+    def test_runner_run_calls_harness_build_prompt_with_args(self):
+        """``runner.run("foo", "bar")`` records a build_prompt call with
+        ``skill_name="foo"``, ``args="bar"``, ``system_prompt=None``."""
+        from clauditor._harnesses._mock import MockHarness
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir="/tmp", harness=mock)
+
+        runner.run("foo", "bar")
+
+        assert len(mock.build_prompt_calls) == 1
+        call = mock.build_prompt_calls[-1]
+        assert call["skill_name"] == "foo"
+        assert call["args"] == "bar"
+        assert call["system_prompt"] is None
+
+    def test_runner_run_threads_system_prompt_kwarg_to_build_prompt(self):
+        """``runner.run("foo", "bar", system_prompt="hello")`` threads
+        ``system_prompt`` through to ``Harness.build_prompt``."""
+        from clauditor._harnesses._mock import MockHarness
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir="/tmp", harness=mock)
+
+        runner.run("foo", "bar", system_prompt="hello")
+
+        assert len(mock.build_prompt_calls) == 1
+        call = mock.build_prompt_calls[-1]
+        assert call["skill_name"] == "foo"
+        assert call["args"] == "bar"
+        assert call["system_prompt"] == "hello"
+
+    def test_runner_run_passes_built_prompt_to_invoke(self):
+        """The string returned by ``Harness.build_prompt`` is exactly what
+        reaches ``Harness.invoke`` as ``prompt``."""
+        from clauditor._harnesses._mock import MockHarness
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir="/tmp", harness=mock)
+
+        runner.run("foo", "bar", system_prompt="hello")
+
+        # ``MockHarness.build_prompt`` returns
+        # ``f"[mock]{system_prompt or ''}|/{skill_name} {args}".rstrip()``.
+        expected_prompt = "[mock]hello|/foo bar"
+        assert len(mock.invoke_calls) == 1
+        assert mock.invoke_calls[-1]["prompt"] == expected_prompt
+
+    def test_runner_run_back_compat_no_system_prompt_kwarg(self):
+        """Calling ``runner.run("foo", "bar")`` with no ``system_prompt``
+        kwarg yields the legacy ``"/foo bar"`` prompt when paired with
+        :class:`ClaudeCodeHarness` (which ignores ``system_prompt``)."""
+        runner = SkillRunner(project_dir="/tmp", harness=ClaudeCodeHarness())
+
+        # Patch ``invoke`` to capture the prompt without spawning a subprocess.
+        captured: dict[str, str] = {}
+
+        def _fake_invoke(prompt, **_kwargs):
+            captured["prompt"] = prompt
+            return InvokeResult(output="", exit_code=0, duration_seconds=0.0)
+
+        with patch.object(runner.harness, "invoke", side_effect=_fake_invoke):
+            runner.run("foo", "bar")
+
+        assert captured["prompt"] == "/foo bar"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1507,6 +1507,70 @@ class TestEvalSpecUserPrompt:
         assert loaded.user_prompt == "Is ramen good?"
 
 
+class TestEvalSpecSystemPrompt:
+    """Tests for the optional ``system_prompt`` field (#150)."""
+
+    def test_from_file_loads_system_prompt(self, tmp_path):
+        """A spec with system_prompt set parses into the dataclass."""
+        data = {
+            "skill_name": "s",
+            "system_prompt": "you are helpful",
+        }
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.system_prompt == "you are helpful"
+
+    def test_from_file_system_prompt_absent_defaults_to_none(self, tmp_path):
+        """Omitting system_prompt leaves the attribute None."""
+        data = {"skill_name": "s"}
+        path = _write_json(tmp_path, data)
+        spec = EvalSpec.from_file(path)
+        assert spec.system_prompt is None
+
+    def test_from_file_system_prompt_empty_string_rejected(self, tmp_path):
+        """An empty-string system_prompt must be rejected — callers should
+        not have to disambiguate ``None`` vs ``""``."""
+        data = {"skill_name": "s", "system_prompt": ""}
+        path = _write_json(tmp_path, data)
+        with pytest.raises(
+            ValueError, match="system_prompt must be a non-empty"
+        ) as excinfo:
+            EvalSpec.from_file(path)
+        assert "'s'" in str(excinfo.value)
+
+    def test_from_file_system_prompt_whitespace_only_rejected(self, tmp_path):
+        """Whitespace-only system_prompt must be rejected at load time."""
+        data = {"skill_name": "s", "system_prompt": "   "}
+        path = _write_json(tmp_path, data)
+        with pytest.raises(
+            ValueError,
+            match="system_prompt must be a non-empty, non-whitespace",
+        ) as excinfo:
+            EvalSpec.from_file(path)
+        assert "'s'" in str(excinfo.value)
+
+    def test_from_file_system_prompt_non_string_rejected(self, tmp_path):
+        """A non-string system_prompt (e.g. a number) is rejected."""
+        data = {"skill_name": "s", "system_prompt": 42}
+        path = _write_json(tmp_path, data)
+        with pytest.raises(
+            ValueError, match="system_prompt must be a non-empty"
+        ) as excinfo:
+            EvalSpec.from_file(path)
+        assert "'s'" in str(excinfo.value)
+
+    def test_to_dict_omits_system_prompt_when_unset(self):
+        """Round-tripping a spec without system_prompt does not inject the key."""
+        spec = EvalSpec(skill_name="s")
+        d = spec.to_dict()
+        assert "system_prompt" not in d
+
+    def test_to_dict_emits_system_prompt_when_set(self):
+        spec = EvalSpec(skill_name="s", system_prompt="hi")
+        d = spec.to_dict()
+        assert d["system_prompt"] == "hi"
+
+
 class TestEvalSpecFromDict:
     """Direct tests for :meth:`EvalSpec.from_dict` (DEC-007 of #52).
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -306,6 +306,10 @@ class TestRun:
         runner = mock_runner(output="explicit output")
         spec = SkillSpec.from_file(skill_path, runner=runner)
         result = spec.run(args="--custom flag")
+        # US-004 of issue #150: ``system_prompt`` is auto-derived from
+        # the skill body when ``EvalSpec.system_prompt`` is unset; for
+        # ``tmp_skill_file``'s default content there is no frontmatter
+        # so the entire content is the body.
         runner.run.assert_called_once_with(
             "run-skill",
             "--custom flag",
@@ -313,6 +317,7 @@ class TestRun:
             allow_hang_heuristic=True,
             timeout=None,
             env=None,
+            system_prompt=skill_path.read_text(encoding="utf-8"),
         )
         assert result.output == "explicit output"
 
@@ -328,6 +333,7 @@ class TestRun:
             allow_hang_heuristic=True,
             timeout=None,
             env=None,
+            system_prompt=skill_path.read_text(encoding="utf-8"),
         )
 
     def test_run_uses_empty_string_when_no_eval_no_args(
@@ -344,6 +350,7 @@ class TestRun:
             allow_hang_heuristic=True,
             timeout=None,
             env=None,
+            system_prompt=skill_path.read_text(encoding="utf-8"),
         )
 
 
@@ -669,6 +676,7 @@ class TestOutputFilesResolutionWithStagedInputs:
             allow_hang_heuristic=True,
             timeout=None,
             env=None,
+            system_prompt=None,
         ):
             assert cwd == run_dir / "inputs"
             (cwd / "cleaned.csv").write_text(cleaned_text)
@@ -1081,3 +1089,129 @@ class TestExampleEvalSpec:
             "example eval spec must not contain legacy 'value' keys; "
             "use per-type semantic keys (needle/pattern/length/count)"
         )
+
+
+# ---------------------------------------------------------------------------
+# US-004 of issue #150: ``SkillSpec.run`` resolves ``system_prompt`` and
+# threads it to ``SkillRunner.run``. Explicit ``EvalSpec.system_prompt``
+# wins; otherwise the body of ``SKILL.md`` (post-frontmatter) is auto-
+# derived. I/O failures during auto-derivation are wrapped in a friendly
+# ``RuntimeError`` that names skill + path with the original exception
+# chained via ``__cause__``.
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptResolution:
+    """``SkillSpec.run`` computes the effective ``system_prompt`` and
+    threads it through ``self.runner.run(...)``.
+
+    Uses :class:`MockHarness` (substituted via ``SkillRunner(harness=...)``)
+    so the assertion can read ``MockHarness.build_prompt_calls`` rather
+    than reaching into a ``MagicMock`` call_args.
+    """
+
+    @staticmethod
+    def _build_runner_with_mock_harness(project_dir):
+        from clauditor._harnesses._mock import MockHarness
+        from clauditor.runner import SkillRunner
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir=project_dir, harness=mock)
+        return runner, mock
+
+    def test_skill_spec_run_auto_derives_system_prompt_from_body(
+        self, tmp_skill_file
+    ):
+        """No explicit ``EvalSpec.system_prompt`` → auto-derive from
+        ``SKILL.md`` body (post-frontmatter)."""
+        body = "# Skill\n\nThis is the body content used as system prompt.\n"
+        content = "---\nname: prompt-skill\n---\n" + body
+        skill_path = tmp_skill_file("prompt-skill", content=content)
+        runner, mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        spec.run("args here")
+
+        assert len(mock.build_prompt_calls) == 1
+        assert mock.build_prompt_calls[-1]["system_prompt"] == body
+
+    def test_skill_spec_run_explicit_eval_spec_system_prompt_wins(
+        self, tmp_skill_file
+    ):
+        """When ``EvalSpec.system_prompt`` is set, it wins over the body."""
+        content = "---\nname: prompt-skill\n---\nBODY"
+        eval_data = {
+            "skill_name": "prompt-skill",
+            "test_args": "",
+            "assertions": [],
+            "system_prompt": "EXPLICIT",
+        }
+        skill_path, _ = tmp_skill_file(
+            "prompt-skill", content=content, eval_data=eval_data
+        )
+        runner, mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        spec.run()
+
+        assert mock.build_prompt_calls[-1]["system_prompt"] == "EXPLICIT"
+
+    def test_skill_spec_run_no_system_prompt_when_eval_spec_explicitly_empty_body(
+        self, tmp_skill_file
+    ):
+        """SKILL.md body is empty (frontmatter only) → auto-derive yields
+        ``""``; the empty value threads through verbatim. Documents the
+        edge case rather than masking it."""
+        # Frontmatter only, no body. ``parse_frontmatter`` returns
+        # ``""`` for the body.
+        content = "---\nname: prompt-skill\n---\n"
+        skill_path = tmp_skill_file("prompt-skill", content=content)
+        runner, mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        spec.run()
+
+        assert mock.build_prompt_calls[-1]["system_prompt"] == ""
+
+    def test_skill_spec_run_missing_skill_md_raises_friendly_error(
+        self, tmp_path
+    ):
+        """``skill_path`` points at a non-existent file → ``RuntimeError``
+        with skill_name + path; ``__cause__`` is ``FileNotFoundError``.
+
+        Uses the direct ``SkillSpec(...)`` constructor (not ``from_file``,
+        which itself raises on missing files) so the auto-derive branch
+        in ``run`` is the surface under test.
+        """
+        missing_path = tmp_path / "missing-skill.md"
+        runner, _mock = self._build_runner_with_mock_harness(tmp_path)
+        spec = SkillSpec(skill_path=missing_path, eval_spec=None, runner=runner)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            spec.run()
+
+        msg = str(exc_info.value)
+        assert spec.skill_name in msg
+        assert str(missing_path) in msg
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+    def test_skill_spec_run_malformed_frontmatter_raises_friendly_error(
+        self, tmp_skill_file
+    ):
+        """Malformed frontmatter (no closing ``---``) → ``parse_frontmatter``
+        raises ``ValueError``; ``RuntimeError`` wraps it with skill_name
+        + path; ``__cause__`` is the original ``ValueError``."""
+        # Opening ``---`` with no closing delimiter is the canonical
+        # ValueError case in ``parse_frontmatter``.
+        content = "---\nname: bad-skill\n# missing closing delimiter\n"
+        skill_path = tmp_skill_file("bad-skill", content=content)
+        runner, _mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            spec.run()
+
+        msg = str(exc_info.value)
+        assert spec.skill_name in msg
+        assert str(skill_path) in msg
+        assert isinstance(exc_info.value.__cause__, ValueError)


### PR DESCRIPTION
## Summary

Super plan for #150 — Multi-harness: skill identity to prompt resolver (`EvalSpec.system_prompt`).

**Phase:** detailing → published (awaiting approval)
**Stories:** 5 implementation stories + Quality Gate + Patterns & Memory
**Decisions:** 13 captured

## Highlights

- Add `Harness.build_prompt(skill_name, args, *, system_prompt) → str` to the protocol; `ClaudeCodeHarness` keeps slash-command synthesis, `MockHarness` records calls + returns a string that includes `system_prompt` so the future Codex strategy is exercised end-to-end before #149 ships.
- Add `EvalSpec.system_prompt: str | None = None` mirroring the existing `user_prompt` field — same validation shape, same test pattern.
- Two-level precedence: explicit `EvalSpec.system_prompt` > auto-derived from `SKILL.md` body. No frontmatter `system_prompt:` override.
- `SkillSpec.run` resolves once and threads via a new `system_prompt` kwarg on `SkillRunner.run` (placed last for stable mock anchoring). Read/parse failures wrap to a `RuntimeError` naming skill + path.
- `MockHarness` and the `TestHarnessProtocol` drift-guard at `tests/test_runner.py:165–226` must be updated in this same PR — the protocol is `runtime_checkable`.

## Plan document

See `plans/super/150-prompt-resolver.md` for the full plan: discovery findings, architecture review (5 areas: security/perf/api/obs/testing), refinement log, story breakdown with TDD, dependency graph, and rules-compliance gate.

## Architecture review outcome

| Area | Rating |
|---|---|
| Security | pass |
| Performance | pass (measured ~0.013 ms per auto-derive) |
| API + Data Model | concern → resolved |
| Observability | concern → resolved |
| Testing | pass |

No blockers. All concerns landed as DEC-006 through DEC-013.

## Next steps

- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)