### PR TITLE
#145: Multi-provider — add OpenAI provider via Responses API

### DIFF
--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -50,7 +50,8 @@ except OpenAIHelperError as exc:
     # exception class keeps the CLI's ``except`` ladder structural.
     print(f"ERROR: {exc}", file=sys.stderr)
     raise
-response_text = result.text_blocks[0] if result.text_blocks else ""
+response_text = result.response_text  # joined text across all blocks
+# Per-block access still available via result.text_blocks if needed.
 # result.input_tokens / result.output_tokens for metrics
 # result.raw_message for refusal / tool-use inspection
 # result.provider in {"anthropic", "openai"}; result.source in
@@ -125,7 +126,7 @@ async def call_openai(
     prompt: str,
     *,
     model: str,
-    transport: str = "auto",  # accepted for signature parity; ignored
+    transport: Literal["api", "cli", "auto"] = "auto",  # accepted for signature parity; ignored
     max_tokens: int = 4096,
 ) -> ModelResult:
     # Defense-in-depth: catch (TypeError, OpenAIError) at AsyncOpenAI()
@@ -148,15 +149,23 @@ async def call_openai(
 
 ## Why this shape
 
-- **One retry taxonomy, consistently applied across providers**:
-  - `RateLimitError` (HTTP 429) → up to 3 retries (4 attempts total).
-  - `APIStatusError` with `status_code >= 500` → 1 retry then raise.
-  - `APIStatusError` 4xx (other than 401/403) → no retry; raise
-    immediately (bad request, not found, conflict, etc).
-  - `AuthenticationError` (401) / `PermissionDeniedError` (403) → no
-    retry; raise immediately with a message pointing at the
-    provider's API-key env var.
-  - `APIConnectionError` → 1 retry then raise.
+- **One retry taxonomy, consistently applied across providers**.
+  Categories are property-based (HTTP status / error kind), not
+  literal SDK exception class names — each provider's per-SDK
+  exceptions are mapped into these categories at the call site.
+  Contributors must NOT catch provider-specific exceptions at call
+  sites; the centralized helper owns categorization.
+  - **rate-limit category** (HTTP 429) → up to 3 retries (4 attempts
+    total). `RATE_LIMIT_MAX_RETRIES = 3`.
+  - **server-error category** (HTTP 5xx) → 1 retry then raise.
+    `SERVER_MAX_RETRIES = 1`.
+  - **client-error category** (HTTP 4xx other than 401/403) → no
+    retry; raise immediately (bad request, not found, conflict, etc).
+  - **auth/permission category** (401/403) → no retry; raise
+    immediately with a message pointing at the provider's API-key
+    env var.
+  - **connection category** (transport-level connection failure) →
+    1 retry then raise. `CONN_MAX_RETRIES = 1`.
   Both Anthropic and OpenAI backends share the same per-category
   retry caps (`RATE_LIMIT_MAX_RETRIES=3`, `SERVER_MAX_RETRIES=1`,
   `CONN_MAX_RETRIES=1`) and the same exponential-backoff formula

--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -1,33 +1,41 @@
-# Rule: Route every Anthropic SDK call through the centralized helper
+# Rule: Route every model SDK call through the centralized helper
 
-When any clauditor module needs to call the Anthropic API, it must go
-through the centralized `clauditor._providers.call_model` dispatcher
-rather than constructing its own `AsyncAnthropic` client or
-`messages.create` call. The dispatcher routes to the backend selected
-by `provider=` (today only `"anthropic"`, which delegates to
-`clauditor._providers._anthropic.call_anthropic`); both layers
-together own retry policy, error categorization, token accounting,
-transport routing, and the `AnthropicHelperError` user-facing error
-envelope. Bypassing them means each new caller re-implements (and
-drifts on) the retry/back-off/auth-error-message logic the rest of
-clauditor depends on.
+When any clauditor module needs to call a model provider's API, it
+must go through the centralized `clauditor._providers.call_model`
+dispatcher rather than constructing its own `AsyncAnthropic` /
+`AsyncOpenAI` client or calling `messages.create` /
+`responses.create` directly. The dispatcher routes to the backend
+selected by `provider=` — today `"anthropic"` (delegating to
+`clauditor._providers._anthropic.call_anthropic`) and `"openai"`
+(delegating to `clauditor._providers._openai.call_openai`, #145).
+Both layers together own retry policy, error categorization, token
+accounting, transport routing, and the `AnthropicHelperError` /
+`OpenAIHelperError` user-facing error envelopes. Bypassing them
+means each new caller re-implements (and drifts on) the
+retry/back-off/auth-error-message logic the rest of clauditor
+depends on.
 
 For one-release back-compat, `clauditor._anthropic` re-exports the
-moved public surface (`call_anthropic`, `AnthropicHelperError`,
-`ClaudeCLIError`, `ModelResult`/`AnthropicResult`, the auth helpers,
-etc.) so existing call sites keep working unmodified — but new code
-should target `clauditor._providers` directly.
+moved Anthropic public surface (`call_anthropic`,
+`AnthropicHelperError`, `ClaudeCLIError`,
+`ModelResult`/`AnthropicResult`, the auth helpers, etc.) so existing
+call sites keep working unmodified — but new code should target
+`clauditor._providers` directly.
 
 ## The pattern
 
 ```python
 # At the call site:
-from clauditor._providers import AnthropicHelperError, call_model
+from clauditor._providers import (
+    AnthropicHelperError,
+    OpenAIHelperError,
+    call_model,
+)
 
 try:
     result = await call_model(
         prompt,
-        provider="anthropic",
+        provider="anthropic",   # or "openai"
         model=model,
         transport="auto",
         max_tokens=4096,
@@ -37,10 +45,16 @@ except AnthropicHelperError as exc:
     # body excerpt). Surface to stderr, set exit code, do NOT retry.
     print(f"ERROR: {exc}", file=sys.stderr)
     raise
+except OpenAIHelperError as exc:
+    # Same shape — pre-formatted user-facing message. Distinct
+    # exception class keeps the CLI's ``except`` ladder structural.
+    print(f"ERROR: {exc}", file=sys.stderr)
+    raise
 response_text = result.text_blocks[0] if result.text_blocks else ""
 # result.input_tokens / result.output_tokens for metrics
 # result.raw_message for refusal / tool-use inspection
-# result.provider == "anthropic"; result.source in {"api", "cli"}
+# result.provider in {"anthropic", "openai"}; result.source in
+# {"api", "cli"} (always "api" for openai per DEC-002 of #145)
 ```
 
 Inside `_providers/__init__.py` (the dispatcher):
@@ -51,15 +65,25 @@ async def call_model(
     *,
     provider: Literal["anthropic", "openai"],
     model: str,
-    transport: str = "auto",
+    transport: Literal["api", "cli", "auto"] = "auto",
     max_tokens: int = 4096,
 ) -> ModelResult:
     if provider == "anthropic":
-        return await _anthropic.call_anthropic(
+        # Deferred per-call import per
+        # ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3,
+        # so test patches that target the canonical seam
+        # ``clauditor._providers._anthropic.call_anthropic`` still fire.
+        from clauditor._providers import _anthropic as _anthropic_mod
+        return await _anthropic_mod.call_anthropic(
             prompt, model=model, transport=transport, max_tokens=max_tokens
         )
     if provider == "openai":
-        raise NotImplementedError("openai provider lands in #145")
+        # Same deferred-import shape; openai backend ignores
+        # ``transport=`` (always source="api" per DEC-002 of #145).
+        from clauditor._providers import _openai as _openai_mod
+        return await _openai_mod.call_openai(
+            prompt, model=model, transport=transport, max_tokens=max_tokens
+        )
     raise ValueError(f"unknown provider: {provider!r}")
 ```
 
@@ -83,89 +107,202 @@ async def call_anthropic(
     max_tokens: int = 4096,
 ) -> AnthropicResult:
     # ... build AsyncAnthropic(), loop with per-exception retry caps,
-    # compute exponential backoff with ±25% jitter, raise
-    # AnthropicHelperError on non-retriable or exhausted failures ...
+    # compute exponential backoff with ±25% jitter (via shared
+    # _providers/_retry.py helpers), raise AnthropicHelperError on
+    # non-retriable or exhausted failures ...
+```
+
+Inside `_providers/_openai.py` (the openai backend body):
+
+```python
+# Same module-level aliases — tests patch _sleep / _monotonic on the
+# openai module specifically so anthropic tests' patches don't leak.
+_sleep = asyncio.sleep
+_monotonic = time.monotonic
+
+
+async def call_openai(
+    prompt: str,
+    *,
+    model: str,
+    transport: str = "auto",  # accepted for signature parity; ignored
+    max_tokens: int = 4096,
+) -> ModelResult:
+    # Defense-in-depth: catch (TypeError, OpenAIError) at AsyncOpenAI()
+    # construction. OpenAI's SDK raises OpenAIError immediately when
+    # OPENAI_API_KEY is missing (Anthropic raises TypeError later, at
+    # messages.create()), so the construction wrap covers both shapes.
+    try:
+        client = AsyncOpenAI()
+    except ImportError:
+        raise
+    except (TypeError, OpenAIError) as exc:
+        raise OpenAIHelperError(
+            "OpenAI SDK client initialization failed — "
+            "verify OPENAI_API_KEY is set."
+        ) from exc
+    # ... loop with per-exception retry caps shared via
+    # _providers/_retry.py (same constants + compute_backoff). Stamps
+    # ModelResult.source="api" unconditionally per DEC-002 of #145.
 ```
 
 ## Why this shape
 
-- **One retry taxonomy, consistently applied**:
+- **One retry taxonomy, consistently applied across providers**:
   - `RateLimitError` (HTTP 429) → up to 3 retries (4 attempts total).
   - `APIStatusError` with `status_code >= 500` → 1 retry then raise.
   - `APIStatusError` 4xx (other than 401/403) → no retry; raise
     immediately (bad request, not found, conflict, etc).
   - `AuthenticationError` (401) / `PermissionDeniedError` (403) → no
-    retry; raise immediately with a message pointing at
-    `ANTHROPIC_API_KEY`.
+    retry; raise immediately with a message pointing at the
+    provider's API-key env var.
   - `APIConnectionError` → 1 retry then raise.
-  If every call site rolled its own, one module would treat 500s as
-  permanent and another as transient; operators would see inconsistent
-  failure behavior from identical API conditions.
-- **Exponential backoff with ±25% jitter**: the delay for retry index
-  `i` is `2 ** i` seconds (i.e. 1 s, 2 s, 4 s) multiplied by a
-  uniform random factor in `[0.75, 1.25]`. Jitter avoids the stampede
-  failure mode where two concurrent callers retry on the same wall-
-  clock tick and both hit the same throttling window again.
+  Both Anthropic and OpenAI backends share the same per-category
+  retry caps (`RATE_LIMIT_MAX_RETRIES=3`, `SERVER_MAX_RETRIES=1`,
+  `CONN_MAX_RETRIES=1`) and the same exponential-backoff formula
+  via the shared `clauditor._providers._retry` module (DEC-007 of
+  `plans/super/145-openai-provider.md`). Per-category ladder
+  decisions live in `compute_retry_decision(category, retry_index)`,
+  the policy-level helper. If every call site rolled its own, one
+  module would treat 500s as permanent and another as transient;
+  hoisting the policy to one shared module keeps every provider
+  in lockstep when the ladder evolves.
+- **Exponential backoff with ±25% jitter** via
+  `_providers/_retry.compute_backoff(retry_index)`: the delay for
+  retry index `i` is `2 ** i` seconds (i.e. 1 s, 2 s, 4 s)
+  multiplied by a uniform random factor in `[0.75, 1.25]`. Jitter
+  avoids the stampede failure mode where two concurrent callers
+  retry on the same wall-clock tick and both hit the same
+  throttling window again.
 - **Auth errors include the env-var hint**: an operator-friendly
-  `"check the ANTHROPIC_API_KEY environment variable"` is attached to
-  every 401/403 message. A scattered SDK-call style would leave this
+  `"check the ANTHROPIC_API_KEY environment variable"` (or
+  `OPENAI_API_KEY` for the OpenAI side) is attached to every
+  401/403 message. A scattered SDK-call style would leave this
   up to each call site and at least one would forget.
-- **`AnthropicHelperError` wraps the original exception**: non-
-  retriable SDK errors are re-raised as
-  `AnthropicHelperError(message) from exc`, so `__cause__` preserves
-  the original exception for callers that want to introspect (e.g.
-  for status code), while new callers can just `except
-  AnthropicHelperError` for the pre-formatted user-facing message.
-- **`_sleep` / `_rand_uniform` module-level aliases** per
-  `.claude/rules/monotonic-time-indirection.md`: tests patch
-  `clauditor._providers._anthropic._sleep` and
-  `clauditor._providers._anthropic._rand_uniform` rather than
-  `asyncio.sleep` / `random.uniform`. Patching the stdlib originals
-  under asyncio corrupts the event loop's own scheduler ticks; the
-  alias indirection keeps the test scope tight.
+- **Per-provider helper-error classes wrap the original exception**:
+  non-retriable SDK errors are re-raised as
+  `AnthropicHelperError(message) from exc` or
+  `OpenAIHelperError(message) from exc`, so `__cause__` preserves
+  the original exception for callers that want to introspect
+  (e.g. for status code), while new callers can just
+  `except AnthropicHelperError` / `except OpenAIHelperError` for
+  the pre-formatted user-facing message. The two classes are
+  siblings of `Exception`, NOT a shared parent class — preserving
+  the structural-routing invariant per
+  `.claude/rules/llm-cli-exit-code-taxonomy.md`.
+- **Per-provider `_sleep` / `_monotonic` / `_rand_uniform` aliases**
+  per `.claude/rules/monotonic-time-indirection.md`: tests patch
+  `clauditor._providers._anthropic._sleep` (or
+  `_providers._openai._sleep`) rather than `asyncio.sleep`.
+  Patching the stdlib originals under asyncio corrupts the event
+  loop's own scheduler ticks; the alias indirection keeps the
+  test scope tight. The shared retry module
+  `_providers/_retry.py` exposes its own `_rand_uniform` for
+  isolated-jitter testing.
 - **`ModelResult` bundles what all callers need**: joined
   `response_text`, per-block `text_blocks`, `input_tokens`,
-  `output_tokens`, `raw_message`, plus `provider` (`"anthropic"` or
-  `"openai"`) and `source` (`"api"` or `"cli"`) so callers can stamp
-  per-call provenance on their reports. Callers that want to
-  distinguish "no text" from "empty text" check `text_blocks`; callers
-  that want refusal handling read `raw_message`; metrics consumers
-  read the token fields. One return type covers every current consumer
-  without forcing them to dig through the raw SDK response. The legacy
-  alias `AnthropicResult = ModelResult` is preserved so existing test
-  fixtures and docstrings keep working.
-- **`ImportError` is raised un-wrapped**: when the `anthropic` SDK is
-  not installed, the helper raises `ImportError` directly (not
-  `AnthropicHelperError`). This preserves the existing
-  `pip install clauditor[grader]` install-hint path every grader
-  entry point already produces when users run the tool without the
-  optional extra.
+  `output_tokens`, `raw_message`, plus `provider` (`"anthropic"`
+  or `"openai"`) and `source` (`"api"` or `"cli"`) so callers can
+  stamp per-call provenance on their reports. Callers that want
+  to distinguish "no text" from "empty text" check `text_blocks`;
+  callers that want refusal handling read `raw_message`; metrics
+  consumers read the token fields. One return type covers every
+  current consumer without forcing them to dig through the raw
+  SDK response. The legacy alias `AnthropicResult = ModelResult`
+  is preserved so existing test fixtures and docstrings keep
+  working.
+- **Asymmetric transport: anthropic supports `{api,cli,auto}`,
+  openai always `source="api"`.** Per DEC-002 of
+  `plans/super/145-openai-provider.md`, OpenAI has no CLI
+  transport axis. `call_openai` accepts the `transport=` kwarg at
+  the signature level so the dispatcher can pass it uniformly,
+  but the OpenAI backend ignores the value and unconditionally
+  stamps `ModelResult.source = "api"`. Callers that want
+  per-provider behavior branch on `result.provider`, not
+  `result.source`.
+- **`ImportError` is raised un-wrapped**: when the `anthropic` or
+  `openai` SDK is not installed, the helper raises `ImportError`
+  directly (not `AnthropicHelperError` / `OpenAIHelperError`).
+  This preserves the existing `pip install clauditor[grader]`
+  install-hint path every grader entry point already produces
+  when users run the tool without the optional extra.
 
 ## Canonical implementation
 
 `src/clauditor/_providers/__init__.py::call_model` — thin async
-dispatcher. Validates `provider`, delegates `provider="anthropic"` to
-`clauditor._providers._anthropic.call_anthropic`, raises
-`NotImplementedError` for `provider="openai"` (lands in #145), and
-raises `ValueError` for unknown values.
+dispatcher. Validates `provider`, delegates `provider="anthropic"`
+to `clauditor._providers._anthropic.call_anthropic` and
+`provider="openai"` to `clauditor._providers._openai.call_openai`
+via deferred per-call imports (per
+`.claude/rules/back-compat-shim-discipline.md` Pattern 3, so test
+patches on the canonical module path fire). Raises `ValueError`
+for unknown values.
 
 `src/clauditor/_providers/_anthropic.py::call_anthropic` — the
-anthropic backend body, single async helper, ~90 effective lines,
-exhaustive unit-tested retry branches in
-`tests/test_providers_anthropic.py`.
-The dataclass `ModelResult` (with back-compat alias `AnthropicResult`)
-and the exception types `AnthropicHelperError` / `ClaudeCLIError` are
-part of the public surface for callers; everything prefixed with `_`
-(`_compute_backoff`, `_body_excerpt`, `_extract_result`, `_sleep`,
-`_rand_uniform`, `_rng`) is internal.
+anthropic backend body, single async helper, exhaustive
+unit-tested retry branches in `tests/test_providers_anthropic.py`.
+The dataclass `ModelResult` (with back-compat alias
+`AnthropicResult`) and the exception types `AnthropicHelperError`
+/ `ClaudeCLIError` are part of the public surface for callers;
+everything prefixed with `_` (`_body_excerpt`, `_extract_result`,
+`_sleep`, `_rand_uniform`, `_rng`) is internal.
+
+`src/clauditor/_providers/_openai.py::call_openai` — the openai
+backend body (US-002+ of #145). Mirrors the anthropic seam's
+structural shape — module-level test-indirection aliases,
+sibling `OpenAIHelperError` exception class, deferred SDK import
+where appropriate. Pins module-level constants
+`DEFAULT_MODEL_L3 = "gpt-5.4"` and `DEFAULT_MODEL_L2 = "gpt-5.4-mini"`
+per DEC-001 of `plans/super/145-openai-provider.md`. Catches
+`(TypeError, OpenAIError)` at `AsyncOpenAI()` construction
+because OpenAI's SDK raises its base `OpenAIError` immediately
+when `OPENAI_API_KEY` is missing, whereas Anthropic raises
+`TypeError` later at `messages.create()` — the `OpenAIError`
+arm of the tuple covers OpenAI's earlier failure point.
+Unit-tested retry branches in `tests/test_providers_openai.py`.
+
+`src/clauditor/_providers/_retry.py` — shared retry policy module
+(DEC-007 of `plans/super/145-openai-provider.md`). Hosts:
+
+- `RATE_LIMIT_MAX_RETRIES = 3` / `SERVER_MAX_RETRIES = 1` /
+  `CONN_MAX_RETRIES = 1` — the per-category retry caps both
+  providers honor.
+- `compute_backoff(retry_index)` — pure helper returning the
+  delay for the `retry_index`-th retry (`2 ** retry_index` plus
+  uniform `±25%` jitter, floored at 0).
+- `compute_retry_decision(category, retry_index)` — pure helper
+  returning `"retry"` or `"raise"` per the shared ladder. Each
+  provider's `except` arms call this rather than open-coding
+  the decision.
+
+Per-provider concerns (the `_sleep` / `_monotonic` /
+`_rand_uniform` / `_rng` test-indirection aliases) stay
+per-provider — patching `_providers._openai._sleep` does not
+clobber Anthropic's sleeping. The retry module owns the *policy*
+(constants + decision logic); each provider owns its own clock
+/ RNG indirection. Unit tests in `tests/test_providers_retry.py`.
+
+`src/clauditor/_providers/_auth.py` — auth sub-seam shared
+across providers. Hosts the per-provider auth helpers
+(`check_any_auth_available`, `check_openai_auth`), the
+multi-provider dispatcher `check_provider_auth(provider,
+cmd_name)` (DEC-006 of #145; see also
+`.claude/rules/multi-provider-dispatch.md`), the env-key probes
+(`_api_key_is_set` / `_openai_api_key_is_set`), and the
+implicit-coupling announcement family (see "Implicit-coupling
+announcements" below).
 
 `src/clauditor/_anthropic.py` — back-compat shim. Re-exports the
-public surface so existing call sites still importing
-`from clauditor._anthropic` keep working unmodified for one release.
-New code targets `clauditor._providers` directly.
+public Anthropic surface so existing call sites still importing
+`from clauditor._anthropic` keep working unmodified for one
+release. New code targets `clauditor._providers` directly. There
+is no analogous `clauditor._openai.py` — the OpenAI surface is
+new and ships in `_providers` from day one.
 
-Call sites (four consumers — paths unchanged; import lines move to
-`from clauditor._providers import call_model` in US-005):
+Call sites (six consumers — paths unchanged from #144; the
+provider parameter resolves from
+`eval_spec.grading_provider or "anthropic"` per
+`.claude/rules/multi-provider-dispatch.md`):
 
 - `src/clauditor/grader.py` — `extract_and_grade`,
   `extract_and_report` (Layer 2 schema extraction).
@@ -176,14 +313,14 @@ Call sites (four consumers — paths unchanged; import lines move to
 - `src/clauditor/triggers.py` — trigger precision judge.
 
 Each call site's shape is the same: build a prompt with a pure
-helper, `await call_model(prompt, provider="anthropic", model=...,
-transport=..., max_tokens=...)`, hand the resulting `text_blocks[0]`
-to a pure parser/builder. See
+helper, `await call_model(prompt, provider=<resolved>, model=...,
+transport=..., max_tokens=...)`, hand the resulting
+`text_blocks[0]` to a pure parser/builder. See
 `.claude/rules/pure-compute-vs-io-split.md` (LLM grader pure split
 anchor) for how the pure layer that surrounds this seam is
 structured.
 
-### Multi-transport routing (CLI + SDK, #86)
+### Multi-transport routing (CLI + SDK, #86) — Anthropic only
 
 `call_anthropic` accepts a `transport: str = "auto"` keyword argument
 (DEC-003 of `plans/super/86-claude-cli-transport.md`). The centralized
@@ -205,11 +342,13 @@ env var > `EvalSpec.transport` > default `"auto"`. The shared helper
 the precedence logic for all six LLM-mediated CLI commands so whitespace
 normalization and env stripping are applied uniformly.
 
-`ModelResult.source` (`"api"` or `"cli"`) records which backend
-handled each call (legacy alias `AnthropicResult.source` is preserved).
-`BlindReport.transport_source` propagates this through blind-compare;
-when the two parallel calls disagree (unlikely in practice), the
-report stamps `"mixed"` (DEC-018).
+`ModelResult.source` (`"api"` or `"cli"`) records which Anthropic
+backend handled each call (legacy alias `AnthropicResult.source` is
+preserved). For OpenAI calls, `source` is always `"api"` per DEC-002
+of `plans/super/145-openai-provider.md` — there is no OpenAI CLI
+transport to record. `BlindReport.transport_source` propagates this
+through blind-compare; when the two parallel calls disagree
+(unlikely in practice), the report stamps `"mixed"` (DEC-018).
 
 ### Implicit-coupling announcements — an emerging family
 
@@ -249,6 +388,19 @@ shape going forward). Three members today:
   `"clauditor._providers"` (canonical replacement),
   `"will be removed"` (future-removal hint).
 
+Per #145 the OpenAI backend deliberately did **not** introduce a
+fourth announcement family. OpenAI's auth posture is strict
+(`OPENAI_API_KEY` only — no CLI fallback, no env-stripping
+implicit-coupling, no shim deprecation surface), so none of the
+three existing announcement triggers map to OpenAI. Adding a
+no-op flag for symmetry would create an empty member of the
+family that future maintainers would have to defend against.
+The empty result is itself the design decision: a future provider
+that introduces a genuinely new implicit-coupling failure mode
+(e.g. a Vertex auth-method-vs-credentials-file precedence
+ambiguity) earns its own announcement family member; OpenAI as
+shipped did not.
+
 The #95 / #144 shape (`Final[str]` constant + public helper) is the target
 pattern for new members — it makes the notice independently testable
 without reaching into `call_anthropic` internals. New announcement
@@ -265,33 +417,39 @@ for the shape.
 
 ## When this rule applies
 
-Any new clauditor feature that needs to call Anthropic — a new
-grader tier, an auto-triage judge, a rubric critic, a regeneration-
-on-low-score loop. Import `call_model` from `clauditor._providers`
-and call it with `provider="anthropic"`. Do NOT construct
-`AsyncAnthropic()` directly in the new module; do NOT catch
-`RateLimitError` / `APIStatusError` at the call site to implement a
-bespoke retry loop. If the centralized retry policy is genuinely
-wrong for a new use case, change the policy in
-`_providers/_anthropic.py` (with tests covering the new branches) so
-every caller inherits the fix.
+Any new clauditor feature that needs to call a model provider — a
+new grader tier, an auto-triage judge, a rubric critic, a
+regeneration-on-low-score loop. Import `call_model` from
+`clauditor._providers` and call it with the resolved `provider=`
+string. Do NOT construct `AsyncAnthropic()` / `AsyncOpenAI()`
+directly in the new module; do NOT catch `RateLimitError` /
+`APIStatusError` at the call site to implement a bespoke retry
+loop. If the centralized retry policy is genuinely wrong for a new
+use case, change the policy in `_providers/_retry.py` (with tests
+covering the new branches) so every provider inherits the fix.
 
 ## When this rule does NOT apply
 
-- Non-Anthropic API clients (OpenAI, local Ollama, a third-party
-  judge service). The centralized helper is Anthropic-specific; a
-  sibling helper per provider is fine, and the rule's shape
-  (centralize retry + error categorization in one seam) should be
-  replicated for each.
-- Synchronous one-off scripts in `scripts/` that want to hit the SDK
-  directly for a diagnostic. They can construct a client inline —
-  but production paths loaded via `import clauditor.*` must go
-  through the helper.
-- Tests that mock Anthropic entirely. The canonical mock target is
-  `clauditor._providers._anthropic.call_anthropic` (or a per-call-site
-  patch of the same symbol), never the `anthropic` SDK directly.
-  Tests that patched the legacy path `clauditor._anthropic.X` need to
-  follow the symbol to its new location — Python's
-  `monkeypatch.setattr` operates on the module where the symbol
-  lives, so re-exports through the back-compat shim do not propagate
-  patches.
+- Non-Anthropic / non-OpenAI API clients (Vertex via direct REST,
+  local Ollama, a third-party judge service). The centralized
+  helper today supports only the two providers; a sibling helper
+  per provider is fine, and the rule's shape (centralize retry +
+  error categorization in one seam) should be replicated for
+  each — typically as a new `_providers/_<name>.py` module with
+  a matching `call_<name>` function and a sibling
+  `<Name>HelperError` class, plus a new branch in
+  `call_model`'s dispatcher.
+- Synchronous one-off scripts in `scripts/` that want to hit an
+  SDK directly for a diagnostic. They can construct a client
+  inline — but production paths loaded via `import clauditor.*`
+  must go through the helper.
+- Tests that mock a provider entirely. The canonical mock
+  targets are
+  `clauditor._providers._anthropic.call_anthropic` and
+  `clauditor._providers._openai.call_openai` (or a per-call-site
+  patch of the same symbols), never the `anthropic` / `openai`
+  SDKs directly. Tests that patched the legacy path
+  `clauditor._anthropic.X` need to follow the symbol to its new
+  location — Python's `monkeypatch.setattr` operates on the
+  module where the symbol lives, so re-exports through the
+  back-compat shim do not propagate patches.

--- a/.claude/rules/multi-provider-dispatch.md
+++ b/.claude/rules/multi-provider-dispatch.md
@@ -90,10 +90,12 @@ def check_provider_auth(provider: str, cmd_name: str) -> None:
 - **One dispatcher seam, N provider branches.** A future
   `provider="vertex"` is one new `if provider == "vertex"` branch
   in `check_provider_auth` plus one new `VertexAuthMissingError`
-  class. No CLI command needs editing — they already pass the
-  resolved provider through the dispatcher and catch all known
-  auth-missing exceptions. This is the linear-extensibility
-  property the centralized dispatcher buys.
+  class. CLI commands DO require one mechanical edit per
+  command — adding a new ``except VertexAuthMissingError``
+  branch to each ladder per the rollout recipe in "When this
+  rule applies" below. That edit shape is uniform copy-paste
+  with no new control-flow logic; uniformity is the
+  linear-extensibility property the centralized dispatcher buys.
 - **Distinct exception classes per provider.** A common ancestor
   (`AuthMissingError`) would defeat the structural-routing
   invariant: every `except AnthropicAuthMissingError` ladder

--- a/.claude/rules/multi-provider-dispatch.md
+++ b/.claude/rules/multi-provider-dispatch.md
@@ -1,0 +1,267 @@
+# Rule: Multi-provider dispatch via `check_provider_auth` + `eval_spec.grading_provider`
+
+When an LLM-mediated CLI command supports more than one model
+provider (today: `"anthropic"` and `"openai"`; future: `"vertex"`,
+`"bedrock"`, …), resolve the active provider from
+`eval_spec.grading_provider` (defaulting to `"anthropic"` when
+unset) and route the pre-call auth guard through the centralized
+`check_provider_auth(provider, cmd_name)` dispatcher in
+`clauditor._providers._auth`. The dispatcher delegates to the
+per-provider helper (`check_any_auth_available` for Anthropic,
+`check_openai_auth` for OpenAI); each helper raises a **distinct**
+exception class so the CLI's `except` ladder remains structural —
+one branch per provider, one exit code per branch — per
+`.claude/rules/llm-cli-exit-code-taxonomy.md`. Adding a future
+provider is one new branch in the dispatcher and one new
+auth-missing exception class; no CLI command needs to learn about
+it.
+
+## The pattern
+
+### Layer 1 — spec field carries the provider selection
+
+```python
+# schemas.py
+@dataclass
+class EvalSpec:
+    # ... other fields ...
+    # ``None`` (default) preserves pre-#145 behavior: caller treats
+    # ``None`` as ``"anthropic"``. When set, must be one of
+    # ``"anthropic"`` / ``"openai"``. Validated at load time.
+    grading_provider: str | None = None
+```
+
+### Layer 2 — CLI seam resolves provider, dispatches auth guard
+
+Five LLM-mediated commands share the same shape (grade, extract,
+triggers, compare --blind, propose-eval). Each resolves the
+provider from `eval_spec.grading_provider`, falls back to
+`"anthropic"`, and runs `check_provider_auth(provider, cmd_name)`
+with two distinct `except` branches:
+
+```python
+# cli/grade.py (and extract, triggers, compare, propose_eval).
+from clauditor._providers import (
+    AnthropicAuthMissingError,
+    OpenAIAuthMissingError,
+    check_provider_auth,
+)
+
+def cmd_grade(args) -> int:
+    # ... arg validation, spec load, dry-run early-return ...
+
+    provider = (
+        spec.eval_spec.grading_provider
+        if spec.eval_spec is not None
+        and spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
+    try:
+        check_provider_auth(provider, "grade")
+    except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    # ... allocate workspace + call_model below ...
+```
+
+### Layer 3 — dispatcher routes by provider
+
+```python
+# _providers/_auth.py
+def check_provider_auth(provider: str, cmd_name: str) -> None:
+    if provider == "anthropic":
+        check_any_auth_available(cmd_name)   # raises AnthropicAuthMissingError
+        return None
+    if provider == "openai":
+        check_openai_auth(cmd_name)          # raises OpenAIAuthMissingError
+        return None
+    raise ValueError(
+        f"check_provider_auth: unknown provider {provider!r} — "
+        "expected 'anthropic' or 'openai'"
+    )
+```
+
+## Why this shape
+
+- **One dispatcher seam, N provider branches.** A future
+  `provider="vertex"` is one new `if provider == "vertex"` branch
+  in `check_provider_auth` plus one new `VertexAuthMissingError`
+  class. No CLI command needs editing — they already pass the
+  resolved provider through the dispatcher and catch all known
+  auth-missing exceptions. This is the linear-extensibility
+  property the centralized dispatcher buys.
+- **Distinct exception classes per provider.** A common ancestor
+  (`AuthMissingError`) would defeat the structural-routing
+  invariant: every `except AnthropicAuthMissingError` ladder
+  exists *because* readers can tell at a glance which provider
+  failed and what exit code to map to. Catching a parent class
+  collapses two distinct categories into one branch and forces
+  a substring match on the message to recover the discriminator.
+  Per `.claude/rules/llm-cli-exit-code-taxonomy.md` the routing
+  must stay structural.
+- **`None` as "use the default" sentinel.** Pre-#145 specs have
+  no `grading_provider` field; treating `None` as `"anthropic"`
+  preserves byte-identical behavior for those specs. Authors who
+  want OpenAI grading add `"grading_provider": "openai"` to
+  their `eval.json`.
+- **Resolution at the CLI seam, not inside the orchestrator.**
+  The five orchestrators (`grade_quality`, `extract_and_grade`,
+  `extract_and_report`, `blind_compare`, `test_triggers_async`)
+  receive the resolved provider as a parameter and pass it to
+  `call_model(provider=...)`. Resolving at the CLI seam keeps
+  the orchestrator pure (no `eval_spec` lookups) and makes the
+  pre-call auth guard the only place where the provider string
+  branches into per-provider control flow.
+- **Dispatcher is pure per `.claude/rules/pure-compute-vs-io-split.md`.**
+  `check_provider_auth` reads `os.environ` only via its
+  delegates; raises on missing auth; emits no stderr; calls no
+  `sys.exit`. The CLI wrapper owns stderr and exit-code mapping.
+  Tests construct dispatcher cases with `pytest.raises(...)`,
+  not `capsys`.
+- **Spec field validated at load time.** `EvalSpec.from_dict`
+  rejects `grading_provider` values outside the literal
+  `{"anthropic", "openai"}` set with a `ValueError`. A typo
+  (`"openi"`) fails at `EvalSpec.from_file`, exit 2 — not at
+  the dispatcher's `ValueError` mid-run. Per
+  `.claude/rules/constant-with-type-info.md`, `bool` values
+  are rejected explicitly even though `True` is `int` /
+  `str`-coercible.
+
+## What NOT to do
+
+- Do NOT substring-match on error messages to identify the
+  provider. The exception class IS the discriminator; reaching
+  into `str(exc)` for `"OPENAI"` or `"ANTHROPIC"` is the
+  anti-pattern this rule structurally prevents.
+- Do NOT hardcode `check_any_auth_available("grade")` (or any
+  other Anthropic-only helper) in a new LLM-mediated CLI command.
+  Always go through `check_provider_auth(provider, cmd_name)`
+  with both `except` branches present, even if the command's
+  initial caller graph only exercises one provider — the
+  forward-compat shape is cheap and prevents the next provider's
+  rollout from touching every command.
+- Do NOT subclass `OpenAIAuthMissingError` from
+  `AnthropicAuthMissingError` (or vice versa) for code reuse.
+  The two classes are siblings of `Exception` by design; a
+  shared ancestor would let a stale `except
+  AnthropicAuthMissingError` ladder catch the OpenAI case and
+  print an Anthropic-flavored error message.
+- Do NOT default `grading_provider` to a string at the
+  dataclass level (e.g. `grading_provider: str = "anthropic"`).
+  The `None` sentinel is what lets `from_dict` distinguish
+  "author did not write this field" from "author wrote
+  'anthropic' explicitly", and what makes pre-#145 specs round-
+  trip without a synthetic field appearing in `to_dict` output.
+- Do NOT resolve the provider inside the orchestrator (e.g.
+  `grade_quality` doing its own `eval_spec.grading_provider or
+  "anthropic"`). The CLI seam owns resolution; orchestrators
+  receive the resolved string.
+
+## Canonical implementation
+
+Spec field: `src/clauditor/schemas.py::EvalSpec.grading_provider`
+— `str | None` field, default `None`, validated at load time
+against the literal set `{"anthropic", "openai"}` per DEC-003 of
+`plans/super/145-openai-provider.md`.
+
+Dispatcher + per-provider helpers (all in
+`src/clauditor/_providers/_auth.py` per DEC-006 of
+`plans/super/145-openai-provider.md`):
+
+- `check_provider_auth(provider, cmd_name)` — public dispatcher.
+  Branches on `provider`, delegates to per-provider helper,
+  raises `ValueError` on unknown values.
+- `check_any_auth_available(cmd_name)` — Anthropic relaxed
+  guard (key OR CLI). Raises `AnthropicAuthMissingError`.
+- `check_openai_auth(cmd_name)` — OpenAI strict guard (key
+  only; no CLI fallback). Raises `OpenAIAuthMissingError`.
+- `_openai_api_key_is_set()` — pure env-read helper for
+  `OPENAI_API_KEY` (whitespace-only counts as absent, mirroring
+  `_api_key_is_set` for `ANTHROPIC_API_KEY`).
+
+Auth-missing exception classes (defined in
+`src/clauditor/_providers/__init__.py` so the class-identity
+invariant holds across re-exports per
+`.claude/rules/back-compat-shim-discipline.md`):
+
+- `AnthropicAuthMissingError` — direct subclass of `Exception`.
+- `OpenAIAuthMissingError` — direct subclass of `Exception`,
+  NOT of `AnthropicAuthMissingError`.
+
+CLI call sites (five LLM-mediated commands using the
+provider-aware guard; `suggest` is a sixth LLM-mediated command
+but routes through `check_any_auth_available` directly because
+its prompt builder has no `eval_spec` to read):
+
+- `src/clauditor/cli/grade.py::cmd_grade` — resolves provider
+  from `spec.eval_spec.grading_provider`; calls
+  `check_provider_auth(provider, "grade")`.
+- `src/clauditor/cli/extract.py::cmd_extract` — same shape;
+  `check_provider_auth(provider, "extract")`.
+- `src/clauditor/cli/triggers.py::cmd_triggers` — same shape;
+  `check_provider_auth(provider, "triggers")`.
+- `src/clauditor/cli/compare.py::_run_blind_compare` — reads
+  `skill_spec.eval_spec.grading_provider`;
+  `check_provider_auth(provider, "compare --blind")`.
+- `src/clauditor/cli/propose_eval.py::_cmd_propose_eval_impl` —
+  proposer is the eval-creation step itself, so there is no
+  `eval_spec` to read; hardcodes
+  `check_provider_auth("anthropic", "propose-eval")`. The
+  `OpenAIAuthMissingError` `except` branch is forward-compat
+  for a future `--proposer-provider` flag.
+
+Traces to DEC-003 and DEC-006 of
+`plans/super/145-openai-provider.md`. Companion rules:
+`.claude/rules/centralized-sdk-call.md` (the dispatcher seam
+this auth guard sits in front of),
+`.claude/rules/precall-env-validation.md` (the per-provider
+auth-missing-exception shape),
+`.claude/rules/llm-cli-exit-code-taxonomy.md` (the structural
+exit-code routing the distinct exception classes preserve), and
+`.claude/rules/spec-cli-precedence.md` (the future four-layer
+precedence resolver for `grading_provider` lands in #146).
+
+## When this rule applies
+
+Any future LLM-mediated CLI command that constructs a
+`call_model(provider=..., ...)` call. The shape is uniform:
+
+1. Resolve `provider = eval_spec.grading_provider or "anthropic"`
+   at the CLI seam (or hardcode for commands that have no
+   `eval_spec`).
+2. Call `check_provider_auth(provider, cmd_name)`.
+3. Catch each provider's auth-missing class in a distinct
+   `except` branch, print to stderr, return exit 2.
+4. Pass `provider` through to the orchestrator so the
+   `call_model` call uses the same value.
+
+The rule also applies retroactively when a new provider lands:
+the new provider's auth-missing class must be added to the
+`except` ladder of every existing LLM-mediated CLI command in
+the same change, so a stale ladder cannot silently miss the new
+class.
+
+## When this rule does NOT apply
+
+- LLM-mediated CLI commands that have no `eval_spec` to read
+  AND no per-provider semantics to express (today: none).
+  A command that genuinely only ever runs against one provider
+  can still use `check_provider_auth("<provider>", cmd_name)`
+  for uniformity, but a direct call to the per-provider helper
+  is acceptable.
+- Non-LLM CLI commands (`validate`, `capture`, `run`, `lint`,
+  `init`, `badge`, `audit`, `trend`). They do not call
+  `call_model` and need no auth guard.
+- Pytest fixtures. The three grader fixtures
+  (`clauditor_grader`, `clauditor_blind_compare`,
+  `clauditor_triggers`) currently route through
+  `check_api_key_only` / `check_any_auth_available` directly
+  rather than `check_provider_auth`; per-provider fixture
+  dispatch is forward-compat work for a future ticket once
+  fixtures grow OpenAI-graded test cases.
+- One-off diagnostic scripts in `scripts/` that hit a provider
+  SDK directly. They can rely on the SDK's own error path.

--- a/.claude/rules/precall-env-validation.md
+++ b/.claude/rules/precall-env-validation.md
@@ -1,34 +1,45 @@
 # Rule: Pre-call environment validation for LLM-mediated CLI commands
 
 When an LLM-mediated CLI command needs an environment variable
-(`ANTHROPIC_API_KEY`, a future proxy cert path, a Vertex project ID,
-a rate-limit budget) to even attempt its side-effectful call, put the
-presence check in a **pure helper co-located with the SDK seam**,
-raise a **distinct exception class** the CLI catches to map to a
-specific exit code, and call the helper from each CLI command
-**AFTER** the `--dry-run` early-return and **BEFORE** any
-`call_anthropic` / orchestrator invocation. Do NOT reuse
-`AnthropicHelperError` for pre-call env misconfig — that class is
-already routed to exit 3 (real API failure) and conflating the two
-makes the CLI's exit-code routing substring-matched rather than
-structural. Do NOT let the SDK's own error propagate as a raw
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, a future proxy cert path, a
+Vertex project ID, a rate-limit budget) to even attempt its
+side-effectful call, put the presence check in a **pure helper
+co-located with the SDK seam**, raise a **distinct exception class
+per provider** the CLI catches to map to a specific exit code, and
+call the helper from each CLI command **AFTER** the `--dry-run`
+early-return and **BEFORE** any `call_model` / orchestrator
+invocation. Do NOT reuse `AnthropicHelperError` / `OpenAIHelperError`
+for pre-call env misconfig — those classes are already routed to
+exit 3 (real API failure) and conflating them with the auth-missing
+classes makes the CLI's exit-code routing substring-matched rather
+than structural. Do NOT let the SDK's own error propagate as a raw
 traceback; operators should see an actionable message naming the
 missing env var, why it is required, and the concrete next step.
 
+For multi-provider commands (today: 5 LLM-mediated CLI commands —
+`grade`, `extract`, `triggers`, `compare --blind`, `propose-eval`),
+route through the shared `check_provider_auth(provider, cmd_name)`
+dispatcher in `clauditor._providers._auth` — see the companion rule
+`.claude/rules/multi-provider-dispatch.md`.
+
 ## The pattern
 
-### Layer 1 — domain exception + pure helper, co-located with the SDK seam
+### Layer 1 — domain exception classes + pure helpers, co-located with the SDK seam
 
-The exception class lives in the same module as `call_anthropic`
-(`src/clauditor/_anthropic.py`) so the auth-concern surface is one
-module, not scattered. The class subclasses `Exception` directly
-(NOT `AnthropicHelperError`) so a CLI `except` ladder routes it to
-a distinct exit code structurally:
+The exception classes live in `src/clauditor/_providers/__init__.py`
+so the auth-concern surface is one package and the **class-identity
+invariant** holds across re-exports (per
+`.claude/rules/back-compat-shim-discipline.md` Pattern 2): every
+`except <Provider>AuthMissingError` ladder catches the same class
+object regardless of which module imported it. Each class
+subclasses `Exception` directly (NOT a helper-error class, NOT a
+shared parent) so a CLI `except` ladder routes each provider's
+auth-missing case to a distinct branch structurally:
 
 ```python
-# src/clauditor/_anthropic.py — sibling to call_anthropic.
+# src/clauditor/_providers/__init__.py — sibling auth-missing classes.
 class AnthropicAuthMissingError(Exception):
-    """Raised by :func:`check_anthropic_auth` when ``ANTHROPIC_API_KEY`` is missing.
+    """Raised when no usable Anthropic auth path is available.
 
     Distinct from :class:`AnthropicHelperError` by design: the CLI
     layer routes ``AnthropicAuthMissingError`` to exit 2 (pre-call
@@ -41,105 +52,198 @@ class AnthropicAuthMissingError(Exception):
     """
 
 
+class OpenAIAuthMissingError(Exception):
+    """Raised when ``OPENAI_API_KEY`` is missing for the OpenAI provider.
+
+    Subclass of :class:`Exception` directly, NOT of
+    :class:`AnthropicAuthMissingError` or any helper-error class —
+    a common ancestor would defeat the structural-routing
+    invariant every CLI dispatcher depends on.
+    """
+```
+
+The pure helpers + message templates live in
+`src/clauditor/_providers/_auth.py`:
+
+```python
+# src/clauditor/_providers/_auth.py — auth helpers shared across providers.
+
+# Anthropic relaxed guard (key OR claude CLI on PATH); strict
+# variant ``check_api_key_only`` is used by pytest fixtures.
 _AUTH_MISSING_TEMPLATE = (
-    "ERROR: ANTHROPIC_API_KEY is not set.\n"
-    "clauditor {cmd_name} calls the Anthropic API directly and needs an API\n"
-    "key — a Claude Pro/Max subscription alone does not grant API access.\n"
-    "Get a key at https://console.anthropic.com/, then export\n"
-    "ANTHROPIC_API_KEY=... and re-run. Subscription support via claude -p\n"
-    "is tracked in #86.\n"
+    "ERROR: No usable authentication found.\n"
+    "clauditor {cmd_name} needs either:\n"
+    "  1. ANTHROPIC_API_KEY exported (API key from "
+    "https://console.anthropic.com/), OR\n"
+    "  2. claude CLI installed and authenticated (Claude Pro/Max "
+    "subscription)\n"
+    "Commands that don't need authentication: validate, capture, run, "
+    "lint, init,\n"
+    "badge, audit, trend."
+)
+
+
+def _api_key_is_set() -> bool:
+    value = os.environ.get("ANTHROPIC_API_KEY")
+    return value is not None and value.strip() != ""
+
+
+def check_any_auth_available(cmd_name: str) -> None:
+    """Anthropic relaxed guard — raise only when no auth path exists."""
+    if _api_key_is_set() or _claude_cli_is_available():
+        return None
+    raise AnthropicAuthMissingError(
+        _AUTH_MISSING_TEMPLATE.format(cmd_name=cmd_name)
+    )
+
+
+# OpenAI strict guard — no CLI fallback, no Pro/Max subscription
+# concept. Mirrors check_api_key_only's shape on the Anthropic side.
+_OPENAI_AUTH_MISSING_TEMPLATE = (
+    "ERROR: OPENAI_API_KEY is not set.\n"
+    "clauditor {cmd_name} calls the OpenAI API directly and needs an API\n"
+    "key. Get a key at https://platform.openai.com/api-keys, then export\n"
+    "OPENAI_API_KEY=... and re-run.\n"
     "Commands that don't need a key: validate, capture, run, lint, init,\n"
     "badge, audit, trend."
 )
 
 
-def check_anthropic_auth(cmd_name: str) -> None:
-    """Pre-flight guard: raise if ``ANTHROPIC_API_KEY`` is missing.
+def _openai_api_key_is_set() -> bool:
+    value = os.environ.get("OPENAI_API_KEY")
+    return value is not None and value.strip() != ""
 
-    Pure function per ``.claude/rules/pure-compute-vs-io-split.md``:
-    reads ``os.environ`` only; does NOT print to stderr, does NOT
-    call ``sys.exit``, does NOT log. The CLI wrapper catches
-    :class:`AnthropicAuthMissingError` and maps it to ``return 2`` +
-    stderr surfacing.
-    """
-    value = os.environ.get("ANTHROPIC_API_KEY")
-    if value is None or value.strip() == "":
-        raise AnthropicAuthMissingError(
-            _AUTH_MISSING_TEMPLATE.format(cmd_name=cmd_name)
-        )
-    return None
+
+def check_openai_auth(cmd_name: str) -> None:
+    """OpenAI strict guard — raise if ``OPENAI_API_KEY`` is missing."""
+    if _openai_api_key_is_set():
+        return None
+    raise OpenAIAuthMissingError(
+        _OPENAI_AUTH_MISSING_TEMPLATE.format(cmd_name=cmd_name)
+    )
+
+
+def check_provider_auth(provider: str, cmd_name: str) -> None:
+    """Public dispatcher routing pre-flight auth guards by provider."""
+    if provider == "anthropic":
+        check_any_auth_available(cmd_name)
+        return None
+    if provider == "openai":
+        check_openai_auth(cmd_name)
+        return None
+    raise ValueError(
+        f"check_provider_auth: unknown provider {provider!r} — "
+        "expected 'anthropic' or 'openai'"
+    )
 ```
 
 ### Layer 2 — CLI call site: AFTER dry-run, BEFORE any API spend
 
 Every LLM-mediated command follows the same shape. Guard lands
 after the `--dry-run` early-return (dry-run is a cost-free preview
-— no API call, no key needed) and before any `call_anthropic` or
-orchestrator invocation:
+— no API call, no key needed) and before any `call_model` /
+orchestrator invocation. Multi-provider commands resolve
+`provider = eval_spec.grading_provider or "anthropic"` and route
+through `check_provider_auth(provider, cmd_name)` with **distinct
+`except` branches per provider** so each auth-missing class maps
+to its own exit-2 routing (see
+`.claude/rules/multi-provider-dispatch.md`):
 
 ```python
-# src/clauditor/cli/grade.py (and propose_eval, suggest, triggers,
-# extract, compare --blind — the six guarded seams today).
+# src/clauditor/cli/grade.py (and extract, triggers, compare --blind,
+# propose-eval — the five provider-aware seams today).
+from clauditor._providers import (
+    AnthropicAuthMissingError,
+    OpenAIAuthMissingError,
+    check_provider_auth,
+)
+
 def cmd_grade(args) -> int:
     # ... arg validation, spec load, dry-run early-return ...
     if args.dry_run:
         print(build_grading_prompt(spec.eval_spec))
         return 0
 
-    # Fail fast if ANTHROPIC_API_KEY is missing. Guard lands AFTER
-    # --dry-run and BEFORE allocate_iteration / call_anthropic so we
-    # do not leave an abandoned iteration-N-tmp/ staging dir behind
-    # when the guard fires, and we do not hit the SDK with a missing
-    # key (which raises a raw TypeError from deep in client init).
+    # Fail fast if the resolved provider's required auth is missing.
+    # Guard lands AFTER --dry-run and BEFORE allocate_iteration /
+    # call_model so we do not leave an abandoned iteration-N-tmp/
+    # staging dir behind when the guard fires, and we do not hit the
+    # SDK with a missing key (which raises a raw TypeError /
+    # OpenAIError from deep in client init).
+    provider = (
+        spec.eval_spec.grading_provider
+        if spec.eval_spec is not None
+        and spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
     try:
-        check_anthropic_auth("grade")
+        check_provider_auth(provider, "grade")
     except AnthropicAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
+    except OpenAIAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
 
-    # ... staging + call_anthropic below ...
+    # ... staging + call_model below ...
 ```
 
-### Layer 3 — pytest fixtures raise the same exception
+The `suggest` command is a sixth LLM-mediated CLI seam but is
+single-provider today (no `eval_spec` to read at the call site);
+it calls `check_any_auth_available("suggest")` directly and
+catches `AnthropicAuthMissingError` only.
+
+### Layer 3 — pytest fixtures raise the same exceptions
 
 Fixture factories that wrap the same async orchestrator call
-`check_anthropic_auth(<fixture-name>)` at the factory-invocation
-seam and let the exception propagate as a pytest setup failure
-(NOT `pytest.skip` — a silent skip in CI under subscription-only
-auth hides a test-config regression; a hard error surfaces it).
-Same class as the CLI uses, so users see one error shape
-regardless of where they hit it:
+the appropriate auth helper at the factory-invocation seam and
+let the exception propagate as a pytest setup failure (NOT
+`pytest.skip` — a silent skip in CI under subscription-only auth
+hides a test-config regression; a hard error surfaces it). Same
+classes as the CLI uses, so users see one error shape regardless
+of where they hit it:
 
 ```python
 # src/clauditor/pytest_plugin.py
 @pytest.fixture
 def clauditor_grader(request, clauditor_spec):
-    from clauditor._anthropic import check_anthropic_auth
+    from clauditor._providers import (
+        check_any_auth_available,
+        check_api_key_only,
+    )
     from clauditor.quality_grader import grade_quality
 
     def _factory(skill_path, eval_path=None, output=None):
         # Pre-flight auth guard at factory-invocation time. Raises
         # ``AnthropicAuthMissingError`` (same class the CLI catches)
-        # when ``ANTHROPIC_API_KEY`` is missing, so a CI run under
-        # subscription-only auth surfaces a clear error instead of
-        # silently skipping.
-        check_anthropic_auth("grader")
+        # so a CI run under subscription-only auth surfaces a clear
+        # error instead of silently skipping. Today the three grader
+        # fixtures are Anthropic-only; per-provider fixture dispatch
+        # (routing through ``check_provider_auth``) is future work.
+        if os.environ.get("CLAUDITOR_FIXTURE_ALLOW_CLI") == "1":
+            check_any_auth_available("grader")
+        else:
+            check_api_key_only("grader")
         # ... spec.run + grade_quality ...
     return _factory
 ```
 
-### Layer 4 — defense-in-depth at the SDK seam
+### Layer 4 — defense-in-depth at each provider's SDK seam
 
-Even with the pre-flight guard, `call_anthropic` itself wraps the
-SDK's `TypeError` (raised from `AsyncAnthropic()` construction and
-from `messages.create()` when no auth is configured) as an
-`AnthropicHelperError` with a **fixed sanitized message** — no
+Even with the pre-flight guard, each provider's `call_*` helper
+wraps the SDK's construction failure as the corresponding
+`<Provider>HelperError` with a **fixed sanitized message** — no
 `str(exc)`, no `exc.args`, no SDK-sourced text. Any future caller
 that bypasses the guard (a new orchestrator, a script that forgets
-the pre-flight) sees a crisp error instead of a raw traceback:
+the pre-flight) sees a crisp error instead of a raw traceback.
+The two providers' wraps differ in **which exceptions** they
+catch because the two SDKs fail at different points:
 
 ```python
-# src/clauditor/_anthropic.py::call_anthropic
+# src/clauditor/_providers/_anthropic.py::call_anthropic
+# Anthropic's AsyncAnthropic() does not validate auth at
+# construction; the missing-key TypeError surfaces only when
+# messages.create() runs. Wrap both sites with the same defense.
 try:
     client = AsyncAnthropic()
 except TypeError as exc:
@@ -151,237 +255,373 @@ except TypeError as exc:
 # ... and again around messages.create(...) ...
 ```
 
+```python
+# src/clauditor/_providers/_openai.py::call_openai
+# OpenAI's AsyncOpenAI() raises OpenAIError IMMEDIATELY at
+# construction when OPENAI_API_KEY is missing (different shape
+# from Anthropic's deferred TypeError). Catch the (TypeError,
+# OpenAIError) tuple at the construction site only — the
+# OpenAIError arm is the load-bearing one for missing-key, and
+# TypeError covers any future SDK config-error path.
+try:
+    client = AsyncOpenAI()
+except ImportError:
+    raise   # un-wrapped per the install-hint contract
+except (TypeError, OpenAIError) as exc:
+    raise OpenAIHelperError(
+        "OpenAI SDK client initialization failed — "
+        "verify OPENAI_API_KEY is set."
+    ) from exc
+```
+
+The asymmetry — Anthropic catches `TypeError` only, OpenAI
+catches `(TypeError, OpenAIError)` — reflects **where** each SDK
+raises on missing-auth, not a difference in defense philosophy.
+Both wraps preserve the original on `__cause__` via
+`raise ... from exc` so debuggers can introspect.
+
 ## Why each piece matters
 
-- **Distinct exception class per exit-code category.** The CLI's
-  `except AnthropicAuthMissingError: return 2` vs
-  `except AnthropicHelperError: return 3` routing is **structural**
-  — a reader can see, at a glance, which category a failure belongs
-  to without knowing the error message contents. Reusing
-  `AnthropicHelperError` for pre-call env misconfig would force the
-  CLI to either (a) substring-match the message ("if 'API_KEY' in
-  str(exc)") or (b) sniff some attribute to disambiguate. Both
-  collapse the exit-2-vs-exit-3 distinction that
-  `.claude/rules/llm-cli-exit-code-taxonomy.md` depends on. The new
-  class keeps routing at the `except` level where it belongs.
-- **Co-location with the SDK seam.** The helper sits next to
-  `call_anthropic` in `_anthropic.py`, not in `cli/__init__.py` or
-  a new `env_check.py`. Anyone reading the SDK seam sees the guard
-  in the same file; anyone adding a new SDK-backed entry point will
-  grep `_anthropic.py` for the helper and wire it in. Scattering
-  the guard to the CLI package makes it easy to miss when a future
-  non-CLI caller (a pytest fixture, a batch-runner script) needs
-  the same protection.
-- **Pure helper + CLI wrapper (pure/IO split).** `check_anthropic_auth`
-  reads `os.environ` and raises — no stderr, no `sys.exit`, no
-  logging. The CLI wrapper emits stderr and returns the exit code.
-  This honors `.claude/rules/pure-compute-vs-io-split.md`: the
-  helper is trivially unit-testable (`monkeypatch.delenv`, assert
+- **Distinct exception classes per exit-code category AND per
+  provider.** The CLI's `except AnthropicAuthMissingError: return 2`
+  vs `except OpenAIAuthMissingError: return 2` vs
+  `except AnthropicHelperError: return 3` vs
+  `except OpenAIHelperError: return 3` routing is **structural**
+  — a reader can see, at a glance, which category a failure
+  belongs to without knowing the error message contents. Reusing
+  any helper-error class for pre-call env misconfig would force
+  the CLI to either (a) substring-match the message
+  ("if 'API_KEY' in str(exc)") or (b) sniff some attribute to
+  disambiguate. Both collapse the exit-2-vs-exit-3 distinction
+  that `.claude/rules/llm-cli-exit-code-taxonomy.md` depends on.
+  Subclassing `OpenAIAuthMissingError` from
+  `AnthropicAuthMissingError` would equally collapse the
+  per-provider distinction — both classes are siblings of
+  `Exception` by design.
+- **Co-location with the SDK seam.** The auth helpers sit next to
+  the SDK callers in `_providers/_auth.py`, not in
+  `cli/__init__.py` or a new `env_check.py`. Anyone reading the
+  `_providers/` package sees the guard in the same package;
+  anyone adding a new SDK-backed entry point will grep
+  `_providers/_auth.py` for the helper and wire it in.
+  Scattering the guard to the CLI package makes it easy to miss
+  when a future non-CLI caller (a pytest fixture, a batch-runner
+  script) needs the same protection.
+- **Pure helpers + CLI wrapper (pure/IO split).**
+  `check_any_auth_available`, `check_openai_auth`, and
+  `check_provider_auth` all read `os.environ` (and probe PATH for
+  the Anthropic-CLI branch) and raise — no stderr, no
+  `sys.exit`, no logging. The CLI wrapper emits stderr and
+  returns the exit code. This honors
+  `.claude/rules/pure-compute-vs-io-split.md`: each helper is
+  trivially unit-testable (`monkeypatch.delenv`, assert
   `pytest.raises`), the CLI integration is a narrow `try/except`,
   and the pytest fixture inherits the same check without
   re-implementing the env read.
-- **Guard AFTER `--dry-run` early-return.** `--dry-run` prints the
-  prompt without any API call; requiring an API key for the preview
-  would be a hostile UX regression. Order is load-bearing: if the
-  guard fires before the dry-run check, the user who wants to see
-  what the prompt looks like (to iterate on their eval spec) is
-  blocked even though no API spend would happen.
-- **Guard BEFORE allocate-workspace / API call.** Firing the guard
-  at the earliest safe point (right after arg validation +
+- **Guard AFTER `--dry-run` early-return.** `--dry-run` prints
+  the prompt without any API call; requiring an API key for the
+  preview would be a hostile UX regression. Order is
+  load-bearing: if the guard fires before the dry-run check, the
+  user who wants to see what the prompt looks like (to iterate on
+  their eval spec) is blocked even though no API spend would
+  happen.
+- **Guard BEFORE allocate-workspace / API call.** Firing the
+  guard at the earliest safe point (right after arg validation +
   dry-run) avoids leaving an abandoned staging dir
   (`iteration-N-tmp/`), avoids burning API tokens on a retry loop
   that will never succeed, and gives the operator an immediate
   actionable error. Delaying the check until the SDK's own
-  `TypeError` fires produces a confusing multi-line traceback from
-  deep inside the `anthropic` package.
-- **Single message template with `{cmd_name}` interpolation.** One
-  template interpolated at raise-time (`clauditor {cmd_name}`)
-  names the specific invocation so users know exactly which command
-  triggered the guard. Five hand-tailored per-command strings would
-  drift stylistically; a single template with one substitution
-  point stays DRY and produces consistent output.
-- **Three durable substrings, not a byte-identical assertion.**
-  Tests pin three load-bearing anchors (`"ANTHROPIC_API_KEY"`,
-  `"Claude Pro"`, `"console.anthropic.com"`) — the env-var name,
-  the product name, the concrete next step. Stylistic copy edits
-  (typo fixes, a reworded clause, a forward-pointer issue number
-  renumber) do not churn tests. A verbatim assertion would force a
-  test change on every prose polish.
+  `TypeError` / `OpenAIError` fires produces a confusing
+  multi-line traceback from deep inside the provider's package.
+- **Single message template per provider with `{cmd_name}`
+  interpolation.** Each provider has one template
+  (`_AUTH_MISSING_TEMPLATE` for Anthropic relaxed,
+  `_AUTH_MISSING_TEMPLATE_KEY_ONLY` for Anthropic strict,
+  `_OPENAI_AUTH_MISSING_TEMPLATE` for OpenAI) interpolated at
+  raise-time (`clauditor {cmd_name}`) so users know exactly
+  which command triggered the guard. Five hand-tailored
+  per-command strings would drift stylistically; one template
+  per provider with one substitution point stays DRY and
+  produces consistent output.
+- **Durable substrings per provider, not byte-identical
+  assertions.** Tests pin per-provider load-bearing anchors —
+  Anthropic: `"ANTHROPIC_API_KEY"`, `"Claude Pro"`,
+  `"console.anthropic.com"` (and `"claude CLI"` for the relaxed
+  variant); OpenAI: `"OPENAI_API_KEY"`, `"platform.openai.com"`.
+  Stylistic copy edits (typo fixes, a reworded clause, a
+  forward-pointer issue number renumber) do not churn tests. A
+  verbatim assertion would force a test change on every prose
+  polish.
 - **Fixture raises, not skips.** Pytest-fixture callers that hit
-  the guard see the **same exception class** the CLI catches, not
-  a `pytest.skip`. A CI pipeline that runs under subscription-only
-  auth with a silent skip would hide the configuration regression
-  ("our test suite skipped all LLM tests because no key was set");
-  a hard error surfaces the gap immediately. If a caller later
-  needs skip semantics, `try/except AnthropicAuthMissingError:
-  pytest.skip(...)` at the test-function level is a one-line
-  change.
-- **Defense-in-depth `TypeError` wrap inside `call_anthropic`.**
-  Even with the pre-flight guard removing the primary path, the
-  SDK's client-init and `messages.create` sites both wrap
-  `TypeError` as a sanitized `AnthropicHelperError`. A new caller
-  that forgets the pre-flight (a new CLI command, a script, a
-  future orchestrator) still sees a crisp error instead of a raw
-  traceback. **Sanitized message only**: no `str(exc)`, no
-  `exc.args`, no SDK-sourced text — defense-in-depth against
-  future SDK versions that might include partial auth state in
-  diagnostics. Original exception preserved on `__cause__` via
-  `raise ... from exc` for debugging.
+  the guard see the **same exception class** the CLI catches,
+  not a `pytest.skip`. A CI pipeline that runs under
+  subscription-only auth with a silent skip would hide the
+  configuration regression ("our test suite skipped all LLM
+  tests because no key was set"); a hard error surfaces the gap
+  immediately.
+- **Defense-in-depth provider-specific exception wraps inside
+  each `call_*` helper.** Even with the pre-flight guard
+  removing the primary path, each provider's SDK construction
+  site wraps its own provider's missing-auth exception family
+  as a sanitized `<Provider>HelperError`. **Sanitized message
+  only**: no `str(exc)`, no `exc.args`, no SDK-sourced text —
+  defense-in-depth against future SDK versions that might
+  include partial auth state in diagnostics. Original exception
+  preserved on `__cause__` via `raise ... from exc` for
+  debugging.
+- **Asymmetric `except` tuples reflect SDK behavior.**
+  Anthropic raises `TypeError` at `messages.create()` time when
+  `ANTHROPIC_API_KEY` is missing; OpenAI raises its base
+  `OpenAIError` immediately at `AsyncOpenAI()` construction.
+  Wrapping `(TypeError, OpenAIError)` on the OpenAI side
+  catches the OpenAI-specific failure shape; wrapping
+  `TypeError` only on the Anthropic side avoids
+  over-catching unrelated `TypeError`s that the future SDK
+  might raise for legitimate API misuse. The defense is shaped
+  to each SDK, not blanket-applied.
 
 ## What NOT to do
 
-- Do NOT reuse `AnthropicHelperError` for the pre-call env check.
-  That class is routed to exit 3 (API failure); conflating it with
-  exit 2 (input validation) breaks the taxonomy.
+- Do NOT reuse `AnthropicHelperError` / `OpenAIHelperError` for
+  the pre-call env check. Those classes are routed to exit 3
+  (API failure); conflating them with exit 2 (input validation)
+  breaks the taxonomy.
+- Do NOT subclass `OpenAIAuthMissingError` from
+  `AnthropicAuthMissingError` (or invent a shared
+  `AuthMissingError` parent). The two classes are siblings of
+  `Exception` by design — a shared ancestor lets a stale
+  `except AnthropicAuthMissingError` ladder catch the OpenAI
+  case and print the wrong-flavored error message.
 - Do NOT put the guard in an argparse `type=` validator. Env-var
-  presence is not an arg-value check; it doesn't fit the argparse
-  contract, and argparse's auto-exit-2 on validation failure fires
-  BEFORE the `--dry-run` check, blocking the preview path.
-- Do NOT let the guard emit stderr itself. The helper stays pure;
-  stderr belongs to the CLI wrapper. Tests for the helper use
-  `pytest.raises`, not `capsys`.
-- Do NOT fire the guard before `--dry-run`. Dry-run is a cost-free
-  preview; requiring auth for a preview is a hostile regression.
+  presence is not an arg-value check; it doesn't fit the
+  argparse contract, and argparse's auto-exit-2 on validation
+  failure fires BEFORE the `--dry-run` check, blocking the
+  preview path.
+- Do NOT let the guard emit stderr itself. The helpers stay
+  pure; stderr belongs to the CLI wrapper. Tests for the
+  helpers use `pytest.raises`, not `capsys`.
+- Do NOT fire the guard before `--dry-run`. Dry-run is a
+  cost-free preview; requiring auth for a preview is a hostile
+  regression.
 - Do NOT fire the guard after workspace allocation / API call.
-  Late failures leave abandoned staging dirs and confuse operators
-  about whether an API round-trip happened.
-- Do NOT skip the defense-in-depth `TypeError` wrap in
-  `call_anthropic`. A future caller that bypasses the guard (a
-  new orchestrator, a migration script, a REPL session) must still
-  see a clean error, not a raw SDK traceback. The wrap costs
-  ~4 lines and catches the whole class of "forgot the guard" bug.
-- Do NOT surface the SDK's `TypeError` text in the user-facing
-  message. A fixed sanitized string is defense-in-depth against
-  hypothetical future SDK versions that include partial auth state
-  in diagnostics. Preserve the original on `__cause__` via
-  `raise ... from exc` for debuggers.
-- Do NOT forget to add the pytest fixtures. Three fixtures wrap
-  `grade_quality`, `blind_compare`, and `test_triggers` today; a
-  future fixture that wraps any `call_anthropic` caller needs the
-  same guard or CI under subscription-only auth surfaces the
-  problem as a multi-line SDK traceback from deep inside an
-  orphaned async task.
+  Late failures leave abandoned staging dirs and confuse
+  operators about whether an API round-trip happened.
+- Do NOT skip the defense-in-depth construction-error wrap in
+  either `call_anthropic` or `call_openai`. A future caller that
+  bypasses the guard (a new orchestrator, a migration script, a
+  REPL session) must still see a clean error, not a raw SDK
+  traceback. The wrap costs ~4 lines per provider and catches
+  the whole class of "forgot the guard" bug.
+- Do NOT collapse the asymmetric `except` tuples to a uniform
+  shape across providers. Anthropic-`TypeError`-only and
+  OpenAI-`(TypeError, OpenAIError)` are deliberate — the
+  OpenAIError arm catches OpenAI's earlier-failing
+  missing-auth shape that has no Anthropic equivalent.
+- Do NOT surface either SDK's exception text in the
+  user-facing message. A fixed sanitized string is
+  defense-in-depth against hypothetical future SDK versions
+  that include partial auth state in diagnostics. Preserve the
+  original on `__cause__` via `raise ... from exc` for
+  debuggers.
+- Do NOT forget to add the pytest fixtures' guard. Three
+  fixtures wrap `grade_quality`, `blind_compare`, and
+  `test_triggers` today; a future fixture that wraps any
+  `call_model` caller needs the same guard or CI under
+  subscription-only auth surfaces the problem as a multi-line
+  SDK traceback from deep inside an orphaned async task.
 
 ## Canonical implementation
 
-Helper + exception class:
+Auth-missing exception classes:
 
-- `src/clauditor/_anthropic.py::AnthropicAuthMissingError` — domain
-  exception class, subclass of `Exception`, sibling of
-  `AnthropicHelperError`.
-- `src/clauditor/_anthropic.py::check_anthropic_auth` — pure
-  helper, reads `os.environ["ANTHROPIC_API_KEY"]`, raises on
-  absent/empty/whitespace-only. Single template
-  (`_AUTH_MISSING_TEMPLATE`) with `{cmd_name}` interpolation.
-- `src/clauditor/_anthropic.py::call_anthropic` — defense-in-depth
-  `except TypeError` branches around `AsyncAnthropic()` construction
-  and `messages.create()`, both raising
-  `AnthropicHelperError("Anthropic SDK client initialization failed
-  — verify ANTHROPIC_API_KEY is set.") from exc`.
+- `src/clauditor/_providers/__init__.py::AnthropicAuthMissingError`
+  — direct subclass of `Exception`, defined at the package
+  root so the class-identity invariant holds across re-exports.
+- `src/clauditor/_providers/__init__.py::OpenAIAuthMissingError`
+  — direct subclass of `Exception`, NOT a subclass of
+  `AnthropicAuthMissingError` or any helper-error class. Per
+  DEC-006 of `plans/super/145-openai-provider.md`.
 
-CLI call sites (six guarded commands today — `compare --blind`
-added in QG pass 2 after initial enumeration of five):
+Helpers + templates (all in
+`src/clauditor/_providers/_auth.py` per DEC-005 of
+`plans/super/144-providers-call-model.md` and DEC-006 of
+`plans/super/145-openai-provider.md`):
+
+- `_AUTH_MISSING_TEMPLATE` — Anthropic relaxed-guard message
+  template (key OR claude CLI). Four durable substrings.
+- `_AUTH_MISSING_TEMPLATE_KEY_ONLY` — Anthropic strict variant
+  used by pytest fixtures.
+- `_OPENAI_AUTH_MISSING_TEMPLATE` — OpenAI strict-guard
+  template. Two durable substrings (`OPENAI_API_KEY`,
+  `platform.openai.com`).
+- `_api_key_is_set` / `_openai_api_key_is_set` — pure env-read
+  helpers; whitespace-only counts as absent for both providers.
+- `check_any_auth_available(cmd_name)` — Anthropic relaxed
+  guard. Raises `AnthropicAuthMissingError`.
+- `check_api_key_only(cmd_name)` — Anthropic strict guard
+  (pytest fixtures). Raises `AnthropicAuthMissingError`.
+- `check_openai_auth(cmd_name)` — OpenAI strict guard. Raises
+  `OpenAIAuthMissingError`.
+- `check_provider_auth(provider, cmd_name)` — public dispatcher
+  routing by `provider`. Branches to `check_any_auth_available`
+  for `"anthropic"` and `check_openai_auth` for `"openai"`;
+  raises `ValueError` on unknown values. See
+  `.claude/rules/multi-provider-dispatch.md` for the call-site
+  contract.
+
+Defense-in-depth construction wraps:
+
+- `src/clauditor/_providers/_anthropic.py::call_anthropic` —
+  `except TypeError` branches around `AsyncAnthropic()`
+  construction and `messages.create()`, both raising
+  `AnthropicHelperError("Anthropic SDK client initialization
+  failed — verify ANTHROPIC_API_KEY is set.") from exc`.
+- `src/clauditor/_providers/_openai.py::call_openai` —
+  `except (TypeError, OpenAIError)` branch around
+  `AsyncOpenAI()` construction (the OpenAI-only failure point;
+  no `responses.create()`-time wrap needed because the
+  missing-key shape surfaces at construction).
+
+CLI call sites — five LLM-mediated commands using the
+provider-aware dispatcher
+`check_provider_auth(provider, cmd_name)` with distinct
+`except` branches per provider:
 
 - `src/clauditor/cli/grade.py::cmd_grade` — after `--dry-run`,
-  before `allocate_iteration()`. `check_anthropic_auth("grade")`.
-- `src/clauditor/cli/propose_eval.py::_cmd_propose_eval_impl` —
-  after `--dry-run`. `check_anthropic_auth("propose-eval")`.
+  before `allocate_iteration()`.
+  `check_provider_auth(provider, "grade")`.
+- `src/clauditor/cli/extract.py::cmd_extract` — after
+  `--dry-run`. `check_provider_auth(provider, "extract")`.
+- `src/clauditor/cli/triggers.py::cmd_triggers` — after
+  `--dry-run`. `check_provider_auth(provider, "triggers")`.
+- `src/clauditor/cli/compare.py::_run_blind_compare` — after
+  `validate_blind_compare_spec`, before
+  `blind_compare_from_spec`.
+  `check_provider_auth(provider, "compare --blind")`.
+- `src/clauditor/cli/propose_eval.py::_cmd_propose_eval_impl`
+  — after `--dry-run`. Hardcodes
+  `check_provider_auth("anthropic", "propose-eval")` because
+  the proposer is the eval-creation step itself (no
+  `eval_spec` to read); the `OpenAIAuthMissingError`
+  `except` branch is forward-compat for a future
+  `--proposer-provider` flag.
+
+Plus the single-provider seam:
+
 - `src/clauditor/cli/suggest.py::_cmd_suggest_impl` — after
   zero-signal early-exit (no `--dry-run` on this command).
-  `check_anthropic_auth("suggest")`.
-- `src/clauditor/cli/triggers.py::cmd_triggers` — after
-  `--dry-run`. `check_anthropic_auth("triggers")`.
-- `src/clauditor/cli/extract.py::cmd_extract` — after `--dry-run`.
-  `check_anthropic_auth("extract")`.
-- `src/clauditor/cli/compare.py::_run_blind_compare` — after
-  `validate_blind_compare_spec`, before `blind_compare_from_spec`.
-  `check_anthropic_auth("compare --blind")`.
+  `check_any_auth_available("suggest")` directly (no
+  `eval_spec` lookup at the suggest seam, so it stays
+  Anthropic-only).
 
-Pytest fixtures (three, all raise the same
-`AnthropicAuthMissingError` at factory-invocation time):
+Pytest fixtures (three, all routing through the Anthropic
+helpers — per-provider fixture dispatch is forward-compat
+work):
 
 - `src/clauditor/pytest_plugin.py::clauditor_grader` —
-  `check_anthropic_auth("grader")`.
+  `check_any_auth_available` (relaxed, opt-in via
+  `CLAUDITOR_FIXTURE_ALLOW_CLI=1`) or `check_api_key_only`
+  (strict default).
 - `src/clauditor/pytest_plugin.py::clauditor_blind_compare` —
-  `check_anthropic_auth("blind_compare")`.
+  same shape.
 - `src/clauditor/pytest_plugin.py::clauditor_triggers` —
-  `check_anthropic_auth("triggers")`.
+  same shape.
 
 Regression tests verify eight commands (`validate`, `capture`,
-`run`, `lint`, `init`, `badge`, `audit`, `trend`) still work with
-`ANTHROPIC_API_KEY` unset — they do not route through
-`call_anthropic`, so the guard must not have been wired into them
-by accident.
+`run`, `lint`, `init`, `badge`, `audit`, `trend`) still work
+with `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` unset — they do
+not route through `call_model`, so neither guard must have
+been wired into them by accident.
 
 Traces to DEC-001, DEC-002, DEC-004, DEC-008, DEC-010, DEC-011,
 DEC-012, DEC-013, DEC-015, DEC-017 of
-`plans/super/83-subscription-auth-gap.md`.
+`plans/super/83-subscription-auth-gap.md` and DEC-006 of
+`plans/super/145-openai-provider.md`.
 
 ## Companion rules
 
-- `.claude/rules/llm-cli-exit-code-taxonomy.md` — codifies the
-  exit-2-vs-exit-3 category split this rule structurally preserves.
-  That rule governs the table of exit codes and the "distinct
-  report fields" shape for async orchestrators that "never raise";
-  this rule governs how to surface a pre-call env misconfig at
-  exit 2 via a **synchronous** exception class upstream of any
-  orchestrator. The two compose cleanly — an LLM-mediated CLI
-  command that wraps a single Anthropic call follows both.
+- `.claude/rules/multi-provider-dispatch.md` — codifies the
+  `check_provider_auth(provider, cmd_name)` dispatch pattern
+  and the `eval_spec.grading_provider or "anthropic"`
+  resolution at CLI seams. This rule defines the
+  per-provider auth-missing exception shape; the multi-
+  provider rule defines how the dispatcher composes them.
+- `.claude/rules/llm-cli-exit-code-taxonomy.md` — codifies
+  the exit-2-vs-exit-3 category split this rule structurally
+  preserves. That rule governs the table of exit codes and
+  the "distinct report fields" shape for async orchestrators
+  that "never raise"; this rule governs how to surface a
+  pre-call env misconfig at exit 2 via a **synchronous**
+  exception class upstream of any orchestrator. The two
+  compose cleanly — an LLM-mediated CLI command that wraps a
+  single model call follows both.
 - `.claude/rules/pure-compute-vs-io-split.md` — codifies the
-  pure-helper + thin-wrapper shape. `check_anthropic_auth` is a
-  direct application: pure env read, caller owns stderr + exit
+  pure-helper + thin-wrapper shape. `check_any_auth_available`,
+  `check_openai_auth`, and `check_provider_auth` are direct
+  applications: pure env read, caller owns stderr + exit
   code.
-- `.claude/rules/centralized-sdk-call.md` — codifies the single
-  `call_anthropic` seam every Anthropic call routes through. This
-  rule extends the seam with a **pre-call** guard; the defense-in-
-  depth `TypeError` wrap is an additive fix inside the existing
-  centralized helper, not a new call surface.
-- `.claude/rules/pre-llm-contract-hard-validate.md` — same spirit
-  ("fail loudly at the earliest safe moment with a specific
-  actionable error"), applied to LLM-output invariants rather than
-  pre-call env. The two rules rhyme: each enforces a structural
-  invariant at a hard boundary, with the validator as the source of
-  truth rather than a prompt assertion or an SDK-side fallback.
+- `.claude/rules/centralized-sdk-call.md` — codifies the
+  single `call_model` / `call_anthropic` / `call_openai` seam
+  every model call routes through. This rule extends the
+  seam with a **pre-call** guard; the defense-in-depth
+  construction-error wraps are additive fixes inside the
+  centralized helpers, not new call surfaces.
+- `.claude/rules/pre-llm-contract-hard-validate.md` — same
+  spirit ("fail loudly at the earliest safe moment with a
+  specific actionable error"), applied to LLM-output
+  invariants rather than pre-call env. The two rules rhyme:
+  each enforces a structural invariant at a hard boundary,
+  with the validator as the source of truth rather than a
+  prompt assertion or an SDK-side fallback.
 
 ## When this rule applies
 
-Any future env-var precondition for an LLM-mediated clauditor CLI
-command. Plausible future callers:
+Any future env-var precondition for an LLM-mediated clauditor
+CLI command. Plausible future callers:
 
-- A Vertex / Bedrock / proxy endpoint env var (`ANTHROPIC_VERTEX_PROJECT_ID`,
-  `ANTHROPIC_BEDROCK_REGION`, a CA cert path) where the SDK would
-  otherwise fail deep with an opaque error.
-- A rate-limit budget env var (`CLAUDITOR_API_BUDGET_USD`) that the
-  CLI must refuse to exceed — the pre-call budget check is the
-  same shape (pure helper, distinct exception class, exit-2
-  routing).
-- A required model-override env var (`CLAUDITOR_GRADING_MODEL`) for
-  a command that has no default model (if we ever remove defaults).
-- An auth-source-selector env var that gates on the presence of
-  one of multiple alternatives (`ANTHROPIC_API_KEY` OR
-  `ANTHROPIC_AUTH_TOKEN` OR a credentials file path — widen the
-  helper's check, keep the exception class).
+- A Vertex / Bedrock / proxy endpoint env var
+  (`ANTHROPIC_VERTEX_PROJECT_ID`, `ANTHROPIC_BEDROCK_REGION`,
+  a CA cert path) where the SDK would otherwise fail deep
+  with an opaque error. Add a `<Provider>AuthMissingError`
+  class, a per-provider helper, and a new branch in
+  `check_provider_auth`.
+- A rate-limit budget env var (`CLAUDITOR_API_BUDGET_USD`)
+  that the CLI must refuse to exceed — the pre-call budget
+  check is the same shape (pure helper, distinct exception
+  class, exit-2 routing).
+- A required model-override env var
+  (`CLAUDITOR_GRADING_MODEL`) for a command that has no
+  default model (if we ever remove defaults).
+- An auth-source-selector env var that gates on the presence
+  of one of multiple alternatives (`ANTHROPIC_API_KEY` OR
+  `ANTHROPIC_AUTH_TOKEN` OR a credentials file path — widen
+  the helper's check, keep the exception class).
 
-The rule also applies retroactively: any existing CLI command that
-hits `call_anthropic` without a pre-call env guard is a latent
-foot-gun — operators will see a raw SDK traceback when they first
-run the command under a misconfigured env. Wire the guard in the
-next time the command is touched.
+The rule also applies retroactively: any existing CLI
+command that hits `call_model` without a pre-call env guard
+is a latent foot-gun — operators will see a raw SDK
+traceback when they first run the command under a
+misconfigured env. Wire the guard in the next time the
+command is touched.
 
 ## When this rule does NOT apply
 
-- Non-LLM-mediated commands (`validate`, `capture`, `run`, `lint`,
-  `init`, `badge`, `audit`, `trend`). They do not route through
-  `call_anthropic`; they do not need an API key; wiring the guard
-  would give a false "this command needs a key" error.
-- Commands whose env-var precondition is enforced elsewhere in the
-  stack with equivalent crispness (e.g. a subprocess that itself
-  prints a clean actionable error on missing env — no need for a
-  parent-side pre-flight duplicate).
+- Non-LLM-mediated commands (`validate`, `capture`, `run`,
+  `lint`, `init`, `badge`, `audit`, `trend`). They do not
+  route through `call_model`; they do not need an API key;
+  wiring the guard would give a false "this command needs a
+  key" error.
+- Commands whose env-var precondition is enforced elsewhere
+  in the stack with equivalent crispness (e.g. a subprocess
+  that itself prints a clean actionable error on missing env
+  — no need for a parent-side pre-flight duplicate).
 - One-off diagnostic scripts in `scripts/` that hit the SDK
-  directly. They can rely on the SDK's own error path; operators
-  running an ad-hoc script are expected to know about their env.
-- Tests that mock `call_anthropic` entirely. The mock substitutes
-  for the real SDK; no env check is needed. Tests that exercise
-  the guard itself set `ANTHROPIC_API_KEY` via `monkeypatch.setenv`
-  (or `delenv` for the raise-path) per standard test discipline.
+  directly. They can rely on the SDK's own error path;
+  operators running an ad-hoc script are expected to know
+  about their env.
+- Tests that mock `call_model` / `call_anthropic` /
+  `call_openai` entirely. The mock substitutes for the real
+  SDK; no env check is needed. Tests that exercise the guards
+  themselves set `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` via
+  `monkeypatch.setenv` (or `delenv` for the raise-path) per
+  standard test discipline.

--- a/plans/super/145-openai-provider.md
+++ b/plans/super/145-openai-provider.md
@@ -5,8 +5,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/145
 - **Branch:** `feature/145-openai-provider`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/145-openai-provider`
-- **Phase:** published
+- **Phase:** devolved
 - **PR:** https://github.com/wjduenow/clauditor/pull/160
+- **Epic:** clauditor-2cq
 - **Sessions:** 1 (2026-04-29)
 - **Depends on:** #144 (CLOSED — `call_model` dispatcher + `ModelResult` envelope shipped)
 - **Blocks:** #146 (`grading_provider` precedence), #147 (sidecar v3 with `provider` field)
@@ -497,7 +498,28 @@ Architecture-natural ordering: foundations → SDK seam → dispatcher → auth 
 
 ## Beads Manifest
 
-(Phase 7 — populated on devolve.)
+**Epic:** `clauditor-2cq` — #145: OpenAI provider via Responses API
+**Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/145-openai-provider`
+**Branch:** `feature/145-openai-provider`
+**PR:** https://github.com/wjduenow/clauditor/pull/160
+
+| Story | Bead ID | Depends on |
+|---|---|---|
+| US-001 — Hoist retry helpers to `_providers/_retry.py` | `clauditor-0y2` | (epic) |
+| US-002 — Add `openai>=1.66.0` + `_providers/_openai.py` happy path | `clauditor-2pf` | US-001 |
+| US-003 — OpenAI response parser edges | `clauditor-n5h` | US-002 |
+| US-004 — OpenAI retry/error branches | `clauditor-4uw` | US-002 |
+| US-005 — Wire OpenAI into `call_model` dispatcher | `clauditor-52b` | US-002, US-004 |
+| US-006 — OpenAI auth helper + `check_provider_auth` dispatcher | `clauditor-4cq` | (epic) |
+| US-007 — `EvalSpec.grading_provider` field | `clauditor-jlo` | (epic) |
+| US-008 — Strip `OPENAI_API_KEY` from skill subprocess env | `clauditor-ejw` | (epic) |
+| US-009 — Wire 4 CLI commands to `check_provider_auth` | `clauditor-5wc` | US-006, US-007 |
+| US-010 — Wire 4 grader call sites | `clauditor-iye` | US-005, US-007 |
+| US-011 — End-to-end tests for `grading_provider="openai"` | `clauditor-t8t` | US-009, US-010 |
+| US-012 — Quality Gate | `clauditor-y16` | US-001..US-011 |
+| US-013 — Patterns & Memory | `clauditor-8gx` | US-012 |
+
+**Initially ready** (zero-dependency starting set): `clauditor-0y2` (US-001), `clauditor-4cq` (US-006), `clauditor-jlo` (US-007), `clauditor-ejw` (US-008).
 
 ## Session Notes
 

--- a/plans/super/145-openai-provider.md
+++ b/plans/super/145-openai-provider.md
@@ -5,7 +5,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/145
 - **Branch:** `feature/145-openai-provider`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/145-openai-provider`
-- **Phase:** detailing
+- **Phase:** published
+- **PR:** https://github.com/wjduenow/clauditor/pull/160
 - **Sessions:** 1 (2026-04-29)
 - **Depends on:** #144 (CLOSED — `call_model` dispatcher + `ModelResult` envelope shipped)
 - **Blocks:** #146 (`grading_provider` precedence), #147 (sidecar v3 with `provider` field)

--- a/plans/super/145-openai-provider.md
+++ b/plans/super/145-openai-provider.md
@@ -1,0 +1,511 @@
+# 145: Multi-provider — add OpenAI provider via Responses API
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/145
+- **Branch:** `feature/145-openai-provider`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/145-openai-provider`
+- **Phase:** detailing
+- **Sessions:** 1 (2026-04-29)
+- **Depends on:** #144 (CLOSED — `call_model` dispatcher + `ModelResult` envelope shipped)
+- **Blocks:** #146 (`grading_provider` precedence), #147 (sidecar v3 with `provider` field)
+
+## Discovery
+
+### What
+
+Add `src/clauditor/_providers/_openai.py` as a sibling to `_anthropic.py`. Implement `call_openai(...)` against the OpenAI **Responses API** with retry/error parity to `call_anthropic`. Wire into the existing `call_model` dispatcher (today raises `NotImplementedError("openai provider lands in #145")` at `_providers/__init__.py:168-169`). Add `OpenAIAuthMissingError` + `check_openai_auth(cmd_name)` mirroring the Anthropic guard pattern.
+
+### Why
+
+Epic A, ticket 2 of 4 in the multi-provider initiative (#143). #144 shipped the dispatcher and `ModelResult` envelope; this ticket fills the OpenAI stub. Responses API was chosen over Chat Completions because its `usage.input_tokens` / `usage.output_tokens` field names match Anthropic's, keeping `ModelResult` uniform with no translation layer (confirmed by domain research — see Refinement). Unblocks #146 (the four-layer precedence resolver).
+
+### Acceptance criteria (from ticket)
+
+1. Unit tests parallel to `test_providers_anthropic.py` covering retry/error branches (429 retries, 5xx transient, 4xx non-retriable, 401 immediate fail) and error categorization.
+2. An eval spec with `grading_provider="openai"` runs L2 extraction and L3 grading end-to-end.
+3. `ModelResult.input_tokens` / `output_tokens` populate correctly from Responses API `usage` fields.
+4. Auth guard fails with actionable error when `OPENAI_API_KEY` is unset.
+
+### Codebase findings (from Codebase Scout)
+
+**Existing Anthropic surface to mirror:**
+- `src/clauditor/_providers/__init__.py:101-173` — `call_model` dispatcher; `provider="openai"` branch at line 168-169 raises `NotImplementedError`.
+- `src/clauditor/_providers/_anthropic.py:467-522` — `call_anthropic(prompt, *, model, max_tokens=4096, transport="auto", subject=None) -> ModelResult`.
+- `src/clauditor/_providers/_anthropic.py:84-110` — module-level test-indirection aliases `_sleep`, `_monotonic`, `_rand_uniform`, `_rng`.
+- `src/clauditor/_providers/_anthropic.py:114-116` — retry constants: `_RATE_LIMIT_MAX_RETRIES = 3`, `_SERVER_MAX_RETRIES = 1`, `_CONN_MAX_RETRIES = 1`.
+- `src/clauditor/_providers/_anthropic.py:255-309` — `_compute_backoff` (`2**i` ± 25% jitter) + `_compute_retry_decision` ladder.
+- `src/clauditor/_providers/_anthropic.py:194-244` — `ModelResult` dataclass; `provider: Literal["anthropic", "openai"]` + `source: Literal["api", "cli"]` already in place.
+- `src/clauditor/_providers/_auth.py:214-252` — `check_any_auth_available(cmd_name)` (key OR claude-CLI). `_auth.py:255-290` — `check_api_key_only(cmd_name)`. Both raise `AnthropicAuthMissingError`.
+- `src/clauditor/_anthropic.py:106-150` — back-compat shim `call_anthropic` wrapper.
+
+**Call sites already passing `provider="anthropic"` to `call_model`:**
+- `grader.py::_quality_grade` (line ~821)
+- `suggest.py::suggest_improvements` (line ~999)
+- `triggers.py::extract_json_trigger` (line ~194)
+- `quality_grader.py::grade_quality` (lines ~812 and ~820, two parallel calls in `blind_compare`)
+
+All four sites use `from clauditor._providers import call_model`. Once `provider="openai"` works, callers swap by passing the resolved provider value.
+
+**CLI auth wiring (4 LLM-mediated commands):**
+- `cli/grade.py:327`, `cli/extract.py:99`, `cli/triggers.py:107`, `cli/propose_eval.py:376` — all call `check_any_auth_available(cmd_name)` AFTER `--dry-run` early-return. (Note: spec mentions 6 commands; only 4 of the modern CLI shape route through `call_model` today.)
+
+**Test surface to mirror:**
+- `tests/test_providers_anthropic.py` — 24 test classes covering: extract/excerpt/jitter/backoff/success/rate-limit/server-error/client-error/connection/import-error/type-error/retry-decision/CLI/result-fields/auto-transport/announcements/transport-resolution/classify/model-result/call-model/grader-imports.
+- `tests/test_providers_auth.py` — `TestExceptionClassIdentity`, `TestApiKeyIsSet`, etc.
+
+**Other infrastructure:**
+- `pyproject.toml:29` — `dependencies = ["anthropic>=0.40.0"]`. `[project.optional-dependencies] grader = []` is an empty back-compat marker.
+- No pricing tables exist (cost is heuristic UX-only; `audit.py` has no per-model dicts).
+- `cli/__init__.py:58-89` — `_resolve_grader_transport` is global, not per-provider; `transport` is Anthropic-specific (DEC-002 of #144 documents OpenAI ignores it).
+- Three announcement flags live in `_providers`: `_announced_cli_transport` (transport), `_announced_implicit_no_api_key` (auth), `_announced_call_anthropic_deprecation` (shim).
+
+### Convention constraints (from Convention Checker)
+
+Applicable rules and the constraint each imposes on this work:
+
+1. **`centralized-sdk-call.md`** — `_openai.py` must dispatch through `call_model`; document the OpenAI backend body shape parallel to the Anthropic one in the rule's "Canonical implementation" section.
+2. **`precall-env-validation.md`** — Distinct `OpenAIAuthMissingError(Exception)` class (subclass of `Exception` directly, NOT `OpenAIHelperError`). Pure helper `check_openai_auth(cmd_name)` reads `os.environ`, raises with single template + `{cmd_name}` interpolation. No stderr inside helper.
+3. **`llm-cli-exit-code-taxonomy.md`** — `OpenAIAuthMissingError` → exit 2; `OpenAIHelperError` → exit 3. Distinct except branches in CLI dispatchers, not substring matching.
+4. **`monotonic-time-indirection.md`** — `_monotonic = time.monotonic` module-level alias in `_openai.py` if measuring duration; tests patch `clauditor._providers._openai._monotonic`.
+5. **`pure-compute-vs-io-split.md`** — Pure helpers (e.g. `_extract_openai_result`, `_compute_backoff` if duplicated, body-excerpt helper) split from the async I/O wrapper. Use the same naming convention as the Anthropic counterparts.
+6. **`non-mutating-scrub.md`** — Any `strip_openai_auth_keys(env)` helper returns new dict, never mutates input.
+7. **`back-compat-shim-discipline.md`** — Does NOT apply (no historical callers to preserve).
+8. **`json-schema-version.md`** — If `ModelResult.source` gains an `"openai-api"` value, downstream sidecars (`grading.json`, `extraction.json`) may need a schema bump. Today `source` is `Literal["api", "cli"]` and `provider` is `Literal["anthropic", "openai"]` — `provider` already accommodates the new value, so no bump expected for #145 (defer the audit-loader work to #147).
+9. **`mock-side-effect-for-distinct-calls.md`** — Tests calling OpenAI twice (e.g. blind-compare two-arm parity) use `side_effect=[...]`, not `return_value=...`.
+10. **`spec-cli-precedence.md`** — Defer the four-layer `grading_provider` precedence to #146; #145 should not introduce that field's resolution chain.
+
+### OpenAI Responses API findings (from Domain Expert)
+
+- **SDK package:** `openai>=1.66.0` (March 2025; first release with `client.responses.create()` + `AsyncOpenAI` async support).
+- **Call shape:** `await client.responses.create(model=..., input=prompt, max_output_tokens=4096)`. Note: `input=` not `messages=`; `max_output_tokens` not `max_tokens`.
+- **Token usage:** `response.usage.input_tokens` / `response.usage.output_tokens` — confirmed parallel to Anthropic. Detail fields (`input_tokens_details.cached_tokens`, `output_tokens_details.reasoning_tokens`) deferred to #154.
+- **Text extraction:** prefer `response.output_text` convenience accessor; walk `response.output[].content[].text` filtering `type=="message"` to populate `text_blocks`.
+- **Exception taxonomy:** 1:1 parallel — `AuthenticationError`, `PermissionDeniedError`, `RateLimitError`, `APIStatusError`, `APIConnectionError`. Retry policy transplants directly.
+- **Refusal/incomplete shape:** `response.status` + `response.incomplete_details.reason` (NOT `stop_reason`). Document divergence; do not normalize.
+- **Default models:** issue's `gpt-5.4` / `gpt-5.4-mini` are not real identifiers (knowledge cutoff Jan 2026). Recommend `gpt-4.1` (L3) and `gpt-4.1-mini` (L2) — both Responses-API-native, currently strongest non-reasoning tier.
+- **Auth env var:** `OPENAI_API_KEY` only. `OPENAI_ORG_ID` / `OPENAI_PROJECT_ID` / `OPENAI_BASE_URL` are SDK-handled; no clauditor guard needed.
+- **Reasoning (o-series):** defer entirely. Different kwargs, different output filtering, different cost model — own design problem, likely overlaps with #154.
+
+### Open scoping questions (for user)
+
+(See "Phase 1 scoping" block below — to be answered before architecture review.)
+
+## Phase 1 scoping (questions for user)
+
+**Q1 — Default model strings.** Issue specifies `gpt-5.4` / `gpt-5.4-mini` which don't exist. What should ship as the default fallback when no `--grading-model` / `EvalSpec.grading_model` is set?
+
+- **A.** `gpt-4.1` (L3) + `gpt-4.1-mini` (L2) per domain expert recommendation (Responses-API-native, current strongest non-reasoning tier).
+- **B.** `gpt-4o` + `gpt-4o-mini` (older, broader compatibility, cheaper).
+- **C.** Pin to a specific snapshot (e.g. `gpt-4.1-2025-04-14`) for reproducibility.
+- **D.** No defaults — require `model=` to be set when `provider="openai"`; raise `ValueError` otherwise.
+
+**Q2 — `transport=` parameter semantics for OpenAI.** OpenAI has no CLI subscription path. What happens when a caller passes `transport=` to `call_model(provider="openai", ...)`?
+
+- **A.** Silently ignored. OpenAI always reports `source="api"` on the returned `ModelResult`. (Matches the existing dispatcher docstring at line 137.)
+- **B.** `transport="cli"` raises `ValueError("openai provider does not support cli transport")`; `"auto"` and `"api"` both resolve to `"api"`.
+- **C.** `"auto"` → silent `"api"`; explicit `"cli"` raises (defensive: catches a misconfigured eval spec).
+
+**Q3 — `grading_provider` spec-field handling.** Acceptance criterion 2 requires "an eval spec with `grading_provider="openai"` runs end-to-end" — but #146 owns the four-layer precedence resolver. How much of the spec-field wiring lands in #145?
+
+- **A.** Minimal spec field: `EvalSpec.grading_provider: Literal["anthropic","openai"] | None = None` with load-time validation; the four grader call sites read `eval_spec.grading_provider or "anthropic"` and pass that to `call_model`. CLI flag deferred to #146.
+- **B.** Spec field + CLI flag (`--grading-provider {anthropic,openai}`) but no env-var or auto-inference; #146 adds the env-var layer + auto-inference from the model string.
+- **C.** Strictly defer all spec/CLI wiring to #146; #145 makes the dispatch work but acceptance criterion 2 is tested via direct `call_model(provider="openai", ...)` calls in unit tests rather than end-to-end. Document the deferral and update the ticket's acceptance.
+
+**Q4 — `openai` SDK dependency placement.** How is the OpenAI SDK installed?
+
+- **A.** Direct dependency alongside `anthropic`: `dependencies = ["anthropic>=0.40.0", "openai>=1.66.0"]`. Both providers always available; no install-time choice. Matches today's Anthropic shape.
+- **B.** Optional extra: `[project.optional-dependencies] openai = ["openai>=1.66.0"]`. Users who only grade with Claude don't pay for the second SDK; importing `_openai.py` raises a clean `ImportError` with `pip install clauditor[openai]` hint.
+- **C.** Direct dependency, but bump the existing empty `grader = []` extra to `grader = ["openai>=1.66.0"]` for symmetry (anthropic stays direct).
+
+**Q5 — Reasoning model (o-series) support.** Defer or ship?
+
+- **A.** Defer entirely. No `reasoning=` kwarg, no o-series defaults, no `output[].type == "reasoning"` filtering. Document a follow-up ticket. Keeps #145 mechanical.
+- **B.** Accept a `reasoning_effort: str | None = None` kwarg on `call_openai` (not `call_model`) for power users who want it via direct calls; do not wire through the dispatcher or graders.
+- **C.** Full support including o-series defaults (e.g. `o4-mini` for L3) — likely 1.5x scope.
+
+## Architecture Review
+
+### Phase 2 (2026-04-29)
+
+| Area | Rating | Key finding |
+|---|---|---|
+| Security | **blocker** | Multi-provider auth dispatch at 4 CLI seams — `check_any_auth_available` is Anthropic-only; need provider-aware routing |
+| API design | concern | Retry helpers (`_compute_backoff`, `_compute_retry_decision`) — hoist to shared `_providers/_retry.py` (DEC-006) or duplicate (symmetry) |
+| Test strategy | pass | ~50–55 new test methods estimated; mock target paths clear (`clauditor._providers._openai.AsyncOpenAI`) |
+| Data model & observability | pass | `ModelResult.provider` already in place; sidecar v3 deferred to #147 explicitly; no new announcement flags needed |
+
+#### Findings detail
+
+**SEC-1 (BLOCKER) — Multi-provider auth dispatch.** `cli/grade.py:327`, `cli/extract.py:99`, `cli/triggers.py:107`, `cli/propose_eval.py:376` all call `check_any_auth_available(cmd_name)` which only inspects `ANTHROPIC_API_KEY` / `claude` CLI presence. With DEC-003 landing `EvalSpec.grading_provider="openai"` support in #145, an operator running a graded skill against an OpenAI-graded spec WITHOUT `OPENAI_API_KEY` set would (a) pass the Anthropic auth check, (b) reach `call_model(provider="openai", ...)`, (c) hit a `TypeError` deep inside `AsyncOpenAI()` construction (or, if defense-in-depth wrap is in place, an `OpenAIHelperError` mid-run). Either way, the CLI exit-code routing diverges from the structural taxonomy (exit 2 for pre-call env, exit 3 for API). Must resolve before stories.
+
+**SEC-2 (CONCERN) — Provider-aware env-stripping for skill subprocess.** `_harnesses/_claude_code.py:54` (`_API_KEY_ENV_VARS`) hardcodes `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`. When `should_strip_api_key_for_skill_subprocess(args)` returns True (CLI transport), only Anthropic keys are stripped; `OPENAI_API_KEY` would still be visible to a `--transport cli` skill subprocess even when grading uses OpenAI. Forward-compat concern only — does not block #145 (no skill subprocess uses OpenAI). Document and defer to #146.
+
+**API-1 (CONCERN) — Retry helper organization.** `_compute_backoff(retry_index)`, `_compute_retry_decision(...)`, retry constants (`_RATE_LIMIT_MAX_RETRIES`, `_SERVER_MAX_RETRIES`, `_CONN_MAX_RETRIES`) in `_anthropic.py` would apply byte-identically to OpenAI (same exception taxonomy, same backoff curve). Decision needed: hoist to `_providers/_retry.py` (DRY, one source of truth) vs. duplicate per-provider for symmetry/easier review.
+
+**API-2 (DOC) — `ModelResult.raw_message` divergence.** OpenAI Responses API surfaces refusal/incomplete state at `response.status` + `response.incomplete_details.reason`, NOT Anthropic's `stop_reason`. Document in `call_openai` docstring; downstream callers introspecting `raw_message` for refusal semantics must branch on `provider`.
+
+**TEST-1 (PASS) — Test parity is mostly mechanical.** ~24 Anthropic test classes. Of those: ~10 mirror cleanly (success/rate-limit/server/client/conn/import/type-error/result-fields/dispatcher/`_extract_*`); ~3 adapt for OpenAI exception classes; ~6 don't apply (CLI transport, auto resolution, transport announcement, classify-invoke-result, transport-resolve, no-shim-imports). Total: ~50–55 new test methods, ~800 LOC.
+
+**DATA-1 (PASS) — Sidecar v3 + audit loader deferred to #147.** `ExtractionReport`, `GradingReport`, `BlindReport` already carry `provider_source: str` in-memory (`grader.py:139`, `quality_grader.py:93`/`:237`); `to_json` excludes the field today per DEC-006 of #144's plan. Sidecar schema bump (`schema_version: 2 → 3` adding `provider_source`) is #147 territory. No #145 work here beyond stamping `provider="openai"` on the returned `ModelResult`.
+
+## Refinement Log
+
+### Phase 1 scoping decisions (2026-04-29)
+
+**DEC-001 — Default model strings: `gpt-5.4` (L3) + `gpt-5.4-mini` (L2).**
+*Rationale:* Confirmed via https://developers.openai.com/api/docs/models — both `gpt-5.4` and `gpt-5.4-mini` are real Responses-API-native models (assistant's January 2026 knowledge cutoff was stale). Ticket's stated defaults stand. `gpt-5.4` for L3 grading ($2.50/$15 per Mtok), `gpt-5.4-mini` for L2 extraction ($0.75/$4.50 per Mtok, 400K context). These strings live in module-level constants in `_providers/_openai.py` (e.g. `_DEFAULT_MODEL_L3`, `_DEFAULT_MODEL_L2`) so #146's resolution chain has a target to fall back to. Note: `gpt-5.5` exists as a stronger tier ($5/$30) but is NOT a default — power users override via `--grading-model`.
+
+**DEC-002 — `transport=` parameter silently ignored for OpenAI; `source="api"` always.**
+*Rationale:* OpenAI has no CLI subscription analogue. Silent-ignore matches the existing dispatcher docstring at `_providers/__init__.py:137` ("Ignored for the future openai backend (no transport axis there)"). `call_openai`'s signature still accepts `transport=...` as a keyword for call-site uniformity with `call_anthropic`, but the body does not consult it. `ModelResult.source` is hardcoded to `"api"` for the OpenAI path. No `ValueError` on `transport="cli"` — defensive raising would surface a confusing failure to anyone composing dispatch with `--transport cli` set globally for the Anthropic side.
+
+**DEC-003 — Minimal `EvalSpec.grading_provider` spec field; CLI flag and full precedence deferred to #146.**
+*Rationale:* Acceptance criterion 2 ("eval spec with `grading_provider="openai"` runs end-to-end") needs at least the spec-side wire-up to be testable, but the four-layer precedence resolver is explicitly #146's scope. #145 adds: (a) `EvalSpec.grading_provider: Literal["anthropic","openai"] | None = None` with load-time validation, (b) the four grader call sites (`grader.py`, `quality_grader.py`, `suggest.py`, `triggers.py`) read `eval_spec.grading_provider or "anthropic"` and pass that to `call_model(provider=...)`. CLI flag `--grading-provider` and `CLAUDITOR_GRADING_PROVIDER` env-var land in #146. Default-to-anthropic preserves all existing behavior for specs that don't set the field.
+
+**DEC-004 — `openai>=1.66.0` as a direct top-level dependency in `pyproject.toml`.**
+*Rationale:* Matches the existing Anthropic-as-direct-dependency shape (`pyproject.toml:29`). Both providers always available; no install-time choice; no `ImportError` branch in `_openai.py` to maintain (in contrast to the existing Anthropic `ImportError` raised un-wrapped per `centralized-sdk-call.md`'s "ImportError raised un-wrapped" subsection — though we keep that defensive branch in `_openai.py` for parity in case a user pip-uninstalls `openai`). Version `>=1.66.0` is the minimum that supports `client.responses.create()` + `AsyncOpenAI` async per the domain expert's findings (March 2025 SDK release).
+
+**DEC-005 — Reasoning models (o-series) deferred entirely.**
+*Rationale:* Reasoning models require a different kwarg surface (`reasoning={"effort": ...}`), different `output[]` filtering (skip `type=="reasoning"` items when joining text), and a different cost model (reasoning tokens billed at output rate, often dwarfing the visible output). All three concerns belong to a sibling ticket — likely overlapping with #154 (harness context sidecar) since `output_tokens_details.reasoning_tokens` is the canonical observability signal. #145 stays mechanical: same kwargs as Anthropic, same response shape, same retry policy. A future `propose-reasoning-models` ticket can extend `call_openai` with the `reasoning_effort` knob without touching the dispatcher.
+
+### Phase 2 architecture decisions (2026-04-29)
+
+**DEC-006 — Single `check_provider_auth(provider, cmd_name)` dispatcher in `_providers/_auth.py`.**
+*Rationale:* Resolves SEC-1 (BLOCKER). Each of the 4 LLM-mediated CLI commands (`grade`, `extract`, `triggers`, `propose-eval`) calls `check_provider_auth(provider, cmd_name)` once after resolving `provider` from `eval_spec.grading_provider or "anthropic"`. The dispatcher internally branches: `"anthropic"` → `check_any_auth_available(cmd_name)` (preserves existing key-OR-CLI semantics); `"openai"` → `check_openai_auth(cmd_name)`. Distinct exception classes (`AnthropicAuthMissingError`, `OpenAIAuthMissingError`) propagate to the CLI, where structural `except` ladders route each to exit 2 per `.claude/rules/llm-cli-exit-code-taxonomy.md`. Single helper avoids duplicating the if/else at every CLI seam; future `provider="vertex"` or `"bedrock"` extension is one branch in the dispatcher.
+
+**DEC-007 — Hoist retry helpers to a new `src/clauditor/_providers/_retry.py` module.**
+*Rationale:* The retry policy is byte-identical between Anthropic and OpenAI (confirmed by domain expert: same exception taxonomy, same backoff curve). Public API of the new module: constants `RATE_LIMIT_MAX_RETRIES = 3`, `SERVER_MAX_RETRIES = 1`, `CONN_MAX_RETRIES = 1`; pure functions `compute_backoff(retry_index)` and `compute_retry_decision(category, retry_counters)`. Both `_anthropic.py` and `_openai.py` import from it. Per-provider concerns stay per-provider: the `_sleep` / `_monotonic` / `_rand_uniform` / `_rng` test-indirection aliases remain on each provider module (so a `monkeypatch.setattr("clauditor._providers._openai._sleep", ...)` patches only OpenAI's sleeping, not Anthropic's). Existing Anthropic tests that monkeypatched `clauditor._providers._anthropic._compute_backoff` follow the symbol to `clauditor._providers._retry.compute_backoff` per `.claude/rules/back-compat-shim-discipline.md` Pattern 3.
+
+**DEC-008 — Add `OPENAI_API_KEY` to `_API_KEY_ENV_VARS` in `_harnesses/_claude_code.py` now.**
+*Rationale:* Resolves SEC-2 (CONCERN). One-line tuple extension: `_API_KEY_ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY")`. When `should_strip_api_key_for_skill_subprocess(args)` returns True (under `--transport cli`), all three keys are stripped from the skill subprocess env, regardless of which provider is actually grading. Defensive: a skill author could spawn a child process that calls OpenAI; stripping the operator's OPENAI_API_KEY ensures the operator's quota is not silently spent by an untrusted skill. Provider-aware stripping (`env_without_api_key(provider=...)`) would be larger; this single-line shim is forward-compat enough for the current threat model and the rule's non-mutating-scrub contract is preserved (the function already returns a new dict).
+
+## Detailed Breakdown
+
+### Story ordering rationale
+
+Architecture-natural ordering: foundations → SDK seam → dispatcher → auth → spec field → wiring → end-to-end → quality gate.
+
+| # | Title | Depends on |
+|---|---|---|
+| US-001 | Hoist retry helpers to `_providers/_retry.py` | none |
+| US-002 | Add `openai>=1.66.0` dependency + `_providers/_openai.py` happy path | US-001 |
+| US-003 | OpenAI response parser edges (`_extract_openai_result`) | US-002 |
+| US-004 | OpenAI retry/error branches (429/5xx/4xx/auth/conn/import/type-error) | US-002 |
+| US-005 | Wire OpenAI into `call_model` dispatcher | US-002, US-004 |
+| US-006 | OpenAI auth helper + `check_provider_auth` dispatcher | none |
+| US-007 | `EvalSpec.grading_provider` field + load-time validation | none |
+| US-008 | Strip `OPENAI_API_KEY` from skill subprocess env | none |
+| US-009 | Wire 4 CLI commands to `check_provider_auth(provider, cmd_name)` | US-006, US-007 |
+| US-010 | Wire 4 grader call sites to read `eval_spec.grading_provider` | US-005, US-007 |
+| US-011 | End-to-end tests for `grading_provider="openai"` path | US-009, US-010 |
+| US-012 | Quality Gate — code review × 4 + CodeRabbit + project validation | US-001..US-011 |
+| US-013 | Patterns & Memory — update conventions and docs | US-012 |
+
+---
+
+### US-001 — Hoist retry helpers to `_providers/_retry.py`
+
+**Description.** Pure refactor: extract `_compute_backoff`, `_compute_retry_decision`, and the three retry constants from `_providers/_anthropic.py` into a new shared module `_providers/_retry.py`. Both `_anthropic.py` and the (future) `_openai.py` import the helpers. No behavior change.
+
+**Traces to:** DEC-007.
+
+**Acceptance criteria:**
+- New file `src/clauditor/_providers/_retry.py` exports public names: `RATE_LIMIT_MAX_RETRIES`, `SERVER_MAX_RETRIES`, `CONN_MAX_RETRIES`, `compute_backoff(retry_index: int) -> float`, `compute_retry_decision(category: str, counters: dict) -> Literal["retry", "raise"]`.
+- `_providers/_anthropic.py` uses imported names; private aliases (`_RATE_LIMIT_MAX_RETRIES`, `_compute_backoff`, `_compute_retry_decision`) removed from `_anthropic.py`.
+- Existing `tests/test_providers_anthropic.py::TestComputeBackoff` and `TestComputeRetryDecision` move to new `tests/test_providers_retry.py` patching `clauditor._providers._retry.*`.
+- `uv run ruff check src/ tests/` clean; `uv run pytest --cov=clauditor --cov-report=term-missing` passes (80% gate).
+
+**Done when:** All Anthropic tests still pass with the moved patch targets per `.claude/rules/back-compat-shim-discipline.md` Pattern 3.
+
+**Files:**
+- `src/clauditor/_providers/_retry.py` (NEW)
+- `src/clauditor/_providers/_anthropic.py` (delete `_compute_backoff`, `_compute_retry_decision`, retry constants; import from `_retry`)
+- `tests/test_providers_retry.py` (NEW; moved from `test_providers_anthropic.py`)
+- `tests/test_providers_anthropic.py` (drop the moved test classes; keep all other tests untouched)
+
+**TDD:** Move existing tests verbatim; verify they pass against the new module path before any other change.
+
+---
+
+### US-002 — Add `openai>=1.66.0` dependency + `_providers/_openai.py` happy path
+
+**Description.** Add `openai>=1.66.0` as a direct dependency in `pyproject.toml`. Create `src/clauditor/_providers/_openai.py` with a working `call_openai(prompt, *, model, max_tokens=4096, transport="auto", subject=None) -> ModelResult` for the success path only: construct `AsyncOpenAI()`, call `.responses.create(input=prompt, model=model, max_output_tokens=max_tokens)`, build `ModelResult` from the response. Module-level test-indirection aliases `_sleep = asyncio.sleep`, `_monotonic = time.monotonic`, `_rand_uniform`/`_rng` per `.claude/rules/monotonic-time-indirection.md`. Module-level constants `DEFAULT_MODEL_L3 = "gpt-5.4"` and `DEFAULT_MODEL_L2 = "gpt-5.4-mini"` per DEC-001. `transport=` and `subject=` accepted but ignored per DEC-002. Define `OpenAIHelperError(Exception)` class.
+
+**Traces to:** DEC-001, DEC-002, DEC-004, DEC-007.
+
+**Acceptance criteria:**
+- `pyproject.toml` `dependencies` includes `"openai>=1.66.0"`.
+- `_providers/_openai.py` defines `call_openai`, `OpenAIHelperError`, `_extract_openai_result`, `DEFAULT_MODEL_L3`, `DEFAULT_MODEL_L2`.
+- Happy-path test: mock `AsyncOpenAI` returning a fake response with `output_text="hello"`, `usage.input_tokens=10`, `usage.output_tokens=5`; assert `result.response_text == "hello"`, `result.input_tokens == 10`, `result.output_tokens == 5`, `result.provider == "openai"`, `result.source == "api"`.
+- `result.raw_message` is `response.model_dump()` (a dict).
+- `result.duration_seconds > 0` via `_monotonic` indirection.
+- Docstring on `call_openai` documents `raw_message` divergence from Anthropic (refusal at `response.status` + `incomplete_details.reason`, NOT `stop_reason`) — addresses API-2.
+
+**Done when:** Happy-path test green; `uv run ruff check` clean.
+
+**Files:**
+- `pyproject.toml` — add `openai>=1.66.0` to `dependencies`.
+- `src/clauditor/_providers/_openai.py` (NEW)
+- `tests/test_providers_openai.py` (NEW) — `TestCallOpenAISuccess` + `TestExtractOpenAIResultHappyPath`.
+
+**TDD:** Write `TestCallOpenAISuccess::test_returns_result_with_tokens` first against an `AsyncOpenAI` mock; implement `call_openai` until green.
+
+---
+
+### US-003 — OpenAI response parser edges (`_extract_openai_result`)
+
+**Description.** Harden `_extract_openai_result(response)` to walk `response.output[]` filtering `type=="message"` (skipping `reasoning` items for forward-compat with #154); populate `text_blocks: list[str]` per-message. Handle missing `output_text`, empty `output[]`, `response.status == "incomplete"`, and `response.usage` with non-int / null fields (defensive int coercion).
+
+**Traces to:** DEC-005 (forward-compat with reasoning items), API-2 (refusal divergence), `.claude/rules/stream-json-schema.md` (defensive parser pattern).
+
+**Acceptance criteria:**
+- `_extract_openai_result` returns `(response_text, text_blocks, input_tokens, output_tokens, raw_message)` tuple (or equivalent shape).
+- Test cases: happy path; `output[]` with mixed `message` + `reasoning` items (only message text in `text_blocks`); empty `output[]` → empty `text_blocks` + `response_text=""`; missing `usage` → 0/0 tokens; null `usage.input_tokens` → 0; `status == "incomplete"` is read but not raised (caller decides).
+- Defensive `try/except (TypeError, ValueError)` on token int coercion.
+
+**Done when:** `TestExtractOpenAIResult` covers ≥6 edge cases; coverage of the helper at 100%.
+
+**Files:**
+- `src/clauditor/_providers/_openai.py` (extend `_extract_openai_result`)
+- `tests/test_providers_openai.py` (extend `TestExtractOpenAIResult`)
+
+**TDD:** Write all edge-case tests first; implement parser until each goes green.
+
+---
+
+### US-004 — OpenAI retry/error branches
+
+**Description.** Implement the full retry/error ladder in `call_openai`: 429 (`RateLimitError`) up to 3 retries with `compute_backoff` from US-001; 5xx (`APIStatusError.status_code >= 500`) 1 retry; 4xx non-auth raises immediately; 401 (`AuthenticationError`) and 403 (`PermissionDeniedError`) raise immediately with auth-hint message naming `OPENAI_API_KEY`; `APIConnectionError` 1 retry; `ImportError` (when `openai` SDK is uninstalled) re-raised un-wrapped per `.claude/rules/centralized-sdk-call.md`'s "ImportError raised un-wrapped" subsection; defensive `TypeError` wrap around `AsyncOpenAI()` construction and `.responses.create()` raises `OpenAIHelperError("OpenAI SDK client initialization failed — verify OPENAI_API_KEY is set.") from exc` per `.claude/rules/precall-env-validation.md`.
+
+**Traces to:** DEC-007, `.claude/rules/centralized-sdk-call.md`, `.claude/rules/precall-env-validation.md`.
+
+**Acceptance criteria:**
+- Retries use `_sleep` and `_rand_uniform` indirected aliases (test-patchable).
+- Auth-error message includes the literal substring `"OPENAI_API_KEY"`.
+- TypeError wrap message is the fixed sanitized string (no `str(exc)`, no `exc.args`).
+- Test classes: `TestCallOpenAIRateLimit` (3-retry exhaust + recovery-after-2), `TestCallOpenAIServerError` (1-retry exhaust + recovery), `TestCallOpenAIClientError` (400/422 immediate), `TestCallOpenAIAuthErrors` (401/403 with hint), `TestCallOpenAIConnectionError` (1-retry exhaust + recovery), `TestCallOpenAIImportError` (re-raised un-wrapped), `TestCallOpenAITypeError` (defense-in-depth wrap with `__cause__` preserved).
+- Test patches use `clauditor._providers._openai.AsyncOpenAI` and `clauditor._providers._openai._sleep` / `._rand_uniform`.
+
+**Done when:** All retry-branch tests green; coverage of `call_openai` ≥ 95%.
+
+**Files:**
+- `src/clauditor/_providers/_openai.py` (extend `call_openai`)
+- `tests/test_providers_openai.py` (extend with retry test classes)
+
+**TDD:** Write each retry-branch test first (parametrized on exception type and retry count), implement until green.
+
+---
+
+### US-005 — Wire OpenAI into `call_model` dispatcher
+
+**Description.** Replace `NotImplementedError("openai provider lands in #145")` at `_providers/__init__.py:168-169` with a deferred-import call to `_openai.call_openai`. Match the Anthropic dispatch shape exactly (deferred import per `.claude/rules/back-compat-shim-discipline.md` Pattern 3). Re-export `OpenAIHelperError` from `_providers/__init__.py` so callers and tests have a single import surface.
+
+**Traces to:** DEC-002, `.claude/rules/centralized-sdk-call.md`, `.claude/rules/back-compat-shim-discipline.md` Pattern 3.
+
+**Acceptance criteria:**
+- `_providers/__init__.py` `call_model` `provider="openai"` branch dispatches via `from clauditor._providers import _openai as _openai_mod; return await _openai_mod.call_openai(prompt, model=model, transport=transport, max_tokens=max_tokens)`.
+- `_providers/__init__.py` exports `OpenAIHelperError` in `__all__`.
+- `tests/test_providers_anthropic.py::TestCallModel` (or moved to `test_providers_init.py`) gains tests: `test_call_model_dispatches_to_openai`, `test_call_model_propagates_openai_helper_error`, `test_call_model_unknown_provider_still_raises_value_error`.
+- Existing Anthropic dispatch tests still pass.
+
+**Done when:** Dispatcher tests green; no production code path can reach the old `NotImplementedError`.
+
+**Files:**
+- `src/clauditor/_providers/__init__.py`
+- `tests/test_providers_anthropic.py` (extend `TestCallModel`) — or new `tests/test_providers_init.py` if size warrants.
+
+**TDD:** Write the three dispatcher tests first.
+
+---
+
+### US-006 — OpenAI auth helper + `check_provider_auth` dispatcher
+
+**Description.** Add to `_providers/_auth.py`: (1) `OpenAIAuthMissingError(Exception)` class, (2) `_OPENAI_AUTH_MISSING_TEMPLATE` string with `{cmd_name}` interpolation naming `OPENAI_API_KEY`, (3) pure helper `check_openai_auth(cmd_name) -> None` reading `os.environ["OPENAI_API_KEY"]` (raises on absent/empty/whitespace-only), (4) public dispatcher `check_provider_auth(provider, cmd_name) -> None` routing `"anthropic"` → `check_any_auth_available` and `"openai"` → `check_openai_auth`. Re-export both new public names from `_providers/__init__.py`.
+
+**Traces to:** DEC-006, `.claude/rules/precall-env-validation.md`.
+
+**Acceptance criteria:**
+- `OpenAIAuthMissingError` is a subclass of `Exception` (NOT `OpenAIHelperError`) — distinct exit-code routing per `.claude/rules/llm-cli-exit-code-taxonomy.md`.
+- Auth message includes literal substrings: `"OPENAI_API_KEY"`, `"console.openai.com"` (or wherever the key is provisioned), the `{cmd_name}` interpolation.
+- Helper is pure: no stderr, no `sys.exit`, no logging.
+- `check_provider_auth("anthropic", "grade")` calls `check_any_auth_available("grade")`; `check_provider_auth("openai", "grade")` calls `check_openai_auth("grade")`; unknown provider raises `ValueError`.
+- Test class `TestCheckOpenAiAuth` parallels `TestAnnounceImplicitNoApiKey` shape: env-set passes; env-unset raises with hint; whitespace-only raises; `cmd_name` interpolation lands in message.
+- Test class `TestCheckProviderAuth` covers each branch + unknown-provider.
+
+**Done when:** Both helpers covered; existing Anthropic auth tests still pass.
+
+**Files:**
+- `src/clauditor/_providers/_auth.py`
+- `src/clauditor/_providers/__init__.py` (add to `__all__`)
+- `tests/test_providers_auth.py` (add `TestCheckOpenAiAuth` + `TestCheckProviderAuth`)
+
+**TDD:** Write the helper tests first.
+
+---
+
+### US-007 — `EvalSpec.grading_provider` field + load-time validation
+
+**Description.** Add `grading_provider: Literal["anthropic", "openai"] | None = None` to the `EvalSpec` dataclass in `src/clauditor/schemas.py`. Validate at load time in `EvalSpec.from_dict`: must be a string in the literal set; null permitted; rejection on unknown value with an error that names the allowed values per the existing `transport` field validator pattern.
+
+**Traces to:** DEC-003, `.claude/rules/eval-spec-stable-ids.md` (NB: applies to id'd entries, not single fields, but the load-time-hard-fail philosophy carries).
+
+**Acceptance criteria:**
+- `EvalSpec.grading_provider` field declared with the right type.
+- `from_dict` validates: rejects `"claude"`, `"gpt"`, `1`, `True`; accepts `None`, `"anthropic"`, `"openai"`.
+- Error message includes the literal substrings `"grading_provider"`, `"anthropic"`, `"openai"`.
+- Test class `TestGradingProviderValidation` in `tests/test_schemas.py` covers happy + 3 reject cases.
+
+**Done when:** Validation tests green; existing eval-spec tests untouched.
+
+**Files:**
+- `src/clauditor/schemas.py`
+- `tests/test_schemas.py` (add `TestGradingProviderValidation`)
+
+**TDD:** Write reject-case tests first.
+
+---
+
+### US-008 — Strip `OPENAI_API_KEY` from skill subprocess env
+
+**Description.** Extend `_API_KEY_ENV_VARS` in `src/clauditor/_harnesses/_claude_code.py` to include `"OPENAI_API_KEY"`. Update `env_without_api_key()` docstring to reflect the new key. Add a regression test asserting `OPENAI_API_KEY` is stripped from the returned env dict.
+
+**Traces to:** DEC-008, `.claude/rules/non-mutating-scrub.md`.
+
+**Acceptance criteria:**
+- `_API_KEY_ENV_VARS` tuple has 3 entries: `("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY")`.
+- `env_without_api_key({"ANTHROPIC_API_KEY": "a", "OPENAI_API_KEY": "b", "FOO": "bar"})` returns `{"FOO": "bar"}`.
+- Input dict is not mutated (per `.claude/rules/non-mutating-scrub.md`).
+
+**Done when:** Test green; `_API_KEY_ENV_VARS` constant exposes all three.
+
+**Files:**
+- `src/clauditor/_harnesses/_claude_code.py`
+- `tests/test_runner.py` (or wherever `env_without_api_key` is tested today) — extend.
+
+**TDD:** Write the OPENAI_API_KEY stripping test first.
+
+---
+
+### US-009 — Wire 4 CLI commands to `check_provider_auth`
+
+**Description.** Update `cli/grade.py:327`, `cli/extract.py:99`, `cli/triggers.py:107`, `cli/propose_eval.py:376` to: (1) resolve `provider = spec.eval_spec.grading_provider or "anthropic"` after spec load and `--dry-run` early-return, (2) call `check_provider_auth(provider, cmd_name)`, (3) catch both `AnthropicAuthMissingError` AND `OpenAIAuthMissingError` (distinct `except` branches each printing to stderr and returning exit 2 per `.claude/rules/llm-cli-exit-code-taxonomy.md`).
+
+**Traces to:** DEC-003, DEC-006, `.claude/rules/precall-env-validation.md`, `.claude/rules/llm-cli-exit-code-taxonomy.md`.
+
+**Acceptance criteria:**
+- All 4 CLI commands resolve provider and dispatch via `check_provider_auth`.
+- Distinct `except AnthropicAuthMissingError:` and `except OpenAIAuthMissingError:` branches; each returns `2`.
+- Per-command tests: spec with `grading_provider="openai"` + missing `OPENAI_API_KEY` → exit 2 with stderr containing `"OPENAI_API_KEY"`.
+- Existing Anthropic-default tests still pass.
+
+**Done when:** Each of the 4 CLI commands has a positive Anthropic test, a positive OpenAI test, and a negative OpenAI-key-missing test.
+
+**Files:**
+- `src/clauditor/cli/grade.py`
+- `src/clauditor/cli/extract.py`
+- `src/clauditor/cli/triggers.py`
+- `src/clauditor/cli/propose_eval.py`
+- `tests/test_cli_grade.py`, `tests/test_cli_extract.py`, `tests/test_cli_triggers.py`, `tests/test_cli_propose_eval.py` (extend each)
+
+**TDD:** For each CLI command, write the negative OpenAI-key-missing test first.
+
+---
+
+### US-010 — Wire 4 grader call sites to read `eval_spec.grading_provider`
+
+**Description.** Update each of the 4 places that today pass `provider="anthropic"` literal to `call_model`: `grader.py::extract_and_grade` / `extract_and_report`, `quality_grader.py::grade_quality` / `blind_compare`, `suggest.py::suggest_improvements`, `triggers.py::extract_json_trigger`. Read `provider = eval_spec.grading_provider or "anthropic"` and pass that. The `provider_source` field on the in-memory `GradingReport` / `ExtractionReport` / `BlindReport` is stamped with the resolved provider value (already implemented; just verify).
+
+**Traces to:** DEC-003, `.claude/rules/centralized-sdk-call.md`.
+
+**Acceptance criteria:**
+- All 4 grader call sites resolve provider from spec.
+- Returned reports carry `provider_source == "openai"` when `eval_spec.grading_provider == "openai"`.
+- Existing tests with no `grading_provider` set still see `provider_source == "anthropic"` (back-compat).
+- One test per call site: `eval_spec.grading_provider="openai"` + mocked `call_model` returning `ModelResult(provider="openai", ...)` → report stamps openai.
+
+**Done when:** Each grader call site routes through resolved provider; report stamping verified.
+
+**Files:**
+- `src/clauditor/grader.py`
+- `src/clauditor/quality_grader.py`
+- `src/clauditor/suggest.py`
+- `src/clauditor/triggers.py`
+- `tests/test_grader.py`, `tests/test_quality_grader.py`, `tests/test_suggest.py`, `tests/test_triggers.py` (extend each)
+
+**TDD:** Write the openai-provider stamping test first per call site.
+
+---
+
+### US-011 — End-to-end test for `grading_provider="openai"` path
+
+**Description.** Add 2 end-to-end tests with mocked `call_model`: (1) `tests/test_grader.py::TestExtractAndReportWithOpenAI` runs L2 extraction with `eval_spec.grading_provider="openai"` and asserts the full report shape is produced, (2) `tests/test_quality_grader.py::TestGradeQualityWithOpenAI` does the same for L3. The mock returns `ModelResult(provider="openai", source="api", ...)`. Confirms acceptance criterion 2 of the issue: "an eval spec with `grading_provider='openai'` runs L2 extraction and L3 grading end-to-end."
+
+**Traces to:** Acceptance criterion 2 (issue #145).
+
+**Acceptance criteria:**
+- L2 test: feeds an `EvalSpec` with `sections=[...]` + `grading_provider="openai"`; mock `call_model` to return a valid extraction JSON; assert `ExtractionReport` shape, fields populated, `provider_source="openai"`.
+- L3 test: feeds an `EvalSpec` with `grading_criteria=[...]` + `grading_provider="openai"`; mock `call_model` for both extraction and grading calls (use `side_effect=[...]` per `.claude/rules/mock-side-effect-for-distinct-calls.md`); assert `GradingReport` populated.
+
+**Done when:** Both tests green; acceptance criterion 2 demonstrably satisfied.
+
+**Files:**
+- `tests/test_grader.py` (extend)
+- `tests/test_quality_grader.py` (extend)
+
+**TDD:** Write both tests first against the future call-site changes from US-010.
+
+---
+
+### US-012 — Quality Gate
+
+**Description.** Run code-reviewer 4× across the full changeset, fixing all real bugs found each pass. Run CodeRabbit if available. Verify project validation: `uv run ruff check src/ tests/` clean; `uv run pytest --cov=clauditor --cov-report=term-missing` passes 80% gate. Verify all `.claude/rules/*.md` constraints from Phase 1 still hold post-implementation.
+
+**Traces to:** Project quality gate.
+
+**Acceptance criteria:**
+- 4 review passes complete; all real bugs fixed.
+- `uv run ruff check src/ tests/` exits 0.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` exits 0; coverage ≥ 80%.
+- No new failures in any pre-existing test.
+
+**Done when:** Last review pass returns no real bugs; project validation green.
+
+**Files:** Any file touched in US-001..US-011.
+
+---
+
+### US-013 — Patterns & Memory
+
+**Description.** Update `.claude/rules/centralized-sdk-call.md` to add `_providers/_openai.py` to the canonical-implementation section and the announcement-family list. Update `.claude/rules/precall-env-validation.md` to add `OpenAIAuthMissingError` + `check_openai_auth` to the canonical-implementation section. Add a new rule `.claude/rules/multi-provider-dispatch.md` if the `check_provider_auth` dispatcher pattern warrants codification (likely yes — future Vertex/Bedrock providers will follow the same shape). Update `docs/architecture.md` (or equivalent) with the multi-provider section reference if such a doc exists.
+
+**Traces to:** `.claude/rules/rule-refresh-vs-delete.md` (refresh-in-place for context-shifted rules).
+
+**Acceptance criteria:**
+- `centralized-sdk-call.md` mentions `_openai.py` in canonical implementation.
+- `precall-env-validation.md` mentions `OpenAIAuthMissingError` and `check_provider_auth`.
+- A new rule may exist (`multi-provider-dispatch.md`) covering the `check_provider_auth(provider, cmd_name)` dispatcher pattern, OR the existing `centralized-sdk-call.md` is extended with that section.
+- No rule files contain stale references to "openai provider lands in #145" or `NotImplementedError` for openai.
+
+**Done when:** Rules documented; the next ticket adding a third provider (Vertex, Bedrock) can find the pattern.
+
+**Files:**
+- `.claude/rules/centralized-sdk-call.md`
+- `.claude/rules/precall-env-validation.md`
+- `.claude/rules/multi-provider-dispatch.md` (NEW, if warranted)
+- `docs/` (if relevant)
+
+## Beads Manifest
+
+(Phase 7 — populated on devolve.)
+
+## Session Notes
+
+### 2026-04-29 — Discovery (session 1)
+
+Spawned four parallel research subagents:
+- Ticket Analyst — fetched #143/#144/#146/#154; confirmed #144 closed, OpenAI stub at `_providers/__init__.py:168-169`; surfaced 5 ambiguities matching the scoping questions above.
+- Codebase Scout — mapped the full Anthropic surface (24 test classes, 3 announcement flags, retry constants, module aliases) and identified all 4 grader call sites passing `provider="anthropic"` today.
+- Convention Checker — swept all 30+ `.claude/rules/*.md` files; 10 apply, 1 explicitly does not (`back-compat-shim-discipline.md`).
+- Domain Expert — confirmed Responses API field-name parallelism with Anthropic (the issue's central claim), identified `gpt-5.4` model strings as non-existent (recommend `gpt-4.1`/`gpt-4.1-mini`), recommended deferring o-series.
+
+Key surprise: dispatcher already accepts `provider="openai"` literal and `ModelResult.provider` is already `Literal["anthropic", "openai"]` — #144's groundwork makes #145 a fill-in, not a redesign.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
-dependencies = ["anthropic>=0.40.0"]
+dependencies = ["anthropic>=0.40.0", "openai>=1.66.0"]
 
 [project.optional-dependencies]
 grader = []  # backward compat — anthropic is now a default dependency
@@ -34,6 +34,7 @@ dev = [
     "pytest>=8.0",
     "ruff>=0.4.0",
     "anthropic>=0.40.0",
+    "openai>=1.66.0",
 ]
 
 [project.scripts]
@@ -99,6 +100,7 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.4.0",
     "anthropic>=0.40.0",
+    "openai>=1.66.0",
     "mkdocs-material>=9.0",
     "mkdocs-include-markdown-plugin>=6.0",
 ]

--- a/src/clauditor/_anthropic.py
+++ b/src/clauditor/_anthropic.py
@@ -74,6 +74,17 @@ from clauditor._providers import (
     resolve_transport,  # noqa: F401
 )
 
+# DEC-007 of ``plans/super/145-openai-provider.md``: the retry helpers
+# moved to ``clauditor._providers._retry``. Re-export under the
+# legacy underscored names so existing call sites that imported
+# ``_compute_backoff`` / ``_compute_retry_decision`` / the retry
+# constants from ``clauditor._anthropic`` keep resolving for the
+# back-compat window. The jitter indirection (``_rand_uniform`` /
+# ``_rng``) also moved with the helpers — tests that patched the
+# legacy path follow the symbols to ``clauditor._providers._retry``
+# per ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3.
+from clauditor._providers import _retry as _retry_mod  # noqa: E402
+
 # Re-export the SDK-seam private surface from the canonical module so
 # tests / call sites that referenced these names via
 # ``clauditor._anthropic`` keep resolving for the back-compat window.
@@ -82,25 +93,32 @@ from clauditor._providers._anthropic import (  # noqa: F401, E402
     _CLI_AUTO_ANNOUNCEMENT,
     _CLI_ERROR_TEMPLATES,
     _CLI_TRANSPORT_TIMEOUT,
-    _CONN_MAX_RETRIES,
-    _RATE_LIMIT_MAX_RETRIES,
-    _SERVER_MAX_RETRIES,
     _VALID_TRANSPORT_VALUES,
     _body_excerpt,
     _build_default_harness,
     _call_via_claude_cli,
     _call_via_sdk,
     _classify_invoke_result,
-    _compute_backoff,
-    _compute_retry_decision,
     _default_harness,
     _extract_result,
     _monotonic,
-    _rand_uniform,
     _resolve_transport,
-    _rng,
     _sleep,
 )
+
+# Module-attribute aliases (NOT ``from X import Y``) so the legacy
+# underscored names are bound on this shim's module object. Tests
+# that monkeypatched ``clauditor._anthropic._compute_backoff`` etc.
+# kept resolving for one release of back-compat. New tests target
+# the canonical home ``clauditor._providers._retry`` per
+# ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3.
+_RATE_LIMIT_MAX_RETRIES = _retry_mod.RATE_LIMIT_MAX_RETRIES
+_SERVER_MAX_RETRIES = _retry_mod.SERVER_MAX_RETRIES
+_CONN_MAX_RETRIES = _retry_mod.CONN_MAX_RETRIES
+_compute_backoff = _retry_mod.compute_backoff
+_compute_retry_decision = _retry_mod.compute_retry_decision
+_rand_uniform = _retry_mod._rand_uniform
+_rng = _retry_mod._rng
 
 
 async def call_anthropic(

--- a/src/clauditor/_harnesses/_claude_code.py
+++ b/src/clauditor/_harnesses/_claude_code.py
@@ -46,25 +46,38 @@ from clauditor.runner import (
 # scheduler ticks are not clobbered.
 _monotonic = time.monotonic
 
-# Env vars stripped by :func:`env_without_api_key`. Both are
-# documented Anthropic SDK env-auth paths (DEC-007 of
-# ``plans/super/64-runner-auth-timeout.md``). Non-auth Anthropic env
-# vars such as ``ANTHROPIC_BASE_URL`` are intentionally preserved
-# (DEC-016).
-_API_KEY_ENV_VARS = frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"})
+# Env vars stripped by :func:`env_without_api_key`. The Anthropic
+# entries are documented Anthropic SDK env-auth paths (DEC-007 of
+# ``plans/super/64-runner-auth-timeout.md``); ``OPENAI_API_KEY`` was
+# added in DEC-008 of ``plans/super/145-openai-provider.md`` so an
+# untrusted skill subprocess running under ``--transport cli`` cannot
+# silently spend the operator's OpenAI quota (parity with the
+# Anthropic stripping when grading via OpenAI). Non-auth env vars such
+# as ``ANTHROPIC_BASE_URL`` and ``OPENAI_BASE_URL`` /
+# ``OPENAI_ORG_ID`` / ``OPENAI_PROJECT_ID`` are intentionally
+# preserved (DEC-016 of #64; #145 §"Auth env var").
+_API_KEY_ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY")
 
 
 def env_without_api_key(
     base_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
-    """Return a new env dict with both auth env vars removed.
+    """Return a new env dict with provider auth env vars removed.
 
     Pure, non-mutating helper per
     ``.claude/rules/non-mutating-scrub.md``. When ``base_env`` is
     ``None``, reads from ``os.environ``. Always returns a new dict
-    (never mutates the input). Strips ``ANTHROPIC_API_KEY`` and
-    ``ANTHROPIC_AUTH_TOKEN``; preserves every other key (including
-    ``ANTHROPIC_BASE_URL``).
+    (never mutates the input). Strips ``ANTHROPIC_API_KEY``,
+    ``ANTHROPIC_AUTH_TOKEN``, and ``OPENAI_API_KEY``; preserves every
+    other key (including ``ANTHROPIC_BASE_URL``, ``OPENAI_BASE_URL``,
+    ``OPENAI_ORG_ID``, and ``OPENAI_PROJECT_ID``).
+
+    ``OPENAI_API_KEY`` is included for parity with the Anthropic
+    stripping when grading via OpenAI under ``--transport cli``: a
+    skill subprocess could spawn a child that calls the OpenAI API,
+    so the operator's quota must not be implicitly delegated to an
+    untrusted skill (DEC-008 of
+    ``plans/super/145-openai-provider.md``).
     """
     source = base_env if base_env is not None else os.environ
     return {k: v for k, v in source.items() if k not in _API_KEY_ENV_VARS}

--- a/src/clauditor/_providers/__init__.py
+++ b/src/clauditor/_providers/__init__.py
@@ -146,8 +146,9 @@ async def call_model(
     Thin shim that owns provider selection. ``provider="anthropic"``
     delegates to :func:`clauditor._providers._anthropic.call_anthropic`
     (which itself owns transport selection between the SDK and the
-    ``claude`` CLI). ``provider="openai"`` raises
-    :class:`NotImplementedError` until #145 lands the OpenAI backend.
+    ``claude`` CLI). ``provider="openai"`` delegates to
+    :func:`clauditor._providers._openai.call_openai` (#145 US-005;
+    no transport axis — DEC-002 of ``plans/super/145-openai-provider.md``).
 
     Per DEC-001 of ``plans/super/144-providers-call-model.md``, the
     signature deliberately does NOT include a ``subject`` parameter:

--- a/src/clauditor/_providers/__init__.py
+++ b/src/clauditor/_providers/__init__.py
@@ -48,6 +48,30 @@ class AnthropicAuthMissingError(Exception):
     """
 
 
+class OpenAIAuthMissingError(Exception):
+    """Raised when ``OPENAI_API_KEY`` is missing for the OpenAI provider.
+
+    Thrown by :func:`check_openai_auth` (and its dispatcher
+    :func:`check_provider_auth` when ``provider="openai"``) when
+    ``OPENAI_API_KEY`` is absent, empty, or whitespace-only.
+
+    Distinct from :class:`AnthropicAuthMissingError` AND from any
+    future ``OpenAIHelperError`` by design (DEC-006 of
+    ``plans/super/145-openai-provider.md``): the CLI layer routes
+    ``OpenAIAuthMissingError`` to exit 2 (pre-call input-validation
+    error per ``.claude/rules/llm-cli-exit-code-taxonomy.md``) — the
+    same exit code the Anthropic auth-missing class routes to, but
+    via a structurally distinct ``except`` branch so future
+    helper-error classes (exit 3) cannot collapse into the same
+    branch by accident.
+
+    Subclass of :class:`Exception` directly, NOT of
+    :class:`AnthropicAuthMissingError` or any helper-error class — a
+    common ancestor would defeat the structural-routing invariant
+    every CLI dispatcher depends on.
+    """
+
+
 # Re-export the auth-helper surface from ``_auth.py``. Imported AFTER
 # ``AnthropicAuthMissingError`` is defined so ``_auth.py``'s deferred
 # / direct ``from clauditor._providers import AnthropicAuthMissingError``
@@ -76,12 +100,16 @@ from clauditor._providers._auth import (  # noqa: E402, I001
     _AUTH_MISSING_TEMPLATE_KEY_ONLY,
     _CALL_ANTHROPIC_DEPRECATION_NOTICE,
     _IMPLICIT_NO_API_KEY_ANNOUNCEMENT,
+    _OPENAI_AUTH_MISSING_TEMPLATE,
     _api_key_is_set,
     _claude_cli_is_available,
+    _openai_api_key_is_set,
     announce_call_anthropic_deprecation,
     announce_implicit_no_api_key,
     check_any_auth_available,
     check_api_key_only,
+    check_openai_auth,
+    check_provider_auth,
 )
 
 # Re-export the SDK-seam public surface from ``_anthropic.py`` (#144
@@ -179,12 +207,15 @@ __all__ = [
     "AnthropicResult",
     "ClaudeCLIError",
     "ModelResult",
+    "OpenAIAuthMissingError",
     "announce_call_anthropic_deprecation",
     "announce_implicit_no_api_key",
     "call_anthropic",
     "call_model",
     "check_any_auth_available",
     "check_api_key_only",
+    "check_openai_auth",
+    "check_provider_auth",
     "resolve_transport",
     # Private surface re-exported for back-compat with the
     # ``clauditor._anthropic`` shim and for tests that introspect
@@ -194,6 +225,8 @@ __all__ = [
     "_AUTH_MISSING_TEMPLATE_KEY_ONLY",
     "_CALL_ANTHROPIC_DEPRECATION_NOTICE",
     "_IMPLICIT_NO_API_KEY_ANNOUNCEMENT",
+    "_OPENAI_AUTH_MISSING_TEMPLATE",
     "_api_key_is_set",
     "_claude_cli_is_available",
+    "_openai_api_key_is_set",
 ]

--- a/src/clauditor/_providers/__init__.py
+++ b/src/clauditor/_providers/__init__.py
@@ -126,6 +126,13 @@ from clauditor._providers._anthropic import (  # noqa: E402, I001
     resolve_transport,
 )
 
+# Re-export the OpenAI-backend public error class (#145 US-005). The
+# ``call_openai`` callable itself is intentionally NOT re-exported at
+# the package level — callers should go through :func:`call_model`
+# (the dispatcher) so transport routing and provider stamping stay
+# centralized.
+from clauditor._providers._openai import OpenAIHelperError  # noqa: E402, I001
+
 async def call_model(
     prompt: str,
     *,
@@ -149,20 +156,22 @@ async def call_model(
     providers. Anthropic-only callers that need ``subject`` continue to
     invoke :func:`call_anthropic` directly.
 
-    Per DEC-002 of the same plan, ``provider="openai"`` raises
-    :class:`NotImplementedError` (not ``AnthropicHelperError``) so the
-    CLI's exit-code ladder can route it distinctly when the seam is
-    finished in #145.
+    Per #145 US-005, ``provider="openai"`` delegates to
+    :func:`clauditor._providers._openai.call_openai`. The OpenAI
+    backend has no transport axis (DEC-002 of
+    ``plans/super/145-openai-provider.md``); the ``transport`` kwarg
+    is forwarded for signature parity but ignored by the OpenAI
+    backend, which always stamps ``ModelResult.source = "api"``.
 
     Args:
         prompt: Single-turn user prompt body, forwarded verbatim.
-        provider: ``"anthropic"`` for the existing backend;
-            ``"openai"`` reserved for #145.
+        provider: ``"anthropic"`` or ``"openai"``.
         model: Provider-specific model name (e.g.
-            ``"claude-sonnet-4-6"`` for anthropic).
+            ``"claude-sonnet-4-6"`` for anthropic,
+            ``"gpt-5-mini"`` for openai).
         transport: Transport selector forwarded to the anthropic
             backend (``"api"``, ``"cli"``, or ``"auto"``). Ignored
-            for the future openai backend (no transport axis there).
+            by the openai backend (no transport axis there).
         max_tokens: Upper bound on response tokens. Defaults to 4096.
 
     Returns:
@@ -172,10 +181,12 @@ async def call_model(
     Raises:
         ValueError: ``provider`` is not ``"anthropic"`` or
             ``"openai"``.
-        NotImplementedError: ``provider="openai"`` — landing in #145.
         AnthropicHelperError: Anthropic backend failure (auth, rate
             limit, server error, connection error). See
             :func:`call_anthropic`.
+        OpenAIHelperError: OpenAI backend failure (auth, rate limit,
+            server error, connection error). See
+            :func:`clauditor._providers._openai.call_openai`.
     """
     if provider == "anthropic":
         # Call via the module attribute so test patches that target
@@ -194,7 +205,22 @@ async def call_model(
             max_tokens=max_tokens,
         )
     if provider == "openai":
-        raise NotImplementedError("openai provider lands in #145")
+        # Deferred per-call import so test patches that target
+        # ``clauditor._providers._openai.call_openai`` (the canonical
+        # patch path per
+        # ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3)
+        # take effect here. A direct import-bound call would resolve
+        # via this module's ``from ... import call_openai`` binding
+        # (if we had one), which a patch on ``_providers._openai``
+        # would NOT affect.
+        from clauditor._providers import _openai as _openai_mod
+
+        return await _openai_mod.call_openai(
+            prompt,
+            model=model,
+            transport=transport,
+            max_tokens=max_tokens,
+        )
     raise ValueError(
         f"call_model: unknown provider {provider!r} — "
         "expected 'anthropic' or 'openai'"
@@ -208,6 +234,7 @@ __all__ = [
     "ClaudeCLIError",
     "ModelResult",
     "OpenAIAuthMissingError",
+    "OpenAIHelperError",
     "announce_call_anthropic_deprecation",
     "announce_implicit_no_api_key",
     "call_anthropic",

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -517,7 +517,16 @@ async def _call_via_sdk(
                 messages=[{"role": "user", "content": prompt}],
             )
         except RateLimitError as exc:
-            if rate_limit_retries >= RATE_LIMIT_MAX_RETRIES:
+            # PR #160 review (CodeRabbit): use the shared
+            # ``compute_retry_decision`` policy helper so the SDK
+            # branch and CLI branch (and the OpenAI backend) all
+            # consult the same per-category ladder. Per-attempt
+            # error messages stay byte-identical for fixture
+            # parity with prior tests.
+            if (
+                compute_retry_decision("rate_limit", rate_limit_retries)
+                == "raise"
+            ):
                 raise AnthropicHelperError(
                     f"Anthropic rate limit ({exc.status_code}) after "
                     f"{RATE_LIMIT_MAX_RETRIES} retries. Body: "
@@ -543,7 +552,7 @@ async def _call_via_sdk(
                     f"({status}): {exc.message}. Body: "
                     f"{_body_excerpt(exc)}"
                 ) from exc
-            if server_retries >= SERVER_MAX_RETRIES:
+            if compute_retry_decision("api", server_retries) == "raise":
                 raise AnthropicHelperError(
                     f"Anthropic server error ({status}) after "
                     f"{SERVER_MAX_RETRIES} retry. Body: "
@@ -554,7 +563,7 @@ async def _call_via_sdk(
             await _sleep(delay)
             continue
         except APIConnectionError as exc:
-            if conn_retries >= CONN_MAX_RETRIES:
+            if compute_retry_decision("connection", conn_retries) == "raise":
                 raise AnthropicHelperError(
                     f"Anthropic connection error after "
                     f"{CONN_MAX_RETRIES} retry: "

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -29,11 +29,14 @@ uniform ``±25%`` jitter band.
 
 Per ``.claude/rules/monotonic-time-indirection.md`` the helper is
 async, so ``time.monotonic`` and ``asyncio.sleep`` are aliased at
-module load. Tests patch ``clauditor._providers._anthropic._sleep``,
-``clauditor._providers._anthropic._rand_uniform``, and
-``clauditor._providers._anthropic._monotonic`` rather than the stdlib
-originals so the asyncio event loop's own scheduler calls are not
-disturbed and tests do not burn wallclock.
+module load. Tests patch ``clauditor._providers._anthropic._sleep``
+and ``clauditor._providers._anthropic._monotonic`` rather than the
+stdlib originals so the asyncio event loop's own scheduler calls
+are not disturbed and tests do not burn wallclock. The jitter
+indirection ``_rand_uniform`` lives in
+:mod:`clauditor._providers._retry` (DEC-007 of #145) — tests that
+need to pin jitter deterministically patch
+``clauditor._providers._retry._rand_uniform``.
 
 CLI transport (US-003 of ``plans/super/86-claude-cli-transport.md``):
 ``call_anthropic(prompt, model=..., transport="auto")`` accepts a
@@ -56,7 +59,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import random
 import shutil
 import sys
 import time
@@ -81,9 +83,24 @@ from clauditor._providers import (
     check_api_key_only,  # noqa: F401
 )
 
+# DEC-007 of ``plans/super/145-openai-provider.md``: the retry policy
+# (constants + decision logic + backoff curve) is byte-identical
+# between Anthropic and OpenAI, so it lives in a shared module.
+# ``compute_backoff`` and ``compute_retry_decision`` are imported and
+# used directly; the retry-cap constants are imported as their public
+# names. The per-provider ``_sleep`` / ``_monotonic`` indirections
+# stay here so a patch on ``_anthropic._sleep`` does not leak into
+# OpenAI's call loop.
+from clauditor._providers._retry import (
+    CONN_MAX_RETRIES,
+    RATE_LIMIT_MAX_RETRIES,
+    SERVER_MAX_RETRIES,
+    compute_backoff,
+    compute_retry_decision,
+)
+
 # Module-level alias per .claude/rules/monotonic-time-indirection.md.
 # ``_sleep`` is patched in retry-branch tests to avoid real wallclock.
-# ``_rand_uniform`` lets tests pin jitter to deterministic values.
 # ``_monotonic`` lets tests pin duration measurements deterministically
 # without clobbering the asyncio event loop's own scheduler ticks.
 _sleep = asyncio.sleep
@@ -94,26 +111,6 @@ _monotonic = time.monotonic
 # Python process; explicit ``transport="cli"`` never flips it.
 _announced_cli_transport = False
 
-
-def _rand_uniform(lo: float, hi: float) -> float:
-    """Return a uniform random float in ``[lo, hi]``.
-
-    Indirected so tests can patch jitter deterministically without
-    clobbering ``random.random`` globally. The default implementation
-    uses a module-local ``random.Random`` instance so patching the
-    stdlib ``random`` module does not affect this helper, and vice
-    versa.
-    """
-    return _rng.uniform(lo, hi)
-
-
-_rng = random.Random()
-
-
-# Per-exception retry caps (bead clauditor-24h.3 acceptance criteria).
-_RATE_LIMIT_MAX_RETRIES = 3
-_SERVER_MAX_RETRIES = 1
-_CONN_MAX_RETRIES = 1
 
 # Body excerpt length when surfacing APIStatusError messages. 512 is
 # enough to include the canonical ``{"error": {"type": "...", "message":
@@ -250,63 +247,6 @@ class ModelResult:
 # working unmodified. ``is`` returns True between the two names — they
 # are the same class object.
 AnthropicResult = ModelResult
-
-
-def _compute_backoff(retry_index: int) -> float:
-    """Return the sleep duration for the ``retry_index``-th retry.
-
-    Formula: ``2 ** retry_index`` seconds with ``±25%`` uniform
-    jitter. Retry indices start at 0, so the first retry waits
-    ``1 s`` (plus jitter), the second ``2 s``, the third ``4 s``.
-    """
-    base = float(2**retry_index)
-    jitter = _rand_uniform(-0.25, 0.25) * base
-    delay = base + jitter
-    # Floor at 0 defensively; negative jitter at retry_index=0 with
-    # deterministic seeds that push to the lower bound could otherwise
-    # bottom out near 0.75 — still positive, but we keep the guard in
-    # case future formula changes flip the sign.
-    return max(delay, 0.0)
-
-
-def _compute_retry_decision(
-    category: str, retry_index: int
-) -> Literal["retry", "raise"]:
-    """Return whether to retry a failure given its category + retry index.
-
-    Pure helper per ``.claude/rules/pure-compute-vs-io-split.md``.
-    Shared by the SDK and CLI transport branches so a failure with
-    the same category retries the same number of times regardless
-    of which transport produced it (DEC-005 retry parity).
-
-    Ladder (retry indices are 0-based — index ``i`` is "the decision
-    made before the ``i+1``-th attempt's delay"):
-
-    - ``"rate_limit"``: retry at indices 0, 1, 2; raise at 3 (matches
-      :data:`_RATE_LIMIT_MAX_RETRIES` = 3 — up to 3 retries ≡ 4
-      total attempts).
-    - ``"auth"``: always raise (no retry at any index).
-    - ``"api"``: retry at index 0; raise at 1 (one retry, matches
-      :data:`_SERVER_MAX_RETRIES` = 1 — used for 5xx SDK errors and
-      the analogous CLI ``api`` category).
-    - ``"connection"``: retry at index 0; raise at 1 (matches
-      :data:`_CONN_MAX_RETRIES` = 1 — SDK ``APIConnectionError``).
-    - ``"transport"``: retry at index 0; raise at 1 (CLI-only;
-      covers subprocess binary-missing, timeout, malformed output).
-    - Any other category: always raise (defensive default — an
-      unknown category is not something we should retry blindly).
-    """
-    if category == "rate_limit":
-        return "retry" if retry_index < _RATE_LIMIT_MAX_RETRIES else "raise"
-    if category == "auth":
-        return "raise"
-    if category == "api":
-        return "retry" if retry_index < _SERVER_MAX_RETRIES else "raise"
-    if category == "connection":
-        return "retry" if retry_index < _CONN_MAX_RETRIES else "raise"
-    if category == "transport":
-        return "retry" if retry_index < _CONN_MAX_RETRIES else "raise"
-    return "raise"
 
 
 def _body_excerpt(exc: Any) -> str:
@@ -577,13 +517,13 @@ async def _call_via_sdk(
                 messages=[{"role": "user", "content": prompt}],
             )
         except RateLimitError as exc:
-            if rate_limit_retries >= _RATE_LIMIT_MAX_RETRIES:
+            if rate_limit_retries >= RATE_LIMIT_MAX_RETRIES:
                 raise AnthropicHelperError(
                     f"Anthropic rate limit ({exc.status_code}) after "
-                    f"{_RATE_LIMIT_MAX_RETRIES} retries. Body: "
+                    f"{RATE_LIMIT_MAX_RETRIES} retries. Body: "
                     f"{_body_excerpt(exc)}"
                 ) from exc
-            delay = _compute_backoff(rate_limit_retries)
+            delay = compute_backoff(rate_limit_retries)
             rate_limit_retries += 1
             await _sleep(delay)
             continue
@@ -603,24 +543,24 @@ async def _call_via_sdk(
                     f"({status}): {exc.message}. Body: "
                     f"{_body_excerpt(exc)}"
                 ) from exc
-            if server_retries >= _SERVER_MAX_RETRIES:
+            if server_retries >= SERVER_MAX_RETRIES:
                 raise AnthropicHelperError(
                     f"Anthropic server error ({status}) after "
-                    f"{_SERVER_MAX_RETRIES} retry. Body: "
+                    f"{SERVER_MAX_RETRIES} retry. Body: "
                     f"{_body_excerpt(exc)}"
                 ) from exc
-            delay = _compute_backoff(server_retries)
+            delay = compute_backoff(server_retries)
             server_retries += 1
             await _sleep(delay)
             continue
         except APIConnectionError as exc:
-            if conn_retries >= _CONN_MAX_RETRIES:
+            if conn_retries >= CONN_MAX_RETRIES:
                 raise AnthropicHelperError(
                     f"Anthropic connection error after "
-                    f"{_CONN_MAX_RETRIES} retry: "
+                    f"{CONN_MAX_RETRIES} retry: "
                     f"{getattr(exc, 'message', repr(exc))}"
                 ) from exc
-            delay = _compute_backoff(conn_retries)
+            delay = compute_backoff(conn_retries)
             conn_retries += 1
             await _sleep(delay)
             continue
@@ -713,8 +653,8 @@ async def _call_via_claude_cli(
     retries; auth no retry; api / 5xx one retry; transport-level
     failures (binary missing, timeout, malformed output) one retry
     then raise. All retry decisions go through
-    :func:`_compute_retry_decision` so SDK and CLI ladders stay
-    lockstep.
+    :func:`clauditor._providers._retry.compute_retry_decision` so
+    SDK and CLI ladders stay lockstep.
 
     DEC-013: ``env=env_without_api_key(os.environ)`` — the parent's
     ``ANTHROPIC_API_KEY`` is never inherited by the child
@@ -779,7 +719,7 @@ async def _call_via_claude_cli(
 
         # Decide retry vs raise using the shared ladder.
         retry_index = retry_counts.get(category, 0)
-        decision = _compute_retry_decision(category, retry_index)
+        decision = compute_retry_decision(category, retry_index)
         if decision == "raise":
             template = _CLI_ERROR_TEMPLATES.get(
                 category, _CLI_ERROR_TEMPLATES["transport"]
@@ -799,7 +739,7 @@ async def _call_via_claude_cli(
 
         if category in retry_counts:
             retry_counts[category] += 1
-        delay = _compute_backoff(retry_index)
+        delay = compute_backoff(retry_index)
         await _sleep(delay)
         continue
 

--- a/src/clauditor/_providers/_auth.py
+++ b/src/clauditor/_providers/_auth.py
@@ -252,6 +252,135 @@ def check_any_auth_available(cmd_name: str) -> None:
     )
 
 
+# DEC-006 (#145 US-006): message template for :func:`check_openai_auth`,
+# the strict pre-flight guard for the OpenAI provider. Mirrors
+# :data:`_AUTH_MISSING_TEMPLATE_KEY_ONLY` (the Anthropic strict variant)
+# in shape — single ``{cmd_name}`` interpolation, naming the env-var
+# users must export, and listing the commands that don't require auth
+# so users see the escape hatch.
+#
+# Two durable substrings tests pin: ``OPENAI_API_KEY`` (the env-var
+# name) and ``platform.openai.com`` (the canonical place to obtain a
+# key — analogous to ``console.anthropic.com`` on the Anthropic side).
+_OPENAI_AUTH_MISSING_TEMPLATE = (
+    "ERROR: OPENAI_API_KEY is not set.\n"
+    "clauditor {cmd_name} calls the OpenAI API directly and needs an API\n"
+    "key. Get a key at https://platform.openai.com/api-keys, then export\n"
+    "OPENAI_API_KEY=... and re-run.\n"
+    "Commands that don't need a key: validate, capture, run, lint, init,\n"
+    "badge, audit, trend."
+)
+
+
+def _openai_api_key_is_set() -> bool:
+    """Return True when ``OPENAI_API_KEY`` is present and non-empty.
+
+    Whitespace-only values count as absent — same shape as
+    :func:`_api_key_is_set` for ``ANTHROPIC_API_KEY``. The OpenAI SDK's
+    own "could not resolve authentication" path triggers on these
+    shapes, and the pre-flight guard's whole point is to catch the
+    SDK's opaque failure with an actionable message upstream.
+    """
+    value = os.environ.get("OPENAI_API_KEY")
+    return value is not None and value.strip() != ""
+
+
+def check_openai_auth(cmd_name: str) -> None:
+    """Pre-flight guard: raise if ``OPENAI_API_KEY`` is missing.
+
+    DEC-006 of ``plans/super/145-openai-provider.md``. Pure helper
+    mirroring :func:`check_api_key_only`'s shape for the OpenAI
+    provider — reads ``os.environ["OPENAI_API_KEY"]`` and raises
+    :class:`OpenAIAuthMissingError` when the value is absent, an empty
+    string, or whitespace-only. There is no CLI-fallback branch (no
+    OpenAI equivalent of the ``claude`` CLI subscription path), so the
+    guard is unconditionally strict.
+
+    Pure function per ``.claude/rules/pure-compute-vs-io-split.md``:
+    reads ``os.environ`` only; does NOT print to stderr, does NOT call
+    ``sys.exit``, does NOT log. The CLI wrapper catches
+    :class:`OpenAIAuthMissingError` (a direct subclass of
+    :class:`Exception`, NOT :class:`AnthropicAuthMissingError` or any
+    helper-error class) and maps it to ``return 2`` per
+    ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+
+    Args:
+        cmd_name: Subcommand label (e.g. ``"grade"``, ``"extract"``,
+            ``"propose-eval"``, ``"triggers"``) interpolated into the
+            error message so users see ``clauditor grade`` for
+            immediately actionable UX.
+
+    Raises:
+        OpenAIAuthMissingError: when ``OPENAI_API_KEY`` is absent, an
+            empty string, or whitespace-only. Message contains the
+            two durable substrings (``OPENAI_API_KEY``,
+            ``platform.openai.com``) and the interpolated command
+            name.
+    """
+    if _openai_api_key_is_set():
+        return None
+    # Local import to avoid a module-load circular hazard analogous to
+    # ``AnthropicAuthMissingError`` (defined in ``_providers/__init__``
+    # so both the auth helpers and the SDK seam reference it). At call
+    # time the parent package is fully initialized.
+    from clauditor._providers import OpenAIAuthMissingError
+
+    raise OpenAIAuthMissingError(
+        _OPENAI_AUTH_MISSING_TEMPLATE.format(cmd_name=cmd_name)
+    )
+
+
+def check_provider_auth(provider: str, cmd_name: str) -> None:
+    """Public dispatcher routing pre-flight auth guards by provider.
+
+    DEC-006 of ``plans/super/145-openai-provider.md``. Single seam
+    every LLM-mediated CLI command targets after resolving
+    ``provider = eval_spec.grading_provider or "anthropic"``. The
+    branches:
+
+    - ``provider == "anthropic"`` →
+      :func:`check_any_auth_available` (the existing relaxed guard
+      preserving #86 DEC-008's key-OR-CLI semantics; raises
+      :class:`AnthropicAuthMissingError`).
+    - ``provider == "openai"`` → :func:`check_openai_auth` (the strict
+      key-only guard for OpenAI; raises
+      :class:`OpenAIAuthMissingError`).
+    - Unknown value → :class:`ValueError`.
+
+    Distinct exception classes per provider keep the CLI's
+    ``except`` ladder structural (one branch per class → one exit
+    code) per ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    Adding a future ``provider="vertex"`` or ``"bedrock"`` is one
+    branch in this dispatcher.
+
+    Pure function per ``.claude/rules/pure-compute-vs-io-split.md``:
+    delegates to pure helpers; does NOT print to stderr, does NOT
+    call ``sys.exit``, does NOT log.
+
+    Args:
+        provider: Either ``"anthropic"`` or ``"openai"``.
+        cmd_name: Subcommand label forwarded to the provider-specific
+            guard for error-message interpolation.
+
+    Raises:
+        AnthropicAuthMissingError: ``provider="anthropic"`` and no
+            usable Anthropic auth path is available.
+        OpenAIAuthMissingError: ``provider="openai"`` and
+            ``OPENAI_API_KEY`` is missing.
+        ValueError: ``provider`` is not one of the known values.
+    """
+    if provider == "anthropic":
+        check_any_auth_available(cmd_name)
+        return None
+    if provider == "openai":
+        check_openai_auth(cmd_name)
+        return None
+    raise ValueError(
+        f"check_provider_auth: unknown provider {provider!r} — "
+        "expected 'anthropic' or 'openai'"
+    )
+
+
 def check_api_key_only(cmd_name: str) -> None:
     """Strict pre-flight guard: raise if ``ANTHROPIC_API_KEY`` is missing.
 

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -307,24 +307,33 @@ async def call_openai(
         APIConnectionError,
         APIStatusError,
         AuthenticationError,
+        OpenAIError,
         PermissionDeniedError,
         RateLimitError,
     )
 
     # Defense-in-depth (per ``.claude/rules/precall-env-validation.md``):
-    # wrap the ``AsyncOpenAI()`` construction site so a future SDK
-    # that raises ``TypeError`` from ``__init__`` (e.g. on an
-    # unresolved auth method) surfaces as a clean
+    # wrap the ``AsyncOpenAI()`` construction site so the SDK's auth
+    # missing-key error (``OpenAIError`` raised when ``OPENAI_API_KEY``
+    # is unset) and any future ``TypeError`` from ``__init__`` (e.g.
+    # on an unresolved auth method) surface as a clean
     # ``OpenAIHelperError`` rather than a raw traceback. Fixed
-    # sanitized message; original ``TypeError`` preserved on
+    # sanitized message; original exception preserved on
     # ``__cause__`` via ``raise ... from``. ``ImportError`` is NOT
     # caught — per the centralized-sdk-call rule, missing-SDK errors
     # must propagate un-wrapped so the install hint surfaces.
+    #
+    # ``OpenAIError`` is the SDK's base exception. ``AuthenticationError``,
+    # ``RateLimitError``, ``APIStatusError``, ``APIConnectionError`` are
+    # all subclasses, but those are raised from ``responses.create()`` —
+    # not from ``AsyncOpenAI()`` construction — so this site only sees
+    # the bare ``OpenAIError`` (or ``TypeError`` for legacy SDK config
+    # errors).
     try:
         client = AsyncOpenAI()
     except ImportError:
         raise
-    except TypeError as exc:
+    except (TypeError, OpenAIError) as exc:
         raise OpenAIHelperError(
             "OpenAI SDK client initialization failed — "
             "verify OPENAI_API_KEY is set."

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -337,8 +337,16 @@ async def call_openai(
     # not from ``AsyncOpenAI()`` construction — so this site only sees
     # the bare ``OpenAIError`` (or ``TypeError`` for legacy SDK config
     # errors).
+    # ``max_retries=0`` disables the SDK's built-in retry loop so the
+    # wrapper's per-category retries (``RATE_LIMIT_MAX_RETRIES``,
+    # ``SERVER_MAX_RETRIES``, ``CONN_MAX_RETRIES``) are the sole retry
+    # mechanism. Without this, the SDK retries 429/5xx/connection
+    # errors itself (default ``max_retries=2`` ≡ 3 attempts) and the
+    # wrapper then catches the exhausted error and retries again,
+    # double-retrying with compounded backoff and obscuring the
+    # actual retry budget. CodeRabbit flagged this on PR #160.
     try:
-        client = AsyncOpenAI()
+        client = AsyncOpenAI(max_retries=0)
     except ImportError:
         raise
     except (TypeError, OpenAIError) as exc:

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -1,0 +1,206 @@
+"""OpenAI provider backend — Responses API seam (US-002 of #145).
+
+Happy-path-only implementation of :func:`call_openai`, the OpenAI
+counterpart to :func:`clauditor._providers._anthropic.call_anthropic`.
+Mirrors the Anthropic seam's structural shape — module-level
+test-indirection aliases for :func:`time.monotonic` /
+:func:`asyncio.sleep`, a sibling exception class
+(:class:`OpenAIHelperError`) for non-retriable failures, and a
+:class:`clauditor._providers.ModelResult` projection — but defers
+retry logic, error categorization, and rich
+``response.output[]`` walking to subsequent beads (US-003 / US-004).
+
+Responses API divergences from Anthropic's ``messages.create``:
+
+- The SDK call is ``client.responses.create(input=..., model=...,
+  max_output_tokens=...)`` rather than ``messages.create(messages=[
+  {"role": "user", ...}], max_tokens=...)``. The single-turn prompt
+  goes through the ``input=`` kwarg directly.
+- The response surfaces joined assistant text via the
+  ``response.output_text`` SDK convenience accessor (Pydantic
+  computed field). Per-block walking of ``response.output[]``
+  filtering ``type == "message"`` is US-003's job and is NOT in
+  scope for this happy path.
+- Refusal / incomplete-output state lives at ``response.status`` +
+  ``response.incomplete_details.reason`` rather than Anthropic's
+  ``stop_reason`` on the raw ``Message``. Callers introspecting
+  :attr:`ModelResult.raw_message` for refusal semantics must
+  branch on :attr:`ModelResult.provider` — see :func:`call_openai`'s
+  docstring.
+- :attr:`ModelResult.raw_message` is the Pydantic-v2 dict from
+  ``response.model_dump()`` rather than Anthropic's raw ``Message``
+  object (DEC-001 of ``plans/super/145-openai-provider.md``). This
+  divergence is documented; downstream consumers across the codebase
+  pre-#145 only ever introspect ``raw_message`` on the Anthropic
+  path.
+
+DEC-002: :attr:`ModelResult.source` is always ``"api"`` — OpenAI has
+no CLI transport axis. The ``transport`` and ``subject`` kwargs are
+accepted at the signature level so the future dispatcher can pass
+them uniformly across providers, but both are ignored here.
+
+Module-level constants (DEC-001 of #145): :data:`DEFAULT_MODEL_L3`
+and :data:`DEFAULT_MODEL_L2` pin the L3-grader and L2-extraction
+defaults to confirmed Responses-API model names. Callers that need
+a per-call override pass ``model=`` explicitly; default-model
+resolution at grader call sites lands in US-010.
+
+Per ``.claude/rules/monotonic-time-indirection.md`` :data:`_sleep`
+and :data:`_monotonic` are aliased at module load. Tests patch
+``clauditor._providers._openai._sleep`` and
+``clauditor._providers._openai._monotonic`` directly so the asyncio
+event loop's own scheduler ticks are not disturbed and an
+Anthropic-side patch on ``_anthropic._sleep`` does not leak into
+OpenAI's call loop. The shared :func:`compute_backoff` jitter
+indirection lives in :mod:`clauditor._providers._retry` and is
+imported when retry logic lands in US-004.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Final
+
+# Late import inside the call site (mirroring _anthropic.py's
+# pattern) is unnecessary here — ``openai`` is a hard dependency
+# per US-002 (DEC-004 of #145, ``openai>=1.66.0``). Import at
+# module load so tests can patch ``AsyncOpenAI`` at the seam.
+from openai import AsyncOpenAI
+
+from clauditor._providers import ModelResult
+
+# Module-level alias per .claude/rules/monotonic-time-indirection.md.
+# ``_sleep`` is patched in (future) retry-branch tests to avoid real
+# wallclock; ``_monotonic`` lets tests pin duration measurements
+# deterministically without clobbering the asyncio event loop's own
+# scheduler ticks.
+_sleep = asyncio.sleep
+_monotonic = time.monotonic
+
+
+# DEC-001 of plans/super/145-openai-provider.md: pin the default
+# models to confirmed Responses-API names per
+# https://developers.openai.com/api/docs/models . L3 grading uses
+# the larger model; L2 schema-extraction uses the smaller one.
+# Callers override per-call via the ``model=`` kwarg; default-model
+# resolution at grader call sites is US-010's job.
+DEFAULT_MODEL_L3: Final[str] = "gpt-5.4"
+DEFAULT_MODEL_L2: Final[str] = "gpt-5.4-mini"
+
+
+class OpenAIHelperError(Exception):
+    """Raised by :func:`call_openai` for non-retriable / exhausted failures.
+
+    Sibling of :class:`clauditor._providers._anthropic.AnthropicHelperError`
+    (DEC-006 of ``plans/super/145-openai-provider.md``): subclass of
+    :class:`Exception` directly, NOT of ``AnthropicHelperError`` — a
+    common ancestor would defeat the structural ``except`` ladder
+    every CLI dispatcher depends on. Retry / categorization branches
+    that raise this class land in US-004.
+    """
+
+
+async def call_openai(
+    prompt: str,
+    *,
+    model: str,
+    max_tokens: int = 4096,
+    transport: str = "auto",
+    subject: str | None = None,
+) -> ModelResult:
+    """Issue a single-turn user prompt against an OpenAI Responses-API model.
+
+    Happy-path-only (US-002 of #145). On success returns a
+    :class:`ModelResult` with :attr:`ModelResult.provider` stamped to
+    ``"openai"`` and :attr:`ModelResult.source` stamped to ``"api"``.
+    Retry logic, error categorization, and rich ``output[]`` walking
+    land in US-003 / US-004.
+
+    Args:
+        prompt: Single-turn user prompt body. Forwarded to the
+            Responses-API ``input=`` kwarg.
+        model: OpenAI model name (e.g. :data:`DEFAULT_MODEL_L3`).
+        max_tokens: Upper bound on response tokens. Forwarded to the
+            Responses-API ``max_output_tokens=`` kwarg (renamed from
+            Anthropic's ``max_tokens``). Defaults to 4096.
+        transport: Accepted for signature parity with
+            :func:`call_anthropic` but **ignored** — OpenAI has no
+            CLI transport axis (DEC-002 of
+            ``plans/super/145-openai-provider.md``).
+            :attr:`ModelResult.source` is always ``"api"``.
+        subject: Accepted for signature parity but **ignored** —
+            ``subject`` is the Claude-Code-CLI ``apiKeySource``
+            telemetry label and has no OpenAI counterpart.
+
+    Returns:
+        :class:`ModelResult` with:
+
+        - ``response_text`` = ``response.output_text`` (the SDK's
+          joined-assistant-text convenience accessor).
+        - ``text_blocks`` = ``[response.output_text]`` when
+          non-empty, else ``[]``. Richer per-block walking of
+          ``response.output[]`` filtering ``type == "message"`` is
+          US-003's job; the happy path collapses to a single block.
+        - ``input_tokens`` / ``output_tokens`` from
+          ``response.usage``.
+        - ``raw_message`` = ``response.model_dump()`` — Pydantic-v2
+          dict serialization. **Divergence from Anthropic**: OpenAI
+          surfaces refusal / incomplete state at
+          ``response.status`` + ``response.incomplete_details.reason``
+          rather than ``stop_reason`` on a raw ``Message`` object.
+          Callers introspecting ``raw_message`` for refusal
+          semantics must branch on ``provider``.
+        - ``provider`` = ``"openai"``; ``source`` = ``"api"``;
+          ``duration_seconds`` measured via the :data:`_monotonic`
+          alias.
+    """
+    # DEC-002: ``transport`` / ``subject`` are accepted for
+    # signature parity but ignored. The names are intentionally
+    # bound (no leading underscore renaming) so the kwargs stay
+    # call-site-discoverable.
+    del transport, subject
+
+    # The OpenAI SDK reads ``OPENAI_API_KEY`` automatically. The
+    # ``check_openai_auth`` pre-flight (US-006 / DEC-006) runs
+    # upstream of this call site at the CLI / fixture boundary.
+    client = AsyncOpenAI()
+
+    start = _monotonic()
+    response: Any = await client.responses.create(
+        input=prompt,
+        model=model,
+        max_output_tokens=max_tokens,
+    )
+    duration = _monotonic() - start
+
+    output_text = getattr(response, "output_text", "") or ""
+    text_blocks = [output_text] if output_text else []
+
+    usage = getattr(response, "usage", None)
+    try:
+        input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        input_tokens = 0
+    try:
+        output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        output_tokens = 0
+
+    # DEC-001 raw_message shape: Pydantic v2 dict via .model_dump().
+    # Defensive against a future SDK that drops the method —
+    # fall back to ``None`` so :attr:`ModelResult.raw_message` stays
+    # tolerable for ``isinstance(..., dict)`` checks downstream.
+    model_dump = getattr(response, "model_dump", None)
+    raw_message = model_dump() if callable(model_dump) else None
+
+    return ModelResult(
+        response_text=output_text,
+        text_blocks=text_blocks,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        raw_message=raw_message,
+        source="api",
+        duration_seconds=duration,
+        provider="openai",
+    )

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -69,14 +69,51 @@ from typing import Any, Final
 from openai import AsyncOpenAI
 
 from clauditor._providers import ModelResult
+from clauditor._providers._retry import (
+    CONN_MAX_RETRIES,
+    RATE_LIMIT_MAX_RETRIES,
+    SERVER_MAX_RETRIES,
+    compute_backoff,
+)
 
 # Module-level alias per .claude/rules/monotonic-time-indirection.md.
-# ``_sleep`` is patched in (future) retry-branch tests to avoid real
+# ``_sleep`` is patched in retry-branch tests to avoid real
 # wallclock; ``_monotonic`` lets tests pin duration measurements
 # deterministically without clobbering the asyncio event loop's own
 # scheduler ticks.
 _sleep = asyncio.sleep
 _monotonic = time.monotonic
+
+
+# Body excerpt length when surfacing APIStatusError messages. 512 is
+# enough to include the canonical
+# ``{"error": {"type": "...", "message": "..."}}`` envelope without
+# flooding stderr. Mirrors :data:`clauditor._providers._anthropic._BODY_EXCERPT_CHARS`.
+# Duplicated rather than imported because each provider may evolve
+# its own body-shape conventions; today they happen to match.
+_BODY_EXCERPT_CHARS = 512
+
+
+def _body_excerpt(exc: Any) -> str:
+    """Return a short string representation of an SDK exception body.
+
+    Mirrors :func:`clauditor._providers._anthropic._body_excerpt`.
+    Duplicated rather than shared because each provider's SDK may
+    evolve different body shapes; today both happen to expose ``.body``
+    as either a decoded dict, raw bytes/string, or ``None``. All three
+    are coerced to a best-effort string truncated to
+    :data:`_BODY_EXCERPT_CHARS`.
+    """
+    body = getattr(exc, "body", None)
+    if body is None:
+        return "<no body>"
+    try:
+        text = body if isinstance(body, str) else repr(body)
+    except Exception:  # noqa: BLE001 - defensive repr
+        text = "<unrenderable body>"
+    if len(text) > _BODY_EXCERPT_CHARS:
+        return text[:_BODY_EXCERPT_CHARS] + "..."
+    return text
 
 
 # DEC-001 of plans/super/145-openai-provider.md: pin the default
@@ -258,33 +295,142 @@ async def call_openai(
     # call-site-discoverable.
     del transport, subject
 
-    # The OpenAI SDK reads ``OPENAI_API_KEY`` automatically. The
-    # ``check_openai_auth`` pre-flight (US-006 / DEC-006) runs
-    # upstream of this call site at the CLI / fixture boundary.
-    client = AsyncOpenAI()
-
-    start = _monotonic()
-    response: Any = await client.responses.create(
-        input=prompt,
-        model=model,
-        max_output_tokens=max_tokens,
-    )
-    duration = _monotonic() - start
-
-    # Delegate the projection to the pure helper per
-    # .claude/rules/pure-compute-vs-io-split.md. Retry branches in
-    # US-004 will reuse the same helper inside the retry loop.
-    response_text, text_blocks, input_tokens, output_tokens, raw_message = (
-        _extract_openai_result(response)
+    # Local imports mirror :func:`call_anthropic`'s pattern. The
+    # ``openai`` SDK is a hard dependency per DEC-004 of #145 so the
+    # ``AsyncOpenAI`` symbol is already imported at module load (the
+    # tests patch the module-level ``AsyncOpenAI`` symbol). Import the
+    # exception classes here so the retry ladder names them locally.
+    # Per ``.claude/rules/centralized-sdk-call.md``: ``ImportError``
+    # is RE-RAISED un-wrapped so callers surface a clean
+    # ``pip install openai>=1.66.0`` hint.
+    from openai import (
+        APIConnectionError,
+        APIStatusError,
+        AuthenticationError,
+        PermissionDeniedError,
+        RateLimitError,
     )
 
-    return ModelResult(
-        response_text=response_text,
-        text_blocks=text_blocks,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        raw_message=raw_message,
-        source="api",
-        duration_seconds=duration,
-        provider="openai",
-    )
+    # Defense-in-depth (per ``.claude/rules/precall-env-validation.md``):
+    # wrap the ``AsyncOpenAI()`` construction site so a future SDK
+    # that raises ``TypeError`` from ``__init__`` (e.g. on an
+    # unresolved auth method) surfaces as a clean
+    # ``OpenAIHelperError`` rather than a raw traceback. Fixed
+    # sanitized message; original ``TypeError`` preserved on
+    # ``__cause__`` via ``raise ... from``. ``ImportError`` is NOT
+    # caught — per the centralized-sdk-call rule, missing-SDK errors
+    # must propagate un-wrapped so the install hint surfaces.
+    try:
+        client = AsyncOpenAI()
+    except ImportError:
+        raise
+    except TypeError as exc:
+        raise OpenAIHelperError(
+            "OpenAI SDK client initialization failed — "
+            "verify OPENAI_API_KEY is set."
+        ) from exc
+
+    rate_limit_retries = 0
+    server_retries = 0
+    conn_retries = 0
+
+    while True:
+        # Duration measures the successful attempt's wall clock only,
+        # excluding retry sleeps (mirrors DEC-020 of the Anthropic
+        # branch). Reset ``start`` on every ``continue`` so a
+        # successful-after-retry call reports the final attempt's
+        # own duration.
+        start = _monotonic()
+        try:
+            response: Any = await client.responses.create(
+                input=prompt,
+                model=model,
+                max_output_tokens=max_tokens,
+            )
+        except RateLimitError as exc:
+            if rate_limit_retries >= RATE_LIMIT_MAX_RETRIES:
+                raise OpenAIHelperError(
+                    f"OpenAI rate limit (429) after "
+                    f"{RATE_LIMIT_MAX_RETRIES} retries. Body: "
+                    f"{_body_excerpt(exc)}"
+                ) from exc
+            delay = compute_backoff(rate_limit_retries)
+            rate_limit_retries += 1
+            await _sleep(delay)
+            continue
+        except (AuthenticationError, PermissionDeniedError) as exc:
+            raise OpenAIHelperError(
+                f"OpenAI authentication failed "
+                f"({exc.status_code}): check the OPENAI_API_KEY "
+                f"environment variable. Body: {_body_excerpt(exc)}"
+            ) from exc
+        except APIStatusError as exc:
+            status = getattr(exc, "status_code", 0)
+            if status < 500:
+                # 4xx (other than 401/403): bad request, not found,
+                # unprocessable entity, etc. No retry.
+                raise OpenAIHelperError(
+                    f"OpenAI API request failed "
+                    f"({status}): {exc.message}. Body: "
+                    f"{_body_excerpt(exc)}"
+                ) from exc
+            if server_retries >= SERVER_MAX_RETRIES:
+                raise OpenAIHelperError(
+                    f"OpenAI server error ({status}) after "
+                    f"{SERVER_MAX_RETRIES} retry. Body: "
+                    f"{_body_excerpt(exc)}"
+                ) from exc
+            delay = compute_backoff(server_retries)
+            server_retries += 1
+            await _sleep(delay)
+            continue
+        except APIConnectionError as exc:
+            if conn_retries >= CONN_MAX_RETRIES:
+                raise OpenAIHelperError(
+                    f"OpenAI connection error after "
+                    f"{CONN_MAX_RETRIES} retry: "
+                    f"{getattr(exc, 'message', repr(exc))}"
+                ) from exc
+            delay = compute_backoff(conn_retries)
+            conn_retries += 1
+            await _sleep(delay)
+            continue
+        except TypeError as exc:
+            # Defense-in-depth wrap (per
+            # ``.claude/rules/precall-env-validation.md``). If a
+            # future caller bypasses the pre-flight auth guard and
+            # the SDK raises ``TypeError`` from
+            # ``responses.create`` (e.g. unresolved auth, malformed
+            # client config), surface a clean
+            # ``OpenAIHelperError`` rather than the raw traceback.
+            # Fixed sanitized message — no ``str(exc)``,
+            # no ``exc.args``. Original exception preserved on
+            # ``__cause__`` via ``raise ... from exc``. Not retried:
+            # a ``TypeError`` is a config error, not transient.
+            raise OpenAIHelperError(
+                "OpenAI SDK client initialization failed — "
+                "verify OPENAI_API_KEY is set."
+            ) from exc
+
+        duration = _monotonic() - start
+
+        # Delegate the projection to the pure helper per
+        # .claude/rules/pure-compute-vs-io-split.md.
+        (
+            response_text,
+            text_blocks,
+            input_tokens,
+            output_tokens,
+            raw_message,
+        ) = _extract_openai_result(response)
+
+        return ModelResult(
+            response_text=response_text,
+            text_blocks=text_blocks,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            raw_message=raw_message,
+            source="api",
+            duration_seconds=duration,
+            provider="openai",
+        )

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -200,7 +200,15 @@ def _extract_openai_result(
                 text = getattr(block, "text", "") or ""
                 if isinstance(text, str):
                     parts.append(text)
-            text_blocks.append("".join(parts))
+            # QG pass 2 (#145): only append when this message yielded
+            # at least one text part. A message item with no
+            # ``output_text`` content blocks (refusal-only, tool-use-
+            # only, or ``content=None``) collapses to no entry rather
+            # than an empty-string entry, so the downstream contract
+            # ``not result.text_blocks`` reliably distinguishes
+            # "no message-typed text" from "message had empty text".
+            if parts:
+                text_blocks.append("".join(parts))
 
     # Prefer the SDK's joined output_text accessor; fall back to
     # joining text_blocks when it is absent or empty.

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -101,6 +101,103 @@ class OpenAIHelperError(Exception):
     """
 
 
+def _extract_openai_result(
+    response: Any,
+) -> tuple[str, list[str], int, int, dict]:
+    """Project a Responses-API response into the ``ModelResult`` payload.
+
+    Pure helper per ``.claude/rules/pure-compute-vs-io-split.md``:
+    no I/O, never raises, defensive against missing or malformed
+    fields. Mirrors the structural shape of
+    :func:`clauditor._providers._anthropic._extract_result` so the
+    two providers' projections stay reviewable side-by-side.
+
+    Walks ``response.output[]`` skipping non-``message`` items
+    (e.g. ``type == "reasoning"`` items emitted by extended-thinking
+    modes — forward-compat with #154's harness-context sidecar
+    work). Each ``message`` item's ``content[]`` is walked for
+    ``type == "output_text"`` blocks; the per-message text is
+    joined and appended to ``text_blocks``.
+
+    Args:
+        response: Responses-API response object (or any duck-typed
+            stand-in). All attribute reads are guarded with
+            :func:`getattr` defaults so a future SDK shape change
+            cannot crash the projection.
+
+    Returns:
+        Tuple of ``(response_text, text_blocks, input_tokens,
+        output_tokens, raw_message)``:
+
+        - ``response_text`` prefers ``response.output_text`` (the
+          SDK's joined-message-text convenience accessor). Falls
+          back to ``"".join(text_blocks)`` when the accessor is
+          absent or empty.
+        - ``text_blocks`` is the per-message joined text list; an
+          empty list means the response had no message-typed
+          output items (refusal, tool-only, incomplete).
+        - ``input_tokens`` / ``output_tokens`` come from
+          ``response.usage`` with defensive ``int()`` coercion;
+          fall back to 0 on missing/null/non-numeric values.
+        - ``raw_message`` is ``response.model_dump()`` (Pydantic-v2
+          dict) when available, else ``{}``.
+    """
+    # Walk response.output[], filtering to message items and
+    # collecting per-message joined text. Non-message items
+    # (reasoning, tool-use, etc.) are skipped; per-block walking is
+    # defensive against a future SDK that adds new content-block
+    # types — we only collect text from output_text blocks.
+    text_blocks: list[str] = []
+    output = getattr(response, "output", None) or []
+    if isinstance(output, list):
+        for item in output:
+            if getattr(item, "type", None) != "message":
+                continue
+            content = getattr(item, "content", None) or []
+            if not isinstance(content, list):
+                continue
+            parts: list[str] = []
+            for block in content:
+                if getattr(block, "type", None) != "output_text":
+                    continue
+                text = getattr(block, "text", "") or ""
+                if isinstance(text, str):
+                    parts.append(text)
+            text_blocks.append("".join(parts))
+
+    # Prefer the SDK's joined output_text accessor; fall back to
+    # joining text_blocks when it is absent or empty.
+    output_text = getattr(response, "output_text", "") or ""
+    if not output_text and text_blocks:
+        output_text = "".join(text_blocks)
+
+    usage = getattr(response, "usage", None)
+    try:
+        input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+    except (TypeError, ValueError, AttributeError):
+        input_tokens = 0
+    try:
+        output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    except (TypeError, ValueError, AttributeError):
+        output_tokens = 0
+
+    # raw_message: prefer the Pydantic-v2 dict (DEC-001 of #145).
+    # Fall back to {} so downstream callers that ``isinstance(...,
+    # dict)`` keep a stable shape. Defensive against a future SDK
+    # that drops .model_dump() entirely.
+    raw_message: dict = {}
+    model_dump = getattr(response, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump()
+        except (TypeError, AttributeError):
+            dumped = None
+        if isinstance(dumped, dict):
+            raw_message = dumped
+
+    return output_text, text_blocks, input_tokens, output_tokens, raw_message
+
+
 async def call_openai(
     prompt: str,
     *,
@@ -174,28 +271,15 @@ async def call_openai(
     )
     duration = _monotonic() - start
 
-    output_text = getattr(response, "output_text", "") or ""
-    text_blocks = [output_text] if output_text else []
-
-    usage = getattr(response, "usage", None)
-    try:
-        input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
-    except (TypeError, ValueError):
-        input_tokens = 0
-    try:
-        output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
-    except (TypeError, ValueError):
-        output_tokens = 0
-
-    # DEC-001 raw_message shape: Pydantic v2 dict via .model_dump().
-    # Defensive against a future SDK that drops the method —
-    # fall back to ``None`` so :attr:`ModelResult.raw_message` stays
-    # tolerable for ``isinstance(..., dict)`` checks downstream.
-    model_dump = getattr(response, "model_dump", None)
-    raw_message = model_dump() if callable(model_dump) else None
+    # Delegate the projection to the pure helper per
+    # .claude/rules/pure-compute-vs-io-split.md. Retry branches in
+    # US-004 will reuse the same helper inside the retry loop.
+    response_text, text_blocks, input_tokens, output_tokens, raw_message = (
+        _extract_openai_result(response)
+    )
 
     return ModelResult(
-        response_text=output_text,
+        response_text=response_text,
         text_blocks=text_blocks,
         input_tokens=input_tokens,
         output_tokens=output_tokens,

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -74,6 +74,7 @@ from clauditor._providers._retry import (
     RATE_LIMIT_MAX_RETRIES,
     SERVER_MAX_RETRIES,
     compute_backoff,
+    compute_retry_decision,
 )
 
 # Module-level alias per .claude/rules/monotonic-time-indirection.md.
@@ -373,7 +374,15 @@ async def call_openai(
                 max_output_tokens=max_tokens,
             )
         except RateLimitError as exc:
-            if rate_limit_retries >= RATE_LIMIT_MAX_RETRIES:
+            # PR #160 review (CodeRabbit): use the shared
+            # ``compute_retry_decision`` policy helper so the
+            # SDK and CLI branches (and the Anthropic backend)
+            # all consult the same per-category ladder. Per-attempt
+            # error messages stay byte-identical for fixture parity.
+            if (
+                compute_retry_decision("rate_limit", rate_limit_retries)
+                == "raise"
+            ):
                 raise OpenAIHelperError(
                     f"OpenAI rate limit (429) after "
                     f"{RATE_LIMIT_MAX_RETRIES} retries. Body: "
@@ -399,7 +408,7 @@ async def call_openai(
                     f"({status}): {exc.message}. Body: "
                     f"{_body_excerpt(exc)}"
                 ) from exc
-            if server_retries >= SERVER_MAX_RETRIES:
+            if compute_retry_decision("api", server_retries) == "raise":
                 raise OpenAIHelperError(
                     f"OpenAI server error ({status}) after "
                     f"{SERVER_MAX_RETRIES} retry. Body: "
@@ -410,7 +419,7 @@ async def call_openai(
             await _sleep(delay)
             continue
         except APIConnectionError as exc:
-            if conn_retries >= CONN_MAX_RETRIES:
+            if compute_retry_decision("connection", conn_retries) == "raise":
                 raise OpenAIHelperError(
                     f"OpenAI connection error after "
                     f"{CONN_MAX_RETRIES} retry: "

--- a/src/clauditor/_providers/_retry.py
+++ b/src/clauditor/_providers/_retry.py
@@ -1,0 +1,118 @@
+"""Shared retry helpers for provider backends (DEC-007 of #145).
+
+The retry policy for the Anthropic and OpenAI provider backends is
+byte-identical: same exception taxonomy (rate-limit / auth /
+api-5xx / connection), same per-category retry caps, same
+exponential backoff curve with ±25% jitter. Hoisting the helpers
+into one shared module is DRY and keeps both providers in lockstep
+when the policy evolves.
+
+Public API:
+
+- :data:`RATE_LIMIT_MAX_RETRIES` (= 3)
+- :data:`SERVER_MAX_RETRIES` (= 1)
+- :data:`CONN_MAX_RETRIES` (= 1)
+- :func:`compute_backoff(retry_index)` — pure helper returning the
+  delay (seconds) before the ``retry_index``-th retry. Formula:
+  ``2 ** retry_index`` plus uniform ``±25%`` jitter, floored at 0.
+- :func:`compute_retry_decision(category, retry_index)` — pure
+  helper returning ``"retry"`` or ``"raise"`` per the shared ladder.
+
+Per-provider concerns stay per-provider. The ``_sleep`` /
+``_monotonic`` / ``_rand_uniform`` / ``_rng`` test-indirection
+aliases live on each provider module so a
+``monkeypatch.setattr("clauditor._providers._openai._sleep", ...)``
+patches only OpenAI's sleeping, not Anthropic's. This module owns
+the *policy* (constants + decision logic); each provider owns its
+own clock / RNG indirection.
+
+Note on jitter: this module exposes its own ``_rand_uniform``
+indirection so :func:`compute_backoff` is patchable in isolation
+(see :class:`tests.test_providers_retry.TestComputeBackoff`). Each
+provider's call loop still uses the shared :func:`compute_backoff`
+and inherits the same jitter contract.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Literal
+
+# Per-exception retry caps. Public per DEC-007 (renamed to drop the
+# leading underscore at the new module boundary).
+RATE_LIMIT_MAX_RETRIES = 3
+SERVER_MAX_RETRIES = 1
+CONN_MAX_RETRIES = 1
+
+
+# Module-local RNG so patching ``random.random`` globally does not
+# affect this helper, and vice versa. Mirrors the per-provider
+# pattern so tests can pin jitter deterministically here without
+# clobbering provider-specific RNG state.
+_rng = random.Random()
+
+
+def _rand_uniform(lo: float, hi: float) -> float:
+    """Return a uniform random float in ``[lo, hi]``.
+
+    Indirected so tests can patch jitter deterministically without
+    clobbering ``random.random`` globally.
+    """
+    return _rng.uniform(lo, hi)
+
+
+def compute_backoff(retry_index: int) -> float:
+    """Return the sleep duration for the ``retry_index``-th retry.
+
+    Formula: ``2 ** retry_index`` seconds with ``±25%`` uniform
+    jitter. Retry indices start at 0, so the first retry waits
+    ``1 s`` (plus jitter), the second ``2 s``, the third ``4 s``.
+    """
+    base = float(2**retry_index)
+    jitter = _rand_uniform(-0.25, 0.25) * base
+    delay = base + jitter
+    # Floor at 0 defensively; negative jitter at retry_index=0 with
+    # deterministic seeds that push to the lower bound could otherwise
+    # bottom out near 0.75 — still positive, but we keep the guard in
+    # case future formula changes flip the sign.
+    return max(delay, 0.0)
+
+
+def compute_retry_decision(
+    category: str, retry_index: int
+) -> Literal["retry", "raise"]:
+    """Return whether to retry a failure given its category + retry index.
+
+    Pure helper per ``.claude/rules/pure-compute-vs-io-split.md``.
+    Shared by every provider backend so a failure with the same
+    category retries the same number of times regardless of which
+    provider produced it (DEC-007 retry parity).
+
+    Ladder (retry indices are 0-based — index ``i`` is "the decision
+    made before the ``i+1``-th attempt's delay"):
+
+    - ``"rate_limit"``: retry at indices 0, 1, 2; raise at 3 (matches
+      :data:`RATE_LIMIT_MAX_RETRIES` = 3 — up to 3 retries ≡ 4
+      total attempts).
+    - ``"auth"``: always raise (no retry at any index).
+    - ``"api"``: retry at index 0; raise at 1 (one retry, matches
+      :data:`SERVER_MAX_RETRIES` = 1 — used for 5xx SDK errors and
+      the analogous CLI ``api`` category).
+    - ``"connection"``: retry at index 0; raise at 1 (matches
+      :data:`CONN_MAX_RETRIES` = 1 — SDK ``APIConnectionError``).
+    - ``"transport"``: retry at index 0; raise at 1 (CLI-only;
+      covers subprocess binary-missing, timeout, malformed output).
+    - Any other category: always raise (defensive default — an
+      unknown category is not something we should retry blindly).
+    """
+    if category == "rate_limit":
+        return "retry" if retry_index < RATE_LIMIT_MAX_RETRIES else "raise"
+    if category == "auth":
+        return "raise"
+    if category == "api":
+        return "retry" if retry_index < SERVER_MAX_RETRIES else "raise"
+    if category == "connection":
+        return "retry" if retry_index < CONN_MAX_RETRIES else "raise"
+    if category == "transport":
+        return "retry" if retry_index < CONN_MAX_RETRIES else "raise"
+    return "raise"

--- a/src/clauditor/cli/compare.py
+++ b/src/clauditor/cli/compare.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 from clauditor._providers import (
     AnthropicAuthMissingError,
-    check_any_auth_available,
+    OpenAIAuthMissingError,
+    check_provider_auth,
 )
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.paths import resolve_clauditor_dir
@@ -224,15 +225,26 @@ def _run_blind_compare(
 
     # Pre-flight auth guard (QG pass 2 of #83 — plans/super/
     # 83-subscription-auth-gap.md; relaxed per #86 DEC-008 —
-    # plans/super/86-claude-cli-transport.md). ``compare --blind`` routes
-    # through ``blind_compare_from_spec`` → ``call_anthropic``, so
-    # subscription-only users need the same actionable exit-2 message the
-    # other five LLM-mediated commands already produce. Lands after spec
-    # validation (which has its own exit-2 surface) and before file I/O
-    # / SDK call.
+    # plans/super/86-claude-cli-transport.md; provider-aware per #145
+    # QG pass 1). ``compare --blind`` routes through
+    # ``blind_compare_from_spec`` → ``call_model`` (#144 US-005,
+    # provider-routed by US-010), so the auth guard must dispatch on
+    # ``eval_spec.grading_provider`` rather than always asking for
+    # Anthropic auth. Lands after spec validation (which has its own
+    # exit-2 surface) and before file I/O / SDK call. Distinct
+    # ``except`` branches per ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    provider = (
+        skill_spec.eval_spec.grading_provider
+        if skill_spec.eval_spec is not None
+        and skill_spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
     try:
-        check_any_auth_available("compare --blind")
+        check_provider_auth(provider, "compare --blind")
     except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/src/clauditor/cli/extract.py
+++ b/src/clauditor/cli/extract.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from clauditor import history
 from clauditor._providers import (
     AnthropicAuthMissingError,
-    check_any_auth_available,
+    OpenAIAuthMissingError,
+    check_provider_auth,
 )
 
 
@@ -94,13 +95,26 @@ def cmd_extract(args: argparse.Namespace) -> int:
         print(f"Prompt:\n{prompt}")
         return 0
 
-    # #83 DEC-002/DEC-011 + #86 DEC-008: fail fast only when neither
-    # ANTHROPIC_API_KEY nor the claude CLI binary is available. Guard
-    # lands AFTER --dry-run (dry-run is a cost-free preview — no API
-    # call, no key needed) and BEFORE extract_and_grade.
+    # #83 DEC-002/DEC-011 + #86 DEC-008 + #145 US-009: fail fast when
+    # the provider's required auth is missing. Provider is resolved
+    # from ``eval_spec.grading_provider`` (defaults to ``"anthropic"``)
+    # so OpenAI-graded skills get an OpenAI-key-required guard.
+    # Guard lands AFTER --dry-run (dry-run is a cost-free preview — no
+    # API call, no key needed) and BEFORE extract_and_grade. Distinct
+    # ``except`` branches per
+    # ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    provider = (
+        spec.eval_spec.grading_provider
+        if spec.eval_spec is not None
+        and spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
     try:
-        check_any_auth_available("extract")
+        check_provider_auth(provider, "extract")
     except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -13,8 +13,9 @@ from clauditor import history
 from clauditor._harnesses._claude_code import env_without_api_key
 from clauditor._providers import (
     AnthropicAuthMissingError,
+    OpenAIAuthMissingError,
     announce_implicit_no_api_key,
-    check_any_auth_available,
+    check_provider_auth,
 )
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.benchmark import Benchmark, compute_benchmark
@@ -317,15 +318,27 @@ def cmd_grade(args: argparse.Namespace) -> int:
         print(f"Prompt:\n{prompt}")
         return 0
 
-    # #83 DEC-002/DEC-011 + #86 DEC-008: fail fast only when neither
-    # ANTHROPIC_API_KEY nor the claude CLI binary is available. Guard
-    # lands AFTER --dry-run (dry-run is a cost-free preview — no API
-    # call, no key needed) and BEFORE allocate_iteration so we do not
-    # leave an abandoned iteration-N-tmp/ staging dir behind when the
-    # guard fires.
+    # #83 DEC-002/DEC-011 + #86 DEC-008 + #145 US-009: fail fast when
+    # the provider's required auth is missing. Provider is resolved
+    # from ``eval_spec.grading_provider`` (defaults to ``"anthropic"``)
+    # so OpenAI-graded skills get an OpenAI-key-required guard.
+    # Guard lands AFTER --dry-run (dry-run is a cost-free preview — no
+    # API call, no key needed) and BEFORE allocate_iteration so we do
+    # not leave an abandoned iteration-N-tmp/ staging dir behind when
+    # the guard fires. Distinct ``except`` branches per
+    # ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    provider = (
+        spec.eval_spec.grading_provider
+        if spec.eval_spec is not None
+        and spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
     try:
-        check_any_auth_available("grade")
+        check_provider_auth(provider, "grade")
     except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/src/clauditor/cli/propose_eval.py
+++ b/src/clauditor/cli/propose_eval.py
@@ -31,7 +31,8 @@ from pathlib import Path
 
 from clauditor._providers import (
     AnthropicAuthMissingError,
-    check_any_auth_available,
+    OpenAIAuthMissingError,
+    check_provider_auth,
 )
 from clauditor.capture_provenance import (
     read_capture_provenance,
@@ -371,13 +372,25 @@ async def _cmd_propose_eval_impl(args: argparse.Namespace) -> int:
         print(prompt, end="" if prompt.endswith("\n") else "\n")
         return 0
 
-    # #83 DEC-002/DEC-011 + #86 DEC-008: fail fast only when neither
-    # ANTHROPIC_API_KEY nor the claude CLI binary is available. Guard
+    # #83 DEC-002/DEC-011 + #86 DEC-008 + #145 US-009: fail fast when
+    # the proposer-provider's required auth is missing. ``propose-eval``
+    # is the eval-creation step itself, so there is no ``eval_spec`` to
+    # read ``grading_provider`` from — the proposer call is hardcoded
+    # to ``provider="anthropic"`` (see ``propose_eval.py``). The
+    # dispatcher is still routed through ``check_provider_auth`` for
+    # uniformity with the other 3 LLM-mediated CLI commands; the
+    # ``OpenAIAuthMissingError`` ``except`` branch is a forward-compat
+    # placeholder for a future ``--proposer-provider`` flag. Guard
     # lands AFTER --dry-run (dry-run is a cost-free preview — no API
     # call, no key needed) and BEFORE the propose_eval orchestrator.
+    # Distinct ``except`` branches per
+    # ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
     try:
-        check_any_auth_available("propose-eval")
+        check_provider_auth("anthropic", "propose-eval")
     except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/src/clauditor/cli/triggers.py
+++ b/src/clauditor/cli/triggers.py
@@ -8,7 +8,8 @@ import sys
 
 from clauditor._providers import (
     AnthropicAuthMissingError,
-    check_any_auth_available,
+    OpenAIAuthMissingError,
+    check_provider_auth,
 )
 
 
@@ -102,13 +103,26 @@ def cmd_triggers(args: argparse.Namespace) -> int:
             print(prompt)
         return 0
 
-    # #83 DEC-002/DEC-011 + #86 DEC-008: fail fast only when neither
-    # ANTHROPIC_API_KEY nor the claude CLI binary is available. Guard
-    # lands AFTER --dry-run (dry-run is a cost-free preview — no API
-    # call, no key needed) and BEFORE test_triggers.
+    # #83 DEC-002/DEC-011 + #86 DEC-008 + #145 US-009: fail fast when
+    # the provider's required auth is missing. Provider is resolved
+    # from ``eval_spec.grading_provider`` (defaults to ``"anthropic"``)
+    # so OpenAI-graded skills get an OpenAI-key-required guard.
+    # Guard lands AFTER --dry-run (dry-run is a cost-free preview — no
+    # API call, no key needed) and BEFORE test_triggers. Distinct
+    # ``except`` branches per
+    # ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    provider = (
+        spec.eval_spec.grading_provider
+        if spec.eval_spec is not None
+        and spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
     try:
-        check_any_auth_available("triggers")
+        check_provider_auth(provider, "triggers")
     except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -812,15 +812,20 @@ async def _extract_call_with_retry(
     from clauditor._providers import call_model
     from clauditor.quality_grader import _emit_parse_retry_notice
 
+    # #145 US-010: Resolve provider from the spec; default to
+    # ``"anthropic"`` for back-compat. Pulled out of the retry loop so
+    # every attempt routes to the same backend.
+    provider = eval_spec.grading_provider or "anthropic"
+
     total_input = 0
     total_output = 0
     last_text = ""
     last_source = "api"
-    last_provider = "anthropic"
+    last_provider = provider
     for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
         api_result = await call_model(
             prompt,
-            provider="anthropic",
+            provider=provider,
             model=model,
             transport=transport,
             max_tokens=4096,

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -798,14 +798,17 @@ async def _extract_call_with_retry(
     transport: str,
     ctx: str,
 ) -> tuple[str, str, str, int, int]:
-    """Issue the extraction Anthropic call with parse retry.
+    """Issue the extraction model call with parse retry.
 
     Returns ``(response_text, source, provider, input_tokens, output_tokens)``
     — the final attempt's response text, the transport source, the
     provider that produced the response, and cumulative token counts
-    across attempts. One retry on ``kind == "json"`` (true decode
-    failures + empty-after-fence-strip) per clauditor-6cf / #94; no
-    retry on ``kind == "shape"`` (valid JSON, wrong top-level type) or
+    across attempts. Routes through ``call_model`` per the
+    spec-resolved provider (``eval_spec.grading_provider``), so the
+    retry semantics apply to whichever backend handles the call.
+    One retry on ``kind == "json"`` (true decode failures +
+    empty-after-fence-strip) per clauditor-6cf / #94; no retry on
+    ``kind == "shape"`` (valid JSON, wrong top-level type) or
     ``kind == "flat_list"`` (section tiering missing) — both indicate
     a model-protocol bug rather than a transient hiccup.
     """
@@ -869,7 +872,7 @@ async def extract_and_grade(
     """Layer 2: Extract structured data with Haiku, then validate against schema.
 
     Thin async wrapper: builds a prompt, issues up to
-    :data:`_GRADER_PARSE_RETRY_LIMIT` Anthropic calls (one retry on
+    :data:`_GRADER_PARSE_RETRY_LIMIT` provider-routed model calls (one retry on
     malformed-JSON response — see clauditor-6cf / #94), parses the
     response, and returns an :class:`AssertionSet`. All verdict logic
     lives in the pure helpers :func:`build_extraction_prompt`,
@@ -910,7 +913,7 @@ async def extract_and_report(
     """Layer 2 wrapper that returns a field-id-keyed :class:`ExtractionReport`.
 
     Thin async wrapper: builds a prompt, issues up to
-    :data:`_GRADER_PARSE_RETRY_LIMIT` Anthropic calls (one retry on
+    :data:`_GRADER_PARSE_RETRY_LIMIT` provider-routed model calls (one retry on
     malformed-JSON response — see clauditor-6cf / #94), parses the
     response, and aggregates an :class:`ExtractionReport`. All verdict
     logic lives in the pure helpers :func:`build_extraction_prompt`,

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -810,12 +810,16 @@ async def _extract_call_with_retry(
     a model-protocol bug rather than a transient hiccup.
     """
     from clauditor._providers import call_model
-    from clauditor.quality_grader import _emit_parse_retry_notice
+    from clauditor.quality_grader import (
+        _emit_parse_retry_notice,
+        _validate_provider_model,
+    )
 
     # #145 US-010: Resolve provider from the spec; default to
     # ``"anthropic"`` for back-compat. Pulled out of the retry loop so
     # every attempt routes to the same backend.
     provider = eval_spec.grading_provider or "anthropic"
+    _validate_provider_model(provider, model, ctx)
 
     total_input = 0
     total_output = 0

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -1175,7 +1175,7 @@ async def grade_quality(
     """Layer 3: Grade skill output against rubric criteria using an LLM.
 
     Thin async wrapper: builds a prompt, issues up to
-    :data:`_GRADER_PARSE_RETRY_LIMIT` Anthropic calls (one retry on
+    :data:`_GRADER_PARSE_RETRY_LIMIT` provider-routed model calls (one retry on
     malformed-JSON response — see clauditor-6cf / #94), parses the
     response, and returns a :class:`GradingReport`. Token counts and
     duration accumulate across attempts. Retry is NOT triggered on

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -30,6 +30,39 @@ if TYPE_CHECKING:
 # an OpenAI model when ``grading_provider="openai"``.
 DEFAULT_GRADING_MODEL = "claude-sonnet-4-6"
 
+
+def _validate_provider_model(provider: str, model: str, ctx: str) -> None:
+    """Fail fast when ``provider="openai"`` is paired with a Claude model.
+
+    PR #160 review (CodeRabbit): the runtime previously allowed the
+    Anthropic-default ``DEFAULT_GRADING_MODEL`` to flow into the OpenAI
+    backend when an eval spec set ``grading_provider="openai"`` without
+    overriding ``grading_model``. The OpenAI SDK then rejected the
+    request with a 4xx model-not-found, surfacing as a generic API
+    error several layers downstream — opaque, hard to map back to the
+    spec author's missing-field bug.
+
+    This guard runs at every orchestrator entry point that accepts a
+    ``provider`` parameter and raises ``ValueError`` so the caller's
+    pre-call validation surface (CLI exit 2 per
+    ``.claude/rules/llm-cli-exit-code-taxonomy.md``) catches it before
+    spending an API call. The model-name check uses the ``"claude-"``
+    prefix because that namespace is Anthropic-exclusive on every
+    public release; an OpenAI model that happened to start with
+    ``"claude-"`` would be a future-incompatible naming collision and
+    is outside the scope of this guard.
+
+    Removable once #146 ships per-provider default-model precedence.
+    """
+    if provider == "openai" and model.startswith("claude-"):
+        raise ValueError(
+            f"{ctx}: provider='openai' requires an OpenAI model name; "
+            f"got Anthropic-default model {model!r}. Set "
+            "EvalSpec.grading_model explicitly (e.g. 'gpt-5.4') when "
+            "using grading_provider='openai'. Tracked in #146."
+        )
+
+
 # Indirection so tests can patch blind_compare timing without affecting
 # the asyncio event loop's own time.monotonic() calls.
 _monotonic = time.monotonic
@@ -688,6 +721,7 @@ async def blind_compare(
     import asyncio as _asyncio
 
     _validate_blind_inputs(user_prompt, output_a, output_b)
+    _validate_provider_model(provider, model, "blind_compare")
     m1, m2 = _pick_blind_mappings(rng)
     args = (user_prompt, output_a, output_b, rubric_hint)
     p1 = _build_blind_prompt_for_mapping(m1, *args)
@@ -1161,6 +1195,7 @@ async def grade_quality(
     # ``"anthropic"`` for back-compat. Pulled out of the retry loop so
     # every attempt routes to the same backend.
     provider = eval_spec.grading_provider or "anthropic"
+    _validate_provider_model(provider, model, "grade_quality")
 
     start = _monotonic()
     total_input_tokens = 0

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -594,6 +594,7 @@ async def _call_blind_side_with_retry(
     model: str,
     transport: str,
     side_label: str,
+    provider: str = "anthropic",
 ) -> tuple[dict | None, str, str, str, int, int]:
     """Run one side of a blind-compare judge with parse retry.
 
@@ -611,12 +612,12 @@ async def _call_blind_side_with_retry(
     total_output = 0
     last_text = ""
     last_source = "api"
-    last_provider = "anthropic"
+    last_provider = provider
     parsed: dict | None = None
     for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
         r = await call_model(
             prompt,
-            provider="anthropic",
+            provider=provider,
             model=model,
             transport=transport,
             max_tokens=2048,
@@ -660,6 +661,7 @@ async def blind_compare(
     model: str = DEFAULT_GRADING_MODEL,
     rng: random.Random | None = None,
     transport: str = "auto",
+    provider: str = "anthropic",
 ) -> BlindReport:
     """Blind A/B judge: call Anthropic twice with swapped positions.
 
@@ -684,12 +686,19 @@ async def blind_compare(
     p1 = _build_blind_prompt_for_mapping(m1, *args)
     p2 = _build_blind_prompt_for_mapping(m2, *args)
     start = _monotonic()
+    # #145 US-010: ``provider`` is resolved by the caller
+    # (``blind_compare_from_spec`` reads it from
+    # ``spec.eval_spec.grading_provider``) and threaded to BOTH
+    # parallel calls. Resolved once here so the two gather'd calls
+    # always agree — never read the spec twice.
     side1, side2 = await _asyncio.gather(
         _call_blind_side_with_retry(
-            p1, model=model, transport=transport, side_label="side1"
+            p1, model=model, transport=transport, side_label="side1",
+            provider=provider,
         ),
         _call_blind_side_with_retry(
-            p2, model=model, transport=transport, side_label="side2"
+            p2, model=model, transport=transport, side_label="side2",
+            provider=provider,
         ),
     )
     duration = _monotonic() - start
@@ -787,6 +796,11 @@ async def blind_compare_from_spec(
 
     effective_model = model if model is not None else spec.eval_spec.grading_model
 
+    # #145 US-010: Resolve provider from the spec; default to
+    # ``"anthropic"`` for back-compat. Single resolution shared
+    # between both parallel judges inside ``blind_compare``.
+    provider = spec.eval_spec.grading_provider or "anthropic"
+
     return await blind_compare(
         user_prompt,
         output_a,
@@ -795,6 +809,7 @@ async def blind_compare_from_spec(
         model=effective_model,
         rng=rng,
         transport=transport,
+        provider=provider,
     )
 
 
@@ -1135,16 +1150,21 @@ async def grade_quality(
 
     prompt = build_grading_prompt(eval_spec, output)
 
+    # #145 US-010: Resolve provider from the spec; default to
+    # ``"anthropic"`` for back-compat. Pulled out of the retry loop so
+    # every attempt routes to the same backend.
+    provider = eval_spec.grading_provider or "anthropic"
+
     start = _monotonic()
     total_input_tokens = 0
     total_output_tokens = 0
     last_response_text = ""
     last_source = "api"
-    last_provider = "anthropic"
+    last_provider = provider
     for attempt in range(_GRADER_PARSE_RETRY_LIMIT):
         api_result = await call_model(
             prompt,
-            provider="anthropic",
+            provider=provider,
             model=model,
             transport=transport,
             max_tokens=4096,

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
     from clauditor.spec import SkillSpec
 
 
+# TODO(#146): ``DEFAULT_GRADING_MODEL`` is Anthropic-specific. Callers
+# passing ``grading_provider="openai"`` (per #145 US-010) MUST also set
+# ``grading_model`` explicitly on the eval spec — handing this Anthropic
+# default to the OpenAI backend produces a 4xx model-not-found from the
+# OpenAI SDK. #146 owns the per-provider default-model precedence
+# resolver; until it lands, the spec author is responsible for naming
+# an OpenAI model when ``grading_provider="openai"``.
 DEFAULT_GRADING_MODEL = "claude-sonnet-4-6"
 
 # Indirection so tests can patch blind_compare timing without affecting

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -874,6 +874,12 @@ class EvalSpec:
             # Tier 1.5 of GitHub #103: emit only on non-default.
             # Omission at load time means default ``False``.
             result["sync_tasks"] = True
+        if self.grading_provider is not None:
+            # DEC-003 of #145: emit only on non-default. Omission at
+            # load time means ``None``, which the four grader call
+            # sites read as ``"anthropic"``. QG pass 3 (#145) caught
+            # the round-trip data-loss when this writer was missed.
+            result["grading_provider"] = self.grading_provider
         if self.output_file is not None:
             result["output_file"] = self.output_file
         if self.output_files:

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -297,6 +297,16 @@ class EvalSpec:
     # guarded at load time per
     # ``.claude/rules/constant-with-type-info.md``.
     sync_tasks: bool = False
+    # DEC-003 of #145: optional per-spec grading provider selector.
+    # ``None`` (default) preserves the pre-#145 behavior: grader call
+    # sites read ``eval_spec.grading_provider or "anthropic"`` and pass
+    # that to ``call_model(provider=...)``. When set, must be one of
+    # ``"anthropic"`` or ``"openai"``. Validated at load time against
+    # the literal set; non-string / bool values rejected per
+    # ``.claude/rules/constant-with-type-info.md``. The CLI flag
+    # ``--grading-provider`` and ``CLAUDITOR_GRADING_PROVIDER`` env-var
+    # land in #146 (full four-layer precedence resolver).
+    grading_provider: str | None = None
 
     @classmethod
     def from_file(cls, path: str | Path) -> EvalSpec:
@@ -729,6 +739,31 @@ class EvalSpec:
                 )
             sync_tasks = raw_sync_tasks
 
+        # DEC-003 of #145: optional per-spec grading provider selector.
+        # Missing or explicit ``null`` → ``None`` (default; grader call
+        # sites fall back to ``"anthropic"``). When set, must be a
+        # non-bool string in the literal set ``{"anthropic", "openai"}``.
+        # Bool guard first per ``.claude/rules/constant-with-type-info.md``.
+        grading_provider: str | None = None
+        if "grading_provider" in data:
+            raw_grading_provider = data["grading_provider"]
+            if raw_grading_provider is None:
+                grading_provider = None
+            elif (
+                isinstance(raw_grading_provider, bool)
+                or not isinstance(raw_grading_provider, str)
+                or raw_grading_provider not in ("anthropic", "openai")
+            ):
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    "'grading_provider' must be one of 'anthropic', "
+                    f"'openai' (or null), got "
+                    f"{type(raw_grading_provider).__name__} "
+                    f"{raw_grading_provider!r}"
+                )
+            else:
+                grading_provider = raw_grading_provider
+
         trigger_tests = None
         if "trigger_tests" in data:
             tt = data["trigger_tests"]
@@ -772,6 +807,7 @@ class EvalSpec:
             timeout=timeout,
             transport=transport,
             sync_tasks=sync_tasks,
+            grading_provider=grading_provider,
         )
 
     def to_dict(self) -> dict:

--- a/src/clauditor/suggest.py
+++ b/src/clauditor/suggest.py
@@ -974,7 +974,16 @@ async def propose_edits(
             api_error=api_error,
         )
 
-    if AsyncAnthropic is None:  # pragma: no cover - import-guard branch
+    # PR #160 review (CodeRabbit): the SDK-installed guard must be
+    # gated on ``provider == "anthropic"`` so an openai-routed call
+    # is not blocked by a missing Anthropic SDK. The dispatcher's
+    # openai branch raises ``ImportError`` itself if the openai SDK
+    # is missing, which we surface via the broad-Exception handler
+    # below with a provider-aware error message.
+    if (
+        provider == "anthropic"
+        and AsyncAnthropic is None
+    ):  # pragma: no cover - import-guard branch
         return _empty_report(
             api_error=(
                 "anthropic SDK not installed — "
@@ -1009,7 +1018,10 @@ async def propose_edits(
             max_tokens=max_tokens,
         )
     except Exception as exc:  # noqa: BLE001 — never raise out of propose_edits
-        return _empty_report(api_error=f"anthropic API error: {exc!r}")
+        # PR #160 review: include the resolved provider in the error
+        # message so an openai-routed run is not mislabeled as an
+        # Anthropic-side failure.
+        return _empty_report(api_error=f"{provider} API error: {exc!r}")
 
     input_tokens = result.input_tokens
     output_tokens = result.output_tokens

--- a/src/clauditor/suggest.py
+++ b/src/clauditor/suggest.py
@@ -934,6 +934,7 @@ async def propose_edits(
     model: str = DEFAULT_SUGGEST_MODEL,
     max_tokens: int = 4096,
     transport: str = "auto",
+    provider: str = "anthropic",
 ) -> SuggestReport:
     """Call Sonnet, parse the response, validate anchors, return a report.
 
@@ -996,9 +997,13 @@ async def propose_edits(
     from clauditor._providers import call_model
 
     try:
+        # #145 US-010: ``provider`` is plumbed by the caller so an
+        # eval spec with ``grading_provider="openai"`` routes through
+        # the OpenAI backend; default ``"anthropic"`` preserves
+        # back-compat for callers that don't set it.
         result = await call_model(
             prompt,
-            provider="anthropic",
+            provider=provider,
             model=model,
             transport=transport,
             max_tokens=max_tokens,

--- a/src/clauditor/triggers.py
+++ b/src/clauditor/triggers.py
@@ -280,6 +280,12 @@ async def test_triggers(
     # ``"anthropic"`` for back-compat. Threaded into every per-query
     # ``classify_query`` call.
     provider = eval_spec.grading_provider or "anthropic"
+    # PR #160 review: fail fast when openai is paired with the
+    # Anthropic-default model so the spec author sees a crisp
+    # actionable error rather than a downstream 4xx model-not-found.
+    from clauditor.quality_grader import _validate_provider_model
+
+    _validate_provider_model(provider, model, "test_triggers")
 
     tasks = [
         classify_query(

--- a/src/clauditor/triggers.py
+++ b/src/clauditor/triggers.py
@@ -187,7 +187,11 @@ async def classify_query(
     inside the dispatcher's anthropic backend — this function just
     awaits the result and projects it onto :class:`TriggerResult`.
     """
-    from clauditor._providers import AnthropicHelperError, call_model
+    from clauditor._providers import (
+        AnthropicHelperError,
+        OpenAIHelperError,
+        call_model,
+    )
 
     prompt = build_trigger_prompt(skill_name, description, query)
 
@@ -199,7 +203,7 @@ async def classify_query(
             transport=transport,
             max_tokens=1024,
         )
-    except AnthropicHelperError as exc:
+    except (AnthropicHelperError, OpenAIHelperError) as exc:
         # Graceful degradation: a single API failure (auth, 5xx
         # exhaustion, network) must not abort the entire trigger batch
         # in ``test_triggers``. ``passed=False`` always — an API error

--- a/src/clauditor/triggers.py
+++ b/src/clauditor/triggers.py
@@ -176,6 +176,7 @@ async def classify_query(
     expected: bool,
     model: str,
     transport: str = "auto",
+    provider: str = "anthropic",
 ) -> TriggerResult:
     """Classify a single query using the LLM.
 
@@ -193,7 +194,7 @@ async def classify_query(
     try:
         result = await call_model(
             prompt,
-            provider="anthropic",
+            provider=provider,
             model=model,
             transport=transport,
             max_tokens=1024,
@@ -271,6 +272,11 @@ async def test_triggers(
     for q in eval_spec.trigger_tests.should_not_trigger:
         queries.append((q, False))
 
+    # #145 US-010: Resolve provider from the spec; default to
+    # ``"anthropic"`` for back-compat. Threaded into every per-query
+    # ``classify_query`` call.
+    provider = eval_spec.grading_provider or "anthropic"
+
     tasks = [
         classify_query(
             skill_name=eval_spec.skill_name,
@@ -279,6 +285,7 @@ async def test_triggers(
             expected=expected,
             model=model,
             transport=transport,
+            provider=provider,
         )
         for q, expected in queries
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2695,6 +2695,101 @@ class TestCmdCompareBlind:
         assert "file-pair form" in err
 
 
+class TestCmdCompareBlindProviderAuth:
+    """#145 QG pass 1 (Bug 3): ``compare --blind`` resolves provider and
+    dispatches the per-provider auth guard.
+
+    Pre-fix: ``_run_blind_compare`` called the Anthropic-only
+    ``check_any_auth_available("compare --blind")`` regardless of
+    ``eval_spec.grading_provider``. A spec declaring
+    ``grading_provider="openai"`` would surface a misleading
+    ANTHROPIC_API_KEY-required error when only OPENAI_API_KEY was set.
+    """
+
+    def test_compare_blind_with_openai_grading_provider_passes_when_key_set(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec with ``grading_provider="openai"`` and ``OPENAI_API_KEY`` set
+        → proceeds through the auth guard. Mocks the blind judge so the
+        test does not actually call OpenAI.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        before, after = _write_pair(tmp_path)
+        eval_spec = _make_eval_spec(
+            user_prompt="Write a hello world",
+            grading_provider="openai",
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        report = _make_blind_report()
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.blind_compare",
+                new=AsyncMock(return_value=report),
+            ),
+        ):
+            rc = main(_blind_argv(before, after))
+        assert rc == 0
+
+    def test_compare_blind_with_openai_grading_provider_exits_2_when_key_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Spec with ``grading_provider="openai"`` and missing
+        ``OPENAI_API_KEY`` → exit 2 with stderr mentioning the env var
+        (not ANTHROPIC_API_KEY).
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # Even if Anthropic key is present, OpenAI provider must require
+        # OPENAI_API_KEY — the spec's grading_provider is the source of
+        # truth.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-irrelevant")
+        before, after = _write_pair(tmp_path)
+        eval_spec = _make_eval_spec(
+            user_prompt="Write a hello world",
+            grading_provider="openai",
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        report = _make_blind_report()
+        # The blind_compare mock should never be reached.
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.blind_compare",
+                new_callable=AsyncMock,
+                return_value=report,
+            ) as mock_blind,
+        ):
+            rc = main(_blind_argv(before, after))
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        assert mock_blind.await_count == 0
+
+    def test_compare_blind_with_default_anthropic_provider_unchanged(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression check: spec with ``grading_provider=None`` (default)
+        still routes through the Anthropic auth guard.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        before, after = _write_pair(tmp_path)
+        eval_spec = _make_eval_spec(user_prompt="Write a hello world")
+        assert eval_spec.grading_provider is None
+        spec = _make_spec(eval_spec=eval_spec)
+        report = _make_blind_report()
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.blind_compare",
+                new=AsyncMock(return_value=report),
+            ),
+        ):
+            rc = main(_blind_argv(before, after))
+        assert rc == 0
+
+
 class TestCmdGradeCompareFlagRemoved:
     """US-003: the legacy --compare flag on grade is gone."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6823,3 +6823,349 @@ class TestResolveGraderTransport:
         captured = capsys.readouterr()
         assert "ERROR:" in captured.err
         assert "sdk" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# #145 US-009: ``check_provider_auth`` wiring on the 4 LLM-mediated CLI
+# commands. Each command (``grade``, ``extract``, ``triggers``) must:
+#   - resolve ``provider = eval_spec.grading_provider or "anthropic"``;
+#   - dispatch via ``check_provider_auth`` (catches both
+#     ``AnthropicAuthMissingError`` and ``OpenAIAuthMissingError``);
+#   - exit 2 with ``OPENAI_API_KEY`` mentioned in stderr when the spec
+#     declares ``grading_provider="openai"`` but no key is set.
+#   - keep working unchanged when ``grading_provider`` is ``None``
+#     (default Anthropic path).
+#
+# The ``propose-eval`` command is covered separately in
+# ``tests/test_cli_propose_eval.py`` — it has no ``eval_spec`` to
+# read ``grading_provider`` from (it's the eval-creation step) and is
+# hardcoded to ``provider="anthropic"`` for the proposer call.
+#
+# Traces to DEC-003, DEC-006 of ``plans/super/145-openai-provider.md``
+# and ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+# ---------------------------------------------------------------------------
+
+
+class TestCmdGradeProviderAuth:
+    """#145 US-009: ``cmd_grade`` resolves provider and dispatches auth."""
+
+    def _make_extraction_set(self):
+        return AssertionSet(
+            results=[
+                AssertionResult(
+                    name="contains hello",
+                    passed=True,
+                    message="ok",
+                    kind="contains",
+                ),
+            ]
+        )
+
+    def test_grade_with_openai_grading_provider_passes_when_key_set(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec with ``grading_provider="openai"`` and ``OPENAI_API_KEY`` set
+        → proceeds through the auth guard. Mocks the grader so the
+        test does not actually call OpenAI.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hello world")
+
+        eval_spec = _make_eval_spec(grading_provider="openai")
+        spec = _make_spec(eval_spec=eval_spec)
+        report = make_grading_report(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+    def test_grade_with_openai_grading_provider_exits_2_when_key_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Spec with ``grading_provider="openai"`` and missing
+        ``OPENAI_API_KEY`` → exit 2 with stderr mentioning the env var.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hello world")
+
+        eval_spec = _make_eval_spec(grading_provider="openai")
+        spec = _make_spec(eval_spec=eval_spec)
+        report = make_grading_report(passed=True)
+
+        # The grader mock should never be reached; the auth guard fires
+        # before allocate_iteration / grade_quality is awaited.
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ) as mock_grade,
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        assert mock_grade.await_count == 0
+
+    def test_grade_with_default_anthropic_provider_unchanged(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression check: spec with ``grading_provider=None`` (default)
+        still routes through the Anthropic guard and proceeds when an
+        ``ANTHROPIC_API_KEY`` is set.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("hello world")
+
+        eval_spec = _make_eval_spec()
+        # Default: no grading_provider override.
+        assert eval_spec.grading_provider is None
+        spec = _make_spec(eval_spec=eval_spec)
+        report = make_grading_report(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+
+class TestCmdExtractProviderAuth:
+    """#145 US-009: ``cmd_extract`` resolves provider and dispatches auth."""
+
+    def _make_extraction_set(self):
+        return AssertionSet(
+            results=[
+                AssertionResult(
+                    name="section:Results:count",
+                    passed=True,
+                    message="ok",
+                    kind="count",
+                ),
+            ]
+        )
+
+    def test_extract_with_openai_grading_provider_passes_when_key_set(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec with ``grading_provider="openai"`` and ``OPENAI_API_KEY`` set
+        → proceeds through the auth guard.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output with results")
+
+        eval_spec = _make_eval_spec(
+            sections=_make_sections(), grading_provider="openai"
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_set()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+    def test_extract_with_openai_grading_provider_exits_2_when_key_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Spec with ``grading_provider="openai"`` and missing
+        ``OPENAI_API_KEY`` → exit 2 with stderr mentioning the env var.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output with results")
+
+        eval_spec = _make_eval_spec(
+            sections=_make_sections(), grading_provider="openai"
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_set()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ) as mock_extract,
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        assert mock_extract.await_count == 0
+
+    def test_extract_with_default_anthropic_provider_unchanged(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression check: spec with ``grading_provider=None`` (default)
+        still routes through the Anthropic guard.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output with results")
+
+        eval_spec = _make_eval_spec(sections=_make_sections())
+        assert eval_spec.grading_provider is None
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_set()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+
+
+class TestCmdTriggersProviderAuth:
+    """#145 US-009: ``cmd_triggers`` resolves provider and dispatches auth."""
+
+    def _make_trigger_report(self):
+        return TriggerReport(
+            skill_name="test-skill",
+            skill_description="A test skill",
+            model="claude-sonnet-4-6",
+            results=[
+                TriggerResult(
+                    query="find activities",
+                    expected_trigger=True,
+                    predicted_trigger=True,
+                    passed=True,
+                    confidence=0.95,
+                    reasoning="Matches skill intent",
+                ),
+            ],
+        )
+
+    def test_triggers_with_openai_grading_provider_passes_when_key_set(
+        self, monkeypatch
+    ):
+        """Spec with ``grading_provider="openai"`` and ``OPENAI_API_KEY`` set
+        → proceeds through the auth guard.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        eval_spec = _make_eval_spec(
+            grading_provider="openai",
+            trigger_tests=TriggerTests(
+                should_trigger=["find activities"],
+                should_not_trigger=["weather today"],
+            ),
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_trigger_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.triggers.test_triggers",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["triggers", "skill.md"])
+
+        assert rc == 0
+
+    def test_triggers_with_openai_grading_provider_exits_2_when_key_missing(
+        self, monkeypatch, capsys
+    ):
+        """Spec with ``grading_provider="openai"`` and missing
+        ``OPENAI_API_KEY`` → exit 2 with stderr mentioning the env var.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        eval_spec = _make_eval_spec(
+            grading_provider="openai",
+            trigger_tests=TriggerTests(
+                should_trigger=["find activities"],
+                should_not_trigger=["weather today"],
+            ),
+        )
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_trigger_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.triggers.test_triggers",
+                new_callable=AsyncMock,
+                return_value=report,
+            ) as mock_test_triggers,
+        ):
+            rc = main(["triggers", "skill.md"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        assert mock_test_triggers.await_count == 0
+
+    def test_triggers_with_default_anthropic_provider_unchanged(
+        self, monkeypatch
+    ):
+        """Regression check: spec with ``grading_provider=None`` (default)
+        still routes through the Anthropic guard.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        eval_spec = _make_eval_spec(
+            trigger_tests=TriggerTests(
+                should_trigger=["find activities"],
+                should_not_trigger=["weather today"],
+            ),
+        )
+        assert eval_spec.grading_provider is None
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_trigger_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.triggers.test_triggers",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["triggers", "skill.md"])
+
+        assert rc == 0

--- a/tests/test_cli_grade_implicit_coupling.py
+++ b/tests/test_cli_grade_implicit_coupling.py
@@ -52,7 +52,7 @@ class TestImplicitNoApiKeyCoupling:
         Returns ``(rc, spec_mock, env_override_captured)``. The mocked
         ``spec.run`` always returns a clean :class:`SkillResult`; the mocked
         ``grade_quality`` returns a passing :class:`GradingReport`. The
-        pre-flight auth guard (:func:`check_any_auth_available`) is stubbed
+        pre-flight auth guard (:func:`check_provider_auth`) is stubbed
         so tests do not depend on the real ``claude`` binary being on PATH
         when only ``ANTHROPIC_AUTH_TOKEN`` (or neither) is set.
         """
@@ -68,7 +68,7 @@ class TestImplicitNoApiKeyCoupling:
         with (
             patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
             patch(
-                "clauditor.cli.grade.check_any_auth_available",
+                "clauditor.cli.grade.check_provider_auth",
                 return_value=None,
             ),
             patch(

--- a/tests/test_cli_propose_eval.py
+++ b/tests/test_cli_propose_eval.py
@@ -1033,3 +1033,112 @@ def test_propose_eval_help_is_registered(capsys):
     assert "--dry-run" in out
     assert "--model" in out
     assert "--json" in out
+
+
+# ---------------------------------------------------------------------------
+# #145 US-009: ``check_provider_auth`` wiring for ``propose-eval``.
+#
+# ``propose-eval`` is the eval-creation step itself, so there is no
+# ``eval_spec`` to read ``grading_provider`` from — the proposer call is
+# hardcoded to ``provider="anthropic"`` in ``propose_eval.py``. The CLI
+# wrapper still routes through ``check_provider_auth`` (with the
+# literal ``"anthropic"`` provider) and catches both
+# ``AnthropicAuthMissingError`` AND ``OpenAIAuthMissingError`` so the
+# structural ``except`` ladder mirrors the other 3 LLM-mediated CLI
+# commands per ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+#
+# The 3 tests below mirror the per-command shape (one positive, one
+# OpenAI-key-missing negative, one default-Anthropic regression). The
+# OpenAI-key-missing case is exercised by patching
+# ``check_provider_auth`` to raise ``OpenAIAuthMissingError`` — a
+# forward-compat exercise of the ``except`` branch the source ships
+# today (today's anthropic-only proposer cannot emit it natively).
+# ---------------------------------------------------------------------------
+
+
+class TestCmdProposeEvalProviderAuth:
+    """#145 US-009: ``cmd_propose_eval`` dispatches via ``check_provider_auth``."""
+
+    def test_propose_eval_with_openai_grading_provider_passes_when_key_set(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """``OPENAI_API_KEY`` set alongside the autouse-fixture's
+        ``ANTHROPIC_API_KEY`` does not change the happy path:
+        ``propose-eval`` is hardcoded to ``provider="anthropic"`` for the
+        proposer call, so the Anthropic guard passes and the command
+        proceeds to write the eval.json.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.propose_eval.propose_eval",
+            new=AsyncMock(return_value=_make_report()),
+        ):
+            rc = main(["propose-eval", str(skill_md)])
+
+        assert rc == 0
+        target = skill_md.with_suffix(".eval.json")
+        assert target.exists()
+
+    def test_propose_eval_with_openai_grading_provider_exits_2_when_key_missing(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """Forward-compat exercise of the ``except OpenAIAuthMissingError``
+        branch: patch ``check_provider_auth`` to raise the OpenAI auth
+        error and assert the CLI maps it to exit 2 with stderr
+        mentioning ``OPENAI_API_KEY``. The proposer call must not be
+        awaited.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        proposer_mock = AsyncMock(return_value=_make_report())
+        with (
+            patch(
+                "clauditor.cli.propose_eval.check_provider_auth",
+                side_effect=OpenAIAuthMissingError(
+                    "ERROR: OPENAI_API_KEY is not set.\n"
+                    "clauditor propose-eval needs an OpenAI API key.\n"
+                    "Get one at https://platform.openai.com/."
+                ),
+            ),
+            patch(
+                "clauditor.cli.propose_eval.propose_eval",
+                new=proposer_mock,
+            ),
+        ):
+            rc = main(["propose-eval", str(skill_md)])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        assert proposer_mock.await_count == 0
+        target = skill_md.with_suffix(".eval.json")
+        assert not target.exists()
+
+    def test_propose_eval_with_default_anthropic_provider_unchanged(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Regression check: with only ``ANTHROPIC_API_KEY`` set (the
+        default autouse-fixture value) and no ``OPENAI_API_KEY``,
+        ``propose-eval`` proceeds through the Anthropic guard and writes
+        the eval.json as before.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        skill_md = _write_skill(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "clauditor.cli.propose_eval.propose_eval",
+            new=AsyncMock(return_value=_make_report()),
+        ):
+            rc = main(["propose-eval", str(skill_md)])
+
+        assert rc == 0
+        target = skill_md.with_suffix(".eval.json")
+        assert target.exists()

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -2471,3 +2471,111 @@ class TestExtractionParseErrorDataclass:
         )
         assert err.section == "Venues"
         assert err.raw == {"Venues": []}
+
+
+class TestExtractAndReportWithOpenAI:
+    """#145 US-011 — End-to-end: an :class:`EvalSpec` with
+    ``grading_provider="openai"`` runs L2 extraction through the full
+    pipeline (prompt build -> ``call_model`` -> parse -> report build)
+    and produces a populated :class:`ExtractionReport` with
+    ``provider_source == "openai"`` plus non-empty extracted data.
+
+    Acceptance criterion 2 of issue #145. Builds on the unit-level
+    wiring tests in :class:`TestExtractAndReportGradingProviderOpenAI`
+    by exercising a non-trivial section/tier shape and asserting on the
+    full report surface (extracted data, token counts, parse_errors).
+    """
+
+    def _spec(self) -> EvalSpec:
+        return EvalSpec(
+            skill_name="venues-skill",
+            sections=[
+                SectionRequirement(
+                    name="Venues",
+                    tiers=[
+                        TierRequirement(
+                            label="primary",
+                            min_entries=2,
+                            fields=[
+                                FieldRequirement(
+                                    name="name",
+                                    required=True,
+                                    id="venues-name",
+                                ),
+                                FieldRequirement(
+                                    name="address",
+                                    required=True,
+                                    id="venues-address",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            grading_provider="openai",
+        )
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_openai_e2e(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full L2 path: spec.grading_provider="openai" flows through
+        ``call_model(provider="openai", ...)``, the mocked OpenAI
+        ``ModelResult`` is parsed into the per-section/tier shape, and
+        the returned :class:`ExtractionReport` is fully populated:
+
+        - ``provider_source == "openai"``
+        - per-field results present for every declared field
+        - token counts from the mocked ``ModelResult``
+        - no parse errors
+        """
+        from clauditor._providers import ModelResult
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = self._spec()
+        # JSON shape that matches the non-trivial section/tier:
+        # two entries with both required fields populated.
+        extraction_payload = {
+            "Venues": {
+                "primary": [
+                    {"name": "The Blue Note", "address": "131 W 3rd St"},
+                    {"name": "Smalls Jazz", "address": "183 W 10th St"},
+                ],
+            },
+        }
+        extraction_text = json.dumps(extraction_payload)
+        fake = ModelResult(
+            response_text=extraction_text,
+            text_blocks=[extraction_text],
+            input_tokens=42,
+            output_tokens=17,
+            source="api",
+            provider="openai",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await extract_and_report(
+                "fake skill output text", spec
+            )
+
+        # Provider stamping (acceptance criterion 2 — primary signal).
+        assert report.provider_source == "openai"
+        # ``call_model`` received ``provider="openai"`` — the spec
+        # field flowed through the resolver to the dispatcher.
+        assert call_mock.await_count == 1
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+        # Token counts propagated from the mocked ``ModelResult``.
+        assert report.input_tokens == 42
+        assert report.output_tokens == 17
+        # No parse errors: the JSON above is shape-valid for the spec.
+        assert report.parse_errors == []
+        # Non-empty extracted data: every declared field id has at
+        # least one record (two entries in this fixture).
+        assert {r.field_id for r in report.results} == {
+            "venues-name",
+            "venues-address",
+        }
+        assert len(report.results) == 4  # 2 entries * 2 fields
+        # Every per-field record passes presence (required fields,
+        # non-empty values).
+        assert all(r.presence_passed for r in report.results)

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1914,6 +1914,116 @@ class TestExtractAndReportProviderSource:
         assert report.provider_source == "anthropic"
 
 
+class TestExtractAndReportGradingProviderOpenAI:
+    """#145 US-010: when ``eval_spec.grading_provider == "openai"``,
+    ``extract_and_report`` and ``extract_and_grade`` route through the
+    OpenAI backend and stamp ``ExtractionReport.provider_source ==
+    "openai"``."""
+
+    def _spec(self, *, grading_provider: str | None = None) -> EvalSpec:
+        return EvalSpec(
+            skill_name="s",
+            sections=[
+                SectionRequirement(
+                    name="Items",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(
+                                    name="name",
+                                    required=True,
+                                    id="items-name",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            grading_provider=grading_provider,
+        )
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_stamps_openai_when_grading_provider_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import ModelResult
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = self._spec(grading_provider="openai")
+        extraction_text = json.dumps(
+            {"Items": {"default": [{"name": "foo"}]}}
+        )
+        fake = ModelResult(
+            response_text=extraction_text,
+            text_blocks=[extraction_text],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await extract_and_report("output", spec)
+        assert report.provider_source == "openai"
+        # Verify ``provider="openai"`` flowed through to call_model.
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_extract_and_grade_stamps_openai_when_grading_provider_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import ModelResult
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = self._spec(grading_provider="openai")
+        extraction_text = json.dumps(
+            {"Items": {"default": [{"name": "foo"}]}}
+        )
+        fake = ModelResult(
+            response_text=extraction_text,
+            text_blocks=[extraction_text],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            await extract_and_grade("output", spec)
+        # ``extract_and_grade`` returns an ``AssertionSet`` (no
+        # provider_source field) — verify the resolved provider flowed
+        # through to ``call_model``.
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_defaults_to_anthropic_when_unset(
+        self,
+    ) -> None:
+        """Back-compat regression: a spec with ``grading_provider=None``
+        (the default) still routes through anthropic."""
+        from clauditor._providers import ModelResult
+
+        spec = self._spec()  # grading_provider default = None
+        extraction_text = json.dumps(
+            {"Items": {"default": [{"name": "foo"}]}}
+        )
+        fake = ModelResult(
+            response_text=extraction_text,
+            text_blocks=[extraction_text],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await extract_and_report("output", spec)
+        assert report.provider_source == "anthropic"
+        assert call_mock.await_args.kwargs["provider"] == "anthropic"
+
+
 class TestExtractionReportDeclaredFieldIds:
     """Copilot fix (PR #34): ``ExtractionReport.to_json`` pre-populates
     every declared field id with an empty list, so the on-disk contract

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1965,7 +1965,11 @@ class TestExtractAndReportGradingProviderOpenAI:
         )
         call_mock = AsyncMock(return_value=fake)
         with patch("clauditor._providers.call_model", call_mock):
-            report = await extract_and_report("output", spec)
+            # PR #160 review: openai+claude-default raises ``ValueError``
+            # per the new fail-fast guard; pass an explicit OpenAI model.
+            report = await extract_and_report(
+                "output", spec, model="gpt-5.4-mini"
+            )
         assert report.provider_source == "openai"
         # Verify ``provider="openai"`` flowed through to call_model.
         assert call_mock.await_args.kwargs["provider"] == "openai"
@@ -1991,7 +1995,8 @@ class TestExtractAndReportGradingProviderOpenAI:
         )
         call_mock = AsyncMock(return_value=fake)
         with patch("clauditor._providers.call_model", call_mock):
-            await extract_and_grade("output", spec)
+            # PR #160 review: pass explicit OpenAI model.
+            await extract_and_grade("output", spec, model="gpt-5.4-mini")
         # ``extract_and_grade`` returns an ``AssertionSet`` (no
         # provider_source field) — verify the resolved provider flowed
         # through to ``call_model``.
@@ -2554,8 +2559,10 @@ class TestExtractAndReportWithOpenAI:
         )
         call_mock = AsyncMock(return_value=fake)
         with patch("clauditor._providers.call_model", call_mock):
+            # PR #160 review: openai+claude-default raises ``ValueError``;
+            # pass an explicit OpenAI model name.
             report = await extract_and_report(
-                "fake skill output text", spec
+                "fake skill output text", spec, model="gpt-5.4-mini"
             )
 
         # Provider stamping (acceptance criterion 2 — primary signal).

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -1544,9 +1544,12 @@ class TestModelResult:
 class TestCallModel:
     """Regression tests for the #144 US-003 ``call_model`` dispatcher.
 
-    Traces to DEC-001 (signature does not include ``subject``) and
-    DEC-002 (``provider="openai"`` raises :class:`NotImplementedError`)
-    of ``plans/super/144-providers-call-model.md``.
+    Traces to DEC-001 (signature does not include ``subject``) of
+    ``plans/super/144-providers-call-model.md`` and #145 US-005
+    (``provider="openai"`` dispatches to
+    :func:`clauditor._providers._openai.call_openai`; the prior
+    ``NotImplementedError`` placeholder from #144 DEC-002 was
+    replaced).
     """
 
     @pytest.mark.asyncio
@@ -1608,17 +1611,56 @@ class TestCallModel:
         assert result.output_tokens == 34
 
     @pytest.mark.asyncio
-    async def test_call_model_openai_raises_not_implemented(self) -> None:
-        """``provider="openai"`` raises :class:`NotImplementedError`
-        with a message pointing at #145 (DEC-002)."""
-        from clauditor._providers import call_model
+    async def test_call_model_dispatches_to_openai(self) -> None:
+        """#145 US-005: ``provider="openai"`` delegates to
+        :func:`clauditor._providers._openai.call_openai` with the
+        forwarded kwargs. Patches the canonical module path per
+        ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3."""
+        from clauditor._providers import ModelResult, call_model
 
-        with pytest.raises(NotImplementedError, match="#145"):
-            await call_model(
-                "the prompt",
+        canned = ModelResult(
+            response_text="ok",
+            provider="openai",
+            source="api",
+            input_tokens=7,
+            output_tokens=11,
+        )
+        with patch(
+            "clauditor._providers._openai.call_openai",
+            new=AsyncMock(return_value=canned),
+        ) as mock_call:
+            result = await call_model(
+                "hi",
                 provider="openai",
-                model="gpt-4o-mini",
+                model="gpt-5.4",
             )
+
+        mock_call.assert_awaited_once_with(
+            "hi",
+            model="gpt-5.4",
+            transport="auto",
+            max_tokens=4096,
+        )
+        assert result is canned
+        assert result.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_call_model_propagates_openai_helper_error(self) -> None:
+        """#145 US-005: an :class:`OpenAIHelperError` raised inside
+        :func:`call_openai` propagates verbatim through the
+        dispatcher — the dispatcher must NOT swallow or wrap it."""
+        from clauditor._providers import OpenAIHelperError, call_model
+
+        with patch(
+            "clauditor._providers._openai.call_openai",
+            new=AsyncMock(side_effect=OpenAIHelperError("simulated")),
+        ):
+            with pytest.raises(OpenAIHelperError, match="simulated"):
+                await call_model(
+                    "hi",
+                    provider="openai",
+                    model="gpt-5.4",
+                )
 
     def test_call_model_signature_does_not_include_subject(self) -> None:
         """DEC-001 guard: ``call_model`` MUST NOT carry a ``subject``

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -28,8 +28,6 @@ from clauditor._anthropic import (
     ClaudeCLIError,
     _body_excerpt,
     _classify_invoke_result,
-    _compute_backoff,
-    _compute_retry_decision,
     _extract_result,
     call_anthropic,
     resolve_transport,
@@ -214,54 +212,6 @@ class TestBodyExcerpt:
         assert _body_excerpt(exc) == "<unrenderable body>"
 
 
-class TestRandUniformDefault:
-    def test_default_path_returns_value_in_range(self) -> None:
-        # Most tests patch _rand_uniform; this one exercises the real
-        # implementation so the stdlib-random wrapper itself is
-        # covered. A few samples pin the contract: values stay inside
-        # the requested closed interval.
-        from clauditor._anthropic import _rand_uniform
-
-        for _ in range(10):
-            val = _rand_uniform(-0.25, 0.25)
-            assert -0.25 <= val <= 0.25
-
-
-class TestComputeBackoff:
-    def test_delay_grows_exponentially(self) -> None:
-        # With zero jitter, delays are 1, 2, 4 seconds.
-        with patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
-        ):
-            assert _compute_backoff(0) == pytest.approx(1.0)
-            assert _compute_backoff(1) == pytest.approx(2.0)
-            assert _compute_backoff(2) == pytest.approx(4.0)
-
-    def test_positive_jitter_extends_delay(self) -> None:
-        # Max positive jitter (0.25) → base * 1.25
-        with patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.25
-        ):
-            assert _compute_backoff(0) == pytest.approx(1.25)
-            assert _compute_backoff(2) == pytest.approx(5.0)
-
-    def test_negative_jitter_shortens_delay(self) -> None:
-        # Max negative jitter (-0.25) → base * 0.75
-        with patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=-0.25
-        ):
-            assert _compute_backoff(0) == pytest.approx(0.75)
-            assert _compute_backoff(1) == pytest.approx(1.5)
-
-    def test_delay_never_negative(self) -> None:
-        # Pathological jitter that tries to push delay negative is
-        # floored at 0.
-        with patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=-100.0
-        ):
-            assert _compute_backoff(0) == 0.0
-
-
 class TestCallAnthropicSuccess:
     @pytest.mark.asyncio
     async def test_success_returns_result_with_tokens(self) -> None:
@@ -330,7 +280,7 @@ class TestCallAnthropicRateLimit:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(AnthropicHelperError) as exc_info:
                 await call_anthropic("p", model="m", transport="api")
@@ -364,7 +314,7 @@ class TestCallAnthropicRateLimit:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="api")
         assert result.response_text == "recovered"
@@ -388,7 +338,7 @@ class TestCallAnthropicRateLimit:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform",
+            "clauditor._providers._retry._rand_uniform",
             side_effect=[0.25, -0.25, 0.25],
         ):
             with pytest.raises(AnthropicHelperError):
@@ -420,7 +370,7 @@ class TestCallAnthropicServerError:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(AnthropicHelperError) as exc_info:
                 await call_anthropic("p", model="m", transport="api")
@@ -444,7 +394,7 @@ class TestCallAnthropicServerError:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="api")
         assert result.response_text == "recovered"
@@ -547,7 +497,7 @@ class TestCallAnthropicConnectionError:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(AnthropicHelperError) as exc_info:
                 await call_anthropic("p", model="m", transport="api")
@@ -568,7 +518,7 @@ class TestCallAnthropicConnectionError:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="api")
         assert result.response_text == "got it"
@@ -675,47 +625,6 @@ class TestCallAnthropicTypeError:
 # ---------------------------------------------------------------------------
 
 
-class TestComputeRetryDecision:
-    """Pure helper extracted per DEC-005 retry parity.
-
-    Shared by SDK and CLI transport branches so a failure with the
-    same category retries the same number of times regardless of
-    which transport produced it.
-    """
-
-    def test_rate_limit_retries_up_to_three_times(self) -> None:
-        assert _compute_retry_decision("rate_limit", 0) == "retry"
-        assert _compute_retry_decision("rate_limit", 1) == "retry"
-        assert _compute_retry_decision("rate_limit", 2) == "retry"
-
-    def test_rate_limit_raises_after_third_retry(self) -> None:
-        assert _compute_retry_decision("rate_limit", 3) == "raise"
-
-    def test_auth_never_retries(self) -> None:
-        assert _compute_retry_decision("auth", 0) == "raise"
-        assert _compute_retry_decision("auth", 5) == "raise"
-
-    def test_api_retries_once_then_raises(self) -> None:
-        assert _compute_retry_decision("api", 0) == "retry"
-        assert _compute_retry_decision("api", 1) == "raise"
-
-    def test_connection_retries_once_then_raises(self) -> None:
-        assert _compute_retry_decision("connection", 0) == "retry"
-        assert _compute_retry_decision("connection", 1) == "raise"
-
-    def test_transport_retries_once_then_raises(self) -> None:
-        assert _compute_retry_decision("transport", 0) == "retry"
-        assert _compute_retry_decision("transport", 1) == "raise"
-
-    def test_unknown_category_raises(self) -> None:
-        """Defensive default: an unknown category is not retried."""
-        assert _compute_retry_decision("mystery", 0) == "raise"
-
-    def test_empty_string_category_raises(self) -> None:
-        """Defensive default: empty-string category is not retried."""
-        assert _compute_retry_decision("", 0) == "raise"
-
-
 # ---------------------------------------------------------------------------
 # _FakePopen-driven fixtures for CLI-transport tests. The real Popen is
 # mocked out at the ``clauditor.runner`` seam per the centralized
@@ -805,7 +714,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(ClaudeCLIError) as exc_info:
                 await call_anthropic("p", model="m", transport="cli")
@@ -831,7 +740,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="cli")
         assert result.response_text == "recovered"
@@ -872,7 +781,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(ClaudeCLIError) as exc_info:
                 await call_anthropic("p", model="m", transport="cli")
@@ -893,7 +802,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="cli")
         assert result.response_text == "recovered"
@@ -909,7 +818,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(ClaudeCLIError) as exc_info:
                 await call_anthropic("p", model="m", transport="cli")
@@ -952,7 +861,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(ClaudeCLIError) as exc_info:
                 await call_anthropic("p", model="m", transport="cli")
@@ -980,7 +889,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="cli")
         assert result.response_text == "recovered after transport"
@@ -1023,7 +932,7 @@ class TestCallViaClaudeCli:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             result = await call_anthropic("p", model="m", transport="cli")
         assert result.response_text == "healed"
@@ -1292,7 +1201,7 @@ class TestAutoTransportResolution:
         ), patch(
             "clauditor._providers._anthropic._sleep", sleep_mock
         ), patch(
-            "clauditor._providers._anthropic._rand_uniform", return_value=0.0
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
         ):
             with pytest.raises(ClaudeCLIError) as exc_info:
                 await call_anthropic("p", model="m", transport="cli")

--- a/tests/test_providers_auth.py
+++ b/tests/test_providers_auth.py
@@ -563,3 +563,332 @@ class TestClaudeCliIsAvailable:
 
         _patch_which(monkeypatch, None)
         assert _claude_cli_is_available() is False
+
+
+class TestCheckOpenAiAuth:
+    """Unit tests for the OpenAI pre-flight auth guard (US-006 / DEC-006).
+
+    Mirrors :class:`TestCheckApiKeyOnly`'s shape — the OpenAI guard is
+    unconditionally strict (no CLI-fallback branch since OpenAI has no
+    equivalent of the ``claude`` CLI subscription path). Pins DEC-006
+    of ``plans/super/145-openai-provider.md``: pure helper raising
+    :class:`OpenAIAuthMissingError` when ``OPENAI_API_KEY`` is absent,
+    empty, or whitespace-only.
+    """
+
+    def test_key_present_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import check_openai_auth
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        assert check_openai_auth("grade") is None
+
+    def test_key_absent_raises_with_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_openai_auth,
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(OpenAIAuthMissingError) as exc_info:
+            check_openai_auth("grade")
+        message = str(exc_info.value)
+        # DEC-006 durable substrings.
+        assert "OPENAI_API_KEY" in message
+        assert "platform.openai.com" in message
+        # Command-name interpolation.
+        assert "clauditor grade" in message
+
+    def test_empty_string_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_openai_auth,
+        )
+
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        with pytest.raises(OpenAIAuthMissingError):
+            check_openai_auth("grade")
+
+    def test_whitespace_only_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_openai_auth,
+        )
+
+        monkeypatch.setenv("OPENAI_API_KEY", "   \t\n")
+        with pytest.raises(OpenAIAuthMissingError):
+            check_openai_auth("grade")
+
+    def test_key_whitespace_surrounded_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-empty value with surrounding whitespace counts as present."""
+        from clauditor._providers import check_openai_auth
+
+        monkeypatch.setenv("OPENAI_API_KEY", "  sk-test  ")
+        assert check_openai_auth("grade") is None
+
+    def test_cmd_name_interpolation_extract(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_openai_auth,
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(OpenAIAuthMissingError) as exc_info:
+            check_openai_auth("extract")
+        assert "clauditor extract" in str(exc_info.value)
+
+    def test_cmd_name_interpolation_propose_eval(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_openai_auth,
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(OpenAIAuthMissingError) as exc_info:
+            check_openai_auth("propose-eval")
+        assert "clauditor propose-eval" in str(exc_info.value)
+
+    def test_openai_auth_missing_error_is_not_anthropic_subclass(
+        self,
+    ) -> None:
+        """DEC-006 (#145) + ``.claude/rules/llm-cli-exit-code-taxonomy.md``:
+        ``OpenAIAuthMissingError`` is a direct subclass of
+        :class:`Exception`, NOT of :class:`AnthropicAuthMissingError`.
+        A common ancestor would defeat the structural-routing
+        invariant CLI dispatchers depend on.
+        """
+        from clauditor._providers import (
+            AnthropicAuthMissingError,
+            OpenAIAuthMissingError,
+        )
+
+        assert not issubclass(OpenAIAuthMissingError, AnthropicAuthMissingError)
+        # And the converse — neither inherits from the other.
+        assert not issubclass(AnthropicAuthMissingError, OpenAIAuthMissingError)
+        # Direct base is Exception.
+        assert OpenAIAuthMissingError.__bases__ == (Exception,)
+
+    def test_constant_substrings(self) -> None:
+        """Prose-presence check on the message template."""
+        from clauditor._providers import _OPENAI_AUTH_MISSING_TEMPLATE
+
+        assert "OPENAI_API_KEY" in _OPENAI_AUTH_MISSING_TEMPLATE
+        assert "platform.openai.com" in _OPENAI_AUTH_MISSING_TEMPLATE
+        assert "{cmd_name}" in _OPENAI_AUTH_MISSING_TEMPLATE
+
+
+class TestCheckProviderAuth:
+    """Unit tests for the multi-provider dispatcher (US-006 / DEC-006).
+
+    Pins DEC-006 of ``plans/super/145-openai-provider.md``: single
+    public seam ``check_provider_auth(provider, cmd_name)`` that
+    routes to the provider-specific guard. Distinct exception classes
+    propagate through (preserving the structural-routing invariant
+    every CLI dispatcher depends on per
+    ``.claude/rules/llm-cli-exit-code-taxonomy.md``).
+    """
+
+    def test_anthropic_delegates_to_check_any_auth_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``provider="anthropic"`` routes to
+        :func:`check_any_auth_available`. Verified by the behavioral
+        contract: when both ``ANTHROPIC_API_KEY`` is unset AND the
+        ``claude`` CLI is absent, the dispatcher raises
+        :class:`AnthropicAuthMissingError` — exactly the relaxed
+        guard's contract.
+        """
+        from clauditor._providers import (
+            AnthropicAuthMissingError,
+            check_provider_auth,
+        )
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        _patch_which(monkeypatch, None)
+        with pytest.raises(AnthropicAuthMissingError):
+            check_provider_auth("anthropic", "grade")
+
+    def test_anthropic_passes_when_key_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import check_provider_auth
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        _patch_which(monkeypatch, None)
+        assert check_provider_auth("anthropic", "grade") is None
+
+    def test_anthropic_passes_when_cli_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DEC-006 explicitly preserves #86 DEC-008's key-OR-CLI
+        semantics for the anthropic branch. CLI presence alone passes
+        the dispatcher's anthropic route."""
+        from clauditor._providers import check_provider_auth
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        _patch_which(monkeypatch, "/usr/local/bin/claude")
+        assert check_provider_auth("anthropic", "grade") is None
+
+    def test_anthropic_delegates_via_module_attribute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tightening test: patch ``check_any_auth_available`` on the
+        canonical ``_providers._auth`` module path and verify the
+        dispatcher actually called it. Catches accidental inline-
+        re-implementation."""
+        import clauditor._providers._auth as _auth
+
+        called_with: list[str] = []
+
+        def _stub(cmd_name: str) -> None:
+            called_with.append(cmd_name)
+            return None
+
+        monkeypatch.setattr(_auth, "check_any_auth_available", _stub)
+        _auth.check_provider_auth("anthropic", "grade")
+        assert called_with == ["grade"]
+
+    def test_openai_delegates_to_check_openai_auth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``provider="openai"`` routes to :func:`check_openai_auth`.
+        Verified behaviorally: when ``OPENAI_API_KEY`` is unset, the
+        dispatcher raises :class:`OpenAIAuthMissingError`."""
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_provider_auth,
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(OpenAIAuthMissingError):
+            check_provider_auth("openai", "grade")
+
+    def test_openai_passes_when_key_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import check_provider_auth
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        assert check_provider_auth("openai", "grade") is None
+
+    def test_openai_delegates_via_module_attribute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tightening test: patch ``check_openai_auth`` on the
+        canonical ``_providers._auth`` module path and verify the
+        dispatcher actually called it."""
+        import clauditor._providers._auth as _auth
+
+        called_with: list[str] = []
+
+        def _stub(cmd_name: str) -> None:
+            called_with.append(cmd_name)
+            return None
+
+        monkeypatch.setattr(_auth, "check_openai_auth", _stub)
+        _auth.check_provider_auth("openai", "extract")
+        assert called_with == ["extract"]
+
+    def test_unknown_provider_raises_value_error(self) -> None:
+        from clauditor._providers import check_provider_auth
+
+        with pytest.raises(ValueError) as exc_info:
+            check_provider_auth("vertex", "grade")
+        # Helpful error message names the unknown value.
+        assert "vertex" in str(exc_info.value)
+
+    def test_empty_string_provider_raises_value_error(self) -> None:
+        from clauditor._providers import check_provider_auth
+
+        with pytest.raises(ValueError):
+            check_provider_auth("", "grade")
+
+    def test_anthropic_propagates_distinct_class(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Structural-routing invariant: the anthropic branch raises
+        :class:`AnthropicAuthMissingError` and NOT
+        :class:`OpenAIAuthMissingError`, so a CLI ``except`` ladder
+        keyed on the OpenAI class would NOT catch the anthropic
+        failure."""
+        from clauditor._providers import (
+            OpenAIAuthMissingError,
+            check_provider_auth,
+        )
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        _patch_which(monkeypatch, None)
+        with pytest.raises(Exception) as exc_info:
+            check_provider_auth("anthropic", "grade")
+        # The raised class is NOT OpenAIAuthMissingError.
+        assert not isinstance(exc_info.value, OpenAIAuthMissingError)
+
+    def test_openai_propagates_distinct_class(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Symmetric structural-routing invariant for the openai branch."""
+        from clauditor._providers import (
+            AnthropicAuthMissingError,
+            check_provider_auth,
+        )
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Exception) as exc_info:
+            check_provider_auth("openai", "grade")
+        # The raised class is NOT AnthropicAuthMissingError.
+        assert not isinstance(exc_info.value, AnthropicAuthMissingError)
+
+
+class TestOpenAiApiKeyIsSet:
+    """Direct unit coverage for ``_openai_api_key_is_set()``.
+
+    Helper is exercised transitively through ``TestCheckOpenAiAuth``,
+    but a dedicated test class pins the whitespace-only-is-absent
+    contract documented in the helper's docstring (mirrors
+    :class:`TestApiKeyIsSet` for the Anthropic side).
+    """
+
+    def test_returns_true_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers._auth import _openai_api_key_is_set
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-real-key")
+        assert _openai_api_key_is_set() is True
+
+    def test_returns_false_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers._auth import _openai_api_key_is_set
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert _openai_api_key_is_set() is False
+
+    def test_returns_false_when_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers._auth import _openai_api_key_is_set
+
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        assert _openai_api_key_is_set() is False
+
+    def test_returns_false_when_whitespace_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers._auth import _openai_api_key_is_set
+
+        monkeypatch.setenv("OPENAI_API_KEY", "   \t\n")
+        assert _openai_api_key_is_set() is False

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -958,3 +958,38 @@ class TestCallOpenAITypeError:
         assert sleep_mock.await_count == 0
         assert isinstance(exc_info.value.__cause__, TypeError)
         assert sdk_text in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_openai_error_at_construction_wrapped(self) -> None:
+        """#145 QG pass 1 (Bug 2): the SDK raises ``openai.OpenAIError``
+        (NOT ``TypeError``) at ``AsyncOpenAI()`` construction when
+        ``OPENAI_API_KEY`` is unset. Without ``OpenAIError`` in the
+        construction-site ``except`` tuple, the missing-key path bypasses
+        the defense-in-depth and surfaces a raw SDK traceback.
+        """
+        from openai import OpenAIError
+
+        sdk_text = "The api_key client option must be set"
+
+        def _raise_at_construct(*args: object, **kwargs: object) -> None:
+            raise OpenAIError(sdk_text)
+
+        sleep_mock = AsyncMock()
+        with patch(
+            "clauditor._providers._openai.AsyncOpenAI",
+            side_effect=_raise_at_construct,
+        ), patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        assert "OpenAI SDK client initialization failed" in msg
+        assert "OPENAI_API_KEY" in msg
+        # SDK-sourced text must NOT leak into the user-facing message.
+        assert sdk_text not in msg
+        # No retry; construction failure is not transient.
+        assert sleep_mock.await_count == 0
+        # Original exception preserved on __cause__ via raise ... from exc.
+        assert isinstance(exc_info.value.__cause__, OpenAIError)
+        assert sdk_text in str(exc_info.value.__cause__)

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -21,6 +21,7 @@ from clauditor._providers._openai import (
     DEFAULT_MODEL_L2,
     DEFAULT_MODEL_L3,
     OpenAIHelperError,
+    _body_excerpt,
     _extract_openai_result,
     call_openai,
 )
@@ -502,3 +503,458 @@ class TestExtractOpenAIResult:
         resp.model_dump = MagicMock(side_effect=TypeError("boom"))
         _, _, _, _, raw = _extract_openai_result(resp)
         assert raw == {}
+
+
+# ---------------------------------------------------------------------------
+# US-004: Retry / error branches in call_openai
+# ---------------------------------------------------------------------------
+
+
+import httpx  # noqa: E402
+from openai import (  # noqa: E402
+    APIConnectionError,
+    APIStatusError,
+    AuthenticationError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+
+
+def _make_rate_limit_error(
+    *, message: str = "rate limit", body: object | None = None
+) -> RateLimitError:
+    req = httpx.Request("POST", "https://example.com/v1/responses")
+    httpx_resp = httpx.Response(429, request=req)
+    return RateLimitError(message, response=httpx_resp, body=body)
+
+
+def _make_status_error(
+    status: int,
+    *,
+    message: str = "boom",
+    body: object | None = None,
+) -> APIStatusError:
+    req = httpx.Request("POST", "https://example.com/v1/responses")
+    httpx_resp = httpx.Response(status, request=req)
+    return APIStatusError(message, response=httpx_resp, body=body)
+
+
+def _make_auth_error(
+    *, message: str = "invalid key", body: object | None = None
+) -> AuthenticationError:
+    req = httpx.Request("POST", "https://example.com/v1/responses")
+    httpx_resp = httpx.Response(401, request=req)
+    return AuthenticationError(message, response=httpx_resp, body=body)
+
+
+def _make_permission_error() -> PermissionDeniedError:
+    req = httpx.Request("POST", "https://example.com/v1/responses")
+    httpx_resp = httpx.Response(403, request=req)
+    return PermissionDeniedError(
+        "forbidden",
+        response=httpx_resp,
+        body={"error": {"message": "nope"}},
+    )
+
+
+def _make_connection_error() -> APIConnectionError:
+    req = httpx.Request("POST", "https://example.com/v1/responses")
+    return APIConnectionError(message="connection reset", request=req)
+
+
+def _patch_async_openai_with_side_effect(side_effect):
+    """Patch ``AsyncOpenAI`` so ``.responses.create`` uses ``side_effect``.
+
+    Distinct from ``_patch_async_openai`` (above) which uses
+    ``return_value`` for the happy path. Per
+    ``.claude/rules/mock-side-effect-for-distinct-calls.md``, the
+    retry tests pass a list / iterable so each retry iteration
+    sees a distinct value.
+    """
+    fake_client = MagicMock()
+    fake_client.responses = MagicMock()
+    fake_client.responses.create = AsyncMock(side_effect=side_effect)
+    fake_class = MagicMock(return_value=fake_client)
+    return (
+        patch("clauditor._providers._openai.AsyncOpenAI", new=fake_class),
+        fake_client,
+    )
+
+
+class TestBodyExcerpt:
+    """Coverage for the OpenAI body-excerpt helper.
+
+    Mirrors :class:`tests.test_providers_anthropic.TestBodyExcerpt`
+    — the helpers are duplicated per-provider, so the tests are too.
+    """
+
+    def test_none_body(self) -> None:
+        exc = MagicMock()
+        exc.body = None
+        assert _body_excerpt(exc) == "<no body>"
+
+    def test_string_body(self) -> None:
+        exc = MagicMock()
+        exc.body = "some error text"
+        assert _body_excerpt(exc) == "some error text"
+
+    def test_dict_body_rendered(self) -> None:
+        exc = MagicMock()
+        exc.body = {"error": {"message": "bad"}}
+        out = _body_excerpt(exc)
+        assert "error" in out
+        assert "bad" in out
+
+    def test_body_truncated_at_limit(self) -> None:
+        exc = MagicMock()
+        exc.body = "x" * 1000
+        out = _body_excerpt(exc)
+        # 512 chars + 3-char ellipsis
+        assert out.endswith("...")
+        assert len(out) == 512 + 3
+
+    def test_unrenderable_body_tolerated(self) -> None:
+        # A body whose ``repr()`` itself raises must fall through to
+        # the "<unrenderable body>" sentinel rather than propagate.
+        class Bad:
+            def __repr__(self) -> str:
+                raise RuntimeError("nope")
+
+        exc = MagicMock()
+        exc.body = Bad()
+        assert _body_excerpt(exc) == "<unrenderable body>"
+
+
+class TestCallOpenAIRateLimit:
+    @pytest.mark.asyncio
+    async def test_retries_three_times_then_raises(self) -> None:
+        # Four failures: retries 0, 1, 2 then raise on attempt 4.
+        # Distinct bodies per call prove the loop keeps iterating.
+        errors = [
+            _make_rate_limit_error(body={"attempt": i}) for i in range(4)
+        ]
+        ctx, fake_client = _patch_async_openai_with_side_effect(errors)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        assert "rate limit" in str(exc_info.value).lower()
+        # 4 create calls, 3 sleeps between them.
+        assert fake_client.responses.create.await_count == 4
+        assert sleep_mock.await_count == 3
+        # Sleeps should be 1, 2, 4 with zero jitter.
+        delays = [c.args[0] for c in sleep_mock.await_args_list]
+        assert delays == [1.0, 2.0, 4.0]
+        # Original SDK exception preserved via __cause__.
+        assert isinstance(exc_info.value.__cause__, RateLimitError)
+
+    @pytest.mark.asyncio
+    async def test_recovery_after_two_retries(self) -> None:
+        # Distinct retry errors followed by a success — per rule
+        # mock-side-effect-for-distinct-calls.md, each call value
+        # is unique so the retry loop actually iterates.
+        resp = _mock_response(
+            output_text="recovered", input_tokens=10, output_tokens=3
+        )
+        sequence = [
+            _make_rate_limit_error(body={"n": 1}),
+            _make_rate_limit_error(body={"n": 2}),
+            resp,
+        ]
+        ctx, fake_client = _patch_async_openai_with_side_effect(sequence)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.response_text == "recovered"
+        assert fake_client.responses.create.await_count == 3
+        assert sleep_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_backoff_respects_jitter_band(self) -> None:
+        # Stub _rand_uniform to ±0.25 extremes; verify delays sit
+        # inside the documented band.
+        errors = [
+            _make_rate_limit_error(body={"n": i}) for i in range(4)
+        ]
+        ctx, _ = _patch_async_openai_with_side_effect(errors)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform",
+            side_effect=[0.25, -0.25, 0.25],
+        ):
+            with pytest.raises(OpenAIHelperError):
+                await call_openai("p", model="gpt-5.4")
+        delays = [c.args[0] for c in sleep_mock.await_args_list]
+        # retry 0: base 1, +25% → 1.25
+        # retry 1: base 2, -25% → 1.5
+        # retry 2: base 4, +25% → 5.0
+        assert delays[0] == pytest.approx(1.25)
+        assert delays[1] == pytest.approx(1.5)
+        assert delays[2] == pytest.approx(5.0)
+
+
+class TestCallOpenAIServerError:
+    @pytest.mark.asyncio
+    async def test_503_retries_once_then_raises(self) -> None:
+        # Two distinct 503s so the side_effect list documents both
+        # the first and the retry arm; the retry is exhausted on
+        # the second and the helper raises.
+        errors = [
+            _make_status_error(503, message="svc1", body={"n": 1}),
+            _make_status_error(503, message="svc2", body={"n": 2}),
+        ]
+        ctx, fake_client = _patch_async_openai_with_side_effect(errors)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        assert "503" in str(exc_info.value)
+        assert "server error" in str(exc_info.value).lower()
+        assert fake_client.responses.create.await_count == 2
+        assert sleep_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_500_recovers_after_one_retry(self) -> None:
+        resp = _mock_response(
+            output_text="recovered", input_tokens=1, output_tokens=1
+        )
+        sequence = [
+            _make_status_error(500, message="internal", body={"n": 1}),
+            resp,
+        ]
+        ctx, _ = _patch_async_openai_with_side_effect(sequence)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.response_text == "recovered"
+        assert sleep_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_502_recovers_after_one_retry(self) -> None:
+        # Coverage parity for the 502 status code branch.
+        resp = _mock_response(output_text="ok")
+        sequence = [
+            _make_status_error(502, message="bad gateway", body={"n": 1}),
+            resp,
+        ]
+        ctx, _ = _patch_async_openai_with_side_effect(sequence)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.response_text == "ok"
+
+
+class TestCallOpenAIClientError:
+    @pytest.mark.asyncio
+    async def test_400_fails_fast_no_retry(self) -> None:
+        err = _make_status_error(
+            400, message="bad request", body={"error": {"message": "nope"}}
+        )
+        ctx, fake_client = _patch_async_openai_with_side_effect(err)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        assert "400" in msg
+        assert "bad request" in msg
+        assert fake_client.responses.create.await_count == 1
+        assert sleep_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_422_fails_fast_no_retry(self) -> None:
+        err = _make_status_error(
+            422, message="unprocessable", body=None
+        )
+        ctx, fake_client = _patch_async_openai_with_side_effect(err)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        assert "422" in str(exc_info.value)
+        assert fake_client.responses.create.await_count == 1
+        assert sleep_mock.await_count == 0
+
+
+class TestCallOpenAIAuthErrors:
+    @pytest.mark.asyncio
+    async def test_401_mentions_api_key_env_var(self) -> None:
+        err = _make_auth_error(
+            message="invalid api key",
+            body={"error": {"message": "invalid key"}},
+        )
+        ctx, fake_client = _patch_async_openai_with_side_effect(err)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "401" in msg
+        # Auth errors must not retry.
+        assert fake_client.responses.create.await_count == 1
+        assert sleep_mock.await_count == 0
+        assert isinstance(exc_info.value.__cause__, AuthenticationError)
+
+    @pytest.mark.asyncio
+    async def test_403_also_mentions_api_key_env_var(self) -> None:
+        err = _make_permission_error()
+        ctx, fake_client = _patch_async_openai_with_side_effect(err)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "403" in msg
+        assert fake_client.responses.create.await_count == 1
+        assert sleep_mock.await_count == 0
+        assert isinstance(
+            exc_info.value.__cause__, PermissionDeniedError
+        )
+
+
+class TestCallOpenAIConnectionError:
+    @pytest.mark.asyncio
+    async def test_retries_once_then_raises(self) -> None:
+        errors = [_make_connection_error(), _make_connection_error()]
+        ctx, fake_client = _patch_async_openai_with_side_effect(errors)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        assert "connection" in str(exc_info.value).lower()
+        assert fake_client.responses.create.await_count == 2
+        assert sleep_mock.await_count == 1
+        assert isinstance(exc_info.value.__cause__, APIConnectionError)
+
+    @pytest.mark.asyncio
+    async def test_recovers_after_one_retry(self) -> None:
+        resp = _mock_response(output_text="got it")
+        sequence = [_make_connection_error(), resp]
+        ctx, _ = _patch_async_openai_with_side_effect(sequence)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.response_text == "got it"
+        assert sleep_mock.await_count == 1
+
+
+class TestCallOpenAIImportError:
+    @pytest.mark.asyncio
+    async def test_async_openai_importerror_re_raises(self) -> None:
+        # Per .claude/rules/centralized-sdk-call.md: ImportError must
+        # be raised UN-WRAPPED (not wrapped in OpenAIHelperError) so
+        # the user gets a clean `pip install openai>=1.66.0` hint
+        # path. Simulate the missing-SDK case by patching the
+        # module-level AsyncOpenAI symbol to raise ImportError on
+        # construction.
+        with patch(
+            "clauditor._providers._openai.AsyncOpenAI",
+            side_effect=ImportError("No module named 'openai'"),
+        ):
+            with pytest.raises(ImportError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        # Not wrapped in OpenAIHelperError — bare ImportError.
+        assert not isinstance(exc_info.value, OpenAIHelperError)
+
+
+class TestCallOpenAITypeError:
+    """Defense-in-depth wrap for SDK ``TypeError``.
+
+    Per ``.claude/rules/precall-env-validation.md``: wrap
+    ``TypeError`` (which the SDK raises when no auth is configured)
+    as ``OpenAIHelperError`` with a fixed sanitized message — no
+    ``str(exc)``, no ``exc.args``. Original exception preserved on
+    ``__cause__`` via ``raise ... from exc``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_typeerror_at_construction_wrapped(self) -> None:
+        # If AsyncOpenAI() construction raises TypeError (e.g. SDK
+        # internal config error), the wrap should fire with the
+        # fixed sanitized message.
+        sdk_text = "Could not resolve authentication method"
+
+        def _raise_at_construct(*args: object, **kwargs: object) -> None:
+            raise TypeError(sdk_text)
+
+        sleep_mock = AsyncMock()
+        with patch(
+            "clauditor._providers._openai.AsyncOpenAI",
+            side_effect=_raise_at_construct,
+        ), patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        assert "OpenAI SDK client initialization failed" in msg
+        assert "OPENAI_API_KEY" in msg
+        # SDK-sourced text must NOT leak into the user-facing message.
+        assert sdk_text not in msg
+        # No retry; construction failure is not transient.
+        assert sleep_mock.await_count == 0
+        assert isinstance(exc_info.value.__cause__, TypeError)
+        assert sdk_text in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_typeerror_at_responses_create_wrapped(self) -> None:
+        # If .responses.create raises TypeError, the wrap should
+        # fire with the fixed sanitized message. No retry.
+        sdk_text = "Could not resolve authentication method"
+        ctx, fake_client = _patch_async_openai_with_side_effect(
+            TypeError(sdk_text)
+        )
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        assert "OpenAI SDK client initialization failed" in msg
+        assert "OPENAI_API_KEY" in msg
+        assert sdk_text not in msg
+        assert fake_client.responses.create.await_count == 1
+        assert sleep_mock.await_count == 0
+        assert isinstance(exc_info.value.__cause__, TypeError)
+        assert sdk_text in str(exc_info.value.__cause__)

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,0 +1,222 @@
+"""Tests for the OpenAI provider backend (bead clauditor-2pf, US-002).
+
+Covers the happy path of :func:`clauditor._providers._openai.call_openai`:
+``ModelResult`` field population, ``provider``/``source`` stamping,
+``_monotonic`` indirection per
+``.claude/rules/monotonic-time-indirection.md``, and ``raw_message``
+shape (``response.model_dump()`` per DEC-001).
+
+Retry branches, error categorization, and the rich
+``response.output[]`` walker for refusal handling are out of scope —
+US-003 / US-004 land them.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clauditor._providers._openai import (
+    DEFAULT_MODEL_L2,
+    DEFAULT_MODEL_L3,
+    OpenAIHelperError,
+    call_openai,
+)
+
+
+def _mock_response(
+    *,
+    output_text: str = "hello",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+    raw_dict: dict | None = None,
+) -> MagicMock:
+    """Build a MagicMock shaped like an OpenAI Responses-API response.
+
+    The real ``openai.types.responses.Response`` object is a Pydantic
+    model with ``output_text`` (joined message text), ``usage``
+    (input/output token counts), and ``model_dump()`` (Pydantic v2
+    dict serialization). Mock just enough of that surface for the
+    happy-path projection.
+    """
+    resp = MagicMock()
+    resp.output_text = output_text
+    resp.usage = MagicMock(
+        input_tokens=input_tokens, output_tokens=output_tokens
+    )
+    resp.model_dump = MagicMock(
+        return_value=raw_dict if raw_dict is not None else {"id": "resp_x"}
+    )
+    return resp
+
+
+def _patch_async_openai(response: MagicMock):
+    """Patch ``AsyncOpenAI`` so ``.responses.create(...)`` returns ``response``.
+
+    Returns the patched class so callers can assert on construction
+    kwargs / call counts when needed.
+    """
+    fake_client = MagicMock()
+    fake_client.responses = MagicMock()
+    fake_client.responses.create = AsyncMock(return_value=response)
+    fake_class = MagicMock(return_value=fake_client)
+    return patch(
+        "clauditor._providers._openai.AsyncOpenAI", new=fake_class
+    ), fake_client
+
+
+class TestModuleConstants:
+    def test_default_models_are_strings(self) -> None:
+        # DEC-001 of plans/super/145-openai-provider.md pins these
+        # to real Responses-API models. Don't assert byte-equality
+        # (DEC-001 reserves the right to refresh per the OpenAI
+        # docs page) but assert shape: non-empty string.
+        assert isinstance(DEFAULT_MODEL_L3, str)
+        assert DEFAULT_MODEL_L3 != ""
+        assert isinstance(DEFAULT_MODEL_L2, str)
+        assert DEFAULT_MODEL_L2 != ""
+
+
+class TestOpenAIHelperError:
+    def test_is_exception_subclass(self) -> None:
+        # Distinct from AnthropicHelperError per DEC-006 of #145 (no
+        # common ancestor). Plain Exception subclass.
+        assert issubclass(OpenAIHelperError, Exception)
+
+    def test_message_is_preserved(self) -> None:
+        exc = OpenAIHelperError("boom")
+        assert str(exc) == "boom"
+
+
+class TestCallOpenAISuccess:
+    @pytest.mark.asyncio
+    async def test_returns_result_with_tokens(self) -> None:
+        resp = _mock_response(
+            output_text="hello",
+            input_tokens=10,
+            output_tokens=5,
+            raw_dict={"id": "resp_x", "status": "completed"},
+        )
+        ctx, fake_client = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("prompt", model="gpt-5.4")
+
+        assert result.response_text == "hello"
+        assert result.text_blocks == ["hello"]
+        assert result.input_tokens == 10
+        assert result.output_tokens == 5
+        # Sanity-check the SDK was invoked with the documented kwargs
+        # (``input=`` and ``max_output_tokens=`` per Responses API,
+        # NOT ``messages=`` / ``max_tokens=``).
+        fake_client.responses.create.assert_awaited_once()
+        kwargs = fake_client.responses.create.call_args.kwargs
+        assert kwargs["input"] == "prompt"
+        assert kwargs["model"] == "gpt-5.4"
+        assert kwargs["max_output_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    async def test_provider_and_source_stamped(self) -> None:
+        resp = _mock_response()
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4-mini")
+        # DEC-002: source is ALWAYS "api" for openai (no CLI
+        # transport axis); provider is "openai" so call_model
+        # consumers can branch on it.
+        assert result.provider == "openai"
+        assert result.source == "api"
+
+    @pytest.mark.asyncio
+    async def test_duration_uses_monotonic_indirection(self) -> None:
+        # Per .claude/rules/monotonic-time-indirection.md: tests patch
+        # the module-level _monotonic alias rather than time.monotonic
+        # so the asyncio event loop's own scheduler ticks are not
+        # disturbed.
+        resp = _mock_response()
+        ctx, _ = _patch_async_openai(resp)
+        with ctx, patch(
+            "clauditor._providers._openai._monotonic",
+            side_effect=[0.0, 1.5],
+        ):
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.duration_seconds == pytest.approx(1.5)
+
+    @pytest.mark.asyncio
+    async def test_raw_message_is_dict(self) -> None:
+        # DEC-001 raw_message divergence: OpenAI surfaces a
+        # Pydantic-v2 dict via .model_dump() rather than Anthropic's
+        # raw Message object. Callers that introspect raw_message
+        # for refusal semantics must branch on provider.
+        raw = {"id": "resp_y", "status": "completed", "output": []}
+        resp = _mock_response(raw_dict=raw)
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4")
+        assert isinstance(result.raw_message, dict)
+        assert result.raw_message == raw
+
+    @pytest.mark.asyncio
+    async def test_empty_output_text_yields_empty_blocks(self) -> None:
+        # Defensive: OpenAI may emit a response with no text content
+        # (refusal, tool-only, incomplete). The minimal happy-path
+        # projection collapses that to text_blocks=[] so callers
+        # checking truthiness of the list can short-circuit.
+        resp = _mock_response(output_text="")
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.response_text == ""
+        assert result.text_blocks == []
+
+    @pytest.mark.asyncio
+    async def test_transport_kwarg_accepted_and_ignored(self) -> None:
+        # DEC-002: transport kwarg is accepted at the signature level
+        # (so the dispatcher can pass it uniformly) but ignored —
+        # OpenAI has no CLI transport axis. source stays "api".
+        resp = _mock_response()
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai(
+                "p", model="gpt-5.4", transport="cli"
+            )
+        assert result.source == "api"
+
+    @pytest.mark.asyncio
+    async def test_subject_kwarg_accepted_and_ignored(self) -> None:
+        # subject is Anthropic-CLI-specific (apiKeySource telemetry).
+        # OpenAI accepts the kwarg for signature uniformity but does
+        # nothing with it.
+        resp = _mock_response()
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai(
+                "p", model="gpt-5.4", subject="L3 grading"
+            )
+        assert result.provider == "openai"
+
+    @pytest.mark.asyncio
+    async def test_garbage_token_counts_default_to_zero(self) -> None:
+        # Defensive parity with _anthropic._extract_result: a future
+        # SDK that emits non-numeric ``input_tokens`` / ``output_tokens``
+        # must not crash the projection. Fall back to 0.
+        resp = _mock_response()
+        resp.usage = MagicMock(
+            input_tokens="not-a-number", output_tokens=object()
+        )
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_threaded_to_max_output_tokens(self) -> None:
+        # The Responses API names the cap ``max_output_tokens`` (not
+        # ``max_tokens``). The wrapper translates.
+        resp = _mock_response()
+        ctx, fake_client = _patch_async_openai(resp)
+        with ctx:
+            await call_openai("p", model="gpt-5.4", max_tokens=2048)
+        kwargs = fake_client.responses.create.call_args.kwargs
+        assert kwargs["max_output_tokens"] == 2048

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -199,6 +199,25 @@ class TestCallOpenAISuccess:
         assert result.source == "api"
 
     @pytest.mark.asyncio
+    async def test_async_openai_constructed_with_max_retries_zero(
+        self,
+    ) -> None:
+        # PR #160 review (CodeRabbit): the AsyncOpenAI client must be
+        # constructed with ``max_retries=0`` so the SDK's built-in
+        # retry loop (default 2 retries on 429/5xx/connection) does
+        # NOT compound with the wrapper's per-category retries
+        # (RATE_LIMIT_MAX_RETRIES=3, SERVER_MAX_RETRIES=1,
+        # CONN_MAX_RETRIES=1). Without this, a single 429 from the
+        # SDK's perspective is actually 3 SDK-level attempts hidden
+        # inside one wrapper-level retry index, double-retrying with
+        # compounded backoff and obscuring the actual retry budget.
+        resp = _mock_response()
+        ctx, _ = _patch_async_openai(resp)
+        with ctx as fake_class:
+            await call_openai("p", model="gpt-5.4")
+        fake_class.assert_called_once_with(max_retries=0)
+
+    @pytest.mark.asyncio
     async def test_subject_kwarg_accepted_and_ignored(self) -> None:
         # subject is Anthropic-CLI-specific (apiKeySource telemetry).
         # OpenAI accepts the kwarg for signature uniformity but does

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -21,6 +21,7 @@ from clauditor._providers._openai import (
     DEFAULT_MODEL_L2,
     DEFAULT_MODEL_L3,
     OpenAIHelperError,
+    _extract_openai_result,
     call_openai,
 )
 
@@ -35,12 +36,26 @@ def _mock_response(
     """Build a MagicMock shaped like an OpenAI Responses-API response.
 
     The real ``openai.types.responses.Response`` object is a Pydantic
-    model with ``output_text`` (joined message text), ``usage``
-    (input/output token counts), and ``model_dump()`` (Pydantic v2
-    dict serialization). Mock just enough of that surface for the
-    happy-path projection.
+    model with ``output[]`` (list of output items: messages,
+    reasoning, tool-use), ``output_text`` (SDK convenience accessor
+    joining message text), ``usage`` (input/output token counts),
+    and ``model_dump()`` (Pydantic v2 dict serialization). Build a
+    single-message ``output[]`` mirroring ``output_text`` so the
+    extractor's per-block walker yields matching ``text_blocks``.
     """
     resp = MagicMock()
+    if output_text:
+        # Build a single message item with one output_text block so
+        # the extractor's walker collects matching text_blocks.
+        msg = MagicMock()
+        msg.type = "message"
+        block = MagicMock()
+        block.type = "output_text"
+        block.text = output_text
+        msg.content = [block]
+        resp.output = [msg]
+    else:
+        resp.output = []
     resp.output_text = output_text
     resp.usage = MagicMock(
         input_tokens=input_tokens, output_tokens=output_tokens
@@ -220,3 +235,270 @@ class TestCallOpenAISuccess:
             await call_openai("p", model="gpt-5.4", max_tokens=2048)
         kwargs = fake_client.responses.create.call_args.kwargs
         assert kwargs["max_output_tokens"] == 2048
+
+
+def _build_message_item(*texts: str) -> MagicMock:
+    """Build a Responses-API ``message``-typed output item.
+
+    Each text becomes one ``output_text``-typed content block. The
+    real SDK shape is ``ResponseOutputMessage`` with ``type ==
+    "message"`` and a ``content`` list of ``ResponseOutputText`` /
+    ``ResponseOutputRefusal`` objects.
+    """
+    item = MagicMock()
+    item.type = "message"
+    blocks = []
+    for text in texts:
+        block = MagicMock()
+        block.type = "output_text"
+        block.text = text
+        blocks.append(block)
+    item.content = blocks
+    return item
+
+
+def _build_reasoning_item() -> MagicMock:
+    """Build a Responses-API ``reasoning``-typed output item.
+
+    Reasoning items appear in the response.output[] list under
+    extended-thinking modes; the helper must skip them when
+    collecting text blocks. Forward-compat with #154's
+    harness-context sidecar work.
+    """
+    item = MagicMock()
+    item.type = "reasoning"
+    # Reasoning items have a ``summary`` field, not ``content``.
+    item.summary = [MagicMock(text="thinking...")]
+    return item
+
+
+def _make_response(
+    *,
+    output: list | None = None,
+    output_text: str | None = "",
+    usage: MagicMock | None = None,
+    raw_dict: dict | None = None,
+    has_model_dump: bool = True,
+) -> MagicMock:
+    """Build a Responses-API response stub for the extractor tests.
+
+    Distinct from the call-site ``_mock_response`` helper: this one
+    exposes ``output`` (the list of output items the extractor
+    walks), where ``_mock_response`` exposes only ``output_text``.
+    Pass ``output_text=None`` to omit the attribute entirely.
+    """
+    resp = MagicMock()
+    resp.output = output if output is not None else []
+    if output_text is None:
+        del resp.output_text
+    else:
+        resp.output_text = output_text
+    if usage is not None:
+        resp.usage = usage
+    else:
+        # Default: simple usage with zero tokens so tests that don't
+        # care about token counts get a clean baseline.
+        u = MagicMock()
+        u.input_tokens = 0
+        u.output_tokens = 0
+        resp.usage = u
+    if has_model_dump:
+        resp.model_dump = MagicMock(
+            return_value=raw_dict
+            if raw_dict is not None
+            else {"id": "resp_x"}
+        )
+    else:
+        del resp.model_dump
+    return resp
+
+
+class TestExtractOpenAIResult:
+    """Defensive parser tests for ``_extract_openai_result``.
+
+    The helper walks ``response.output[]`` skipping non-message
+    items (reasoning, tool-use), collects text from ``output_text``
+    blocks, and falls back to ``response.output_text`` when the
+    walker yields nothing. Token coercion mirrors
+    ``_anthropic._extract_result``'s defensive shape.
+    """
+
+    def test_happy_path_message_only(self) -> None:
+        # Single message with one output_text block. text_blocks
+        # captures the per-message joined text; response_text
+        # prefers the SDK's output_text accessor.
+        resp = _make_response(
+            output=[_build_message_item("hello world")],
+            output_text="hello world",
+        )
+        text, blocks, in_t, out_t, raw = _extract_openai_result(resp)
+        assert blocks == ["hello world"]
+        assert text == "hello world"
+
+    def test_filters_reasoning_items(self) -> None:
+        # Reasoning items in the response.output[] list must be
+        # skipped — only message-typed items contribute to
+        # text_blocks. Forward-compat with #154's harness-context
+        # sidecar work where reasoning summaries land elsewhere.
+        resp = _make_response(
+            output=[
+                _build_reasoning_item(),
+                _build_message_item("msg"),
+            ],
+            output_text="msg",
+        )
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == ["msg"]
+        assert text == "msg"
+
+    def test_multiple_message_blocks_joined(self) -> None:
+        # Two message items with one output_text block each. The
+        # walker collects per-message joined text into text_blocks;
+        # response_text mirrors the SDK's joined accessor.
+        resp = _make_response(
+            output=[
+                _build_message_item("first"),
+                _build_message_item("second"),
+            ],
+            output_text="firstsecond",
+        )
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == ["first", "second"]
+        assert text == "firstsecond"
+
+    def test_empty_output_yields_empty(self) -> None:
+        # Empty response.output[] list AND empty output_text — the
+        # extractor returns empty containers without raising.
+        resp = _make_response(output=[], output_text="")
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert text == ""
+        assert blocks == []
+
+    def test_missing_usage_yields_zero_tokens(self) -> None:
+        # Defensive: a response with no ``usage`` attribute (or
+        # usage=None) must not crash the projection. Token counts
+        # default to 0.
+        resp = _make_response(output=[], output_text="")
+        del resp.usage
+        _, _, in_t, out_t, _ = _extract_openai_result(resp)
+        assert in_t == 0
+        assert out_t == 0
+
+    def test_null_usage_input_tokens_yields_zero(self) -> None:
+        # Defensive: usage.input_tokens = None (a future SDK quirk
+        # or an incomplete response) must coerce to 0 rather than
+        # raising TypeError on int(None).
+        usage = MagicMock()
+        usage.input_tokens = None
+        usage.output_tokens = None
+        resp = _make_response(output=[], output_text="", usage=usage)
+        _, _, in_t, out_t, _ = _extract_openai_result(resp)
+        assert in_t == 0
+        assert out_t == 0
+
+    def test_string_usage_field_falls_back_to_zero(self) -> None:
+        # Defensive parity with _anthropic._extract_result: a
+        # non-numeric string in input_tokens / output_tokens falls
+        # back to 0 rather than crashing the projection.
+        usage = MagicMock()
+        usage.input_tokens = "not a number"
+        usage.output_tokens = "garbage"
+        resp = _make_response(output=[], output_text="", usage=usage)
+        _, _, in_t, out_t, _ = _extract_openai_result(resp)
+        assert in_t == 0
+        assert out_t == 0
+
+    def test_status_incomplete_does_not_raise(self) -> None:
+        # An ``incomplete`` status (max_output_tokens exhausted,
+        # filtered, etc.) must not abort the extractor. The caller
+        # decides what to do — the helper just projects what's
+        # there.
+        resp = _make_response(
+            output=[_build_message_item("partial")],
+            output_text="partial",
+            raw_dict={
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        )
+        resp.status = "incomplete"
+        resp.incomplete_details = MagicMock(reason="max_output_tokens")
+        text, blocks, _, _, raw = _extract_openai_result(resp)
+        assert text == "partial"
+        assert blocks == ["partial"]
+        assert raw["status"] == "incomplete"
+
+    def test_raw_message_dict_round_trip(self) -> None:
+        # raw_message is the Pydantic-v2 dict from
+        # ``response.model_dump()``. Round-trip the canned dict to
+        # confirm the helper does not mutate or reshape it.
+        raw = {"id": "x", "status": "completed"}
+        resp = _make_response(
+            output=[], output_text="", raw_dict=raw
+        )
+        _, _, _, _, got = _extract_openai_result(resp)
+        assert got == raw
+
+    def test_raw_message_fallback_on_missing_model_dump(self) -> None:
+        # Defensive against a future SDK that drops .model_dump():
+        # raw_message falls back to {} (NOT None — a dict matches
+        # the documented shape downstream callers may isinstance).
+        resp = _make_response(
+            output=[], output_text="", has_model_dump=False
+        )
+        _, _, _, _, raw = _extract_openai_result(resp)
+        assert raw == {}
+
+    def test_output_text_attribute_missing_falls_back_to_blocks(
+        self,
+    ) -> None:
+        # If the SDK ever drops the convenience output_text
+        # accessor, the helper falls back to joining text_blocks so
+        # response_text stays populated.
+        resp = _make_response(
+            output=[_build_message_item("alpha", "beta")],
+            output_text=None,
+        )
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == ["alphabeta"]
+        assert text == "alphabeta"
+
+    def test_skips_non_output_text_content_blocks(self) -> None:
+        # Defensive: a message item whose content[] mixes
+        # output_text blocks with other types (refusal, future
+        # block types) must skip the non-text blocks without
+        # raising.
+        msg = MagicMock()
+        msg.type = "message"
+        text_block = MagicMock()
+        text_block.type = "output_text"
+        text_block.text = "real"
+        refusal = MagicMock()
+        refusal.type = "refusal"
+        refusal.refusal = "I cannot help"
+        msg.content = [refusal, text_block]
+        resp = _make_response(output=[msg], output_text="real")
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        # Only the output_text block contributes; refusal is skipped.
+        assert blocks == ["real"]
+        assert text == "real"
+
+    def test_message_with_non_list_content_is_skipped(self) -> None:
+        # Defensive: a future SDK shape change where ``content`` is
+        # a string or scalar must not crash the walker.
+        msg = MagicMock()
+        msg.type = "message"
+        msg.content = "not-a-list"
+        resp = _make_response(output=[msg], output_text="")
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == []
+        assert text == ""
+
+    def test_model_dump_raising_falls_back_to_empty_dict(self) -> None:
+        # Defensive: if .model_dump() exists but raises (a future
+        # SDK quirk, a partial response object), the helper falls
+        # back to {} rather than propagating.
+        resp = _make_response(output=[], output_text="")
+        resp.model_dump = MagicMock(side_effect=TypeError("boom"))
+        _, _, _, _, raw = _extract_openai_result(resp)
+        assert raw == {}

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -375,6 +375,47 @@ class TestExtractOpenAIResult:
         assert text == ""
         assert blocks == []
 
+    def test_message_with_content_none_yields_no_block(self) -> None:
+        # QG pass 2 (#145): a message item with ``content=None``
+        # (refusal-only / placeholder) must NOT produce an empty-string
+        # entry in text_blocks. The contract is symmetric: zero
+        # output_text blocks → zero text_blocks entries, regardless of
+        # whether ``content`` was None, missing, or an empty list.
+        item = MagicMock()
+        item.type = "message"
+        item.content = None
+        resp = _make_response(output=[item], output_text="")
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == []
+        assert text == ""
+
+    def test_message_with_content_empty_list_yields_no_block(self) -> None:
+        # Symmetric with ``content=None``: an empty content list
+        # produces no text_blocks entry (not [""]). Pins the QG pass 2
+        # asymmetry fix in ``_providers/_openai.py``.
+        item = MagicMock()
+        item.type = "message"
+        item.content = []
+        resp = _make_response(output=[item], output_text="")
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == []
+        assert text == ""
+
+    def test_message_with_only_non_output_text_blocks_yields_no_block(self) -> None:
+        # A message item with only ``refusal``-typed content blocks
+        # (or other non-``output_text`` types) yields no text_blocks
+        # entry. Symmetric with content=None / content=[].
+        item = MagicMock()
+        item.type = "message"
+        refusal = MagicMock()
+        refusal.type = "refusal"
+        refusal.refusal = "I cannot help with that."
+        item.content = [refusal]
+        resp = _make_response(output=[item], output_text="")
+        text, blocks, _, _, _ = _extract_openai_result(resp)
+        assert blocks == []
+        assert text == ""
+
     def test_missing_usage_yields_zero_tokens(self) -> None:
         # Defensive: a response with no ``usage`` attribute (or
         # usage=None) must not crash the projection. Token counts

--- a/tests/test_providers_retry.py
+++ b/tests/test_providers_retry.py
@@ -1,0 +1,114 @@
+"""Tests for the shared retry helpers in ``clauditor._providers._retry``.
+
+DEC-007 of ``plans/super/145-openai-provider.md`` hoisted the retry
+policy (constants + decision logic + backoff curve) out of
+``clauditor._providers._anthropic`` so the future OpenAI provider can
+share it. The test classes ``TestComputeBackoff``,
+``TestComputeRetryDecision``, and ``TestRandUniformDefault`` previously
+lived in ``tests/test_providers_anthropic.py`` and patched
+``clauditor._providers._anthropic._rand_uniform``; per
+``.claude/rules/back-compat-shim-discipline.md`` Pattern 3 they
+follow the symbols to their new home and patch
+``clauditor._providers._retry._rand_uniform``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from clauditor._providers._retry import (
+    compute_backoff,
+    compute_retry_decision,
+)
+
+
+class TestRandUniformDefault:
+    def test_default_path_returns_value_in_range(self) -> None:
+        # Most tests patch _rand_uniform; this one exercises the real
+        # implementation so the stdlib-random wrapper itself is
+        # covered. A few samples pin the contract: values stay inside
+        # the requested closed interval.
+        from clauditor._providers._retry import _rand_uniform
+
+        for _ in range(10):
+            val = _rand_uniform(-0.25, 0.25)
+            assert -0.25 <= val <= 0.25
+
+
+class TestComputeBackoff:
+    def test_delay_grows_exponentially(self) -> None:
+        # With zero jitter, delays are 1, 2, 4 seconds.
+        with patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            assert compute_backoff(0) == pytest.approx(1.0)
+            assert compute_backoff(1) == pytest.approx(2.0)
+            assert compute_backoff(2) == pytest.approx(4.0)
+
+    def test_positive_jitter_extends_delay(self) -> None:
+        # Max positive jitter (0.25) → base * 1.25
+        with patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.25
+        ):
+            assert compute_backoff(0) == pytest.approx(1.25)
+            assert compute_backoff(2) == pytest.approx(5.0)
+
+    def test_negative_jitter_shortens_delay(self) -> None:
+        # Max negative jitter (-0.25) → base * 0.75
+        with patch(
+            "clauditor._providers._retry._rand_uniform", return_value=-0.25
+        ):
+            assert compute_backoff(0) == pytest.approx(0.75)
+            assert compute_backoff(1) == pytest.approx(1.5)
+
+    def test_delay_never_negative(self) -> None:
+        # Pathological jitter that tries to push delay negative is
+        # floored at 0.
+        with patch(
+            "clauditor._providers._retry._rand_uniform", return_value=-100.0
+        ):
+            assert compute_backoff(0) == 0.0
+
+
+class TestComputeRetryDecision:
+    """Pure helper extracted per DEC-005 retry parity (#86) and
+    re-homed per DEC-007 retry-helper hoist (#145).
+
+    Shared by SDK and CLI transport branches across every provider so
+    a failure with the same category retries the same number of times
+    regardless of which transport produced it.
+    """
+
+    def test_rate_limit_retries_up_to_three_times(self) -> None:
+        assert compute_retry_decision("rate_limit", 0) == "retry"
+        assert compute_retry_decision("rate_limit", 1) == "retry"
+        assert compute_retry_decision("rate_limit", 2) == "retry"
+
+    def test_rate_limit_raises_after_third_retry(self) -> None:
+        assert compute_retry_decision("rate_limit", 3) == "raise"
+
+    def test_auth_never_retries(self) -> None:
+        assert compute_retry_decision("auth", 0) == "raise"
+        assert compute_retry_decision("auth", 5) == "raise"
+
+    def test_api_retries_once_then_raises(self) -> None:
+        assert compute_retry_decision("api", 0) == "retry"
+        assert compute_retry_decision("api", 1) == "raise"
+
+    def test_connection_retries_once_then_raises(self) -> None:
+        assert compute_retry_decision("connection", 0) == "retry"
+        assert compute_retry_decision("connection", 1) == "raise"
+
+    def test_transport_retries_once_then_raises(self) -> None:
+        assert compute_retry_decision("transport", 0) == "retry"
+        assert compute_retry_decision("transport", 1) == "raise"
+
+    def test_unknown_category_raises(self) -> None:
+        """Defensive default: an unknown category is not retried."""
+        assert compute_retry_decision("mystery", 0) == "raise"
+
+    def test_empty_string_category_raises(self) -> None:
+        """Defensive default: empty-string category is not retried."""
+        assert compute_retry_decision("", 0) == "raise"

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -3380,3 +3380,115 @@ class TestCombineBlindResults:
         assert r3.provider_source == "openai"
 
 
+class TestGradeQualityWithOpenAI:
+    """#145 US-011 — End-to-end: an :class:`EvalSpec` with
+    ``grading_provider="openai"`` runs L3 grading through the full
+    pipeline (prompt build -> ``call_model`` -> parse -> report build)
+    and produces a populated :class:`GradingReport` with
+    ``provider_source == "openai"`` plus per-criterion verdicts.
+
+    Acceptance criterion 2 of issue #145. Builds on the unit-level
+    wiring tests in :class:`TestGradingProviderOpenAIWiring` by
+    asserting on the full report surface (per-criterion results,
+    metric properties, token counts) rather than just the
+    provider-stamping signal.
+
+    ``grade_quality`` makes a single ``call_model`` invocation per
+    happy-path attempt (L3 only — L2 extraction is orchestrated
+    separately in :mod:`clauditor.spec` and is not part of the
+    ``grade_quality`` entry point), so this test uses
+    ``return_value=`` per the second-paragraph contract of
+    ``.claude/rules/mock-side-effect-for-distinct-calls.md``.
+    """
+
+    def _spec(self) -> EvalSpec:
+        return EvalSpec(
+            skill_name="rubric-skill",
+            description="A test skill for rubric grading",
+            grading_criteria=[
+                "Output contains actionable recommendations",
+                "Tone is professional and clear",
+                "All requested topics are covered",
+            ],
+            grading_provider="openai",
+        )
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_openai_e2e(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full L3 path: spec.grading_provider="openai" flows through
+        ``call_model(provider="openai", ...)``, the mocked OpenAI
+        ``ModelResult`` is parsed into per-criterion verdicts, and the
+        returned :class:`GradingReport` is fully populated:
+
+        - ``provider_source == "openai"``
+        - per-criterion results aligned to the spec's criteria
+        - aggregated pass_rate / mean_score from parsed verdicts
+        - token counts from the mocked ``ModelResult``
+        """
+        from clauditor._providers import ModelResult
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = self._spec()
+        # JSON shape positionally aligned to spec.grading_criteria.
+        grading_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.92,
+                "evidence": "Three concrete next-step bullets at the end.",
+                "reasoning": "Each recommendation names an actor + action.",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.88,
+                "evidence": "No slang; consistent register throughout.",
+                "reasoning": "Sentence structure stays declarative.",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": False,
+                "score": 0.55,
+                "evidence": "Topic 3 (rollback) is not mentioned.",
+                "reasoning": "Two of three topics covered; one omitted.",
+            },
+        ]
+        verdict_text = json.dumps(grading_data)
+        fake = ModelResult(
+            response_text=verdict_text,
+            text_blocks=[verdict_text],
+            input_tokens=120,
+            output_tokens=240,
+            source="api",
+            provider="openai",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await grade_quality("fake skill output", spec)
+
+        # Provider stamping (acceptance criterion 2 — primary signal).
+        assert report.provider_source == "openai"
+        # ``call_model`` was called exactly once with ``provider="openai"``
+        # — the spec field flowed through the resolver to the dispatcher.
+        assert call_mock.await_count == 1
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+        # Per-criterion verdicts populated, positionally aligned to spec.
+        assert len(report.results) == 3
+        assert [r.criterion for r in report.results] == [
+            "Output contains actionable recommendations",
+            "Tone is professional and clear",
+            "All requested topics are covered",
+        ]
+        assert [r.passed for r in report.results] == [True, True, False]
+        # Aggregated metrics computed from per-criterion scores.
+        assert report.pass_rate == pytest.approx(2 / 3)
+        assert report.mean_score == pytest.approx(
+            (0.92 + 0.88 + 0.55) / 3
+        )
+        # Token counts propagated from the mocked ``ModelResult``.
+        assert report.input_tokens == 120
+        assert report.output_tokens == 240
+
+

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -683,7 +683,10 @@ class TestGradingProviderOpenAIWiring:
         )
         call_mock = AsyncMock(return_value=fake)
         with patch("clauditor._providers.call_model", call_mock):
-            report = await grade_quality("output", spec)
+            # PR #160 review: openai+claude-default-model raises
+            # ``ValueError`` per the new ``_validate_provider_model``
+            # fail-fast guard; pass an explicit OpenAI model name.
+            report = await grade_quality("output", spec, model="gpt-5.4")
         assert report.provider_source == "openai"
         # Verify ``provider="openai"`` flowed through to call_model.
         assert call_mock.await_args.kwargs["provider"] == "openai"
@@ -737,6 +740,7 @@ class TestGradingProviderOpenAIWiring:
                 "out_a",
                 "out_b",
                 provider="openai",
+                model="gpt-5.4",
             )
         assert report.provider_source == "openai"
         # Both calls received the same resolved provider.
@@ -789,6 +793,88 @@ class TestGradingProviderOpenAIWiring:
             report = await grade_quality("output", spec)
         assert report.provider_source == "anthropic"
         assert call_mock.await_args.kwargs["provider"] == "anthropic"
+
+
+class TestValidateProviderModel:
+    """PR #160 review (CodeRabbit): fail-fast guard rejects the
+    Anthropic-default model when ``provider="openai"`` so the spec
+    author sees a crisp actionable error rather than a downstream
+    4xx model-not-found from the OpenAI SDK. Removable once #146
+    ships per-provider default-model precedence."""
+
+    def test_openai_with_claude_model_raises(self) -> None:
+        from clauditor.quality_grader import (
+            DEFAULT_GRADING_MODEL,
+            _validate_provider_model,
+        )
+
+        with pytest.raises(ValueError, match="provider='openai'"):
+            _validate_provider_model(
+                "openai", DEFAULT_GRADING_MODEL, "test_ctx"
+            )
+
+    def test_openai_with_claude_prefixed_model_raises(self) -> None:
+        from clauditor.quality_grader import _validate_provider_model
+
+        with pytest.raises(ValueError, match="claude-haiku-4"):
+            _validate_provider_model(
+                "openai", "claude-haiku-4", "test_ctx"
+            )
+
+    def test_openai_with_openai_model_passes(self) -> None:
+        from clauditor.quality_grader import _validate_provider_model
+
+        # No exception — fully resolved to a non-Claude OpenAI model.
+        _validate_provider_model("openai", "gpt-5.4", "test_ctx")
+
+    def test_anthropic_with_claude_model_passes(self) -> None:
+        from clauditor.quality_grader import (
+            DEFAULT_GRADING_MODEL,
+            _validate_provider_model,
+        )
+
+        # The default pairing — must not fire the guard.
+        _validate_provider_model(
+            "anthropic", DEFAULT_GRADING_MODEL, "test_ctx"
+        )
+
+    def test_error_message_includes_context(self) -> None:
+        from clauditor.quality_grader import _validate_provider_model
+
+        with pytest.raises(ValueError, match="my_orchestrator"):
+            _validate_provider_model(
+                "openai", "claude-sonnet-4-6", "my_orchestrator"
+            )
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_raises_on_openai_with_claude_default(
+        self,
+    ) -> None:
+        """Integration: ``grade_quality`` invokes the guard before any
+        ``call_model`` invocation so the API call never fires."""
+        spec = EvalSpec(
+            skill_name="test-skill",
+            description="A test skill for unit tests",
+            grading_criteria=["c1"],
+            grading_provider="openai",
+        )
+        # No call_model patch needed — the guard fires before the
+        # call would be made.
+        with pytest.raises(ValueError, match="provider='openai'"):
+            await grade_quality("output", spec)
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_raises_on_openai_with_claude_default(
+        self,
+    ) -> None:
+        with pytest.raises(ValueError, match="provider='openai'"):
+            await blind_compare(
+                "query",
+                "out_a",
+                "out_b",
+                provider="openai",
+                # model defaults to DEFAULT_GRADING_MODEL (claude-)
+            )
 
 
 class TestParseGradingResponse:
@@ -3466,7 +3552,12 @@ class TestGradeQualityWithOpenAI:
         )
         call_mock = AsyncMock(return_value=fake)
         with patch("clauditor._providers.call_model", call_mock):
-            report = await grade_quality("fake skill output", spec)
+            # PR #160 review: openai+claude-default-model raises
+            # ``ValueError`` (CodeRabbit fail-fast guard); pass an
+            # explicit OpenAI model name.
+            report = await grade_quality(
+                "fake skill output", spec, model="gpt-5.4"
+            )
 
         # Provider stamping (acceptance criterion 2 — primary signal).
         assert report.provider_source == "openai"

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -624,6 +624,173 @@ class TestProviderSourcePropagation:
         assert report.provider_source == "mixed"
 
 
+class TestGradingProviderOpenAIWiring:
+    """#145 US-010: when ``eval_spec.grading_provider == "openai"``,
+    ``grade_quality`` and ``blind_compare`` route through the OpenAI
+    backend and stamp ``provider_source == "openai"`` on the returned
+    report."""
+
+    def _spec_with_openai(self) -> EvalSpec:
+        return EvalSpec(
+            skill_name="test-skill",
+            description="A test skill for unit tests",
+            grading_criteria=[
+                "Output contains actionable recommendations",
+                "Tone is professional and clear",
+                "All requested topics are covered",
+            ],
+            grading_provider="openai",
+        )
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_stamps_openai_when_grading_provider_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import ModelResult
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = self._spec_with_openai()
+        grading_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.85,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": True,
+                "score": 0.8,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+        ]
+        fake = ModelResult(
+            response_text=json.dumps(grading_data),
+            text_blocks=[json.dumps(grading_data)],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await grade_quality("output", spec)
+        assert report.provider_source == "openai"
+        # Verify ``provider="openai"`` flowed through to call_model.
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_blind_compare_stamps_openai_when_grading_provider_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``blind_compare`` accepts a ``provider`` kwarg; both parallel
+        judge calls must use the SAME resolved provider value. The
+        composition helper :func:`blind_compare_from_spec` resolves it
+        from ``spec.eval_spec.grading_provider`` once, before the
+        ``asyncio.gather``, so the two sides cannot disagree."""
+        from clauditor._providers import ModelResult
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        verdict = json.dumps(
+            {
+                "preference": "1",
+                "confidence": 0.8,
+                "score_1": 0.8,
+                "score_2": 0.4,
+                "reasoning": "r",
+            }
+        )
+        # Per .claude/rules/mock-side-effect-for-distinct-calls.md:
+        # ``blind_compare`` calls ``call_model`` twice (once per side
+        # of the position swap), so distinct results are wired through
+        # ``side_effect=[...]``. Both sides return ``provider="openai"``
+        # so ``provider_source`` lands as ``"openai"`` not ``"mixed"``.
+        side1 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+        )
+        side2 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+        )
+        call_mock = AsyncMock(side_effect=[side1, side2])
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await blind_compare(
+                "query",
+                "out_a",
+                "out_b",
+                provider="openai",
+            )
+        assert report.provider_source == "openai"
+        # Both calls received the same resolved provider.
+        assert call_mock.await_count == 2
+        for call in call_mock.await_args_list:
+            assert call.kwargs["provider"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_defaults_to_anthropic_when_unset(
+        self,
+    ) -> None:
+        """Back-compat regression: a spec with ``grading_provider=None``
+        still routes through anthropic."""
+        from clauditor._providers import ModelResult
+
+        spec = _make_spec()  # grading_provider default = None
+        grading_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.85,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": True,
+                "score": 0.8,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+        ]
+        fake = ModelResult(
+            response_text=json.dumps(grading_data),
+            text_blocks=[json.dumps(grading_data)],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+        )
+        call_mock = AsyncMock(return_value=fake)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await grade_quality("output", spec)
+        assert report.provider_source == "anthropic"
+        assert call_mock.await_args.kwargs["provider"] == "anthropic"
+
+
 class TestParseGradingResponse:
     def test_valid_json(self):
         data = [

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3054,6 +3054,31 @@ class TestEnvWithoutApiKey:
         assert result == base
         assert result is not base
 
+    def test_strips_openai_api_key(self):
+        """DEC-008 of plans/super/145-openai-provider.md (US-008).
+
+        ``OPENAI_API_KEY`` is stripped alongside the Anthropic auth
+        env vars so that under ``--transport cli`` an untrusted skill
+        subprocess cannot silently spend the operator's OpenAI quota.
+        Non-mutating per ``.claude/rules/non-mutating-scrub.md``.
+        """
+        base = {
+            "OPENAI_API_KEY": "secret",
+            "ANTHROPIC_API_KEY": "anth",
+            "FOO": "bar",
+        }
+        original = dict(base)
+        result = env_without_api_key(base)
+        # Both API keys stripped, unrelated key preserved.
+        assert "OPENAI_API_KEY" not in result
+        assert "ANTHROPIC_API_KEY" not in result
+        assert result["FOO"] == "bar"
+        # Non-mutating: input dict still has all three original keys.
+        assert base == original
+        assert "OPENAI_API_KEY" in base
+        assert "ANTHROPIC_API_KEY" in base
+        assert base["FOO"] == "bar"
+
 
 class TestEnvWithSyncTasks:
     """Pure-unit tests for :func:`clauditor.runner.env_with_sync_tasks`.

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2082,6 +2082,101 @@ class TestEvalSpecTransport:
         assert "transport" not in round_tripped
 
 
+class TestGradingProviderValidation:
+    """US-007 / DEC-003 of #145: ``EvalSpec.grading_provider`` parsing.
+
+    Optional field with default ``None``. When set, must be a non-bool
+    string in the literal set ``{"anthropic", "openai"}``; ``null`` is
+    permitted (equivalent to omission). Unknown strings, non-strings,
+    bools, lists, etc. are rejected at load time with a ``ValueError``
+    that names the field and the allowed values per
+    ``.claude/rules/constant-with-type-info.md``.
+    """
+
+    # --- Reject cases (write FIRST per TDD) ---
+
+    def test_unknown_string_claude_rejects(self, tmp_path):
+        """``"claude"`` is not in the literal set — rejected with an
+        error naming ``grading_provider``, ``anthropic``, ``openai``.
+        """
+        data = {"skill_name": "s", "grading_provider": "claude"}
+        with pytest.raises(ValueError) as exc_info:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(exc_info.value)
+        assert "grading_provider" in msg
+        assert "anthropic" in msg
+        assert "openai" in msg
+
+    def test_unknown_string_gpt_rejects(self, tmp_path):
+        """``"gpt"`` is not in the literal set."""
+        data = {"skill_name": "s", "grading_provider": "gpt"}
+        with pytest.raises(ValueError) as exc_info:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(exc_info.value)
+        assert "grading_provider" in msg
+        assert "anthropic" in msg
+        assert "openai" in msg
+
+    def test_int_rejects(self, tmp_path):
+        """Non-string int rejected."""
+        data = {"skill_name": "s", "grading_provider": 1}
+        with pytest.raises(ValueError) as exc_info:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(exc_info.value)
+        assert "grading_provider" in msg
+        assert "anthropic" in msg
+        assert "openai" in msg
+
+    def test_bool_rejects(self, tmp_path):
+        """Bool guard: ``isinstance(True, str)`` is False, but we still
+        reject explicitly with a type error per
+        ``.claude/rules/constant-with-type-info.md``.
+        """
+        data = {"skill_name": "s", "grading_provider": True}
+        with pytest.raises(ValueError) as exc_info:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(exc_info.value)
+        assert "grading_provider" in msg
+        assert "anthropic" in msg
+        assert "openai" in msg
+
+    def test_list_rejects(self, tmp_path):
+        """Non-string list rejected."""
+        data = {"skill_name": "s", "grading_provider": []}
+        with pytest.raises(ValueError) as exc_info:
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+        msg = str(exc_info.value)
+        assert "grading_provider" in msg
+        assert "anthropic" in msg
+        assert "openai" in msg
+
+    # --- Accept cases ---
+
+    def test_missing_defaults_to_none(self, tmp_path):
+        """No ``grading_provider`` key → ``.grading_provider is None``."""
+        data = {"skill_name": "s"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.grading_provider is None
+
+    def test_explicit_null_is_none(self, tmp_path):
+        """``{"grading_provider": null}`` → ``.grading_provider is None``."""
+        data = {"skill_name": "s", "grading_provider": None}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.grading_provider is None
+
+    def test_anthropic_loads(self, tmp_path):
+        """``"anthropic"`` is a valid value."""
+        data = {"skill_name": "s", "grading_provider": "anthropic"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.grading_provider == "anthropic"
+
+    def test_openai_loads(self, tmp_path):
+        """``"openai"`` is a valid value."""
+        data = {"skill_name": "s", "grading_provider": "openai"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.grading_provider == "openai"
+
+
 class TestAssertionKeySpec:
     """Tests for ``AssertionKeySpec`` + ``ASSERTION_TYPE_REQUIRED_KEYS``
     (DEC-008 of #61, DEC-001/DEC-012 of #67). The constant is the

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2176,6 +2176,53 @@ class TestGradingProviderValidation:
         spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
         assert spec.grading_provider == "openai"
 
+    # --- Round-trip via to_dict (QG pass 3 fix) ---
+
+    def test_to_dict_includes_grading_provider_when_set(self, tmp_path):
+        """``to_dict()`` emits ``grading_provider`` when non-default.
+
+        QG pass 3 caught the writer-side gap: US-007 added the field
+        to ``__init__`` / ``from_dict`` but missed ``to_dict``. A spec
+        loaded with ``grading_provider="openai"`` and round-tripped
+        via ``to_dict`` would silently lose the field, downgrading
+        downstream grader calls to Anthropic.
+        """
+        data = {"skill_name": "s", "grading_provider": "openai"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        result = spec.to_dict()
+        assert result["grading_provider"] == "openai"
+
+    def test_to_dict_omits_grading_provider_when_none(self, tmp_path):
+        """Default ``None`` is omitted from ``to_dict`` output to
+        keep diffs minimal — matches the convention for other optional
+        fields (``transport``, ``sync_tasks``, ``allow_hang_heuristic``).
+        Reload of the omitted form yields ``None``.
+        """
+        data = {"skill_name": "s"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        result = spec.to_dict()
+        assert "grading_provider" not in result
+
+    def test_to_dict_round_trip_preserves_grading_provider(
+        self, tmp_path
+    ):
+        """End-to-end: from_dict → to_dict → from_dict yields a spec
+        whose ``grading_provider`` matches the original. Pins the
+        QG pass 3 round-trip data-loss regression.
+        """
+        data = {"skill_name": "s", "grading_provider": "openai"}
+        spec1 = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        round_tripped = spec1.to_dict()
+        spec2 = EvalSpec.from_dict(round_tripped, spec_dir=tmp_path)
+        assert spec2.grading_provider == "openai"
+
+    def test_to_dict_round_trip_anthropic(self, tmp_path):
+        """Symmetric round-trip for explicit ``"anthropic"``."""
+        data = {"skill_name": "s", "grading_provider": "anthropic"}
+        spec1 = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        spec2 = EvalSpec.from_dict(spec1.to_dict(), spec_dir=tmp_path)
+        assert spec2.grading_provider == "anthropic"
+
 
 class TestAssertionKeySpec:
     """Tests for ``AssertionKeySpec`` + ``ASSERTION_TYPE_REQUIRED_KEYS``

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -2029,6 +2029,45 @@ class TestProposeEdits:
         assert "prompt build error" in report.api_error
         assert "prompt kaboom" in report.api_error
 
+    @pytest.mark.asyncio
+    async def test_suggest_stamps_openai_when_grading_provider_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#145 US-010: ``propose_edits`` accepts a ``provider`` kwarg
+        and threads it through to ``call_model``. The CLI layer (a
+        future ticket) resolves it from ``spec.eval_spec.grading_provider``;
+        this test verifies the function-level wiring."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        si = _suggest_input_with_signals()
+        result = _mock_anthropic_result(
+            text=_good_envelope_text(motivated_by=["a1"])
+        )
+        call_mock = AsyncMock(return_value=result)
+        with patch("clauditor._providers.call_model", call_mock):
+            report = await propose_edits(si, provider="openai")
+        # propose_edits succeeded — no api/parse errors.
+        assert report.api_error is None
+        assert report.parse_error is None
+        # Verify ``provider="openai"`` flowed through to call_model.
+        call_mock.assert_awaited_once()
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_suggest_defaults_to_anthropic_when_provider_unset(
+        self,
+    ) -> None:
+        """Back-compat regression: ``propose_edits`` without the
+        ``provider`` kwarg still routes through anthropic."""
+        si = _suggest_input_with_signals()
+        result = _mock_anthropic_result(
+            text=_good_envelope_text(motivated_by=["a1"])
+        )
+        call_mock = AsyncMock(return_value=result)
+        with patch("clauditor._providers.call_model", call_mock):
+            await propose_edits(si)
+        call_mock.assert_awaited_once()
+        assert call_mock.await_args.kwargs["provider"] == "anthropic"
+
 
 class TestRenderUnifiedDiff:
     def test_single_edit_produces_expected_hunk(self) -> None:

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -494,7 +494,9 @@ class TestTriggersGradingProviderOpenAI:
             '{"triggered": true, "confidence": 0.9, "reasoning": "yes"}'
         )
         with patch("clauditor._providers.call_model", call):
-            await run_test_triggers(spec)
+            # PR #160 review: openai+claude-default raises ``ValueError``;
+            # pass an explicit OpenAI model name.
+            await run_test_triggers(spec, model="gpt-5.4")
         # All 3 per-query call_model invocations must have received
         # ``provider="openai"``.
         assert call.await_count == 3

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -382,6 +382,37 @@ class TestClassifyQuery:
         assert result.passed is False
         assert "API error" in result.reasoning
 
+    @pytest.mark.asyncio
+    async def test_classify_query_returns_failed_result_on_openai_helper_error(
+        self,
+    ):
+        """#145 QG pass 1: an :class:`OpenAIHelperError` from the OpenAI
+        backend must be caught with the same graceful-degradation contract
+        as :class:`AnthropicHelperError`. Without this, a single OpenAI
+        failure (auth, rate-limit exhaustion, conn error, 5xx) escapes
+        ``asyncio.gather`` and aborts the whole ``test_triggers`` batch
+        when ``provider="openai"``.
+        """
+        from clauditor._providers import OpenAIHelperError
+
+        call = AsyncMock(side_effect=OpenAIHelperError("simulated openai"))
+        with patch("clauditor._providers.call_model", call):
+            result = await classify_query(
+                "skill",
+                "desc",
+                "query",
+                True,
+                "test-model",
+                provider="openai",
+            )
+        assert result.predicted_trigger is False
+        assert result.passed is False
+        assert result.confidence == 0.0
+        assert "API error" in result.reasoning
+        assert "simulated openai" in result.reasoning
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
+
 
 # --- test_triggers tests ---
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -442,3 +442,61 @@ class TestTestTriggers:
         # All 3 queries should have been sent through the helper
         assert call.await_count == 3
         assert len(report.results) == 3
+
+
+class TestTriggersGradingProviderOpenAI:
+    """#145 US-010: when ``eval_spec.grading_provider == "openai"``,
+    ``test_triggers`` resolves the provider once from the spec and
+    threads it into every per-query ``classify_query`` call."""
+
+    @pytest.mark.asyncio
+    async def test_triggers_stamps_openai_when_grading_provider_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = _make_eval_spec(
+            should_trigger=["a", "b"],
+            should_not_trigger=["c"],
+        )
+        spec.grading_provider = "openai"
+        call = _mock_call_anthropic(
+            '{"triggered": true, "confidence": 0.9, "reasoning": "yes"}'
+        )
+        with patch("clauditor._providers.call_model", call):
+            await run_test_triggers(spec)
+        # All 3 per-query call_model invocations must have received
+        # ``provider="openai"``.
+        assert call.await_count == 3
+        for c in call.await_args_list:
+            assert c.kwargs["provider"] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_triggers_defaults_to_anthropic_when_unset(self) -> None:
+        """Back-compat regression: a spec with ``grading_provider=None``
+        still routes through anthropic."""
+        spec = _make_eval_spec(
+            should_trigger=["a"],
+        )
+        # grading_provider default = None
+        call = _mock_call_anthropic(
+            '{"triggered": true, "confidence": 0.9, "reasoning": "yes"}'
+        )
+        with patch("clauditor._providers.call_model", call):
+            await run_test_triggers(spec)
+        assert call.await_count == 1
+        assert call.await_args.kwargs["provider"] == "anthropic"
+
+    @pytest.mark.asyncio
+    async def test_classify_query_provider_kwarg_threaded(self) -> None:
+        """``classify_query`` accepts a ``provider`` kwarg and threads
+        it directly into ``call_model``."""
+        call = _mock_call_anthropic(
+            '{"triggered": true, "confidence": 0.9, "reasoning": "ok"}'
+        )
+        with patch("clauditor._providers.call_model", call):
+            await classify_query(
+                "skill", "desc", "q", True, "test-model",
+                provider="openai",
+            )
+        call.assert_awaited_once()
+        assert call.await_args.kwargs["provider"] == "openai"

--- a/uv.lock
+++ b/uv.lock
@@ -178,11 +178,13 @@ version = "0.1.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "openai" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "anthropic" },
+    { name = "openai" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -192,6 +194,7 @@ dev = [
     { name = "anthropic" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
+    { name = "openai" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -202,6 +205,8 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.40.0" },
+    { name = "openai", specifier = ">=1.66.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=1.66.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
@@ -211,6 +216,7 @@ dev = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=6.0" },
     { name = "mkdocs-material", specifier = ">=9.0" },
+    { name = "openai", specifier = ">=1.66.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -691,6 +697,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695 },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1093,6 +1118,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196 },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393 },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds OpenAI as a sibling provider to Anthropic, using the **Responses API**. Closes #145.

13 stories shipped + 4 QG fix passes:
- US-001 retry hoist → `_providers/_retry.py`
- US-002 happy path → `_providers/_openai.py`
- US-003 response parser edges (`_extract_openai_result`)
- US-004 retry/error branches (parity with Anthropic)
- US-005 wire OpenAI into `call_model` dispatcher
- US-006 `OpenAIAuthMissingError` + `check_provider_auth` dispatcher
- US-007 `EvalSpec.grading_provider` field + load-time validation
- US-008 strip `OPENAI_API_KEY` from skill subprocess env
- US-009 wire 4 LLM-mediated CLI commands to `check_provider_auth`
- US-010 wire 4 grader call sites to read `eval_spec.grading_provider`
- US-011 end-to-end tests for `grading_provider="openai"`
- US-012 Quality Gate (4 review passes; 4 HIGH bugs caught + fixed)
- US-013 Patterns & Memory (3 rules refreshed/created)

## Changes

- **New module:** `src/clauditor/_providers/_openai.py` (mirrors `_anthropic.py` shape)
- **New shared module:** `src/clauditor/_providers/_retry.py` (retry helpers hoisted from `_anthropic.py`)
- **Auth helpers** in `_providers/_auth.py`: `OpenAIAuthMissingError`, `check_openai_auth`, `check_provider_auth(provider, cmd_name)` dispatcher
- **Dispatcher wired:** `call_model(provider="openai", ...)` now dispatches to `call_openai` (was `NotImplementedError`)
- **Spec field:** `EvalSpec.grading_provider: Literal["anthropic","openai"] | None`
- **5 LLM-mediated CLI commands** route through `check_provider_auth` with distinct except branches
- **4 grader call sites** read `eval_spec.grading_provider or "anthropic"` and pass to `call_model`
- **3 new/updated rules:** `centralized-sdk-call.md`, `precall-env-validation.md`, `multi-provider-dispatch.md` (NEW)

Default models per [OpenAI docs](https://developers.openai.com/api/docs/models): `gpt-5.4` (L3 grading) + `gpt-5.4-mini` (L2 extraction).

## Testing

- 2809 tests pass (was 2691 → +118 new). All CI green.
- `_providers/_openai.py`, `_providers/_retry.py`, `_providers/_auth.py`: **100% coverage**.
- Total project coverage: **98.52%**.

## Compounding update

US-013 refreshed three rules:
- `.claude/rules/centralized-sdk-call.md` — widened to multi-provider
- `.claude/rules/precall-env-validation.md` — added OpenAI auth helpers
- `.claude/rules/multi-provider-dispatch.md` (NEW) — codifies the per-provider dispatch pattern

## Follow-up beads

- `clauditor-pjm` (P3) pytest fixture provider routing
- `clauditor-edb` (P4) `clauditor doctor` checks `OPENAI_API_KEY`
- `clauditor-nl7` (P4) `cli/suggest.py` provider plumbing
- `clauditor-m0m` (P4) catch base helper-error class at `responses.create()` / `messages.create()`

## Plan
[`plans/super/145-openai-provider.md`](plans/super/145-openai-provider.md)
