### PR TITLE
#162: 4 polish items from #145 (C1–C4)

### DIFF
--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -235,6 +235,26 @@ async def call_openai(
   This preserves the existing `pip install clauditor[grader]`
   install-hint path every grader entry point already produces
   when users run the tool without the optional extra.
+- **Base-class catch-all defends the exit-3 routing** (US-004 of
+  #162). Each provider's retry loop ends with a final
+  `except AnthropicError as exc:` (in `call_anthropic`) /
+  `except OpenAIError as exc:` (in `call_openai`) branch — the
+  bare SDK base class. This lands AFTER all typed branches
+  (`RateLimitError`, `APIStatusError`, `AuthenticationError`,
+  `PermissionDeniedError`, `APIConnectionError`, `TypeError`)
+  so subclass matching takes precedence per Python's `except`
+  first-match semantics. A future SDK version's new typed error
+  not yet in the ladder would otherwise escape uncaught and
+  bypass the exit-3 routing in CLI dispatchers; the catch-all
+  wraps it as the corresponding `*HelperError` with message
+  `f"API request failed: {type(exc).__name__}: {str(exc)[:500]}"`
+  per DEC-003 of #162 — class name is always safe, 500-char cap
+  on `str(exc)` bounds prompt/body leakage. The branch does
+  NOT retry (without category info, no sound retry decision is
+  possible) and preserves `__cause__` via `raise ... from exc`
+  so debuggers can introspect the original SDK exception. File
+  anchors: `_providers/_anthropic.py::call_anthropic` retry
+  loop, `_providers/_openai.py::call_openai` retry loop.
 
 ## Canonical implementation
 

--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -247,12 +247,19 @@ async def call_openai(
   not yet in the ladder would otherwise escape uncaught and
   bypass the exit-3 routing in CLI dispatchers; the catch-all
   wraps it as the corresponding `*HelperError` with message
-  `f"API request failed: {type(exc).__name__}: {str(exc)[:500]}"`
-  per DEC-003 of #162 — class name is always safe, 500-char cap
-  on `str(exc)` bounds prompt/body leakage. The branch does
-  NOT retry (without category info, no sound retry decision is
-  possible) and preserves `__cause__` via `raise ... from exc`
-  so debuggers can introspect the original SDK exception. File
+  `f"API request failed: {type(exc).__name__}"` — class name only
+  per the post-merge security tightening of DEC-003 of #162.
+  Earlier drafts truncated `str(exc)` to 500 chars, but a
+  CodeRabbit review pass on PR #163 surfaced a stronger argument:
+  this branch handles unknown SDK error shapes by definition, so
+  we cannot assume the SDK's `__str__` is well-behaved (a future
+  SDK error type's message could pack prompt fragments,
+  response-body excerpts, or echoed headers). Truncation bounds
+  size, not exposure. The class name alone is always safe;
+  diagnostic content is preserved on `__cause__` via
+  `raise ... from exc` so debuggers can introspect the full
+  original SDK exception. The branch does NOT retry (without
+  category info, no sound retry decision is possible). File
   anchors: `_providers/_anthropic.py::call_anthropic` retry
   loop, `_providers/_openai.py::call_openai` retry loop.
 

--- a/.claude/rules/llm-cli-exit-code-taxonomy.md
+++ b/.claude/rules/llm-cli-exit-code-taxonomy.md
@@ -135,7 +135,13 @@ Two commands share this taxonomy verbatim:
 - `src/clauditor/cli/suggest.py::_cmd_suggest_impl` — DEC-008 in
   `plans/super/27-suggest-proposer.md`. Uses `SuggestReport` with
   `api_error`, `parse_error`, `validation_errors` (anchor
-  failures).
+  failures). Per US-003 of #162 also loads
+  `SkillSpec.from_file(args.skill)` at the seam, resolves
+  `provider = skill_spec.eval_spec.grading_provider or
+  "anthropic"`, and dispatches `check_provider_auth(provider,
+  "suggest")` with distinct `AnthropicAuthMissingError` and
+  `OpenAIAuthMissingError` except branches — both routing to
+  exit 2, structurally separate from `*HelperError` (exit 3).
 - `src/clauditor/cli/propose_eval.py::_cmd_propose_eval_impl` —
   DEC-006 in `plans/super/52-propose-eval.md`. Uses
   `ProposeEvalReport` with `api_error` and `validation_errors`;

--- a/.claude/rules/multi-provider-dispatch.md
+++ b/.claude/rules/multi-provider-dispatch.md
@@ -194,10 +194,8 @@ invariant holds across re-exports per
 - `OpenAIAuthMissingError` — direct subclass of `Exception`,
   NOT of `AnthropicAuthMissingError`.
 
-CLI call sites (five LLM-mediated commands using the
-provider-aware guard; `suggest` is a sixth LLM-mediated command
-but routes through `check_any_auth_available` directly because
-its prompt builder has no `eval_spec` to read):
+CLI call sites (six LLM-mediated commands, all using the
+provider-aware guard post-#162):
 
 - `src/clauditor/cli/grade.py::cmd_grade` — resolves provider
   from `spec.eval_spec.grading_provider`; calls
@@ -215,6 +213,16 @@ its prompt builder has no `eval_spec` to read):
   `check_provider_auth("anthropic", "propose-eval")`. The
   `OpenAIAuthMissingError` `except` branch is forward-compat
   for a future `--proposer-provider` flag.
+- `src/clauditor/cli/suggest.py::_cmd_suggest_impl` — post-#162
+  US-003 loads `SkillSpec.from_file(args.skill)` after the
+  zero-failing-signals early-exit, resolves
+  `provider = skill_spec.eval_spec.grading_provider or
+  "anthropic"`, calls
+  `check_provider_auth(provider, "suggest")` with distinct
+  `AnthropicAuthMissingError` and `OpenAIAuthMissingError`
+  exit-2 branches, and plumbs `provider=` into
+  `propose_edits(...)`. Mirrors the
+  `cli/triggers.py:114-127` pattern.
 
 Traces to DEC-003 and DEC-006 of
 `plans/super/145-openai-provider.md`. Companion rules:
@@ -271,6 +279,5 @@ class.
   the resolved provider is `"openai"` (OpenAI has no CLI
   transport). File anchor: `src/clauditor/pytest_plugin.py`
   (the three fixture factories ~lines 220-432).
-- One-off diagnostic scripts in `scripts/` that hit a provider
 - One-off diagnostic scripts in `scripts/` that hit a provider
   SDK directly. They can rely on the SDK's own error path.

--- a/.claude/rules/multi-provider-dispatch.md
+++ b/.claude/rules/multi-provider-dispatch.md
@@ -258,12 +258,19 @@ class.
 - Non-LLM CLI commands (`validate`, `capture`, `run`, `lint`,
   `init`, `badge`, `audit`, `trend`). They do not call
   `call_model` and need no auth guard.
-- Pytest fixtures. The three grader fixtures
+- Pytest fixtures. Post-#162 the three grader fixtures
   (`clauditor_grader`, `clauditor_blind_compare`,
-  `clauditor_triggers`) currently route through
-  `check_api_key_only` / `check_any_auth_available` directly
-  rather than `check_provider_auth`; per-provider fixture
-  dispatch is forward-compat work for a future ticket once
-  fixtures grow OpenAI-graded test cases.
+  `clauditor_triggers`) load the spec first, resolve
+  `provider = spec.eval_spec.grading_provider or "anthropic"`,
+  then dispatch: the Anthropic branch retains the
+  `CLAUDITOR_FIXTURE_ALLOW_CLI` opt-in toggle (relaxed
+  `check_any_auth_available` vs strict `check_api_key_only`); any
+  non-Anthropic provider routes through
+  `check_provider_auth(provider, fixture_label)`. Per DEC-004 of
+  #162, `CLAUDITOR_FIXTURE_ALLOW_CLI=1` is silently no-op when
+  the resolved provider is `"openai"` (OpenAI has no CLI
+  transport). File anchor: `src/clauditor/pytest_plugin.py`
+  (the three fixture factories ~lines 220-432).
+- One-off diagnostic scripts in `scripts/` that hit a provider
 - One-off diagnostic scripts in `scripts/` that hit a provider
   SDK directly. They can rely on the SDK's own error path.

--- a/.claude/rules/precall-env-validation.md
+++ b/.claude/rules/precall-env-validation.md
@@ -215,15 +215,29 @@ def clauditor_grader(request, clauditor_spec):
 
     def _factory(skill_path, eval_path=None, output=None):
         # Pre-flight auth guard at factory-invocation time. Raises
-        # ``AnthropicAuthMissingError`` (same class the CLI catches)
-        # so a CI run under subscription-only auth surfaces a clear
-        # error instead of silently skipping. Today the three grader
-        # fixtures are Anthropic-only; per-provider fixture dispatch
-        # (routing through ``check_provider_auth``) is future work.
-        if os.environ.get("CLAUDITOR_FIXTURE_ALLOW_CLI") == "1":
-            check_any_auth_available("grader")
+        # ``AnthropicAuthMissingError`` or ``OpenAIAuthMissingError``
+        # (same classes the CLI catches) so a CI run under
+        # subscription-only auth surfaces a clear error instead of
+        # silently skipping. Post-#162 the fixtures resolve the
+        # provider from the loaded spec and dispatch through
+        # ``check_provider_auth(provider, "grader")`` for non-Anthropic
+        # providers; the Anthropic branch retains the
+        # ``CLAUDITOR_FIXTURE_ALLOW_CLI`` opt-in for relaxed-vs-strict
+        # auth (env var is silently no-op when provider="openai" per
+        # DEC-004 of #162 — OpenAI has no CLI transport).
+        provider = (
+            spec.eval_spec.grading_provider
+            if spec.eval_spec is not None
+            and spec.eval_spec.grading_provider is not None
+            else "anthropic"
+        )
+        if provider == "anthropic":
+            if os.environ.get("CLAUDITOR_FIXTURE_ALLOW_CLI") == "1":
+                check_any_auth_available("grader")
+            else:
+                check_api_key_only("grader")
         else:
-            check_api_key_only("grader")
+            check_provider_auth(provider, "grader")
         # ... spec.run + grade_quality ...
     return _factory
 ```
@@ -509,14 +523,19 @@ provider-aware dispatcher
 Plus the single-provider seam:
 
 - `src/clauditor/cli/suggest.py::_cmd_suggest_impl` — after
-  zero-signal early-exit (no `--dry-run` on this command).
-  `check_any_auth_available("suggest")` directly (no
-  `eval_spec` lookup at the suggest seam, so it stays
-  Anthropic-only).
+  zero-signal early-exit (no `--dry-run` on this command). Per
+  US-003 of #162, loads `SkillSpec.from_file(args.skill)` at the
+  CLI seam, resolves `provider = skill_spec.eval_spec.grading_provider
+  or "anthropic"`, then calls `check_provider_auth(provider,
+  "suggest")` with distinct `AnthropicAuthMissingError` and
+  `OpenAIAuthMissingError` exit-2 branches. Plumbs `provider=`
+  to `propose_edits(...)`. Mirrors the
+  `cli/triggers.py:114-127` shape.
 
-Pytest fixtures (three, all routing through the Anthropic
-helpers — per-provider fixture dispatch is forward-compat
-work):
+Pytest fixtures (three, post-#162 routing through
+`check_provider_auth(provider, fixture_label)` for non-Anthropic
+providers; Anthropic branch retains the
+`CLAUDITOR_FIXTURE_ALLOW_CLI` opt-in toggle):
 
 - `src/clauditor/pytest_plugin.py::clauditor_grader` —
   `check_any_auth_available` (relaxed, opt-in via

--- a/.claude/rules/precall-env-validation.md
+++ b/.claude/rules/precall-env-validation.md
@@ -188,10 +188,15 @@ def cmd_grade(args) -> int:
     # ... staging + call_model below ...
 ```
 
-The `suggest` command is a sixth LLM-mediated CLI seam but is
-single-provider today (no `eval_spec` to read at the call site);
-it calls `check_any_auth_available("suggest")` directly and
-catches `AnthropicAuthMissingError` only.
+The `suggest` command is a sixth LLM-mediated CLI seam. Post-#162
+US-003 it follows the same provider-aware pattern: loads
+`SkillSpec.from_file(args.skill)` at the CLI seam (after the
+zero-failing-signals early-exit), resolves `provider =
+skill_spec.eval_spec.grading_provider or "anthropic"`, and
+dispatches `check_provider_auth(provider, "suggest")` with
+distinct `AnthropicAuthMissingError` and `OpenAIAuthMissingError`
+exit-2 branches. The `provider=` value is plumbed into
+`propose_edits(...)`.
 
 ### Layer 3 — pytest fixtures raise the same exceptions
 
@@ -210,27 +215,30 @@ def clauditor_grader(request, clauditor_spec):
     from clauditor._providers import (
         check_any_auth_available,
         check_api_key_only,
+        check_provider_auth,
     )
     from clauditor.quality_grader import grade_quality
 
     def _factory(skill_path, eval_path=None, output=None):
-        # Pre-flight auth guard at factory-invocation time. Raises
-        # ``AnthropicAuthMissingError`` or ``OpenAIAuthMissingError``
-        # (same classes the CLI catches) so a CI run under
-        # subscription-only auth surfaces a clear error instead of
-        # silently skipping. Post-#162 the fixtures resolve the
-        # provider from the loaded spec and dispatch through
-        # ``check_provider_auth(provider, "grader")`` for non-Anthropic
-        # providers; the Anthropic branch retains the
-        # ``CLAUDITOR_FIXTURE_ALLOW_CLI`` opt-in for relaxed-vs-strict
-        # auth (env var is silently no-op when provider="openai" per
-        # DEC-004 of #162 — OpenAI has no CLI transport).
-        provider = (
-            spec.eval_spec.grading_provider
-            if spec.eval_spec is not None
-            and spec.eval_spec.grading_provider is not None
-            else "anthropic"
-        )
+        # Post-#162 US-001: load the spec FIRST so we can read
+        # ``eval_spec.grading_provider`` and dispatch the auth guard
+        # through the right provider. ``AnthropicAuthMissingError``
+        # or ``OpenAIAuthMissingError`` (same classes the CLI
+        # catches) propagate as pytest setup failures so a CI run
+        # under subscription-only auth surfaces a clear error
+        # instead of silently skipping.
+        spec = clauditor_spec(skill_path, eval_path)
+        # Validate spec shape BEFORE the auth dispatch so a missing
+        # eval.json surfaces as ``"No eval spec found..."`` rather
+        # than being masked by an auth-missing error (CodeRabbit
+        # finding on PR #163).
+        if spec.eval_spec is None:
+            raise ValueError(f"No eval spec found for {skill_path}")
+        provider = spec.eval_spec.grading_provider or "anthropic"
+        # Anthropic branch retains the ``CLAUDITOR_FIXTURE_ALLOW_CLI``
+        # opt-in for relaxed-vs-strict auth; for non-Anthropic
+        # providers the env var is silently no-op (DEC-004 of #162 —
+        # OpenAI has no CLI transport).
         if provider == "anthropic":
             if os.environ.get("CLAUDITOR_FIXTURE_ALLOW_CLI") == "1":
                 check_any_auth_available("grader")
@@ -520,7 +528,7 @@ provider-aware dispatcher
   `except` branch is forward-compat for a future
   `--proposer-provider` flag.
 
-Plus the single-provider seam:
+Plus the sixth LLM-mediated seam (post-#162 also provider-aware):
 
 - `src/clauditor/cli/suggest.py::_cmd_suggest_impl` — after
   zero-signal early-exit (no `--dry-run` on this command). Per

--- a/plans/super/162-polish-followups.md
+++ b/plans/super/162-polish-followups.md
@@ -1,0 +1,320 @@
+# 162: Follow-ups from #145 — 4 polish items (C1–C4)
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/162
+- **Branch:** `feature/162-polish-followups`
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/162-polish-followups`
+- **Phase:** detailing
+- **PR:** TBD
+- **Epic:** TBD (created at devolve)
+- **Sessions:** 1 (2026-05-01)
+- **Depends on:** #145 (CLOSED — multi-provider OpenAI shipped in #160)
+- **Blocks:** none (all items independent of #146/#147)
+- **Source beads:** `clauditor-pjm` (C1, P3), `clauditor-edb` (C2, P4), `clauditor-nl7` (C3, P4), `clauditor-m0m` (C4, P4)
+
+## Discovery
+
+### What
+
+Umbrella issue grouping 4 independent polish/parity follow-ups discovered during QG passes for #145 (multi-provider OpenAI support). Each is small in scope; together they close out the parity gaps that QG surfaced but #145 chose not to land in the merge PR:
+
+- **C1** — Provider-aware auth in pytest fixtures (`pytest_plugin.py`)
+- **C2** — `clauditor doctor` reports `OPENAI_API_KEY` status (info-level)
+- **C3** — `cli/suggest.py` plumbs `provider=` from spec to `propose_edits`
+- **C4** — Both providers' retry loops catch base SDK error class as final fallback
+
+### Why
+
+QG passes for #145 surfaced four gaps where the OpenAI provider work is functionally complete but parity/observability is incomplete:
+
+- C1: a user with `grading_provider="openai"` + `OPENAI_API_KEY` (no Anthropic key) hits the pytest fixtures and sees a misleading "ANTHROPIC_API_KEY missing" error.
+- C2: OpenAI users have no way to verify their auth posture via `clauditor doctor`.
+- C3: `clauditor suggest` always routes through Anthropic regardless of `eval.json`, silently overriding the spec author's `grading_provider` choice.
+- C4: a future SDK version's new typed error not yet in the retry ladder would escape uncaught and bypass the exit-3 routing per `.claude/rules/llm-cli-exit-code-taxonomy.md`.
+
+All four are low-risk, scoped to small surfaces, and inherit existing patterns from `#145`'s shipped work.
+
+### Acceptance criteria (from ticket)
+
+1. **C1**: pytest fixtures resolve provider from spec, dispatch through `check_provider_auth(provider, label)` with both `AnthropicAuthMissingError` and `OpenAIAuthMissingError` except branches. `CLAUDITOR_FIXTURE_ALLOW_CLI` semantics preserved for Anthropic; OpenAI always strict key-only.
+2. **C2**: `clauditor doctor` emits an info-level (not error) check for `OPENAI_API_KEY` presence regardless of whether key is set.
+3. **C3**: `cli/suggest.py` loads `EvalSpec`, resolves `provider = eval_spec.grading_provider or "anthropic"`, calls `check_provider_auth(provider, "suggest")` with dual except branches, passes `provider=` to `propose_edits(...)`.
+4. **C4**: Both `_providers/_anthropic.py::call_anthropic` and `_providers/_openai.py::call_openai` retry loops catch base `AnthropicError` / `OpenAIError` as final except branch, wrapping as the corresponding `*HelperError`. Order preserves: subclass branches before base catch-all.
+
+### Codebase findings (from Codebase Scout)
+
+#### C1 — `src/clauditor/pytest_plugin.py`
+
+Three fixtures requiring identical refactoring (lines 220–372):
+
+- **`clauditor_grader`** lines 220–260 — auth check at lines 248–251 (between `_fixture_allow_cli()` branch on `check_any_auth_available` vs `check_api_key_only`); spec loaded at line 252.
+- **`clauditor_blind_compare`** lines 292–341 — auth at 329–332; spec at 333.
+- **`clauditor_triggers`** lines 345–372 — auth at 363–366; spec at 367.
+
+Fix: reorder to load spec first (so `eval_spec.grading_provider` is reachable), then dispatch via `check_provider_auth(provider, fixture_label)` with both auth-missing except branches. `CLAUDITOR_FIXTURE_ALLOW_CLI` env var becomes Anthropic-only since OpenAI has no CLI transport.
+
+Test surface: `tests/test_pytest_plugin.py` (no existing OpenAI-routed fixture tests; new tests needed).
+
+#### C2 — `src/clauditor/cli/doctor.py`
+
+Lines 50–141. Current shape:
+
+- Lines 105–121 — `ANTHROPIC_API_KEY` `[ok]`/`[info]` check via `(label, status, message)` tuple appended to `checks` list.
+- Lines 123–140 — `claude` CLI check mirrors same pattern.
+
+Add: after line 121, append `("openai-key-available", "ok"/"info", "...")` tuple. Probe by env presence only (no SDK call). `[info]` regardless of presence per ticket — OpenAI is opt-in.
+
+Test surface: `tests/test_doctor.py` — three existing tests (`ok_when_set`, `info_when_unset`, `info_when_whitespace`) for Anthropic; mirror for OpenAI.
+
+#### C3 — `src/clauditor/cli/suggest.py`
+
+`_cmd_suggest_impl` at lines 199–239:
+
+- Line 205: `check_any_auth_available("suggest")` — Anthropic-only guard today.
+- Line 235: `propose_edits(suggest_input, model=..., transport=...)` — no `provider=` kwarg.
+
+`propose_edits` signature at `src/clauditor/suggest.py` lines 931–938 already accepts `provider="anthropic"` default. The plumbing target exists; only the CLI seam needs work.
+
+Pattern to mirror: `cli/triggers.py` lines 114–127 — load `SkillSpec.from_file(skill_path)`, resolve provider, dispatch through `check_provider_auth`, pass `provider=` through.
+
+Source of skill path: `args.skill` at line 110 — already in scope.
+
+Test surface: `tests/test_suggest.py` — no provider-routed tests today; new test for OpenAI-spec routing.
+
+#### C4 — `_providers/_anthropic.py` + `_providers/_openai.py`
+
+**Anthropic** (`call_anthropic` retry loop, lines 513–603):
+- Imports at 473–480: `RateLimitError, APIStatusError, AuthenticationError, PermissionDeniedError, APIConnectionError`. **`AnthropicError` not yet imported** — must add.
+- Try block at 514–518; except ladder at 519–598 ends with `TypeError`.
+- Add: `except anthropic.AnthropicError as exc: raise AnthropicHelperError(...) from exc` AFTER the TypeError branch (line 598).
+
+**OpenAI** (`call_openai` retry loop, lines 370–447):
+- Imports at 315–322: includes `OpenAIError` (already imported).
+- Try block at 371–375; except ladder at 376–447 ends with `TypeError`.
+- Add: `except OpenAIError as exc: raise OpenAIHelperError(...) from exc` AFTER the TypeError branch.
+
+**Order critical**: bare-class catch-all MUST land after all subclass branches (`RateLimitError`, `APIStatusError`, `AuthenticationError`, `PermissionDeniedError`, `APIConnectionError`, `TypeError`) so subclass matching takes precedence.
+
+Test surface:
+- `tests/test_providers_anthropic.py` — typed-subclass tests exist; new test class for bare base-class wrap.
+- `tests/test_providers_openai.py` — typed-subclass tests from #145 US-003/US-004; new test class for bare base-class wrap.
+
+### Convention constraints (from Convention Checker)
+
+| Rule | Item(s) | Constraint |
+|------|---------|-----------|
+| `multi-provider-dispatch.md` | C1, C3 | Resolve provider from spec at the seam; call `check_provider_auth(provider, cmd_name)` with distinct except branches per provider. |
+| `precall-env-validation.md` | C1, C2, C3 | Pure auth helpers, raise distinct per-provider exception classes; CLI/fixture wrapper owns stderr + exit code. |
+| `llm-cli-exit-code-taxonomy.md` | C3, C4 | Exit 2 for auth-missing, exit 3 for `*HelperError`. C4 catch-all preserves exit-3 routing for unknown SDK errors. |
+| `centralized-sdk-call.md` | C3, C4 | All `call_model` calls dispatch through the centralized seam; retry policy + error categorization owned there. |
+| `pure-compute-vs-io-split.md` | C2, C3 | Pure helpers (env-read, parse, validate); CLI wrapper owns I/O. |
+| `mock-side-effect-for-distinct-calls.md` | C1 | Tests with mocks called >1x per test must use `side_effect=[...]`, not `return_value`. |
+| `back-compat-shim-discipline.md` | n/a | No new exception classes introduced (only re-using existing); class-identity invariant unaffected. |
+| `rule-refresh-vs-delete.md` | post-merge | `multi-provider-dispatch.md` "When this rule does NOT apply" §("Pytest fixtures... routing through the Anthropic helpers... per-provider fixture dispatch is forward-compat work") becomes stale once C1 lands — refresh in Patterns & Memory story. |
+
+Rules NOT applicable: `monotonic-time-indirection`, `non-mutating-scrub`, `path-validation`, `skill-identity-from-frontmatter`, `bundled-skill-docs-sync`, `json-schema-version`, `constant-with-type-info`, `pre-llm-contract-hard-validate` (anchor validator already in place — no new contract added).
+
+## Phase 1 scoping (answered)
+
+- **Q1 = A** — Single PR with 4 implementation stories + Quality Gate + Patterns & Memory. Matches the umbrella issue's intent and lets the reviewer see all parity gaps closed in one delta.
+- **Q2 = A** — `SkillSpec.from_file(args.skill)` then read `skill_spec.eval_spec.grading_provider`. Mirrors `cli/triggers.py:114-127` exactly. No new resolution path invented.
+- **Q3 = A** — `f"API request failed: {exc}"`. Uniform across both providers. `str(exc)` on Anthropic's typed errors already calls into the SDK's reasonable `__str__`.
+- **Q4 = A** — `CLAUDITOR_FIXTURE_ALLOW_CLI=1` is silently ignored when provider resolves to `"openai"`. The env var is documented today as gating CLI transport (Anthropic-only); OpenAI has no CLI transport, so the variable is a no-op for that branch. No warning needed — the user sees no behavior change.
+- **Q5 = B** — Per-provider `TestBaseErrorCatchAll` class with two tests each: (1) bare base-class instance wraps to `*HelperError("API request failed: ...")`, (2) ordering-regression — `RateLimitError` (subclass) still caught by its specific branch, not the new catch-all.
+
+## Phase 2 architecture review
+
+| Area | Rating | Notes |
+|------|--------|-------|
+| **Security — auth routing** | pass | (1) `SkillSpec.from_file` is pure file-read+parse+validate (no side effects pre-auth). (2) Missing-spec edge case: existing `_load_spec_or_report` in `cli/triggers.py` returns `None` on read failure → exit 2 before any auth check. (3) `check_provider_auth` routes structurally by exact string match — no fallback when provider="openai". (4) `check_openai_auth` is unconditionally strict (no CLI fallback). (6) No env values logged — only fixed templates and presence indicators. |
+| **Security — C4 catch-all message content** | concern | `f"API request failed: {exc}"` (Q3=A) calls `str(exc)` on the SDK exception. Today's typed branches already include body excerpts (truncated) for `APIStatusError`, but the catch-all is for *future* SDK error types we haven't seen. Risk: a hypothetical future SDK error whose `__str__` echoes prompt/response body would surface in stderr. See refinement Q-R1. |
+| **Performance** | pass | No new queries, no new loops, no new I/O. C2 reads env (O(1)). C3 adds one `SkillSpec.from_file` (already on the path for triggers/grade). C4 is a single new except branch. |
+| **Data Model** | pass | No schema changes, no new sidecars, no migrations. |
+| **API Design** | pass | `propose_edits` already accepts `provider=` kwarg (default "anthropic"); C3 only plumbs it. C4 wraps as existing `*HelperError` types (no new exception classes). C2 extends doctor's existing `(label, status, message)` tuple format. |
+| **Observability** | pass | C2 surfaces OpenAI auth posture in `clauditor doctor` (info-level — no false-error noise for Anthropic-only users). C4 ensures unknown SDK errors land in the existing exit-3 routing instead of escaping as raw tracebacks. |
+| **Testing strategy** | concern | (1) C1 falls under `pytester-inprocess-coverage-hazard.md` — new tests must use `__wrapped__` direct calls, NOT `runpytest_inprocess + mock.patch` on already-coverage-instrumented modules. (2) C3 vacuous-test risk — tests must construct an EvalSpec with a *distinct* `grading_provider="openai"` value (not the default) and assert the value flows to `call_model`'s `provider=` kwarg. (3) C4 catch-all dead-code risk — first test MUST use a bare `Exception` instance NOT in any typed branch's class hierarchy. Both concerns are scoping refinements, not blockers — embedded in story acceptance criteria. |
+
+### Refinement decisions (DEC log)
+
+- **DEC-001** — PR shape. Single PR with 4 implementation stories + Quality Gate + Patterns & Memory. Rationale: matches the umbrella-issue intent, lets reviewers see all parity gaps closed in one delta, no cross-story dependencies require ordering. (Q1=A)
+- **DEC-002** — C3 EvalSpec source. `cli/suggest.py` loads via `SkillSpec.from_file(args.skill)` and reads `skill_spec.eval_spec.grading_provider`. Mirrors `cli/triggers.py:114-127`; no new resolution path invented. (Q2=A)
+- **DEC-003** — C4 message format. `f"API request failed: {type(exc).__name__}: {str(exc)[:500]}"` for both providers. Class name is always safe and useful; 500-char cap on `str(exc)` bounds any prompt/body leakage well below typical sizes while preserving diagnostic info ("invalid_request_error: ..."). Supersedes Q3=A after security review concern. (Q-R1=C)
+- **DEC-004** — `CLAUDITOR_FIXTURE_ALLOW_CLI=1` UX with `provider="openai"`. Silently no-op. The env var is documented today as gating CLI transport (Anthropic-only); OpenAI has no CLI transport, so the variable has nothing to gate. No warning, no error. (Q4=A)
+- **DEC-005** — C4 test coverage shape. Per-provider `TestBaseErrorCatchAll` class with two tests each: (1) bare base-class wraps to `*HelperError("API request failed: ...")`, (2) ordering regression — `RateLimitError` (subclass) still routes to its specific branch. (Q5=B)
+- **DEC-006** — C1 test discipline (pytester-coverage-hazard guardrail). New tests for the OpenAI fixture path use `__wrapped__` direct calls, NOT `runpytest_inprocess + mock.patch` on already-coverage-instrumented modules. Per `.claude/rules/pytester-inprocess-coverage-hazard.md`. (Architecture review concern.)
+- **DEC-007** — C3 vacuous-test guardrail. Tests construct an EvalSpec with a *distinct* `grading_provider="openai"` value (NOT the default-anthropic path) and assert `call_mock.await_args.kwargs["provider"] == "openai"` — proves the field is actually consulted, not just plumbed inertly. (Architecture review concern.)
+- **DEC-008** — C4 dead-code guardrail. The first catch-all test MUST construct an `AnthropicError`/`OpenAIError` instance that is NOT a subclass of any specifically-caught typed exception (`RateLimitError`, `APIStatusError`, `AuthenticationError`, `PermissionDeniedError`, `APIConnectionError`). Otherwise the test passes via the typed branch and the catch-all is unexercised. (Architecture review concern.)
+- **DEC-009** — Post-merge rule refresh. `.claude/rules/multi-provider-dispatch.md` (and `precall-env-validation.md`) currently document "Pytest fixtures... routing through the Anthropic helpers... per-provider fixture dispatch is forward-compat work". Once US-001 lands, that's stale. Refresh in-place per `.claude/rules/rule-refresh-vs-delete.md`; preserve historical validation notes byte-verbatim.
+
+## Phase 4 — Detailed Breakdown
+
+Six stories total. Stories US-001 through US-004 are independent (no cross-dependencies); US-005 (Quality Gate) depends on all four; US-006 (Patterns & Memory) depends on US-005. Order below matches the ticket's C1→C4 enumeration; Ralph may execute US-001 through US-004 in parallel.
+
+### US-001 — C1: Provider-aware auth in pytest fixtures
+
+**Description.** Reorder the three `pytest_plugin.py` fixtures (`clauditor_grader`, `clauditor_blind_compare`, `clauditor_triggers`) to load the `SkillSpec` *before* the auth check, then resolve `provider = spec.eval_spec.grading_provider or "anthropic"` and dispatch through `check_provider_auth(provider, fixture_label)` with both `AnthropicAuthMissingError` and `OpenAIAuthMissingError` except branches. `CLAUDITOR_FIXTURE_ALLOW_CLI=1` becomes Anthropic-only (silently no-op when provider resolves to `"openai"`).
+
+**Traces to.** DEC-001, DEC-004, DEC-006.
+
+**Acceptance criteria.**
+- All three fixtures resolve `provider` from `spec.eval_spec.grading_provider` with `"anthropic"` fallback when None or absent.
+- Dispatch routes through `check_provider_auth(provider, fixture_label)`; both auth-missing exceptions caught explicitly per `.claude/rules/multi-provider-dispatch.md`.
+- `CLAUDITOR_FIXTURE_ALLOW_CLI=1` toggle is read only inside the Anthropic branch; silently no-op when provider resolves to `"openai"` (DEC-004).
+- New tests in `tests/test_pytest_plugin.py::TestClauditorFixturesAuthGuardOpenAI` covering: provider="openai" + missing OPENAI_API_KEY raises `OpenAIAuthMissingError` (no Anthropic fallback even when `ANTHROPIC_API_KEY` is set); provider="openai" + key set passes; provider="openai" + `CLAUDITOR_FIXTURE_ALLOW_CLI=1` is no-op.
+- New tests use `__wrapped__` direct calls per `.claude/rules/pytester-inprocess-coverage-hazard.md` (DEC-006).
+- Existing `TestClauditorFixturesAuthGuard` tests still pass (Anthropic path unchanged).
+- `uv run ruff check src/ tests/` passes; `uv run pytest --cov=clauditor --cov-report=term-missing` passes; coverage ≥80%.
+
+**Done when.** Three fixtures dispatch through `check_provider_auth`; OpenAI branch is unit-tested via `__wrapped__`; existing Anthropic tests green; quality gates clean.
+
+**Files.**
+- `src/clauditor/pytest_plugin.py` — three fixtures' auth-check + spec-load reorder (~lines 220-372).
+- `tests/test_pytest_plugin.py` — new `TestClauditorFixturesAuthGuardOpenAI` class.
+
+**Depends on.** none.
+
+**TDD.**
+- T1: provider="openai" + OPENAI_API_KEY unset + ANTHROPIC_API_KEY set → `OpenAIAuthMissingError` raised at factory invocation (no Anthropic fallback).
+- T2: provider="openai" + OPENAI_API_KEY set → fixture factory returns successfully.
+- T3: provider="openai" + `CLAUDITOR_FIXTURE_ALLOW_CLI=1` set → strict OpenAI key check still applied (env var is no-op).
+- T4: provider unset (None in spec) + ANTHROPIC_API_KEY set → existing Anthropic happy path.
+- T5: provider="anthropic" explicit + `CLAUDITOR_FIXTURE_ALLOW_CLI=1` → existing relaxed-guard behavior preserved.
+
+### US-002 — C2: clauditor doctor checks OPENAI_API_KEY
+
+**Description.** Add an info-level `OPENAI_API_KEY` presence check to `cli/doctor.py` after the existing `ANTHROPIC_API_KEY` check. Probe by env presence only; status is `[ok]` when set + non-whitespace, `[info]` when unset or whitespace-only (never `[fail]` — OpenAI is opt-in via `grading_provider="openai"`).
+
+**Traces to.** DEC-001.
+
+**Acceptance criteria.**
+- `cli/doctor.py` appends `("openai-api-key-available", "ok"|"info", message)` tuple after the `ANTHROPIC_API_KEY` check (~line 121).
+- Status logic mirrors Anthropic's: `[ok]` if key set + non-whitespace; `[info]` if unset or whitespace-only.
+- Three new tests in `tests/test_doctor.py::TestDoctorOpenAIKeyCheck` mirroring the three Anthropic tests (`ok_when_set`, `info_when_unset`, `info_when_whitespace`).
+- Doctor output never echoes the key value itself — only presence status.
+- Existing Anthropic and `claude` CLI doctor tests still pass.
+- `uv run ruff check src/ tests/` passes; coverage ≥80%.
+
+**Done when.** Running `clauditor doctor` with `OPENAI_API_KEY` set shows the new `[ok]` line; unset shows `[info]`. Three new tests green.
+
+**Files.**
+- `src/clauditor/cli/doctor.py` — add OpenAI check tuple after line 121.
+- `tests/test_doctor.py` — new `TestDoctorOpenAIKeyCheck` class with 3 tests.
+
+**Depends on.** none.
+
+**TDD.**
+- T1: `OPENAI_API_KEY="sk-test-1"` → `[ok]` line present in output, `OPENAI_API_KEY` substring present.
+- T2: `OPENAI_API_KEY` unset → `[info]` line present (NOT `[fail]`).
+- T3: `OPENAI_API_KEY="   "` (whitespace-only) → `[info]` (matches Anthropic's whitespace handling).
+
+### US-003 — C3: cli/suggest.py provider plumbing
+
+**Description.** Extend `_cmd_suggest_impl` in `src/clauditor/cli/suggest.py` to load `SkillSpec.from_file(args.skill)` (mirror `cli/triggers.py:114-127` per DEC-002), resolve `provider = spec.eval_spec.grading_provider or "anthropic"`, dispatch through `check_provider_auth(provider, "suggest")` with both auth-missing except branches (exit 2), and pass `provider=provider` to `propose_edits(...)`. Replace the existing single `check_any_auth_available("suggest")` call.
+
+**Traces to.** DEC-001, DEC-002, DEC-007.
+
+**Acceptance criteria.**
+- `_cmd_suggest_impl` loads `SkillSpec` AFTER arg validation + dry-run early return, BEFORE the auth check (per `.claude/rules/precall-env-validation.md`).
+- Provider resolves from `spec.eval_spec.grading_provider` (None → `"anthropic"` fallback).
+- `check_provider_auth(provider, "suggest")` replaces `check_any_auth_available("suggest")`; both `AnthropicAuthMissingError` and `OpenAIAuthMissingError` caught with distinct exit-2 branches per `.claude/rules/llm-cli-exit-code-taxonomy.md`.
+- `propose_edits(suggest_input, model=..., transport=..., provider=provider)` — new kwarg plumbed through.
+- Spec-load failure (`FileNotFoundError`, `ValueError` from EvalSpec validation) exits with crisp ERROR message before any auth check (mirrors `_load_spec_or_report` shape from `cli/triggers.py`).
+- New tests in `tests/test_suggest.py::TestCmdSuggestProviderPlumbing` use a *distinct* `grading_provider="openai"` value (NOT default), patch `clauditor._providers.call_model`, run `cmd_suggest(args)`, assert `call_mock.await_args.kwargs["provider"] == "openai"` (DEC-007).
+- `uv run ruff check src/ tests/` passes; coverage ≥80%.
+
+**Done when.** `clauditor suggest` on a skill with `grading_provider="openai"` routes through OpenAI; existing Anthropic flow unchanged; tests green.
+
+**Files.**
+- `src/clauditor/cli/suggest.py` — add SkillSpec load + provider resolution + dual-except auth dispatch + provider kwarg plumbing (~lines 199-239).
+- `tests/test_suggest.py` — new `TestCmdSuggestProviderPlumbing` class.
+
+**Depends on.** none.
+
+**TDD.**
+- T1: skill with `grading_provider="openai"` + OPENAI_API_KEY set → `call_model` receives `provider="openai"` (DEC-007 distinct-value assertion).
+- T2: skill with no `grading_provider` field → `call_model` receives `provider="anthropic"` (default path).
+- T3: skill with `grading_provider="openai"` + OPENAI_API_KEY unset → exits 2, stderr contains `OpenAIAuthMissingError` template, no `call_model` invocation.
+- T4: skill with `grading_provider="openai"` + ANTHROPIC_API_KEY set + OPENAI_API_KEY unset → still exits 2 (no Anthropic fallback even when Anthropic auth is available).
+- T5: missing skill file → exits 1 (or 2 per existing convention) with crisp error before any auth check.
+
+### US-004 — C4: base helper-error catch-all in retry loops
+
+**Description.** Add a final `except` branch in both `_providers/_anthropic.py::call_anthropic` and `_providers/_openai.py::call_openai` retry loops that catches the SDK base exception class (`anthropic.AnthropicError` / `openai.OpenAIError`) and wraps as the corresponding `*HelperError` with message format `f"API request failed: {type(exc).__name__}: {str(exc)[:500]}"` (DEC-003). The catch-all lands AFTER all typed branches so subclass matching takes precedence per Python's `except` first-match semantics.
+
+**Traces to.** DEC-001, DEC-003, DEC-005, DEC-008.
+
+**Acceptance criteria.**
+- `src/clauditor/_providers/_anthropic.py`: import `AnthropicError` from anthropic SDK; add `except AnthropicError as exc:` AFTER the `TypeError` branch in `call_anthropic`'s retry-loop ladder. Wraps as `AnthropicHelperError(f"API request failed: {type(exc).__name__}: {str(exc)[:500]}") from exc`.
+- `src/clauditor/_providers/_openai.py`: `OpenAIError` is already imported; add `except OpenAIError as exc:` AFTER the `TypeError` branch in `call_openai`'s retry-loop ladder. Same wrap shape.
+- Order verified: bare base catch-all is LAST in each ladder; subclass branches (`RateLimitError`, `APIStatusError`, `AuthenticationError`, `PermissionDeniedError`, `APIConnectionError`, `TypeError`) still match first.
+- New `tests/test_providers_anthropic.py::TestCallAnthropicBaseErrorCatchAll` class with two tests:
+  - `test_bare_anthropic_error_wraps_to_helper_error`: construct an `AnthropicError` instance NOT in any typed branch's hierarchy (DEC-008), mock client raises it, assert `AnthropicHelperError` raised with `"API request failed:"` prefix and class name in message; `__cause__` preserves original.
+  - `test_rate_limit_subclass_routes_to_specific_branch_not_catch_all`: ordering regression — exhaust `RateLimitError` retries, assert message indicates rate-limit-specific handling (NOT generic catch-all phrasing); `mock_client.messages.create.await_count == 4`.
+- Mirror `tests/test_providers_openai.py::TestCallOpenAIBaseErrorCatchAll` with the same two-test shape.
+- Existing typed-branch tests in both files still pass (subclass branches unchanged).
+- `uv run ruff check src/ tests/` passes; coverage ≥80%.
+
+**Done when.** Both retry loops have catch-all branches; four new tests (two per provider) green; existing tests green.
+
+**Files.**
+- `src/clauditor/_providers/_anthropic.py` — add `AnthropicError` import + new except branch in `call_anthropic`'s retry ladder.
+- `src/clauditor/_providers/_openai.py` — add new except branch in `call_openai`'s retry ladder (`OpenAIError` already imported).
+- `tests/test_providers_anthropic.py` — new `TestCallAnthropicBaseErrorCatchAll` class with 2 tests.
+- `tests/test_providers_openai.py` — new `TestCallOpenAIBaseErrorCatchAll` class with 2 tests.
+
+**Depends on.** none.
+
+**TDD.**
+- T1 (Anthropic catch-all): `AnthropicError("simulated unknown failure")` instance (DEC-008 — not a subclass of any typed branch) → `AnthropicHelperError`, message contains `"API request failed:"` AND `"AnthropicError"` AND truncated payload.
+- T2 (Anthropic ordering): `RateLimitError` exhausted → message indicates rate-limit (subclass branch wins); `await_count` proves retry policy applied.
+- T3 (OpenAI catch-all): `OpenAIError("simulated unknown failure")` → `OpenAIHelperError`, message contains `"API request failed:"` AND `"OpenAIError"` AND truncated payload.
+- T4 (OpenAI ordering): `RateLimitError` exhausted → rate-limit-specific message; ordering preserved.
+
+### US-005 — Quality Gate
+
+**Description.** Run code-reviewer agent 4 times across the full changeset, fixing all real findings each pass. Run CodeRabbit (or pr-reviewer agent) once on the staged diff. Project validation must pass after all fixes.
+
+**Traces to.** DEC-001.
+
+**Acceptance criteria.**
+- `uv run ruff check src/ tests/` passes (no warnings).
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes; coverage ≥80%.
+- 4 passes of code-reviewer agent across the full diff vs `dev` branch; each pass either fixes all real findings OR documents false positives in the plan's Session Notes.
+- 1 pass of CodeRabbit review (or pr-reviewer agent) on the staged diff; same fix-or-document policy.
+- All US-001 through US-004 new tests still pass; pre-existing test suite still green.
+- No new TODO comments, no skipped tests added, no `--no-verify` git operations.
+
+**Done when.** All quality gates green; reviewer findings resolved or documented; final `pytest` + `ruff` clean.
+
+**Files.** Any files touched by US-001 through US-004 (review surface).
+
+**Depends on.** US-001, US-002, US-003, US-004.
+
+### US-006 — Patterns & Memory
+
+**Description.** Refresh `.claude/rules/*.md` files whose canonical-implementation sections describe surfaces modified in this batch. Per `.claude/rules/rule-refresh-vs-delete.md`: refresh in-place, preserve historical validation notes byte-verbatim. No new rules introduced.
+
+**Traces to.** DEC-001, DEC-009.
+
+**Acceptance criteria.**
+- `.claude/rules/multi-provider-dispatch.md` — refresh "When this rule does NOT apply" section to reflect that pytest fixtures NOW route through `check_provider_auth` (the "forward-compat work for a future ticket" sentence becomes stale once US-001 lands).
+- `.claude/rules/precall-env-validation.md` — spot-check the "Pytest fixtures (three, all routing through the Anthropic helpers — per-provider fixture dispatch is forward-compat work)" mention in the Canonical implementation section; refresh to match the post-#162 reality.
+- `.claude/rules/llm-cli-exit-code-taxonomy.md` — Canonical implementation section: add `cli/suggest.py` to the list of single-call commands routing through `check_provider_auth` with the dual-except shape.
+- `.claude/rules/centralized-sdk-call.md` — Canonical implementation section: add a one-paragraph note about the C4 base-class catch-all in both providers' retry loops (defense-in-depth against unknown future SDK error types).
+- All four refreshed rules pass any rule-self-test if present (e.g. `tests/test_rules.py` if it exists; otherwise N/A).
+- No new memory files added (the patterns are captured in the rules above).
+
+**Done when.** Four rule files refreshed; all post-#162 documentation reflects the new shape; preserved historical validation notes unchanged.
+
+**Files.**
+- `.claude/rules/multi-provider-dispatch.md`
+- `.claude/rules/precall-env-validation.md`
+- `.claude/rules/llm-cli-exit-code-taxonomy.md`
+- `.claude/rules/centralized-sdk-call.md`
+
+**Depends on.** US-005.
+
+## Beads Manifest
+
+To be filled in at devolve time.

--- a/plans/super/162-polish-followups.md
+++ b/plans/super/162-polish-followups.md
@@ -5,8 +5,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/162
 - **Branch:** `feature/162-polish-followups`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/162-polish-followups`
-- **Phase:** detailing
-- **PR:** TBD
+- **Phase:** published
+- **PR:** https://github.com/wjduenow/clauditor/pull/163
 - **Epic:** TBD (created at devolve)
 - **Sessions:** 1 (2026-05-01)
 - **Depends on:** #145 (CLOSED — multi-provider OpenAI shipped in #160)

--- a/plans/super/162-polish-followups.md
+++ b/plans/super/162-polish-followups.md
@@ -5,7 +5,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/162
 - **Branch:** `feature/162-polish-followups`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/162-polish-followups`
-- **Phase:** approved
+- **Phase:** devolved
 - **PR:** https://github.com/wjduenow/clauditor/pull/163
 - **Epic:** TBD (created at devolve)
 - **Sessions:** 1 (2026-05-01)
@@ -317,4 +317,22 @@ Six stories total. Stories US-001 through US-004 are independent (no cross-depen
 
 ## Beads Manifest
 
-To be filled in at devolve time.
+- **Epic:** `clauditor-3dy` — `#162: Follow-ups from #145 — 4 polish items (C1–C4)` (P3)
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/162-polish-followups`
+- **Branch:** `feature/162-polish-followups`
+- **PR:** https://github.com/wjduenow/clauditor/pull/163
+
+### Tasks (all parented under `clauditor-3dy`)
+
+| Story | Bead | Title | Priority | Depends on |
+|-------|------|-------|----------|------------|
+| US-001 | `clauditor-pjm` | C1: pytest fixtures provider-aware auth | P3 | none |
+| US-002 | `clauditor-edb` | C2: clauditor doctor checks `OPENAI_API_KEY` | P4 | none |
+| US-003 | `clauditor-nl7` | C3: cli/suggest.py provider plumbing | P4 | none |
+| US-004 | `clauditor-m0m` | C4: base helper-error catch-all | P4 | none |
+| US-005 | `clauditor-3dy.1` | Quality Gate — code review x4 + CodeRabbit | P3 | clauditor-pjm, clauditor-edb, clauditor-nl7, clauditor-m0m |
+| US-006 | `clauditor-3dy.2` | Patterns & Memory — refresh 4 `.claude/rules/*.md` | P3 | clauditor-3dy.1 |
+
+US-001 through US-004 (the four `C*` source beads) are independent and Ralph-parallelizable — `bd ready` shows them all as unblocked.
+
+Each implementation bead carries an appended `notes` block pointing to its US-### in this plan and the DEC-### entries it traces to (so a Ralph worker reading the bead in isolation has the full context: plan path, story id, decisions, test discipline guardrails).

--- a/plans/super/162-polish-followups.md
+++ b/plans/super/162-polish-followups.md
@@ -5,7 +5,7 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/162
 - **Branch:** `feature/162-polish-followups`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/162-polish-followups`
-- **Phase:** published
+- **Phase:** approved
 - **PR:** https://github.com/wjduenow/clauditor/pull/163
 - **Epic:** TBD (created at devolve)
 - **Sessions:** 1 (2026-05-01)

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -471,6 +471,7 @@ async def _call_via_sdk(
     """SDK (HTTP) transport branch. See :func:`call_anthropic` for policy."""
     try:
         from anthropic import (
+            AnthropicError,
             APIConnectionError,
             APIStatusError,
             AsyncAnthropic,
@@ -595,6 +596,24 @@ async def _call_via_sdk(
             raise AnthropicHelperError(
                 "Anthropic SDK client initialization failed — "
                 "verify ANTHROPIC_API_KEY is set."
+            ) from exc
+        except AnthropicError as exc:
+            # US-004 of #162 (DEC-003, DEC-005, DEC-008): bare base
+            # ``anthropic.AnthropicError`` catch-all. Any future SDK
+            # version that raises a typed exception not in the ladder
+            # above (e.g. a new subclass not yet anticipated) would
+            # otherwise escape uncaught and bypass the exit-3 routing.
+            # This branch lands AFTER all typed branches so subclass
+            # matching takes precedence per Python's ``except``
+            # first-match semantics. Message format: class name
+            # (always safe) + ``str(exc)[:500]`` (bounded to cap any
+            # prompt/body leakage). Original exception preserved on
+            # ``__cause__`` via ``raise ... from exc``. Not retried:
+            # without category information we cannot make a sound
+            # retry decision.
+            raise AnthropicHelperError(
+                f"API request failed: {type(exc).__name__}: "
+                f"{str(exc)[:500]}"
             ) from exc
 
         duration = _monotonic() - start

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -605,15 +605,21 @@ async def _call_via_sdk(
             # otherwise escape uncaught and bypass the exit-3 routing.
             # This branch lands AFTER all typed branches so subclass
             # matching takes precedence per Python's ``except``
-            # first-match semantics. Message format: class name
-            # (always safe) + ``str(exc)[:500]`` (bounded to cap any
-            # prompt/body leakage). Original exception preserved on
-            # ``__cause__`` via ``raise ... from exc``. Not retried:
+            # first-match semantics. Message format: class name only
+            # — ``str(exc)`` is intentionally NOT surfaced here per
+            # the post-merge security tightening of DEC-003 (#162):
+            # this branch handles unknown SDK error shapes by
+            # definition, so we cannot assume the SDK's ``__str__``
+            # is well-behaved (a future SDK error type's message
+            # could pack prompt fragments, response-body excerpts,
+            # or echoed headers). Truncation bounds size, not
+            # exposure. Diagnostic content is preserved on
+            # ``__cause__`` via ``raise ... from exc`` — debuggers
+            # can introspect the original exception. Not retried:
             # without category information we cannot make a sound
             # retry decision.
             raise AnthropicHelperError(
-                f"API request failed: {type(exc).__name__}: "
-                f"{str(exc)[:500]}"
+                f"API request failed: {type(exc).__name__}"
             ) from exc
 
         duration = _monotonic() - start

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -445,6 +445,24 @@ async def call_openai(
                 "OpenAI SDK client initialization failed — "
                 "verify OPENAI_API_KEY is set."
             ) from exc
+        except OpenAIError as exc:
+            # US-004 of #162 (DEC-003, DEC-005, DEC-008): bare base
+            # ``openai.OpenAIError`` catch-all. Any future SDK version
+            # that raises a typed exception not in the ladder above
+            # (e.g. a new subclass not yet anticipated) would
+            # otherwise escape uncaught and bypass the exit-3 routing.
+            # This branch lands AFTER all typed branches so subclass
+            # matching takes precedence per Python's ``except``
+            # first-match semantics. Message format: class name
+            # (always safe) + ``str(exc)[:500]`` (bounded to cap any
+            # prompt/body leakage). Original exception preserved on
+            # ``__cause__`` via ``raise ... from exc``. Not retried:
+            # without category information we cannot make a sound
+            # retry decision.
+            raise OpenAIHelperError(
+                f"API request failed: {type(exc).__name__}: "
+                f"{str(exc)[:500]}"
+            ) from exc
 
         duration = _monotonic() - start
 

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -453,15 +453,21 @@ async def call_openai(
             # otherwise escape uncaught and bypass the exit-3 routing.
             # This branch lands AFTER all typed branches so subclass
             # matching takes precedence per Python's ``except``
-            # first-match semantics. Message format: class name
-            # (always safe) + ``str(exc)[:500]`` (bounded to cap any
-            # prompt/body leakage). Original exception preserved on
-            # ``__cause__`` via ``raise ... from exc``. Not retried:
+            # first-match semantics. Message format: class name only
+            # — ``str(exc)`` is intentionally NOT surfaced here per
+            # the post-merge security tightening of DEC-003 (#162):
+            # this branch handles unknown SDK error shapes by
+            # definition, so we cannot assume the SDK's ``__str__``
+            # is well-behaved (a future SDK error type's message
+            # could pack prompt fragments, response-body excerpts,
+            # or echoed headers). Truncation bounds size, not
+            # exposure. Diagnostic content is preserved on
+            # ``__cause__`` via ``raise ... from exc`` — debuggers
+            # can introspect the original exception. Not retried:
             # without category information we cannot make a sound
             # retry decision.
             raise OpenAIHelperError(
-                f"API request failed: {type(exc).__name__}: "
-                f"{str(exc)[:500]}"
+                f"API request failed: {type(exc).__name__}"
             ) from exc
 
         duration = _monotonic() - start

--- a/src/clauditor/cli/doctor.py
+++ b/src/clauditor/cli/doctor.py
@@ -120,6 +120,28 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             )
         )
 
+    # OpenAI key is opt-in via ``grading_provider="openai"`` in the eval
+    # spec. Status is never ``[fail]`` — users grading exclusively with
+    # Anthropic don't need it. Report ``[ok]`` when set + non-whitespace,
+    # ``[info]`` otherwise. Output never echoes the key value itself.
+    openai_key_value = os.environ.get("OPENAI_API_KEY")
+    openai_key_available = (
+        openai_key_value is not None and openai_key_value.strip() != ""
+    )
+    if openai_key_available:
+        checks.append(
+            ("openai-api-key-available", "ok", "OPENAI_API_KEY is set")
+        )
+    else:
+        checks.append(
+            (
+                "openai-api-key-available",
+                "info",
+                "OPENAI_API_KEY not set "
+                "(only required for grading_provider=\"openai\")",
+            )
+        )
+
     cli_transport_available = claude_path is not None
     if cli_transport_available:
         checks.append(

--- a/src/clauditor/cli/suggest.py
+++ b/src/clauditor/cli/suggest.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 from clauditor._providers import (
     AnthropicAuthMissingError,
-    check_any_auth_available,
+    OpenAIAuthMissingError,
+    check_provider_auth,
 )
 from clauditor.paths import derive_skill_name, resolve_clauditor_dir
+from clauditor.spec import SkillSpec
 from clauditor.suggest import (
     NoPriorGradeError,
     load_suggest_input,
@@ -101,11 +103,19 @@ async def _cmd_suggest_impl(args: argparse.Namespace) -> int:
     - exit 1 when no prior grading.json exists or the proposer returns
       unparseable JSON (no sidecar).
     - exit 2 when any proposal anchor fails validation (no sidecar),
-      OR when no usable authentication is available — the pre-flight
-      ``check_any_auth_available("suggest")`` guard raises
-      ``AnthropicAuthMissingError`` before any API call per #83
-      DEC-002/DEC-011 and #86 DEC-008 (no sidecar).
-    - exit 3 on Anthropic API errors (no sidecar).
+      OR when no usable authentication is available for the resolved
+      provider — the pre-flight ``check_provider_auth(provider,
+      "suggest")`` guard raises ``AnthropicAuthMissingError`` /
+      ``OpenAIAuthMissingError`` before any API call per #83
+      DEC-002/DEC-011, #86 DEC-008, and #145 DEC-006 (no sidecar).
+    - exit 3 on provider API errors (no sidecar).
+
+    #162 US-003: provider is resolved from
+    ``spec.eval_spec.grading_provider`` (defaults to ``"anthropic"``)
+    so OpenAI-graded skills route through OpenAI for the proposer
+    call. ``SkillSpec.from_file`` is loaded after the zero-failing-
+    signals early-exit and before the auth check, mirroring the
+    pattern in ``cli/triggers.py``.
     """
     skill_path = Path(args.skill)
     if not skill_path.exists():
@@ -195,15 +205,45 @@ async def _cmd_suggest_impl(args: argparse.Namespace) -> int:
         )
         return 0
 
-    # #83 DEC-002/DEC-011 + #86 DEC-008: fail fast only when neither
-    # ANTHROPIC_API_KEY nor the claude CLI binary is available.
+    # #162 US-003: load the spec so we can read
+    # ``eval_spec.grading_provider`` for the auth dispatch + provider
+    # plumbing below. Mirrors ``cli/triggers.py:114-127`` per DEC-002.
+    # The early ``skill_path.exists()`` check above already covered the
+    # missing-skill-file case (rc=1); the try/except here covers a
+    # TOCTOU race plus ``EvalSpec.from_file`` validation failures.
+    try:
+        skill_spec = SkillSpec.from_file(skill_path)
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        print(
+            f"Error: cannot load spec for {skill_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # #83 DEC-002/DEC-011 + #86 DEC-008 + #145 DEC-006: fail fast when
+    # the provider's required auth is missing. Provider is resolved
+    # from ``eval_spec.grading_provider`` (defaults to ``"anthropic"``)
+    # so OpenAI-graded skills get an OpenAI-key-required guard.
     # ``suggest`` has no --dry-run; the guard lands AFTER the zero-
     # failing-signals early-exit (so the "all passed" path still works
-    # without auth — it never calls Anthropic) and BEFORE the
-    # propose_edits orchestrator.
+    # without auth — it never calls Anthropic / OpenAI) and BEFORE the
+    # propose_edits orchestrator. Distinct ``except`` branches per
+    # ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    provider = (
+        skill_spec.eval_spec.grading_provider
+        if skill_spec.eval_spec is not None
+        and skill_spec.eval_spec.grading_provider is not None
+        else "anthropic"
+    )
     try:
-        check_any_auth_available("suggest")
+        check_provider_auth(provider, "suggest")
     except AnthropicAuthMissingError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
 
@@ -236,6 +276,7 @@ async def _cmd_suggest_impl(args: argparse.Namespace) -> int:
         suggest_input,
         model=args.model,
         transport=_resolve_grader_transport(args),
+        provider=provider,
     )
 
     # DEC-008 row 3: API / prompt-build failure.

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -251,12 +251,14 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
         # ``.claude/rules/multi-provider-dispatch.md``; both classes
         # propagate as pytest setup failures.
         spec = clauditor_spec(skill_path, eval_path)
-        provider = (
-            spec.eval_spec.grading_provider
-            if spec.eval_spec is not None
-            and spec.eval_spec.grading_provider is not None
-            else "anthropic"
-        )
+        # Validate spec shape BEFORE the auth dispatch (CodeRabbit
+        # finding on PR #163): otherwise a missing/invalid auth key
+        # would mask the more useful ``"No eval spec found..."``
+        # error for users whose underlying problem is a missing
+        # eval.json, sending them to debug their auth instead.
+        if spec.eval_spec is None:
+            raise ValueError(f"No eval spec found for {skill_path}")
+        provider = spec.eval_spec.grading_provider or "anthropic"
         if provider == "anthropic":
             if _fixture_allow_cli():
                 check_any_auth_available("grader")
@@ -264,8 +266,6 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
                 check_api_key_only("grader")
         else:
             check_provider_auth(provider, "grader")
-        if spec.eval_spec is None:
-            raise ValueError(f"No eval spec found for {skill_path}")
         if output is None:
             result = spec.run()
             output = result.output
@@ -345,12 +345,14 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
         # ``CLAUDITOR_FIXTURE_ALLOW_CLI=1`` is honored only on the
         # Anthropic branch (DEC-004 of #162); silently no-op for OpenAI.
         spec = clauditor_spec(skill_path, eval_path)
-        provider = (
-            spec.eval_spec.grading_provider
-            if spec.eval_spec is not None
-            and spec.eval_spec.grading_provider is not None
-            else "anthropic"
-        )
+        # Validate spec shape BEFORE the auth dispatch (CodeRabbit
+        # finding on PR #163): a missing/invalid auth key would
+        # otherwise mask the more useful ``ValueError`` raised by
+        # ``blind_compare_from_spec`` when ``eval_spec`` /
+        # ``user_prompt`` are absent.
+        if spec.eval_spec is None:
+            raise ValueError(f"No eval spec found for {skill_path}")
+        provider = spec.eval_spec.grading_provider or "anthropic"
         if provider == "anthropic":
             if _fixture_allow_cli():
                 check_any_auth_available("blind_compare")
@@ -392,12 +394,14 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
         # ``CLAUDITOR_FIXTURE_ALLOW_CLI=1`` is honored only on the
         # Anthropic branch (DEC-004 of #162); silently no-op for OpenAI.
         spec = clauditor_spec(skill_path, eval_path)
-        provider = (
-            spec.eval_spec.grading_provider
-            if spec.eval_spec is not None
-            and spec.eval_spec.grading_provider is not None
-            else "anthropic"
-        )
+        # Validate spec shape BEFORE the auth dispatch (CodeRabbit
+        # finding on PR #163): a missing/invalid auth key would
+        # otherwise mask the more useful ``"No eval spec found..."``
+        # error for users whose underlying problem is a missing
+        # eval.json.
+        if spec.eval_spec is None:
+            raise ValueError(f"No eval spec found for {skill_path}")
+        provider = spec.eval_spec.grading_provider or "anthropic"
         if provider == "anthropic":
             if _fixture_allow_cli():
                 check_any_auth_available("triggers")
@@ -405,8 +409,6 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
                 check_api_key_only("triggers")
         else:
             check_provider_auth(provider, "triggers")
-        if spec.eval_spec is None:
-            raise ValueError(f"No eval spec found for {skill_path}")
         return asyncio.run(run_triggers(spec.eval_spec, model))
 
     return _factory

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -222,8 +222,11 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
     import asyncio
 
     from clauditor._providers import (
+        AnthropicAuthMissingError,
+        OpenAIAuthMissingError,
         check_any_auth_available,
         check_api_key_only,
+        check_provider_auth,
     )
     from clauditor.quality_grader import grade_quality
 
@@ -234,22 +237,40 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
         eval_path: str | Path | None = None,
         output: str | None = None,
     ):
-        # DEC-005 / DEC-013 (#83) + DEC-009 (#86): pre-flight auth guard
-        # at factory-invocation time. Raises ``AnthropicAuthMissingError``
-        # (same class the CLI catches) when no usable auth is available,
-        # so a CI run under subscription-only auth surfaces a clear error
-        # instead of silently skipping.
+        # US-001 of #162 (provider-aware fixture auth): the spec loads
+        # FIRST so we can resolve ``provider = eval_spec.grading_provider
+        # or "anthropic"``, then dispatch the auth guard via
+        # :func:`check_provider_auth` (DEC-006 of #145). Pre-#162 fixtures
+        # hardcoded Anthropic auth, so an OpenAI-graded skill saw a
+        # misleading ``"ANTHROPIC_API_KEY missing"`` error when only
+        # ``OPENAI_API_KEY`` was set.
         #
-        # Fixtures stay stricter than the CLI by default (DEC-009): only
-        # ``ANTHROPIC_API_KEY`` passes. Users who deliberately want the
-        # CLI transport to participate in fixture tests opt in with
-        # ``CLAUDITOR_FIXTURE_ALLOW_CLI=1`` (any truthy value), which
-        # routes through :func:`check_any_auth_available` instead.
-        if _fixture_allow_cli():
-            check_any_auth_available("grader")
-        else:
-            check_api_key_only("grader")
+        # For the Anthropic branch only, ``CLAUDITOR_FIXTURE_ALLOW_CLI=1``
+        # opts into the relaxed guard (DEC-009 of #86). DEC-004 of #162:
+        # the env var is silently no-op when ``provider == "openai"`` —
+        # OpenAI has no CLI transport, so the env var has nothing to gate.
+        # Distinct ``except`` branches per provider per
+        # ``.claude/rules/multi-provider-dispatch.md``; both classes
+        # propagate as pytest setup failures.
         spec = clauditor_spec(skill_path, eval_path)
+        provider = (
+            spec.eval_spec.grading_provider
+            if spec.eval_spec is not None
+            and spec.eval_spec.grading_provider is not None
+            else "anthropic"
+        )
+        try:
+            if provider == "anthropic":
+                if _fixture_allow_cli():
+                    check_any_auth_available("grader")
+                else:
+                    check_api_key_only("grader")
+            else:
+                check_provider_auth(provider, "grader")
+        except AnthropicAuthMissingError:
+            raise
+        except OpenAIAuthMissingError:
+            raise
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
         if output is None:
@@ -310,8 +331,11 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
     import asyncio
 
     from clauditor._providers import (
+        AnthropicAuthMissingError,
+        OpenAIAuthMissingError,
         check_any_auth_available,
         check_api_key_only,
+        check_provider_auth,
     )
     from clauditor.quality_grader import BlindReport, blind_compare_from_spec
 
@@ -323,14 +347,31 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
         *,
         model: str | None = None,
     ) -> BlindReport:
-        # DEC-005 / DEC-013 (#83) + DEC-009 (#86): pre-flight auth guard
-        # at factory-invocation time (same as ``clauditor_grader``). See
-        # that fixture for rationale.
-        if _fixture_allow_cli():
-            check_any_auth_available("blind_compare")
-        else:
-            check_api_key_only("blind_compare")
+        # US-001 of #162 (provider-aware fixture auth): see
+        # :func:`clauditor_grader` for rationale. Spec loads FIRST so we
+        # can resolve ``provider = eval_spec.grading_provider or
+        # "anthropic"``, then dispatch via :func:`check_provider_auth`.
+        # ``CLAUDITOR_FIXTURE_ALLOW_CLI=1`` is honored only on the
+        # Anthropic branch (DEC-004 of #162); silently no-op for OpenAI.
         spec = clauditor_spec(skill_path, eval_path)
+        provider = (
+            spec.eval_spec.grading_provider
+            if spec.eval_spec is not None
+            and spec.eval_spec.grading_provider is not None
+            else "anthropic"
+        )
+        try:
+            if provider == "anthropic":
+                if _fixture_allow_cli():
+                    check_any_auth_available("blind_compare")
+                else:
+                    check_api_key_only("blind_compare")
+            else:
+                check_provider_auth(provider, "blind_compare")
+        except AnthropicAuthMissingError:
+            raise
+        except OpenAIAuthMissingError:
+            raise
         effective_model = model or request.config.getoption("--clauditor-model")
         return asyncio.run(
             blind_compare_from_spec(
@@ -347,8 +388,11 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
     import asyncio
 
     from clauditor._providers import (
+        AnthropicAuthMissingError,
+        OpenAIAuthMissingError,
         check_any_auth_available,
         check_api_key_only,
+        check_provider_auth,
     )
     from clauditor.triggers import test_triggers as run_triggers
 
@@ -357,14 +401,31 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
     def _factory(
         skill_path: str | Path, eval_path: str | Path | None = None
     ):
-        # DEC-005 / DEC-013 (#83) + DEC-009 (#86): pre-flight auth guard
-        # at factory-invocation time (same as ``clauditor_grader``). See
-        # that fixture for rationale.
-        if _fixture_allow_cli():
-            check_any_auth_available("triggers")
-        else:
-            check_api_key_only("triggers")
+        # US-001 of #162 (provider-aware fixture auth): see
+        # :func:`clauditor_grader` for rationale. Spec loads FIRST so we
+        # can resolve ``provider = eval_spec.grading_provider or
+        # "anthropic"``, then dispatch via :func:`check_provider_auth`.
+        # ``CLAUDITOR_FIXTURE_ALLOW_CLI=1`` is honored only on the
+        # Anthropic branch (DEC-004 of #162); silently no-op for OpenAI.
         spec = clauditor_spec(skill_path, eval_path)
+        provider = (
+            spec.eval_spec.grading_provider
+            if spec.eval_spec is not None
+            and spec.eval_spec.grading_provider is not None
+            else "anthropic"
+        )
+        try:
+            if provider == "anthropic":
+                if _fixture_allow_cli():
+                    check_any_auth_available("triggers")
+                else:
+                    check_api_key_only("triggers")
+            else:
+                check_provider_auth(provider, "triggers")
+        except AnthropicAuthMissingError:
+            raise
+        except OpenAIAuthMissingError:
+            raise
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
         return asyncio.run(run_triggers(spec.eval_spec, model))

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -222,8 +222,6 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
     import asyncio
 
     from clauditor._providers import (
-        AnthropicAuthMissingError,
-        OpenAIAuthMissingError,
         check_any_auth_available,
         check_api_key_only,
         check_provider_auth,
@@ -259,18 +257,13 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
             and spec.eval_spec.grading_provider is not None
             else "anthropic"
         )
-        try:
-            if provider == "anthropic":
-                if _fixture_allow_cli():
-                    check_any_auth_available("grader")
-                else:
-                    check_api_key_only("grader")
+        if provider == "anthropic":
+            if _fixture_allow_cli():
+                check_any_auth_available("grader")
             else:
-                check_provider_auth(provider, "grader")
-        except AnthropicAuthMissingError:
-            raise
-        except OpenAIAuthMissingError:
-            raise
+                check_api_key_only("grader")
+        else:
+            check_provider_auth(provider, "grader")
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
         if output is None:
@@ -331,8 +324,6 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
     import asyncio
 
     from clauditor._providers import (
-        AnthropicAuthMissingError,
-        OpenAIAuthMissingError,
         check_any_auth_available,
         check_api_key_only,
         check_provider_auth,
@@ -360,18 +351,13 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
             and spec.eval_spec.grading_provider is not None
             else "anthropic"
         )
-        try:
-            if provider == "anthropic":
-                if _fixture_allow_cli():
-                    check_any_auth_available("blind_compare")
-                else:
-                    check_api_key_only("blind_compare")
+        if provider == "anthropic":
+            if _fixture_allow_cli():
+                check_any_auth_available("blind_compare")
             else:
-                check_provider_auth(provider, "blind_compare")
-        except AnthropicAuthMissingError:
-            raise
-        except OpenAIAuthMissingError:
-            raise
+                check_api_key_only("blind_compare")
+        else:
+            check_provider_auth(provider, "blind_compare")
         effective_model = model or request.config.getoption("--clauditor-model")
         return asyncio.run(
             blind_compare_from_spec(
@@ -388,8 +374,6 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
     import asyncio
 
     from clauditor._providers import (
-        AnthropicAuthMissingError,
-        OpenAIAuthMissingError,
         check_any_auth_available,
         check_api_key_only,
         check_provider_auth,
@@ -414,18 +398,13 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
             and spec.eval_spec.grading_provider is not None
             else "anthropic"
         )
-        try:
-            if provider == "anthropic":
-                if _fixture_allow_cli():
-                    check_any_auth_available("triggers")
-                else:
-                    check_api_key_only("triggers")
+        if provider == "anthropic":
+            if _fixture_allow_cli():
+                check_any_auth_available("triggers")
             else:
-                check_provider_auth(provider, "triggers")
-        except AnthropicAuthMissingError:
-            raise
-        except OpenAIAuthMissingError:
-            raise
+                check_api_key_only("triggers")
+        else:
+            check_provider_auth(provider, "triggers")
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
         return asyncio.run(run_triggers(spec.eval_spec, model))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6006,7 +6006,13 @@ class TestCmdSuggest:
 
         captured = {}
 
-        async def _fake_propose(suggest_input, *, model=None, transport="auto"):
+        async def _fake_propose(
+            suggest_input,
+            *,
+            model=None,
+            transport="auto",
+            provider="anthropic",
+        ):
             captured["source_iteration"] = suggest_input.source_iteration
             return self._fake_report(source_iteration=suggest_input.source_iteration)
 
@@ -6026,7 +6032,13 @@ class TestCmdSuggest:
 
         captured = {}
 
-        async def _fake_propose(suggest_input, *, model=None, transport="auto"):
+        async def _fake_propose(
+            suggest_input,
+            *,
+            model=None,
+            transport="auto",
+            provider="anthropic",
+        ):
             captured["transcripts"] = suggest_input.transcript_events
             return self._fake_report()
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -32,7 +32,7 @@ class TestDoctorTransportChecks:
         out = capsys.readouterr().out
         lines = [
             line for line in out.splitlines()
-            if "api-key-available" in line
+            if "ANTHROPIC_API_KEY" in line
         ]
         assert len(lines) == 1
         assert lines[0].startswith("[ok]")
@@ -49,7 +49,7 @@ class TestDoctorTransportChecks:
         out = capsys.readouterr().out
         lines = [
             line for line in out.splitlines()
-            if "api-key-available" in line
+            if "ANTHROPIC_API_KEY" in line
         ]
         assert len(lines) == 1
         # DEC-021: info (not failure) when unset.
@@ -67,7 +67,7 @@ class TestDoctorTransportChecks:
         out = capsys.readouterr().out
         lines = [
             line for line in out.splitlines()
-            if "api-key-available" in line
+            if "ANTHROPIC_API_KEY" in line
         ]
         assert len(lines) == 1
         assert lines[0].startswith("[info]")
@@ -301,3 +301,61 @@ class TestDoctorTransportChecks:
         ]
         assert check_idxs
         assert summary_idx > max(check_idxs)
+
+
+class TestDoctorOpenAIKeyCheck:
+    """US-002 of #162 — OpenAI key presence reported as info, never fail."""
+
+    def test_openai_api_key_check_ok_when_key_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-1")
+        rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "openai-api-key-available" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[ok]")
+        assert "OPENAI_API_KEY" in lines[0]
+        # Key value itself must NOT be echoed.
+        assert "sk-test-1" not in lines[0]
+
+    def test_openai_api_key_check_info_when_key_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "openai-api-key-available" in line
+        ]
+        assert len(lines) == 1
+        # Status is info (NOT fail) — OpenAI is opt-in.
+        assert lines[0].startswith("[info]")
+        assert not lines[0].startswith("[fail]")
+
+    def test_openai_api_key_check_info_when_key_whitespace(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Whitespace-only key counts as unset."""
+        monkeypatch.setenv("OPENAI_API_KEY", "   ")
+        rc = main(["doctor"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [
+            line for line in out.splitlines()
+            if "openai-api-key-available" in line
+        ]
+        assert len(lines) == 1
+        assert lines[0].startswith("[info]")

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -1799,3 +1799,96 @@ class TestNoProductionImportsFromAnthropicShim:
             "back-compat shim ``clauditor._anthropic`` is the only "
             "exempt file. Offenders:\n" + "\n".join(offenders)
         )
+
+
+class TestCallAnthropicBaseErrorCatchAll:
+    """Bare base ``anthropic.AnthropicError`` catch-all (US-004 of #162).
+
+    Pins DEC-003 (message format ``f"API request failed:
+    {type(exc).__name__}: {str(exc)[:500]}"``), DEC-005 (two tests:
+    catch-all wraps + ordering regression), and DEC-008 (the
+    catch-all test MUST construct an ``AnthropicError`` instance NOT
+    in any typed branch's hierarchy — otherwise the test passes via
+    the typed branch and the catch-all is dead code).
+    """
+
+    @pytest.mark.asyncio
+    async def test_bare_anthropic_error_wraps_to_helper_error(self) -> None:
+        # DEC-008: define a one-line subclass guaranteed NOT to match
+        # any typed branch (RateLimitError, APIStatusError,
+        # AuthenticationError, PermissionDeniedError,
+        # APIConnectionError, TypeError). This proves the catch-all
+        # branch is exercised — using a bare AnthropicError() also
+        # works since AnthropicError itself is not in any typed
+        # branch's hierarchy, but the explicit subclass is more
+        # robust against future SDK changes that might promote
+        # AnthropicError to a typed alias.
+        from anthropic import AnthropicError
+
+        class _UnknownAnthropicError(AnthropicError):
+            pass
+
+        sdk_text = "simulated unknown failure with payload " + "x" * 600
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(
+            side_effect=_UnknownAnthropicError(sdk_text)
+        )
+        sleep_mock = AsyncMock()
+        with patch(
+            "anthropic.AsyncAnthropic", return_value=mock_client
+        ), patch(
+            "clauditor._providers._anthropic._sleep", sleep_mock
+        ):
+            with pytest.raises(AnthropicHelperError) as exc_info:
+                await call_anthropic("p", model="m", transport="api")
+        msg = str(exc_info.value)
+        # DEC-003: message format anchors.
+        assert msg.startswith("API request failed:")
+        assert "_UnknownAnthropicError" in msg
+        # ``str(exc)[:500]`` cap: the full 600-char tail is NOT in
+        # the user-facing message, but a 500-char prefix IS.
+        assert sdk_text not in msg
+        assert sdk_text[:500] in msg
+        # Not retried: without category info, the catch-all cannot
+        # make a sound retry decision.
+        assert mock_client.messages.create.await_count == 1
+        assert sleep_mock.await_count == 0
+        # Original exception preserved on ``__cause__``.
+        assert isinstance(exc_info.value.__cause__, _UnknownAnthropicError)
+        assert isinstance(exc_info.value.__cause__, AnthropicError)
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_subclass_routes_to_specific_branch_not_catch_all(
+        self,
+    ) -> None:
+        # DEC-005 ordering regression: ``RateLimitError`` is a
+        # subclass of ``AnthropicError``, so without correct branch
+        # ordering the bare catch-all would swallow it. Exhaust the
+        # rate-limit retries and assert the message indicates the
+        # rate-limit-specific branch (NOT the generic catch-all
+        # phrasing) and the retry count proves the rate-limit
+        # ladder applied.
+        errors = [
+            _make_rate_limit_error(body={"attempt": i}) for i in range(4)
+        ]
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=errors)
+        sleep_mock = AsyncMock()
+        with patch(
+            "anthropic.AsyncAnthropic", return_value=mock_client
+        ), patch(
+            "clauditor._providers._anthropic._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            with pytest.raises(AnthropicHelperError) as exc_info:
+                await call_anthropic("p", model="m", transport="api")
+        msg = str(exc_info.value)
+        # Rate-limit-specific branch fired: message says "rate
+        # limit", NOT the generic catch-all "API request failed:".
+        assert "rate limit" in msg.lower()
+        assert "429" in msg
+        assert not msg.startswith("API request failed:")
+        # The rate-limit ladder applied: 4 attempts (initial + 3
+        # retries) per RATE_LIMIT_MAX_RETRIES=3.
+        assert mock_client.messages.create.await_count == 4

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -1805,11 +1805,15 @@ class TestCallAnthropicBaseErrorCatchAll:
     """Bare base ``anthropic.AnthropicError`` catch-all (US-004 of #162).
 
     Pins DEC-003 (message format ``f"API request failed:
-    {type(exc).__name__}: {str(exc)[:500]}"``), DEC-005 (two tests:
-    catch-all wraps + ordering regression), and DEC-008 (the
-    catch-all test MUST construct an ``AnthropicError`` instance NOT
-    in any typed branch's hierarchy — otherwise the test passes via
-    the typed branch and the catch-all is dead code).
+    {type(exc).__name__}"`` — class name only, no ``str(exc)`` per the
+    post-merge security tightening: this branch handles unknown SDK
+    error shapes by definition, so we cannot assume the SDK's
+    ``__str__`` is well-behaved; diagnostic content is preserved on
+    ``__cause__``), DEC-005 (two tests: catch-all wraps + ordering
+    regression), and DEC-008 (the catch-all test MUST construct an
+    ``AnthropicError`` instance NOT in any typed branch's hierarchy —
+    otherwise the test passes via the typed branch and the catch-all
+    is dead code).
     """
 
     @pytest.mark.asyncio
@@ -1828,7 +1832,11 @@ class TestCallAnthropicBaseErrorCatchAll:
         class _UnknownAnthropicError(AnthropicError):
             pass
 
-        sdk_text = "simulated unknown failure with payload " + "x" * 600
+        # Use a payload that would be considered sensitive (simulates
+        # a hypothetical future SDK error type echoing prompt text).
+        # The catch-all message MUST NOT surface this content — it
+        # only names the exception class.
+        sdk_text = "user prompt fragment: SECRET_TOKEN abc123 " + "x" * 600
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(
             side_effect=_UnknownAnthropicError(sdk_text)
@@ -1842,20 +1850,28 @@ class TestCallAnthropicBaseErrorCatchAll:
             with pytest.raises(AnthropicHelperError) as exc_info:
                 await call_anthropic("p", model="m", transport="api")
         msg = str(exc_info.value)
-        # DEC-003: message format anchors.
+        # DEC-003 (post-merge security tightening): message format is
+        # exactly ``API request failed: <ClassName>`` — class name
+        # only, no SDK message content.
         assert msg.startswith("API request failed:")
         assert "_UnknownAnthropicError" in msg
-        # ``str(exc)[:500]`` cap: the full 600-char tail is NOT in
-        # the user-facing message, but a 500-char prefix IS.
+        # Security: NONE of the SDK's ``str(exc)`` content reaches the
+        # user-facing message. Even a single-char prefix from the
+        # untrusted payload would be a regression.
+        assert "user prompt fragment" not in msg
+        assert "SECRET_TOKEN" not in msg
         assert sdk_text not in msg
-        assert sdk_text[:500] in msg
+        assert sdk_text[:50] not in msg
         # Not retried: without category info, the catch-all cannot
         # make a sound retry decision.
         assert mock_client.messages.create.await_count == 1
         assert sleep_mock.await_count == 0
-        # Original exception preserved on ``__cause__``.
+        # Diagnostic content preserved on ``__cause__`` — debuggers
+        # can introspect the original exception (full ``str(exc)``
+        # available via ``str(exc_info.value.__cause__)``).
         assert isinstance(exc_info.value.__cause__, _UnknownAnthropicError)
         assert isinstance(exc_info.value.__cause__, AnthropicError)
+        assert "SECRET_TOKEN" in str(exc_info.value.__cause__)
 
     @pytest.mark.asyncio
     async def test_rate_limit_subclass_routes_to_specific_branch_not_catch_all(

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1059,11 +1059,15 @@ class TestCallOpenAIBaseErrorCatchAll:
     """Bare base ``openai.OpenAIError`` catch-all (US-004 of #162).
 
     Pins DEC-003 (message format ``f"API request failed:
-    {type(exc).__name__}: {str(exc)[:500]}"``), DEC-005 (two tests:
-    catch-all wraps + ordering regression), and DEC-008 (the
-    catch-all test MUST construct an ``OpenAIError`` instance NOT in
-    any typed branch's hierarchy — otherwise the test passes via the
-    typed branch and the catch-all is dead code).
+    {type(exc).__name__}"`` — class name only, no ``str(exc)`` per the
+    post-merge security tightening: this branch handles unknown SDK
+    error shapes by definition, so we cannot assume the SDK's
+    ``__str__`` is well-behaved; diagnostic content is preserved on
+    ``__cause__``), DEC-005 (two tests: catch-all wraps + ordering
+    regression), and DEC-008 (the catch-all test MUST construct an
+    ``OpenAIError`` instance NOT in any typed branch's hierarchy —
+    otherwise the test passes via the typed branch and the catch-all
+    is dead code).
     """
 
     @pytest.mark.asyncio
@@ -1079,7 +1083,11 @@ class TestCallOpenAIBaseErrorCatchAll:
         class _UnknownOpenAIError(OpenAIError):
             pass
 
-        sdk_text = "simulated unknown failure with payload " + "x" * 600
+        # Use a payload that would be considered sensitive (simulates
+        # a hypothetical future SDK error type echoing prompt text).
+        # The catch-all message MUST NOT surface this content — it
+        # only names the exception class.
+        sdk_text = "user prompt fragment: SECRET_TOKEN abc123 " + "x" * 600
         ctx, fake_client = _patch_async_openai_with_side_effect(
             _UnknownOpenAIError(sdk_text)
         )
@@ -1090,20 +1098,28 @@ class TestCallOpenAIBaseErrorCatchAll:
             with pytest.raises(OpenAIHelperError) as exc_info:
                 await call_openai("p", model="gpt-5.4")
         msg = str(exc_info.value)
-        # DEC-003: message format anchors.
+        # DEC-003 (post-merge security tightening): message format is
+        # exactly ``API request failed: <ClassName>`` — class name
+        # only, no SDK message content.
         assert msg.startswith("API request failed:")
         assert "_UnknownOpenAIError" in msg
-        # ``str(exc)[:500]`` cap: the full 600-char tail is NOT in
-        # the user-facing message, but a 500-char prefix IS.
+        # Security: NONE of the SDK's ``str(exc)`` content reaches the
+        # user-facing message. Even a single-char prefix from the
+        # untrusted payload would be a regression.
+        assert "user prompt fragment" not in msg
+        assert "SECRET_TOKEN" not in msg
         assert sdk_text not in msg
-        assert sdk_text[:500] in msg
+        assert sdk_text[:50] not in msg
         # Not retried: without category info, the catch-all cannot
         # make a sound retry decision.
         assert fake_client.responses.create.await_count == 1
         assert sleep_mock.await_count == 0
-        # Original exception preserved on ``__cause__``.
+        # Diagnostic content preserved on ``__cause__`` — debuggers
+        # can introspect the original exception (full ``str(exc)``
+        # available via ``str(exc_info.value.__cause__)``).
         assert isinstance(exc_info.value.__cause__, _UnknownOpenAIError)
         assert isinstance(exc_info.value.__cause__, OpenAIError)
+        assert "SECRET_TOKEN" in str(exc_info.value.__cause__)
 
     @pytest.mark.asyncio
     async def test_rate_limit_subclass_routes_to_specific_branch_not_catch_all(

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1053,3 +1053,86 @@ class TestCallOpenAITypeError:
         # Original exception preserved on __cause__ via raise ... from exc.
         assert isinstance(exc_info.value.__cause__, OpenAIError)
         assert sdk_text in str(exc_info.value.__cause__)
+
+
+class TestCallOpenAIBaseErrorCatchAll:
+    """Bare base ``openai.OpenAIError`` catch-all (US-004 of #162).
+
+    Pins DEC-003 (message format ``f"API request failed:
+    {type(exc).__name__}: {str(exc)[:500]}"``), DEC-005 (two tests:
+    catch-all wraps + ordering regression), and DEC-008 (the
+    catch-all test MUST construct an ``OpenAIError`` instance NOT in
+    any typed branch's hierarchy — otherwise the test passes via the
+    typed branch and the catch-all is dead code).
+    """
+
+    @pytest.mark.asyncio
+    async def test_bare_openai_error_wraps_to_helper_error(self) -> None:
+        # DEC-008: define a one-line subclass guaranteed NOT to match
+        # any typed branch (RateLimitError, APIStatusError,
+        # AuthenticationError, PermissionDeniedError,
+        # APIConnectionError, TypeError). This proves the catch-all
+        # branch is exercised regardless of any future SDK changes
+        # that might re-classify a bare OpenAIError() instance.
+        from openai import OpenAIError
+
+        class _UnknownOpenAIError(OpenAIError):
+            pass
+
+        sdk_text = "simulated unknown failure with payload " + "x" * 600
+        ctx, fake_client = _patch_async_openai_with_side_effect(
+            _UnknownOpenAIError(sdk_text)
+        )
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        # DEC-003: message format anchors.
+        assert msg.startswith("API request failed:")
+        assert "_UnknownOpenAIError" in msg
+        # ``str(exc)[:500]`` cap: the full 600-char tail is NOT in
+        # the user-facing message, but a 500-char prefix IS.
+        assert sdk_text not in msg
+        assert sdk_text[:500] in msg
+        # Not retried: without category info, the catch-all cannot
+        # make a sound retry decision.
+        assert fake_client.responses.create.await_count == 1
+        assert sleep_mock.await_count == 0
+        # Original exception preserved on ``__cause__``.
+        assert isinstance(exc_info.value.__cause__, _UnknownOpenAIError)
+        assert isinstance(exc_info.value.__cause__, OpenAIError)
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_subclass_routes_to_specific_branch_not_catch_all(
+        self,
+    ) -> None:
+        # DEC-005 ordering regression: ``RateLimitError`` is a
+        # subclass of ``OpenAIError``, so without correct branch
+        # ordering the bare catch-all would swallow it. Exhaust the
+        # rate-limit retries and assert the message indicates the
+        # rate-limit-specific branch (NOT the generic catch-all
+        # phrasing) and the retry count proves the rate-limit
+        # ladder applied.
+        errors = [
+            _make_rate_limit_error(body={"attempt": i}) for i in range(4)
+        ]
+        ctx, fake_client = _patch_async_openai_with_side_effect(errors)
+        sleep_mock = AsyncMock()
+        with ctx, patch(
+            "clauditor._providers._openai._sleep", sleep_mock
+        ), patch(
+            "clauditor._providers._retry._rand_uniform", return_value=0.0
+        ):
+            with pytest.raises(OpenAIHelperError) as exc_info:
+                await call_openai("p", model="gpt-5.4")
+        msg = str(exc_info.value)
+        # Rate-limit-specific branch fired: message says "rate
+        # limit", NOT the generic catch-all "API request failed:".
+        assert "rate limit" in msg.lower()
+        assert not msg.startswith("API request failed:")
+        # The rate-limit ladder applied: 4 attempts (initial + 3
+        # retries) per RATE_LIMIT_MAX_RETRIES=3.
+        assert fake_client.responses.create.await_count == 4

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -671,13 +671,21 @@ class TestClauditorGraderFactory:
         with pytest.raises(ValueError, match="No eval spec found"):
             factory(tmp_path / "skill.md")
 
-    def test_output_none_triggers_spec_run(self, tmp_path):
+    def test_output_none_triggers_spec_run(self, tmp_path, monkeypatch):
         """output=None path calls spec.run() and feeds its output into
         grade_quality — covers the branch that tests typically bypass
         by passing output= directly.
         """
+        # US-001 of #162: provider resolves from
+        # ``eval_spec.grading_provider``; an unconstrained MagicMock
+        # would yield a non-None ``grading_provider`` MagicMock and
+        # trip the dispatcher's unknown-provider ``ValueError``. Pin
+        # the attribute to ``None`` so resolution falls through to
+        # ``"anthropic"``.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         request = self._request_with_model()
         mock_eval_spec = MagicMock()
+        mock_eval_spec.grading_provider = None
 
         mock_run_result = MagicMock()
         mock_run_result.output = "captured skill output"
@@ -904,6 +912,26 @@ class TestClauditorFixturesAuthGuard:
         )
         return request
 
+    def _stub_spec_factory(self, *, grading_provider=None):
+        """Build a fake ``clauditor_spec`` that returns a stub spec.
+
+        Per US-001 of #162 the fixture loads the spec BEFORE running the
+        auth guard so it can resolve ``provider =
+        eval_spec.grading_provider or "anthropic"``. Existing tests that
+        expect Anthropic-path behavior pass ``grading_provider=None``
+        (or ``"anthropic"``) so resolution falls through to the
+        Anthropic auth branch and the legacy assertions still hold.
+        """
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = grading_provider
+
+        def factory(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        return factory
+
     def test_clauditor_grader_raises_on_missing_key(
         self, tmp_path, monkeypatch
     ):
@@ -914,12 +942,9 @@ class TestClauditorFixturesAuthGuard:
 
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         request = self._request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            # Should never be reached — guard fires first.
-            raise AssertionError("spec factory called before auth guard")
-
-        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        factory = clauditor_grader.__wrapped__(
+            request, self._stub_spec_factory()
+        )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md")
         msg = str(excinfo.value)
@@ -938,11 +963,9 @@ class TestClauditorFixturesAuthGuard:
 
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         request = self._request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
-        factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
+        factory = clauditor_triggers.__wrapped__(
+            request, self._stub_spec_factory()
+        )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md")
         msg = str(excinfo.value)
@@ -970,12 +993,8 @@ class TestClauditorFixturesAuthGuard:
                 "--clauditor-no-api-key": False,
             }.get(opt)
         )
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
         factory = clauditor_blind_compare.__wrapped__(
-            request, fake_clauditor_spec
+            request, self._stub_spec_factory()
         )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md", "a", "b")
@@ -1031,6 +1050,28 @@ class TestPytestFixturesStrictMode:
             _anthropic.shutil, "which", lambda name: path
         )
 
+    def _stub_spec_factory(self, *, grading_provider=None, raises=None):
+        """Build a fake ``clauditor_spec`` for the strict-mode tests.
+
+        Per US-001 of #162 the fixture loads the spec FIRST. Tests that
+        want the auth guard to fire pass ``raises=None`` so resolution
+        falls through to ``"anthropic"``. Tests that want to confirm
+        "guard passed → spec factory reached" pass a sentinel exception
+        as ``raises`` and the stub raises it after returning the spec
+        access the auth guard needs.
+        """
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = grading_provider
+
+        def factory(skill_path, eval_path=None):
+            if raises is not None:
+                raise raises
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        return factory
+
     def test_grader_strict_default_cli_on_path_still_raises(
         self, tmp_path, monkeypatch
     ):
@@ -1041,11 +1082,9 @@ class TestPytestFixturesStrictMode:
         # CLAUDITOR_FIXTURE_ALLOW_CLI auto-cleared by conftest.
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
-        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        factory = clauditor_grader.__wrapped__(
+            request, self._stub_spec_factory()
+        )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md")
         assert "ANTHROPIC_API_KEY" in str(excinfo.value)
@@ -1058,11 +1097,9 @@ class TestPytestFixturesStrictMode:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
-        factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
+        factory = clauditor_triggers.__wrapped__(
+            request, self._stub_spec_factory()
+        )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md")
         assert "ANTHROPIC_API_KEY" in str(excinfo.value)
@@ -1075,12 +1112,8 @@ class TestPytestFixturesStrictMode:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._blind_compare_request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
         factory = clauditor_blind_compare.__wrapped__(
-            request, fake_clauditor_spec
+            request, self._stub_spec_factory()
         )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md", "a", "b")
@@ -1095,14 +1128,19 @@ class TestPytestFixturesStrictMode:
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._request()
 
-        # If the guard passes, the factory proceeds to call
-        # clauditor_spec. We raise a sentinel from the spec factory so
-        # the test proves "guard did NOT raise" without invoking a real
-        # grading call.
-        _sentinel = RuntimeError("guard passed; spec factory reached")
+        # If the guard passes, the factory proceeds past the auth check.
+        # Per US-001 of #162 the spec is loaded BEFORE the guard, so we
+        # raise the sentinel from spec.run() to prove the guard did NOT
+        # raise: the test reaches the post-guard ``spec.run()`` call.
+        _sentinel = RuntimeError("guard passed; spec.run reached")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
 
         def fake_clauditor_spec(skill_path, eval_path=None):
-            raise _sentinel
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            spec.run.side_effect = _sentinel
+            return spec
 
         factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
         with pytest.raises(RuntimeError) as excinfo:
@@ -1116,14 +1154,27 @@ class TestPytestFixturesStrictMode:
         monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._request()
-        _sentinel = RuntimeError("guard passed; spec factory reached")
+
+        # Guard passes → factory reaches ``run_triggers`` which fires
+        # the sentinel via the patched ``test_triggers`` import below.
+        _sentinel = RuntimeError("guard passed; run_triggers reached")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
 
         def fake_clauditor_spec(skill_path, eval_path=None):
-            raise _sentinel
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
 
-        factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
-        with pytest.raises(RuntimeError) as excinfo:
-            factory(tmp_path / "skill.md")
+        with patch(
+            "clauditor.triggers.test_triggers",
+            side_effect=_sentinel,
+        ):
+            factory = clauditor_triggers.__wrapped__(
+                request, fake_clauditor_spec
+            )
+            with pytest.raises(RuntimeError) as excinfo:
+                factory(tmp_path / "skill.md")
         assert excinfo.value is _sentinel
 
     def test_blind_compare_allow_cli_opt_in_cli_on_path_passes_guard(
@@ -1133,16 +1184,25 @@ class TestPytestFixturesStrictMode:
         monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._blind_compare_request()
-        _sentinel = RuntimeError("guard passed; spec factory reached")
+
+        _sentinel = RuntimeError("guard passed; blind_compare_from_spec reached")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
 
         def fake_clauditor_spec(skill_path, eval_path=None):
-            raise _sentinel
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
 
-        factory = clauditor_blind_compare.__wrapped__(
-            request, fake_clauditor_spec
-        )
-        with pytest.raises(RuntimeError) as excinfo:
-            factory(tmp_path / "skill.md", "a", "b")
+        with patch(
+            "clauditor.quality_grader.blind_compare_from_spec",
+            side_effect=_sentinel,
+        ):
+            factory = clauditor_blind_compare.__wrapped__(
+                request, fake_clauditor_spec
+            )
+            with pytest.raises(RuntimeError) as excinfo:
+                factory(tmp_path / "skill.md", "a", "b")
         assert excinfo.value is _sentinel
 
     def test_grader_allow_cli_opt_in_no_cli_still_raises(
@@ -1155,11 +1215,9 @@ class TestPytestFixturesStrictMode:
         monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
         self._patch_which(monkeypatch, None)
         request = self._request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
-        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        factory = clauditor_grader.__wrapped__(
+            request, self._stub_spec_factory()
+        )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md")
         msg = str(excinfo.value)
@@ -1177,11 +1235,9 @@ class TestPytestFixturesStrictMode:
         monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "0")
         self._patch_which(monkeypatch, "/usr/local/bin/claude")
         request = self._request()
-
-        def fake_clauditor_spec(skill_path, eval_path=None):
-            raise AssertionError("spec factory called before auth guard")
-
-        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        factory = clauditor_grader.__wrapped__(
+            request, self._stub_spec_factory()
+        )
         with pytest.raises(AnthropicAuthMissingError) as excinfo:
             factory(tmp_path / "skill.md")
         msg = str(excinfo.value)
@@ -1189,3 +1245,307 @@ class TestPytestFixturesStrictMode:
         assert "ANTHROPIC_API_KEY" in msg
         assert "Claude Pro" in msg
         assert "console.anthropic.com" in msg
+
+
+class TestClauditorFixturesAuthGuardOpenAI:
+    """US-001 of #162: provider-aware auth in pytest fixtures.
+
+    Spec loads FIRST in each fixture; ``provider =
+    eval_spec.grading_provider or "anthropic"`` resolves to OpenAI
+    when the spec declares it; the auth dispatcher then routes to
+    :func:`check_openai_auth`, raising :class:`OpenAIAuthMissingError`
+    (a sibling of :class:`AnthropicAuthMissingError`, NOT a subclass)
+    when ``OPENAI_API_KEY`` is missing — even if ``ANTHROPIC_API_KEY``
+    is set.
+
+    DEC-004 of #162: ``CLAUDITOR_FIXTURE_ALLOW_CLI=1`` is silently
+    no-op for the OpenAI branch (OpenAI has no CLI transport).
+
+    All tests use ``__wrapped__`` direct calls per
+    ``.claude/rules/pytester-inprocess-coverage-hazard.md`` (DEC-006
+    of #162) — no ``pytester.runpytest_inprocess`` + ``mock.patch``
+    combinations under coverage.
+    """
+
+    def _request(self, model: str = "gpt-5.4"):
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {"--clauditor-model": model}.get(opt)
+        )
+        return request
+
+    def _blind_compare_request(self):
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 300,
+                "--clauditor-claude-bin": "claude",
+                "--clauditor-model": None,
+                "--clauditor-no-api-key": False,
+            }.get(opt)
+        )
+        return request
+
+    def _stub_spec_factory(self, *, grading_provider="openai"):
+        """Build a fake ``clauditor_spec`` returning an OpenAI-graded spec."""
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = grading_provider
+
+        def factory(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        return factory
+
+    # ------------------------------------------------------------------
+    # T1: provider="openai" + OPENAI_API_KEY unset + ANTHROPIC_API_KEY set
+    #     → OpenAIAuthMissingError raised (no Anthropic fallback).
+    # ------------------------------------------------------------------
+
+    def test_grader_openai_provider_missing_key_raises_openai_error(
+        self, tmp_path, monkeypatch
+    ):
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # ANTHROPIC_API_KEY is set — proves no fallback.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = self._request()
+        factory = clauditor_grader.__wrapped__(
+            request, self._stub_spec_factory()
+        )
+        with pytest.raises(OpenAIAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md")
+        msg = str(excinfo.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "platform.openai.com" in msg
+        assert "clauditor grader" in msg
+
+    def test_triggers_openai_provider_missing_key_raises_openai_error(
+        self, tmp_path, monkeypatch
+    ):
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = self._request()
+        factory = clauditor_triggers.__wrapped__(
+            request, self._stub_spec_factory()
+        )
+        with pytest.raises(OpenAIAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md")
+        msg = str(excinfo.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "platform.openai.com" in msg
+        assert "clauditor triggers" in msg
+
+    def test_blind_compare_openai_provider_missing_key_raises_openai_error(
+        self, tmp_path, monkeypatch
+    ):
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = self._blind_compare_request()
+        factory = clauditor_blind_compare.__wrapped__(
+            request, self._stub_spec_factory()
+        )
+        with pytest.raises(OpenAIAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md", "a", "b")
+        msg = str(excinfo.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "platform.openai.com" in msg
+        assert "clauditor blind_compare" in msg
+
+    # ------------------------------------------------------------------
+    # T2: provider="openai" + OPENAI_API_KEY set → guard passes,
+    #     factory proceeds past the auth seam.
+    # ------------------------------------------------------------------
+
+    def test_grader_openai_provider_with_key_passes_guard(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        request = self._request()
+
+        # Guard passes → factory reaches ``spec.run()``. Sentinel proves
+        # auth check did NOT raise.
+        _sentinel = RuntimeError("guard passed; spec.run reached")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "openai"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            spec.run.side_effect = _sentinel
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(RuntimeError) as excinfo:
+            factory(tmp_path / "skill.md")
+        assert excinfo.value is _sentinel
+
+    # ------------------------------------------------------------------
+    # T3: provider="openai" + CLAUDITOR_FIXTURE_ALLOW_CLI=1 → strict
+    #     OpenAI key check still applied (env var is no-op for OpenAI
+    #     per DEC-004 of #162).
+    # ------------------------------------------------------------------
+
+    def test_grader_openai_provider_allow_cli_env_is_noop(
+        self, tmp_path, monkeypatch
+    ):
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        # CLAUDITOR_FIXTURE_ALLOW_CLI=1 is honored only for the
+        # Anthropic branch — OpenAI must still raise.
+        monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
+        # Patch ``which`` so a ``claude`` binary appears available; if
+        # the fixture were (incorrectly) routing through the relaxed
+        # Anthropic guard this test would silently pass under it.
+        import clauditor._anthropic as _anthropic
+
+        monkeypatch.setattr(
+            _anthropic.shutil, "which", lambda name: "/usr/local/bin/claude"
+        )
+        request = self._request()
+        factory = clauditor_grader.__wrapped__(
+            request, self._stub_spec_factory()
+        )
+        with pytest.raises(OpenAIAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md")
+        # Confirm we surface the OPENAI message, not the Anthropic one.
+        msg = str(excinfo.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "platform.openai.com" in msg
+
+    def test_triggers_openai_provider_allow_cli_env_is_noop(
+        self, tmp_path, monkeypatch
+    ):
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
+        import clauditor._anthropic as _anthropic
+
+        monkeypatch.setattr(
+            _anthropic.shutil, "which", lambda name: "/usr/local/bin/claude"
+        )
+        request = self._request()
+        factory = clauditor_triggers.__wrapped__(
+            request, self._stub_spec_factory()
+        )
+        with pytest.raises(OpenAIAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md")
+        msg = str(excinfo.value)
+        assert "OPENAI_API_KEY" in msg
+
+    def test_blind_compare_openai_provider_allow_cli_env_is_noop(
+        self, tmp_path, monkeypatch
+    ):
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
+        import clauditor._anthropic as _anthropic
+
+        monkeypatch.setattr(
+            _anthropic.shutil, "which", lambda name: "/usr/local/bin/claude"
+        )
+        request = self._blind_compare_request()
+        factory = clauditor_blind_compare.__wrapped__(
+            request, self._stub_spec_factory()
+        )
+        with pytest.raises(OpenAIAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md", "a", "b")
+        msg = str(excinfo.value)
+        assert "OPENAI_API_KEY" in msg
+
+    # ------------------------------------------------------------------
+    # T4: provider unset (None in spec) + ANTHROPIC_API_KEY set →
+    #     existing Anthropic happy path.
+    # ------------------------------------------------------------------
+
+    def test_grader_provider_none_falls_back_to_anthropic(
+        self, tmp_path, monkeypatch
+    ):
+        """Unset ``grading_provider`` defaults to ``"anthropic"``."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        request = self._request()
+
+        _sentinel = RuntimeError("anthropic happy path reached")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            spec.run.side_effect = _sentinel
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(RuntimeError) as excinfo:
+            factory(tmp_path / "skill.md")
+        assert excinfo.value is _sentinel
+
+    def test_grader_eval_spec_none_falls_back_to_anthropic(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec with ``eval_spec=None`` resolves provider to ``"anthropic"``."""
+        from clauditor._providers import AnthropicAuthMissingError
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        request = self._request()
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = None
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(AnthropicAuthMissingError) as excinfo:
+            factory(tmp_path / "skill.md")
+        assert "ANTHROPIC_API_KEY" in str(excinfo.value)
+
+    # ------------------------------------------------------------------
+    # T5: provider="anthropic" explicit + CLAUDITOR_FIXTURE_ALLOW_CLI=1
+    #     → existing relaxed-guard behavior preserved (CLI on PATH
+    #     passes the guard).
+    # ------------------------------------------------------------------
+
+    def test_grader_anthropic_provider_explicit_allow_cli_relaxed(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLAUDITOR_FIXTURE_ALLOW_CLI", "1")
+        import clauditor._anthropic as _anthropic
+
+        monkeypatch.setattr(
+            _anthropic.shutil, "which", lambda name: "/usr/local/bin/claude"
+        )
+        request = self._request()
+
+        # Guard passes → spec.run sentinel proves the relaxed check
+        # accepted CLI presence as auth.
+        _sentinel = RuntimeError("relaxed guard accepted CLI")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "anthropic"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            spec.run.side_effect = _sentinel
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(RuntimeError) as excinfo:
+            factory(tmp_path / "skill.md")
+        assert excinfo.value is _sentinel

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1050,22 +1050,19 @@ class TestPytestFixturesStrictMode:
             _anthropic.shutil, "which", lambda name: path
         )
 
-    def _stub_spec_factory(self, *, grading_provider=None, raises=None):
+    def _stub_spec_factory(self, *, grading_provider=None):
         """Build a fake ``clauditor_spec`` for the strict-mode tests.
 
-        Per US-001 of #162 the fixture loads the spec FIRST. Tests that
-        want the auth guard to fire pass ``raises=None`` so resolution
-        falls through to ``"anthropic"``. Tests that want to confirm
-        "guard passed → spec factory reached" pass a sentinel exception
-        as ``raises`` and the stub raises it after returning the spec
-        access the auth guard needs.
+        Per US-001 of #162 the fixture loads the spec FIRST and reads
+        ``spec.eval_spec.grading_provider`` to pick the auth helper.
+        ``grading_provider=None`` exercises the default-to-anthropic
+        path; passing ``"openai"`` (or another provider string)
+        exercises the dispatcher branch.
         """
         eval_spec = MagicMock()
         eval_spec.grading_provider = grading_provider
 
         def factory(skill_path, eval_path=None):
-            if raises is not None:
-                raise raises
             spec = MagicMock()
             spec.eval_spec = eval_spec
             return spec
@@ -1495,12 +1492,18 @@ class TestClauditorFixturesAuthGuardOpenAI:
             factory(tmp_path / "skill.md")
         assert excinfo.value is _sentinel
 
-    def test_grader_eval_spec_none_falls_back_to_anthropic(
+    def test_grader_eval_spec_none_raises_value_error_before_auth(
         self, tmp_path, monkeypatch
     ):
-        """Spec with ``eval_spec=None`` resolves provider to ``"anthropic"``."""
-        from clauditor._providers import AnthropicAuthMissingError
-
+        """Spec with ``eval_spec=None`` raises ``ValueError`` BEFORE
+        the auth guard fires (CodeRabbit fix on PR #163). Otherwise a
+        missing/invalid auth key would mask the more useful "no eval
+        spec found" error for users whose underlying problem is a
+        missing eval.json — they'd debug auth instead of fixing the
+        spec.
+        """
+        # Both keys unset — proves the auth guard was NOT reached
+        # (otherwise we'd see ``AnthropicAuthMissingError``).
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         request = self._request()
@@ -1511,9 +1514,9 @@ class TestClauditorFixturesAuthGuardOpenAI:
             return spec
 
         factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
-        with pytest.raises(AnthropicAuthMissingError) as excinfo:
+        with pytest.raises(ValueError) as excinfo:
             factory(tmp_path / "skill.md")
-        assert "ANTHROPIC_API_KEY" in str(excinfo.value)
+        assert "No eval spec found" in str(excinfo.value)
 
     # ------------------------------------------------------------------
     # T5: provider="anthropic" explicit + CLAUDITOR_FIXTURE_ALLOW_CLI=1

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -735,6 +735,33 @@ class TestClauditorTriggersFactory:
             factory(tmp_path / "skill.md")
 
 
+class TestClauditorBlindCompareFactory:
+    """Direct coverage of clauditor_blind_compare error branch."""
+
+    def test_raises_value_error_when_spec_lacks_eval(self, tmp_path):
+        """Blind-compare factory raises ValueError if spec.eval_spec
+        is None — validates the spec shape BEFORE the auth dispatch
+        per CodeRabbit fix on PR #163, so a missing eval.json
+        surfaces as the actual problem rather than being masked by
+        an auth-missing error.
+        """
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {"--clauditor-model": "claude-sonnet-4-6"}.get(opt)
+        )
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            mock_spec = MagicMock()
+            mock_spec.eval_spec = None
+            return mock_spec
+
+        factory = clauditor_blind_compare.__wrapped__(
+            request, fake_clauditor_spec
+        )
+        with pytest.raises(ValueError, match="No eval spec found"):
+            factory(tmp_path / "skill.md", "output A", "output B")
+
+
 class TestClauditorNoApiKeyOption:
     """US-007: ``--clauditor-no-api-key`` pytest option parity.
 

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -2210,3 +2210,278 @@ class TestWriteSidecar:
         json_path, diff_path = write_sidecar(report, "", clauditor_dir)
         assert json_path.is_absolute()
         assert diff_path.is_absolute()
+
+
+class TestCmdSuggestProviderPlumbing:
+    """#162 US-003: ``cli/suggest.py`` resolves provider from spec and
+    threads it through to ``propose_edits`` / ``call_model``.
+
+    Per DEC-002 the spec is loaded from
+    ``SkillSpec.from_file(args.skill)`` and provider resolution
+    mirrors ``cli/triggers.py:114-127``. Per DEC-007 the OpenAI test
+    uses a *distinct* ``grading_provider="openai"`` value (NOT the
+    default-anthropic path) so a hardcoded ``provider="anthropic"``
+    bug at the CLI seam would fail the assertion — proving the field
+    is actually consulted, not just plumbed inertly.
+    """
+
+    def _setup_failing_run(self, tmp_path: Path, monkeypatch) -> Path:
+        """Stage a skill .md + iteration-1/<skill>/{grading.json,
+        assertions.json} fixture with failing signals so the
+        zero-failing-signals early-exit does not short-circuit.
+        """
+        from clauditor.quality_grader import GradingReport, GradingResult
+        from clauditor.schemas import GradeThresholds
+
+        (tmp_path / ".git").mkdir()
+        skill_md = tmp_path / "my-skill.md"
+        # Body contains the anchor ``_good_envelope_text`` defaults to
+        # ("Do the thing.") so propose_edits' anchor validation passes
+        # and the success path through call_model fires.
+        skill_md.write_text("# My Skill\n\nDo the thing.\n")
+
+        skill_dir = tmp_path / ".clauditor" / "iteration-1" / "my-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        grading = GradingReport(
+            skill_name="my-skill",
+            model="claude-sonnet-4-6",
+            results=[
+                GradingResult(
+                    id="c1",
+                    criterion="Is the output correct?",
+                    passed=False,
+                    score=0.2,
+                    evidence="e",
+                    reasoning="r",
+                ),
+            ],
+            duration_seconds=0.0,
+            thresholds=GradeThresholds(),
+            metrics={},
+        )
+        (skill_dir / "grading.json").write_text(grading.to_json())
+
+        # Failing assertions.json so suggest_input has at least one
+        # failing signal and the auth + provider plumbing path runs.
+        assertions_payload = {
+            "schema_version": 1,
+            "skill": "my-skill",
+            "iteration": 1,
+            "runs": [
+                {
+                    "run": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "results": [
+                        {
+                            "id": "a1",
+                            "name": "contains hello",
+                            "passed": False,
+                            "kind": "contains",
+                            "message": "no match",
+                            "transcript_path": None,
+                        }
+                    ],
+                }
+            ],
+        }
+        (skill_dir / "assertions.json").write_text(
+            json.dumps(assertions_payload)
+        )
+
+        monkeypatch.chdir(tmp_path)
+        return skill_md
+
+    def _make_spec_with_provider(self, provider: str | None):
+        """Build a MagicMock SkillSpec carrying an EvalSpec with the
+        requested ``grading_provider``."""
+        from unittest.mock import MagicMock
+
+        from clauditor.schemas import EvalSpec
+        from clauditor.spec import SkillSpec
+
+        eval_spec = EvalSpec(
+            skill_name="my-skill",
+            description="A test skill",
+            test_args="--depth quick",
+            assertions=[{"type": "contains", "needle": "hello"}],
+            sections=[],
+            grading_criteria=["Is the output relevant?"],
+            grading_model="claude-sonnet-4-6",
+            grading_provider=provider,
+        )
+        spec = MagicMock(spec=SkillSpec)
+        spec.skill_name = "my-skill"
+        spec.eval_spec = eval_spec
+        return spec
+
+    def test_openai_grading_provider_plumbs_provider_kwarg(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """T1 / DEC-007 vacuous-test guardrail: spec with a *distinct*
+        ``grading_provider="openai"`` value flows through to
+        ``call_model`` as ``provider="openai"``. A hardcoded
+        ``provider="anthropic"`` bug at the CLI seam would fail this
+        assertion.
+        """
+        from clauditor.cli import main
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # ANTHROPIC_API_KEY left unset to prove no Anthropic
+        # fallback when the spec selects OpenAI.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        skill_md = self._setup_failing_run(tmp_path, monkeypatch)
+        spec = self._make_spec_with_provider("openai")
+        result = _mock_anthropic_result(
+            text=_good_envelope_text(motivated_by=["a1"])
+        )
+        call_mock = AsyncMock(return_value=result)
+
+        with (
+            patch(
+                "clauditor.cli.suggest.SkillSpec.from_file",
+                return_value=spec,
+            ),
+            patch("clauditor._providers.call_model", call_mock),
+        ):
+            rc = main(["suggest", str(skill_md.name)])
+
+        assert rc == 0, f"expected exit 0; got {rc}"
+        call_mock.assert_awaited_once()
+        # DEC-007 distinct-value assertion: provider="openai" must
+        # have flowed all the way to call_model. A test that used
+        # the default "anthropic" value would silently pass even if
+        # provider= were hardcoded.
+        assert call_mock.await_args.kwargs["provider"] == "openai"
+
+    def test_default_anthropic_when_grading_provider_unset(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """T2: spec with no ``grading_provider`` field (None) →
+        ``call_model`` receives ``provider="anthropic"`` (default
+        path).
+        """
+        from clauditor.cli import main
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        skill_md = self._setup_failing_run(tmp_path, monkeypatch)
+        spec = self._make_spec_with_provider(None)
+        assert spec.eval_spec.grading_provider is None
+        result = _mock_anthropic_result(
+            text=_good_envelope_text(motivated_by=["a1"])
+        )
+        call_mock = AsyncMock(return_value=result)
+
+        with (
+            patch(
+                "clauditor.cli.suggest.SkillSpec.from_file",
+                return_value=spec,
+            ),
+            patch("clauditor._providers.call_model", call_mock),
+        ):
+            rc = main(["suggest", str(skill_md.name)])
+
+        assert rc == 0, f"expected exit 0; got {rc}"
+        call_mock.assert_awaited_once()
+        assert call_mock.await_args.kwargs["provider"] == "anthropic"
+
+    def test_openai_grading_provider_exits_2_when_key_missing(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """T3: spec with ``grading_provider="openai"`` and missing
+        ``OPENAI_API_KEY`` → exit 2 with stderr mentioning
+        ``OPENAI_API_KEY``; no ``call_model`` invocation.
+        """
+        from clauditor.cli import main
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        skill_md = self._setup_failing_run(tmp_path, monkeypatch)
+        spec = self._make_spec_with_provider("openai")
+        call_mock = AsyncMock()
+
+        with (
+            patch(
+                "clauditor.cli.suggest.SkillSpec.from_file",
+                return_value=spec,
+            ),
+            patch("clauditor._providers.call_model", call_mock),
+        ):
+            rc = main(["suggest", str(skill_md.name)])
+
+        assert rc == 2, f"expected exit 2; got {rc}"
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        # Auth guard fires before propose_edits / call_model.
+        assert call_mock.await_count == 0
+
+    def test_openai_provider_no_anthropic_fallback_when_anthropic_key_set(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """T4: spec with ``grading_provider="openai"`` +
+        ``ANTHROPIC_API_KEY`` set + ``OPENAI_API_KEY`` unset → still
+        exits 2. Anthropic auth must NOT satisfy an OpenAI-routed
+        skill — regression check that ``check_provider_auth`` does
+        not silently fall through.
+        """
+        from clauditor.cli import main
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        skill_md = self._setup_failing_run(tmp_path, monkeypatch)
+        spec = self._make_spec_with_provider("openai")
+        call_mock = AsyncMock()
+
+        with (
+            patch(
+                "clauditor.cli.suggest.SkillSpec.from_file",
+                return_value=spec,
+            ),
+            patch("clauditor._providers.call_model", call_mock),
+        ):
+            rc = main(["suggest", str(skill_md.name)])
+
+        assert rc == 2, f"expected exit 2; got {rc}"
+        err = capsys.readouterr().err
+        assert "OPENAI_API_KEY" in err
+        assert call_mock.await_count == 0
+
+    def test_spec_load_failure_exits_cleanly_before_auth_check(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """T5: ``SkillSpec.from_file`` raising ``ValueError`` (e.g.
+        invalid eval.json) → exit 2 with crisp error message before
+        any auth check. Mirrors ``_load_spec_or_report`` shape from
+        ``cli/triggers.py``.
+        """
+        from clauditor.cli import main
+
+        # No env vars set — proves the auth check is not reached.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        skill_md = self._setup_failing_run(tmp_path, monkeypatch)
+        call_mock = AsyncMock()
+
+        with (
+            patch(
+                "clauditor.cli.suggest.SkillSpec.from_file",
+                side_effect=ValueError("eval.json: bad grading_provider value"),
+            ),
+            patch("clauditor._providers.call_model", call_mock),
+        ):
+            rc = main(["suggest", str(skill_md.name)])
+
+        assert rc == 2, f"expected exit 2; got {rc}"
+        err = capsys.readouterr().err
+        assert "cannot load spec" in err
+        # Auth-missing template substrings must NOT appear — proves
+        # the spec-load failure short-circuited before the auth
+        # dispatcher.
+        assert "ANTHROPIC_API_KEY" not in err
+        assert "OPENAI_API_KEY" not in err
+        assert call_mock.await_count == 0

--- a/tests/test_suggest.py
+++ b/tests/test_suggest.py
@@ -2484,4 +2484,43 @@ class TestCmdSuggestProviderPlumbing:
         # dispatcher.
         assert "ANTHROPIC_API_KEY" not in err
         assert "OPENAI_API_KEY" not in err
+
+    def test_spec_load_toctou_filenotfound_exits_cleanly(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """TOCTOU race: ``skill_path.exists()`` passed but
+        ``SkillSpec.from_file`` later hit ``FileNotFoundError`` (e.g.
+        the file was deleted between the early-exit check and the
+        spec load). The defensive branch routes to exit 1 with the
+        SDK's error message — distinct from the spec-validation
+        ``ValueError`` path (exit 2) since this is a parse-layer
+        failure (something happened to the file mid-flight) rather
+        than an input-validation failure.
+        """
+        from clauditor.cli import main
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        skill_md = self._setup_failing_run(tmp_path, monkeypatch)
+        call_mock = AsyncMock()
+
+        with (
+            patch(
+                "clauditor.cli.suggest.SkillSpec.from_file",
+                side_effect=FileNotFoundError(
+                    f"[Errno 2] No such file: {skill_md}"
+                ),
+            ),
+            patch("clauditor._providers.call_model", call_mock),
+        ):
+            rc = main(["suggest", str(skill_md.name)])
+
+        assert rc == 1, f"expected exit 1 (parse-layer); got {rc}"
+        err = capsys.readouterr().err
+        assert "Error:" in err
+        # No auth check fired — TOCTOU branch short-circuited first.
+        assert "ANTHROPIC_API_KEY" not in err
+        assert "OPENAI_API_KEY" not in err
+        assert call_mock.await_count == 0
         assert call_mock.await_count == 0


### PR DESCRIPTION
## Summary

Implements all 4 polish/parity follow-ups from #145 (OpenAI provider work). Plan-only PR has graduated to a fully implemented branch.

**Phase:** implemented (awaiting review)
**Stories landed:** 6/6 (4 implementation + Quality Gate + Patterns & Memory)
**Beads closed:** clauditor-3dy (epic), clauditor-pjm, clauditor-edb, clauditor-nl7, clauditor-m0m, clauditor-3dy.1, clauditor-3dy.2

## What changed

- **C1 (US-001 / clauditor-pjm)** — pytest fixtures (`clauditor_grader`, `clauditor_blind_compare`, `clauditor_triggers`) now load the spec first, resolve `provider = spec.eval_spec.grading_provider or "anthropic"`, and dispatch through `check_provider_auth(provider, fixture_label)` with both `AnthropicAuthMissingError` and `OpenAIAuthMissingError` except branches. `CLAUDITOR_FIXTURE_ALLOW_CLI=1` is silently no-op when provider resolves to `"openai"` per DEC-004.
- **C2 (US-002 / clauditor-edb)** — `clauditor doctor` reports `OPENAI_API_KEY` presence at info-level. `[ok]` if set + non-whitespace, `[info]` otherwise (never `[fail]` — OpenAI is opt-in).
- **C3 (US-003 / clauditor-nl7)** — `cli/suggest.py::_cmd_suggest_impl` loads `SkillSpec.from_file(args.skill)` (mirrors `cli/triggers.py:114-127` per DEC-002), resolves provider, dispatches `check_provider_auth(provider, "suggest")` with dual exit-2 except branches, and plumbs `provider=` to `propose_edits(...)`.
- **C4 (US-004 / clauditor-m0m)** — both providers' retry loops now end with a final `except AnthropicError` / `except OpenAIError` catch-all wrapping as `*HelperError("API request failed: {type(exc).__name__}: {str(exc)[:500]}")` per DEC-003. Catch-all lands LAST so subclass branches still match first.

## Quality

- **Tests:** 2860 passed, 1 skipped (~19 new). Coverage **98.45%** (gate 80%).
- **Ruff:** clean.
- **Quality Gate:** 4 parallel code-reviewer passes converged on one fix (redundant try/except in fixtures, dropped in `e5ca1ab`); other findings advisory + documented.
- **Patterns & Memory:** 4 `.claude/rules/*.md` refreshed in-place per `rule-refresh-vs-delete.md`.

## Plan + decisions

[`plans/super/162-polish-followups.md`](plans/super/162-polish-followups.md) — 9 decisions (DEC-001..DEC-009).

## Test plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run pytest --cov=clauditor` passes; coverage ≥80%
- [x] 4 implementation stories landed via independent worktree branches, merged sequentially
- [x] Quality Gate converged + fixed
- [x] Rule refreshes verified
- [ ] Reviewer approval

Ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenAI API key availability check in the `doctor` command
  * Enhanced provider-aware authentication validation in `suggest` command and test fixtures

* **Bug Fixes**
  * Improved error handling to catch and properly route unhandled SDK errors instead of allowing them to escape uncaught

* **Tests**
  * Added comprehensive test coverage for multi-provider workflows, authentication gating, and error handling

* **Documentation**
  * Updated rules and guidelines for centralized provider dispatch and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->