### PR TITLE
#151: Multi-harness EvalSpec.harness four-layer precedence (plan)

### DIFF
--- a/.claude/rules/spec-cli-precedence.md
+++ b/.claude/rules/spec-cli-precedence.md
@@ -473,6 +473,221 @@ picks the provider),
 `.claude/rules/plan-contradiction-stop.md` (the deferred-default-
 flip migration discipline).
 
+### Four-layer precedence — harness (#151)
+
+`harness` for the skill-running subprocess (which CLI binary
+clauditor `exec`s to *run* the skill — `claude-code` for the
+Anthropic Claude Code harness, `codex` for the OpenAI Codex
+harness), introduced in #151:
+
+- **CLI flag**: `--harness {claude-code,codex,auto}` on the four
+  skill-running commands — `validate`, `grade`, `capture`, `run`.
+  Deliberately **NOT** wired on the LLM-mediated grader CLIs
+  (`extract`, `triggers`, `compare --blind`, `propose-eval`,
+  `suggest`) because those commands do not run a skill subprocess
+  — they call `call_model` directly and have no harness axis.
+  Validated by the shared `_harness_choice` argparse type helper
+  in `src/clauditor/cli/__init__.py`.
+- **Env var**: `CLAUDITOR_HARNESS={claude-code,codex,auto}`.
+  Whitespace-only values are normalized to `None` (treated as
+  unset) so an accidental `export CLAUDITOR_HARNESS=" "` does not
+  override everything. The CLI seam strips the value before
+  calling the pure resolver; the resolver also strips
+  defensively so direct callers (tests, future programmatic
+  invocations) get the same robustness.
+- **Spec field**: `EvalSpec.harness: str = "auto"` — per-skill
+  preference set by the skill author in `eval.json`. Validated at
+  load time against the literal set `{"claude-code", "codex",
+  "auto"}` per DEC-001 / DEC-008. `to_dict` skips emission when
+  the value equals the default `"auto"` so pre-#151 specs round-
+  trip byte-identical (omitting the field is the canonical "no
+  preference" shape).
+- **Default**: `"auto"` — auto-resolves at runtime via
+  `shutil.which("claude")` first, then `shutil.which("codex")`.
+  Hard-fails with a three-escape-hatch error message ("Install
+  one of the harness CLIs, or pin a harness explicitly via
+  `--harness=<name>`, the `CLAUDITOR_HARNESS=<name>` env var, or
+  the `harness` field in `eval.json`") when neither binary is
+  found, per DEC-002.
+
+Resolution lives in
+`src/clauditor/_providers/__init__.py::resolve_harness` (the
+pure helper, returning `tuple[str, str | None]` where the first
+element is the resolved name and the second is `"codex"` when
+the auto branch picked codex / `None` otherwise) and
+`src/clauditor/cli/__init__.py::_resolve_harness` (the thin CLI
+wrapper that owns stderr + `SystemExit(2)` routing on
+`ValueError` and fires the auto→codex announcement). Like
+`_resolve_grader_transport` and `_resolve_grading_provider`, the
+resolution is centralized at the CLI layer; the result is then
+threaded down to `SkillSpec.run` as a kwarg (see DEC-004 below).
+
+The harness construction dispatcher
+`src/clauditor/_harnesses/__init__.py::construct_harness(name)`
+materializes the named harness with deferred per-call imports
+of `_claude_code` and `_codex` (back-compat-shim discipline
+Pattern 3 — `__init__.py` is already imported by both
+submodules at protocol-class load time, so eager top-level
+imports here would circular-import). The dispatcher rejects
+`"auto"` explicitly: callers must resolve auto via
+`resolve_harness` before constructing. Per DEC-009 the
+dispatcher lives in `_harnesses/__init__.py` (mirroring
+`call_model` in `_providers/__init__.py`), keeping one seam per
+concern — PATH lookup belongs to the resolver, instance
+construction belongs to the harness package.
+
+The resolved harness threads into `SkillSpec.run` via the new
+keyword-only `harness_name_override: str | None = None` kwarg
+(per DEC-004). When non-`None`, `SkillSpec.run` materializes a
+fresh `SkillRunner` with the named harness rather than mutating
+the shared `self.runner.harness` attribute — construction cost
+is negligible and the immutability buys safe concurrent reuse.
+The five skill-running call sites (`cli/validate.py`,
+`cli/grade.py`, `cli/capture.py`, `cli/run.py`, plus the
+pytest fixture in `pytest_plugin.py`) all resolve the harness
+at the seam and pass `harness_name_override=` to `spec.run`.
+
+**PATH-lookup-in-pure-resolver precedent.** Unlike `transport`
+and `grading_provider`, the auto branch of `resolve_harness`
+reads PATH via `shutil.which` to pick a binary. This is the
+**first four-layer resolver in clauditor that touches PATH from
+the pure layer**, and it is acceptable because PATH is an
+operator-controlled contract, not local mutable state —
+operators set it once at session start, and the resolver's
+read is idempotent within a process. The pre-existing
+precedent for PATH reads inside `_providers/_auth.py` is
+`_claude_cli_is_available`, but that helper is consumed by the
+auth dispatcher (a different axis); `resolve_harness` is the
+first to combine the four-layer precedence shape with PATH
+discovery. Future resolvers needing PATH discovery (e.g. a
+hypothetical `editor` knob that finds `vim` / `nano` / `code`,
+or a `differ` knob that finds `delta` / `git diff` / `diff`)
+inherit the precedent and the rationale: keep the PATH read in
+the resolver layer, not in `EvalSpec.from_dict` (DEC-008
+explicitly rejected load-time PATH validation — author intent
+should not be conditioned on the validating machine's PATH,
+which differs from the running machine's).
+
+**Harness ≠ provider — distinct dispatch axes (DEC-010).** Codex
+is a **harness**, NOT a **provider**. The auth dispatcher
+`check_provider_auth(provider, cmd_name)` does NOT route Codex;
+the CLI seam directly calls
+`clauditor._providers._auth.check_codex_auth(cmd_name)` when the
+resolved harness is `"codex"`. The two checks compose
+independently when a `grade` invocation resolves both axes:
+`check_provider_auth` runs first (gating the LLM-grader call),
+then `check_codex_auth` runs second (gating the skill
+subprocess), and both fire when applicable per DEC-012.
+`CodexAuthMissingError` is a direct subclass of `Exception`,
+**NOT** a subclass of `AnthropicAuthMissingError` /
+`OpenAIAuthMissingError` / any helper-error class — preserving
+the structural-routing invariant per
+`.claude/rules/llm-cli-exit-code-taxonomy.md` and
+`.claude/rules/multi-provider-dispatch.md`. The CLI's `except`
+ladder gets a third sibling branch
+(`except CodexAuthMissingError as exc: ... return 2`) alongside
+the two provider-auth branches; the harness vs provider axis
+distinction is structural, not message-based. The auth check is
+strict-OR: at least one of `CODEX_API_KEY` or `OPENAI_API_KEY`
+must be set (whitespace-trimmed non-empty) per DEC-003. There
+is no CLI-fallback / subscription analog like Claude Pro/Max.
+
+**Auto→codex announcement (DEC-007).** When the auto branch
+picks `"codex"` (because `claude` is not on PATH but `codex`
+is), the CLI wrapper `_resolve_harness` fires
+`announce_auto_codex_harness()` once per process before
+returning the resolved name. The announcement names the env
+vars Codex needs (`CODEX_API_KEY` / `OPENAI_API_KEY`) and the
+two pin-it-explicitly escape hatches (`--harness=claude-code`
+and `CLAUDITOR_HARNESS=claude-code`). Per the
+"Implicit-coupling announcements — an emerging family"
+subsection of `.claude/rules/centralized-sdk-call.md`, the
+helper lives in `_providers/_auth.py` because the notice is
+auth-coupled (it names the env vars users must export). Same
+print-and-flip + `Final[str]` constant + public-helper shape
+as `announce_implicit_no_api_key` (#95) and
+`announce_call_anthropic_deprecation` (#144). Explicit non-
+`"auto"` selections at any precedence layer (and auto resolving
+to `"claude-code"`) do NOT fire the announcement — the notice
+exists to surface the *implicit* fallback decision to surprised
+users, not to re-announce what the user typed.
+
+**`--baseline` arm propagation (DEC-013).** The `--baseline`
+branch of `cli/grade.py::cmd_grade` propagates the resolved
+harness to BOTH the primary and baseline `spec.run` calls —
+there is no separate `--baseline-harness` flag. The A/B
+comparison's whole point is to isolate the "with skill vs
+without skill" variable; allowing the harness to differ
+between the two arms would muddy the delta with a confound. The
+baseline arm constructs a fresh `SkillRunner` with the override
+harness via `construct_harness(harness_name)` (rather than
+mutating `spec.runner.harness`) so the primary and baseline
+runs each get a clean harness instance with no shared mutable
+state. When the resolved harness is `"claude-code"` (the
+default `SkillRunner` shape) the baseline arm skips the
+override and uses `spec.runner` as-is — a small optimization
+that costs no expressiveness because both arms use the same
+harness class regardless.
+
+Canonical implementation paths:
+
+- Pure helpers (no I/O at the precedence-decision layer; the
+  one PATH read sits inside `resolve_harness`'s auto branch):
+  `clauditor._providers.resolve_harness`,
+  `clauditor._harnesses.construct_harness`.
+- Pure auth helpers:
+  `clauditor._providers._auth.check_codex_auth`,
+  `clauditor._providers._auth._codex_api_key_is_set`.
+- One-shot stderr announcement:
+  `clauditor._providers._auth.announce_auto_codex_harness` +
+  the `_announced_auto_codex_harness` flag and
+  `_AUTO_CODEX_ANNOUNCEMENT` `Final[str]` constant.
+- CLI wrappers (own stderr + `SystemExit(2)` routing,
+  announcement firing): `clauditor.cli._resolve_harness`,
+  `clauditor.cli._harness_choice` (argparse `type=` validator).
+- Spec-field load + serialization:
+  `clauditor.schemas.EvalSpec.harness` (default `"auto"`),
+  `EvalSpec.from_dict` validator block,
+  `EvalSpec.to_dict` (skips emission when value equals default).
+- Resolved-name threading:
+  `clauditor.spec.SkillSpec.run(*, harness_name_override=...)`,
+  which calls `construct_harness` and materializes a fresh
+  `SkillRunner` when the override is non-`None`.
+- CLI call sites (skill-running commands only — not LLM-grader
+  CLIs): `cli/validate.py::cmd_validate`,
+  `cli/grade.py::cmd_grade` (both the primary arm and the
+  `--baseline` arm), `cli/capture.py::cmd_capture`,
+  `cli/run.py::cmd_run`. Each calls `_resolve_harness(args,
+  spec.eval_spec)`, dispatches `check_codex_auth(cmd_name)`
+  when the resolved name is `"codex"`, and threads
+  `harness_name_override=harness_name` into `spec.run`.
+- Pytest fixture: `clauditor.pytest_plugin.clauditor_spec` —
+  honors `eval_spec.harness` automatically. The factory reads
+  the spec field (when set to a non-`"auto"` value) and threads
+  it as `harness_name_override` to `spec.run`. Operator-intent
+  `harness_name_override=` passed to the fixture wins over the
+  spec field per DEC-005, mirroring the four-layer CLI
+  precedence inside fixture-land.
+
+Traces to DEC-001 through DEC-013 of
+`plans/super/151-harness-precedence.md`. Companion rules:
+`.claude/rules/harness-protocol-shape.md` (the protocol surface
+`construct_harness` materializes; canonical implementations of
+`ClaudeCodeHarness` and `CodexHarness`),
+`.claude/rules/centralized-sdk-call.md` (the implicit-coupling
+announcement family `announce_auto_codex_harness` belongs to),
+`.claude/rules/precall-env-validation.md` (the
+`CodexAuthMissingError`-as-sibling-of-`Exception` shape and the
+distinct exit-2 routing branch alongside the provider auth
+classes),
+`.claude/rules/multi-provider-dispatch.md` (the structural
+routing invariant the harness-vs-provider axis distinction
+preserves — `check_provider_auth` does NOT route Codex),
+`.claude/rules/back-compat-shim-discipline.md` (Pattern 3: the
+deferred per-call imports inside `construct_harness` that keep
+test patches on `clauditor._harnesses._claude_code.ClaudeCodeHarness`
+/ `clauditor._harnesses._codex.CodexHarness` working).
+
 ### Implicit coupling at the operator-intent layers
 
 An adjacent pattern to the precedence rule: when a CLI flag (or its

--- a/.claude/rules/test-infra-shutil-which-coupling.md
+++ b/.claude/rules/test-infra-shutil-which-coupling.md
@@ -1,0 +1,155 @@
+# Rule: Autouse-pinned `shutil.which` couples every PATH-based resolver
+
+When a `tests/conftest.py` autouse fixture patches `shutil.which`
+(typically to `lambda name: None`) on a singleton module attribute
+to make one PATH-sensitive resolver deterministic, the patch
+**globally clobbers every other reader of `shutil.which`** — including
+future PATH-based resolvers added long after the autouse pin
+shipped. The trap is that the symptom appears far from the cause:
+the new resolver fails on every test in the suite under its default
+"auto" mode, and the failure has no obvious link to the `tests/conftest.py`
+fixture that has been working fine for months.
+
+The fix is **NOT** to remove or scope-tighten the original `which`
+pin (other tests rely on its determinism). The fix is to add a
+**parallel autouse pin at a higher precedence layer** — typically
+an environment variable that the new resolver consults *before*
+falling through to its `shutil.which` branch. The env-var pin
+short-circuits the resolver above the PATH-lookup, so the global
+`which → None` patch never matters.
+
+## The trap
+
+```python
+# tests/conftest.py — autouse fixture, shipped by feature A.
+@pytest.fixture(autouse=True)
+def _force_api_transport_in_tests(monkeypatch):
+    """Force ``call_anthropic(transport="auto")`` to resolve to API."""
+    import clauditor._anthropic as _anthropic
+    # ``shutil.which`` is a module-level attribute on the singleton
+    # ``shutil`` module — patching it here affects EVERY reader.
+    monkeypatch.setattr(_anthropic.shutil, "which", lambda name: None)
+```
+
+Months later, feature B adds a second PATH-based resolver:
+
+```python
+# src/clauditor/_providers/__init__.py — feature B's resolver.
+def resolve_harness(env, spec, ...) -> str:
+    # ... CLI flag, env var, spec field precedence layers ...
+    # Final layer: auto-detect from PATH.
+    if shutil.which("claude") is not None:
+        return "claude-code"
+    if shutil.which("codex") is not None:
+        return "codex"
+    raise ValueError("no harness binary on PATH")
+```
+
+Every test in the suite that exercises a code path touching
+`resolve_harness` under the default `"auto"` precedence value
+now raises `ValueError`, with a stack trace that points at the
+new resolver — NOT at the autouse fixture two release-cycles old
+that silently made the `which` lookup return `None`.
+
+## The fix
+
+Add a parallel autouse pin at the env-var precedence layer the new
+resolver consults BEFORE falling through to PATH:
+
+```python
+@pytest.fixture(autouse=True)
+def _force_api_transport_in_tests(monkeypatch):
+    import clauditor._anthropic as _anthropic
+    monkeypatch.setattr(_anthropic.shutil, "which", lambda name: None)
+    # NEW: pin the env-var layer so the harness resolver
+    # short-circuits at a higher precedence layer before the
+    # auto-PATH-lookup branch fires.
+    monkeypatch.setenv("CLAUDITOR_HARNESS", "claude-code")
+```
+
+Tests that legitimately want to exercise the auto-PATH-lookup branch
+(e.g. tests for the no-binary-on-PATH error path, or for the env-var
+layer's own behavior) override the autouse default inline:
+
+```python
+def test_auto_resolves_codex_when_claude_absent(monkeypatch):
+    monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/codex" if name == "codex" else None)
+    assert resolve_harness(...) == "codex"
+```
+
+## Why this is non-obvious
+
+- **Singleton patch, distant symptom.** `shutil.which` is one
+  attribute on one module. Patching it inside an autouse fixture
+  for feature A is invisible to a contributor adding feature B's
+  resolver — they have no signal that PATH is mocked. The first
+  test run with the new resolver fails everywhere at once, with
+  no obvious link to `conftest.py`.
+- **The fix lives outside the new feature.** A contributor
+  diagnosing the failure naturally looks at the new resolver's
+  code, not at `tests/conftest.py` autouse machinery shipped by
+  an unrelated subsystem. The fix is a one-line `monkeypatch.setenv`
+  in conftest, not a code change in the resolver.
+- **You cannot tighten the original `which` pin.** It is autouse
+  precisely because every test needs the determinism — narrowing
+  it to "only tests that exercise transport" would require
+  auditing the entire suite. Layering a parallel pin is cheaper
+  and safer.
+- **Parallel pins must target the precedence layer above PATH.**
+  Adding another `which` patch achieves nothing; the original
+  already returns `None`. The pin must work *one layer up* — env
+  var, CLI flag, spec field — so the resolver short-circuits
+  before the (already-pinned) PATH lookup matters.
+
+## Canonical example
+
+`tests/conftest.py::_force_api_transport_in_tests` (lines ~733-757)
+combines the original `monkeypatch.setattr(_anthropic.shutil, "which",
+...)` pin (from #86) with the parallel
+`monkeypatch.setenv("CLAUDITOR_HARNESS", "claude-code")` pin (from
+#151 US-005). The harness resolver is
+`src/clauditor/_providers/__init__.py::resolve_harness` (4-layer
+precedence: CLI > env > spec > PATH-auto). The env-var pin
+short-circuits at layer 2, so the `shutil.which("claude")` lookup at
+layer 4 never fires under the autouse default.
+
+The harness anchor in `.claude/rules/spec-cli-precedence.md` documents
+the resolver's precedence shape; this rule documents the test-infra
+coupling that the resolver inherited at integration time.
+
+## When this rule applies
+
+Any future feature that:
+
+- Adds a new PATH-based resolver via `shutil.which` to production
+  code, AND
+- The resolver has a default value that triggers the PATH-auto
+  branch under normal test conditions (e.g. `transport="auto"`,
+  `harness="auto"`).
+
+Before merging the new resolver, audit `tests/conftest.py` for
+existing autouse `shutil.which` patches. If one exists, add a
+parallel autouse pin at the precedence layer immediately above the
+new resolver's PATH lookup.
+
+The rule generalizes to any autouse-pinned global singleton (not
+just `shutil.which`): when an autouse fixture clobbers a
+process-wide default to make one resolver deterministic, every
+future resolver that consults the same default inherits the patch
+and needs a parallel-layer pin to opt out.
+
+## When this rule does NOT apply
+
+- Tests that explicitly want to exercise the auto-PATH-lookup
+  branch. Those tests should `monkeypatch.delenv` the parallel-
+  layer pin and `monkeypatch.setattr(shutil, "which", ...)` to a
+  test-specific stub inside the test body — overriding both the
+  autouse env pin AND the autouse `which` pin locally.
+- Production-code resolvers that read `shutil.which` from a
+  module the autouse fixture does NOT touch. The original pin
+  patches a specific module's `shutil` attribute (e.g.
+  `clauditor._anthropic.shutil.which`); a resolver in an
+  unpatched module is unaffected.
+- Diagnostic scripts in `scripts/` that bypass pytest entirely.
+  Autouse fixtures only fire under pytest collection.

--- a/plans/super/151-harness-precedence.md
+++ b/plans/super/151-harness-precedence.md
@@ -5,8 +5,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/151
 - **Branch:** `feature/151-harness-precedence`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/151-harness-precedence`
-- **PR:** _(pending)_
-- **Phase:** detailing
+- **PR:** https://github.com/wjduenow/clauditor/pull/166
+- **Phase:** published
 - **Epic:** _(pending devolve)_
 - **Sessions:** 1 (2026-05-03)
 - **Total decisions:** 13 (DEC-001 through DEC-013)

--- a/plans/super/151-harness-precedence.md
+++ b/plans/super/151-harness-precedence.md
@@ -1,0 +1,1016 @@
+# 151: Multi-harness — `EvalSpec.harness` field + `--harness` CLI flag (four-layer precedence)
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/151
+- **Branch:** `feature/151-harness-precedence`
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/151-harness-precedence`
+- **PR:** _(pending)_
+- **Phase:** detailing
+- **Epic:** _(pending devolve)_
+- **Sessions:** 1 (2026-05-03)
+- **Total decisions:** 13 (DEC-001 through DEC-013)
+- **Stories:** 8 implementation + Quality Gate + Patterns & Memory = 10
+- **Depends on:** #148 (CLOSED — Harness protocol extracted), #149 (CLOSED — CodexHarness shipped)
+- **Blocks:** #152
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Promote harness selection (which subprocess CLI runs the skill —
+`ClaudeCodeHarness` invoking `claude -p` vs `CodexHarness` invoking
+`codex exec --json`) from a runner-construction kwarg to a full
+four-layer-precedence knob mirroring the established pattern from
+`transport` (#86) and `grading_provider` (#146).
+
+Adds:
+1. `EvalSpec.harness` spec field accepting `{"claude-code", "codex", "auto"}`
+2. `--harness` CLI flag on the four skill-execution commands
+   (`validate`, `grade`, `capture`, `run`)
+3. `CLAUDITOR_HARNESS` env var with whitespace normalization
+4. `_resolve_harness(args, eval_spec)` shared helper in `cli/__init__.py`
+5. Auto-resolution: `auto` → prefer `claude` on PATH, fall back to `codex`,
+   fail with actionable error if neither
+6. `check_codex_auth(cmd_name)` per-harness auth guard accepting
+   `CODEX_API_KEY` or `OPENAI_API_KEY`
+7. `CodexAuthMissingError` sibling exception class (per `precall-env-validation.md`)
+8. One-time stderr announcement on `auto → codex` resolution
+
+**Why:** Epic #143 multi-harness initiative. #148 extracted the `Harness`
+protocol; #149 shipped `CodexHarness` as the second non-mock implementation;
+#151 exposes harness selection at all four operator-intent layers so a CI
+pipeline can force `--harness codex` for a single run, a skill author can
+declare `"harness": "codex"` per-skill in `eval.json`, and an operator with
+only Codex installed gets auto-resolution without extra ceremony.
+
+**Done when (per ticket acceptance):**
+1. Tests cover all four precedence layers (CLI > env > spec > default)
+2. `clauditor validate --harness codex` runs the skill under `CodexHarness`
+3. `"harness": "codex"` in `eval.json` works without any CLI flag
+4. `.claude/rules/spec-cli-precedence.md` canonical-implementations section
+   updated with `harness` as a sixth four-layer-precedence anchor
+
+**Out of scope (per ticket):**
+- Per-grader-call harness selection. Harness governs skill execution only;
+  `grading_provider` (#146) and `transport` (#86) govern grader calls. They
+  are independent axes — the `--harness` flag does NOT land on the five
+  LLM-mediated grader commands (`extract`, `triggers`, `compare`,
+  `propose-eval`, `suggest`) because those don't run skills.
+
+### Codebase findings
+
+#### `SkillRunner.__init__` already accepts `harness=`
+
+Post #148, `runner.py:228-264` already accepts a keyword-only
+`harness: Harness | None = None`:
+
+```python
+def __init__(
+    self,
+    project_dir: str | Path | None = None,
+    timeout: int = 300,
+    claude_bin: str = "claude",
+    *,
+    harness: Harness | None = None,
+):
+    from clauditor._harnesses._claude_code import ClaudeCodeHarness
+    # ...
+    if harness is not None:
+        if claude_bin != "claude":
+            _warnings.warn(...)
+        self.harness = harness
+    else:
+        self.harness = ClaudeCodeHarness(claude_bin=claude_bin)
+```
+
+So the runner-side surface is ready. The gap #151 closes is the
+**resolution + plumbing** layer: how does `SkillSpec.run` (or the CLI seam
+above it) decide which `Harness` instance to pass?
+
+#### `EvalSpec` parallel fields (the precedence template)
+
+`schemas.py`:
+- `transport: str | None = None` — line 307, validator 740-760, `to_dict` 959.
+- `grading_provider: str | None = None` — line 338, validator 789-808,
+  `to_dict` 968. Accepts `{"anthropic", "openai", "auto"} | None`.
+- `sync_tasks` — line 319, validator 769-778, `to_dict` 963.
+
+The validator pattern is identical: literal-set membership check with
+`bool` guard and per-field `ValueError` message naming the allowed set.
+`to_dict` emits the field only when non-`None` (minimal-diff round-trip).
+
+#### `_resolve_*` helper template
+
+`cli/__init__.py:77-176` houses two existing four-layer resolvers:
+
+- `_resolve_grader_transport(args, eval_spec=None) -> str` (77-107)
+- `_resolve_grading_provider(args, eval_spec=None) -> str` (110-176)
+
+Both are **thin CLI wrappers** that:
+1. Read the CLI value via `getattr(args, "<field>", None)`
+2. Read env via `os.environ.get("CLAUDITOR_<FIELD>")`, whitespace-normalize
+3. Read the spec value via `eval_spec.<field> if eval_spec else None`
+4. Delegate to a **pure** `clauditor._providers.resolve_<field>(cli, env, spec, ...)` helper
+5. Catch `ValueError` from the pure resolver, print to stderr,
+   `raise SystemExit(2)`
+
+Argparse type validators (`_transport_choice`, `_provider_choice`) live
+nearby (44-73). They reject malformed CLI values at argparse time
+(exit 2 directly via `argparse.ArgumentTypeError`).
+
+#### `CodexHarness` already shipped (#149)
+
+`src/clauditor/_harnesses/_codex.py:466-510`:
+- `name: ClassVar[str] = "codex"` (line 493)
+- `__init__(*, codex_bin: str = "codex", model: str | None = None)` (495-510)
+- `strip_auth_keys` (512-524) strips `CODEX_API_KEY`, `OPENAI_API_KEY`,
+  `OPENAI_BASE_URL` (case-insensitive). The double-strip exists because
+  Codex CLI consumes `OPENAI_API_KEY` natively.
+
+#### Auth machinery
+
+`_providers/_auth.py`:
+- `check_any_auth_available(cmd_name)` (214-252) — Anthropic relaxed (key OR `claude` on PATH)
+- `check_openai_auth(cmd_name)` (288-330) — OpenAI strict (key only)
+- `check_provider_auth(provider, cmd_name)` (333-350) — dispatcher
+- `announce_implicit_no_api_key()` (69-88) — public helper, one-shot
+- `announce_call_anthropic_deprecation()` (127-143) — public helper, one-shot
+- Reset pattern: tests `monkeypatch.setattr(..., False)` autouse fixture
+
+For #151, the analogous pieces:
+- `check_codex_auth(cmd_name)` — accepts `CODEX_API_KEY` OR `OPENAI_API_KEY`
+  (per ticket); raises `CodexAuthMissingError` (new, sibling of `Exception`)
+- `_announced_auto_codex_harness` flag + `_AUTO_CODEX_ANNOUNCEMENT` constant
+  + `announce_auto_codex_harness()` helper (analogous to the implicit-no-api-key family)
+
+#### Inline `auto → cli` announcement (the comparable shape)
+
+`_providers/_anthropic.py:112` declares `_announced_cli_transport: bool = False`
+and `_CLI_AUTO_ANNOUNCEMENT` constant (185-188). The print-and-flip lives
+**inline** inside `call_anthropic` (453-456) — NOT in a public helper. Per
+`centralized-sdk-call.md` "Implicit-coupling announcements", new members
+should use the `Final[str]` constant + public helper shape (the post-#86
+pattern), so `auto → codex` should ship with a public helper for testability.
+
+#### `SkillResult.harness_metadata`
+
+`runner.py:101` — `harness_metadata: dict[str, Any] = field(default_factory=dict)`.
+Post-#148/DEC-007 forward-compat surface; `CodexHarness` populates this
+with `reasoning` items per #149. `#151` does NOT need to extend this; the
+`name: ClassVar` on each harness already provides identity.
+
+#### CLI commands today
+
+`cli/grade.py`, `cli/validate.py`, `cli/capture.py`, `cli/run.py` are the
+four skill-execution seams. Each already has a `--transport` block; each
+loads the spec via `SkillSpec.from_file`, resolves transport via
+`_resolve_grader_transport`, runs auth via `check_provider_auth`, then
+calls `spec.run(...)`. The `harness` resolution should fire at the same
+seam (after spec load, before `spec.run`), and the resolved harness should
+thread into `spec.run` as a new keyword override — see Q4 below.
+
+`cli/extract.py`, `cli/triggers.py`, `cli/compare.py`, `cli/propose_eval.py`,
+`cli/suggest.py` are LLM-mediated graders that do NOT run skills. They get
+no `--harness` flag (out-of-scope per ticket).
+
+### Convention constraints (load-bearing for this work)
+
+1. **`spec-cli-precedence.md`** (CORE) — adds `harness` as a sixth
+   four-layer-precedence anchor. Update the canonical-implementations
+   section in the same PR. The shape is uniform CLI > env > spec > default;
+   per-knob deviation must be called out (e.g. our `auto` resolution is
+   PATH-based, not config-based).
+
+2. **`pure-compute-vs-io-split.md`** — `_resolve_harness()` (the CLI
+   wrapper) and the underlying pure `resolve_harness(cli, env, spec)` are
+   split: pure helper raises `ValueError`, CLI wrapper owns stderr +
+   `SystemExit(2)`. Auto-resolution's `shutil.which()` call is the one
+   I/O surface; it lives in the pure helper because it's idempotent and
+   `which()` is the contract (operators set PATH, not the resolver).
+
+3. **`constant-with-type-info.md`** — `EvalSpec.harness` validator rejects
+   anything outside `{"claude-code", "codex", "auto"}`, with a `bool`
+   guard.
+
+4. **`precall-env-validation.md`** — `CodexAuthMissingError` is a direct
+   subclass of `Exception` (NOT `AnthropicAuthMissingError` or any shared
+   parent). Sibling pattern preserves structural CLI routing per
+   `llm-cli-exit-code-taxonomy.md`. Auth check fires AFTER `--dry-run`
+   early-return AND BEFORE any harness invocation. Defense-in-depth at the
+   `CodexHarness.invoke` site is already in place per #149.
+
+5. **`harness-protocol-shape.md`** — protocol surface unchanged. Auth is
+   not on the protocol; per-harness construction args (`codex_bin`,
+   `claude_bin`) live in `__init__`. The CLI seam is where harness
+   selection is made; the harness is constructed and passed to
+   `SkillRunner` (or `SkillSpec.run`). This is consistent with the
+   existing `harness=` kwarg on `SkillRunner.__init__`.
+
+6. **`centralized-sdk-call.md`** "Implicit-coupling announcements" family —
+   `_announced_auto_codex_harness` joins the existing three flags. Use the
+   public-helper shape (`announce_auto_codex_harness()`), not inline. Home
+   the flag/constant/helper in `_providers/_auth.py` (auth-coupled — the
+   notice says "auto-resolved to codex; ensure CODEX_API_KEY / OPENAI_API_KEY
+   is set").
+
+7. **`llm-cli-exit-code-taxonomy.md`** — invalid `--harness` / env value
+   routes to exit 2 via argparse `type=` validator (CLI) or `SystemExit(2)`
+   from the resolver wrapper (env). `CodexAuthMissingError` routes to
+   exit 2 (pre-call input-validation category, NOT exit 3 which is
+   reserved for actual SDK call failures).
+
+8. **`back-compat-shim-discipline.md`** — adding a new spec field. No
+   existing module is being split, so Patterns 1-3 don't apply directly.
+   But: tests that monkeypatch the resolver should target
+   `clauditor._providers.resolve_harness` (canonical), not
+   `clauditor.cli._resolve_harness` (the wrapper).
+
+9. **`pytester-inprocess-coverage-hazard.md`** — does NOT apply (no
+   pytester-inproc tests added).
+
+10. **`bundled-skill-docs-sync.md`** — does NOT apply (no SKILL.md
+    workflow change).
+
+Non-applicable rules (briefly): `json-schema-version.md` (no new sidecar),
+`monotonic-time-indirection.md` (resolver is sync), `stream-json-schema.md`
+(no streaming JSON), `pre-llm-contract-hard-validate.md` (config validation,
+not LLM-output), `eval-spec-stable-ids.md` (singleton config, not list
+entries), `path-validation.md` / `subprocess-cwd.md` /
+`project-root-home-exclusion.md` (no path manipulation),
+`sidecar-during-staging.md` (no sidecar), `non-mutating-scrub.md`
+(per-harness `strip_auth_keys` already non-mutating per #149),
+`positional-id-zip-validation.md`, `mock-side-effect-for-distinct-calls.md`,
+`per-type-drift-hints.md`, `permissive-parser-strict-validator.md`,
+`internal-skill-live-test-tmp-symlink.md`, `dual-version-external-schema-embed.md`,
+`data-vs-asserter-split.md`, `in-memory-dict-loader-path.md`,
+`readme-promotion-recipe.md`, `plan-contradiction-stop.md`,
+`llm-judge-prompt-injection.md`, `skill-identity-from-frontmatter.md`,
+`rule-refresh-vs-delete.md` (not a refactor — see post-merge note in
+the rule-applicability appendix).
+
+### Architecture review areas (Phase 2 candidates)
+
+- **Auth design** — `CodexAuthMissingError`, `check_codex_auth` env-key
+  acceptance (`CODEX_API_KEY` OR `OPENAI_API_KEY`), defense-in-depth
+- **CLI / argparse design** — `_harness_choice` validator, default-`None`
+  vs default-`"auto"` decision, flag placement (only on 4 commands)
+- **Auto-resolution semantics** — `shutil.which("claude")` first, then
+  `shutil.which("codex")`, error message when neither found
+- **Announcement family extension** — public-helper shape in `_auth.py`,
+  one-shot per process, test reset pattern
+- **Multi-harness dispatcher analog** — should we extract a sibling
+  `multi-harness-dispatch.md` rule? (Probably defer until #152's third
+  harness lands.)
+- **`SkillSpec.run` plumbing** — does `SkillSpec` get a `harness_override`
+  kwarg (mirroring `timeout_override`, `env_override`)? Or does the CLI
+  construct the `Harness` instance and pass it to `SkillRunner` directly,
+  bypassing `SkillSpec.run`? See Q4.
+- **Pytest fixture extension** — does `clauditor_spec` factory grow a
+  `harness=` kwarg? See Q5.
+
+---
+
+## Phase 1 scoping (questions for user)
+
+**Q1 — Spec field default sentinel: `None` or `"auto"`?**
+
+Per #146 DEC-001a, `grading_provider` shipped as `str | None = None` with
+runtime treatment of `None == "auto"`, deferred default-flip to a follow-up.
+The reasoning was back-compat: existing CLI seams used falsy-`None`
+short-circuits. For `harness`, no such call sites exist yet (this is a
+greenfield field), so the constraint is weaker.
+
+- **A.** `harness: str | None = None`. Treat `None` as `"auto"` at the
+  resolver. `to_dict` emits the field only when non-`None`. Mirrors #146's
+  conservative default; preserves the "minimal-diff round-trip" property
+  for existing eval.json files (which all lack the field today).
+- **B.** `harness: str = "auto"`. Direct match to ticket text. `to_dict`
+  always emits `"harness": "auto"`. Slightly noisier round-trip but no
+  sentinel ambiguity. Pre-#151 specs that omitted the field still load
+  fine (default applies).
+- **C.** Same as B but `to_dict` skips emission when value is `"auto"`
+  (the default). Best-of-both: ticket-exact field signature, minimal-diff
+  round-trip. Adds one `if self.harness != "auto"` branch in `to_dict`.
+
+**Recommendation:** **C** — matches ticket verbatim and preserves
+round-trip minimalism. Differs from #146's choice because we have no
+falsy-`None` legacy short-circuits to migrate around.
+
+**Q2 — Auto-resolution failure mode (neither `claude` nor `codex` on PATH).**
+
+When `harness="auto"` resolves at runtime and neither binary is found:
+
+- **A.** Raise `ValueError` from the pure resolver; CLI wrapper prints
+  `"ERROR: --harness=auto found neither 'claude' nor 'codex' on PATH"`
+  and exits 2. Hard fail at resolve time (pre-spec-run).
+- **B.** Fall through to `claude-code`. Skill subprocess later fails with
+  the existing `claude not found` error from `ClaudeCodeHarness.invoke`.
+  Soft fall-through, late surfacing.
+- **C.** Same as A but the message also lists the spec field path the user
+  could set (`'harness': 'claude-code'` or `'codex'`) and the env var to
+  set explicitly. Most actionable.
+
+**Recommendation:** **C** — operator intent direction, fail loud at
+resolve time, actionable message.
+
+**Q3 — `check_codex_auth` env-key acceptance.**
+
+The ticket says "accepts `CODEX_API_KEY` or `OPENAI_API_KEY`". Resolution
+options:
+
+- **A.** Strict OR: at least one of the two must be set (non-empty,
+  whitespace-trimmed). If neither, raise `CodexAuthMissingError` with a
+  message naming both. Mirrors `check_any_auth_available`'s relaxed shape
+  (key OR CLI on PATH). **Codex CLI on PATH is NOT a substitute** — `auto`
+  resolution already used PATH; auth is an additional check.
+- **B.** Hierarchy: prefer `CODEX_API_KEY`; fall back to `OPENAI_API_KEY`
+  with a one-time stderr advisory ("using OPENAI_API_KEY for Codex
+  authentication"). Most informative; one extra announcement family member.
+- **C.** Same as A but warn on `OPENAI_API_KEY`-only via the same
+  `auto → codex` notice (don't add a second announcement). Simpler.
+
+**Recommendation:** **A** — simplest, parallels `check_openai_auth`.
+
+**Q4 — `SkillSpec.run` plumbing for the resolved harness.**
+
+The harness instance must reach `SkillRunner.run()`. Three placements:
+
+- **A.** `SkillSpec.run` grows a keyword arg `harness_override:
+  Harness | None = None`. Mirrors `timeout_override` / `env_override`
+  shape per `spec-cli-precedence.md`. CLI constructs the `Harness`
+  instance from the resolved string and passes it. Requires the caller
+  (CLI) to know how to construct `ClaudeCodeHarness` / `CodexHarness`
+  from a string — minor coupling.
+- **B.** `SkillSpec.run` grows a keyword arg `harness_name_override:
+  str | None = None`. The runner / spec internally constructs the
+  harness from the name. CLI passes a string only. Construction logic
+  lives in one place (`SkillSpec.run` or a sibling helper).
+- **C.** CLI bypasses `SkillSpec.run` for harness override, constructs
+  its own `SkillRunner(harness=<harness>)` and calls `runner.run(...)`
+  directly. Skips `SkillSpec.run`'s timeout / env / cwd resolution
+  layer. **Worst** — duplicates `SkillSpec.run`'s integration.
+
+**Recommendation:** **B** — string-typed override is simpler at the seam
+boundary, harness construction stays in one place. If a future caller
+needs a custom-instantiated harness (e.g. mock in tests), they pass a
+fully-constructed `SkillRunner(harness=mock)` per the existing #148
+contract — that path is unchanged.
+
+**Q5 — Pytest fixture support for `harness`.**
+
+`clauditor_spec` and `clauditor_grader` fixture factories don't currently
+expose a harness override.
+
+- **A.** In scope: add `harness=` kwarg to `clauditor_spec` (and downstream
+  `clauditor_runner`). Tests that want to pin a harness pass it; tests that
+  don't get auto-resolution honoring `eval_spec.harness`. ~15 lines.
+- **B.** Out of scope. Fixtures continue to use `ClaudeCodeHarness` by
+  default. Tests that need Codex construct `SkillRunner(harness=CodexHarness())`
+  directly. Defer for a follow-up.
+- **C.** Compromise: extend the fixture factory to honor
+  `eval_spec.harness` only (no kwarg override). Tests with Codex specs
+  Just Work; explicit override remains direct construction.
+
+**Recommendation:** **C** — keeps fixture surface stable, picks up the
+spec field "for free", explicit override is rare and the direct
+construction path is fine.
+
+**Q6 — `--harness` flag on `cli/run.py` semantics.**
+
+`cli/run.py` is the lowest-level "run a skill once and print output"
+command. Today it doesn't load an `EvalSpec` (it accepts a skill name +
+args, no eval needed).
+
+- **A.** Add `--harness` flag, default `None`. Resolve via env > default.
+  No spec field path (no spec is loaded).
+- **B.** Same as A but if `--eval-spec` is passed (it isn't today, but
+  could be), spec field also participates. Forward-compat for a
+  hypothetical flag.
+- **C.** Skip `cli/run.py` for #151 — it's a thin debug helper. Land
+  `--harness` only on `validate`, `grade`, `capture`. Smaller surface.
+
+**Recommendation:** **A** — ticket lists `cli/run.py` explicitly. Three-
+layer (CLI > env > default; no spec) is fine. The argparse `type=` validator
+is shared.
+
+**Q7 — Announcement scope on `auto → codex` resolution.**
+
+Mirrors `auto → cli` (transport) which fires once per process via the
+inline-flip-at-call-site pattern.
+
+- **A.** One-shot per process. `_announced_auto_codex_harness` flag in
+  `_providers/_auth.py` (auth-coupled). Public helper
+  `announce_auto_codex_harness()` called from `_resolve_harness()` (or
+  the underlying pure helper) when the auto-branch picks codex AND the
+  flag is False. Standard pattern.
+- **B.** One-shot per CLI command. Reset between commands. More noise;
+  no clear value-add for batch invocations.
+- **C.** Always announce when auto-resolves to codex. Noisy.
+
+**Recommendation:** **A** — matches the existing announcement-family
+contract.
+
+**Q8 — Validator strictness vs harness installation.**
+
+Should `EvalSpec.from_dict` cross-check that the declared harness is
+actually installed (e.g. reject `"harness": "codex"` if `codex` isn't on
+PATH)?
+
+- **A.** No load-time PATH check. Validator only checks the literal-set
+  membership. Missing-binary errors surface at `harness.invoke` time.
+- **B.** Load-time check: when `harness != "auto"` and the corresponding
+  binary isn't on PATH, emit a stderr WARNING (not error) via the
+  conformance-style soft-warn hook in `SkillSpec.from_file`. Spec still
+  loads; user sees a hint.
+- **C.** Hard load-time failure. **Bad** — locks specs to the operator's
+  current env, breaks portability.
+
+**Recommendation:** **A** — keeps validation pure (no I/O), portability
+preserved. Auto-resolution failure mode (Q2-C) already handles the
+missing-binary case at resolve time when `harness="auto"`.
+
+---
+
+## Phase 1 Decisions (locked)
+
+- **DEC-001 (Q1=C):** `EvalSpec.harness: str = "auto"` (literal default,
+  not `None` sentinel). `to_dict` skips emission when value equals
+  `"auto"` to preserve minimal-diff round-trip on pre-#151 specs. Differs
+  from #146's `None` sentinel because no falsy-`None` legacy short-
+  circuits exist for this greenfield field.
+- **DEC-002 (Q2=C):** Auto-resolution failure (neither `claude` nor
+  `codex` on PATH) raises `ValueError` from the pure resolver; CLI
+  wrapper exits 2 with a message naming all three escape hatches:
+  `--harness=<name>` flag, `CLAUDITOR_HARNESS=<name>` env var, and the
+  `'harness'` field path in `eval.json`.
+- **DEC-003 (Q3=A):** `check_codex_auth(cmd_name)` is strict-OR — at
+  least one of `CODEX_API_KEY` or `OPENAI_API_KEY` must be set
+  (non-empty, whitespace-trimmed). No CLI-on-PATH fallback (parallels
+  `check_openai_auth`'s shape; Codex has no documented "subscription
+  only" auth analog like Claude Pro/Max).
+- **DEC-004 (Q4=B):** `SkillSpec.run` grows
+  `harness_name_override: str | None = None` (string-typed). A new
+  pure helper `_harnesses.construct_harness(name) -> Harness`
+  constructs the instance from the literal name. CLI passes a string
+  only. Tests that need a custom mock harness keep using the existing
+  #148 contract (`SkillRunner(harness=mock)`).
+- **DEC-005 (Q5=C):** Pytest fixture factories (`clauditor_spec`,
+  `clauditor_runner`, downstream graders) honor `eval_spec.harness`
+  automatically via the same resolver path; NO new `harness=` kwarg on
+  the factory. Tests needing a non-spec harness construct
+  `SkillRunner(harness=...)` directly.
+- **DEC-006 (Q6=A):** `cli/run.py` gets `--harness`, three-layer
+  precedence (CLI > env > default). The shared `_resolve_harness`
+  helper accepts `eval_spec=None` so the spec layer is skipped cleanly.
+- **DEC-007 (Q7=A):** One-shot-per-process announcement on
+  `auto → codex` resolution. `_announced_auto_codex_harness` flag +
+  `_AUTO_CODEX_ANNOUNCEMENT` constant + `announce_auto_codex_harness()`
+  public helper, all in `_providers/_auth.py` (auth-coupled — the
+  notice mentions `CODEX_API_KEY`/`OPENAI_API_KEY`). Mirrors the post-
+  #86 public-helper shape.
+- **DEC-008 (Q8=A):** No load-time PATH check in `EvalSpec.from_dict`
+  for the harness binary. Validator only enforces literal-set
+  membership (`{"claude-code","codex","auto"}`). Missing-binary
+  surfaces at auto-resolve time (DEC-002) or at `harness.invoke` time
+  (existing error path).
+
+---
+
+## Architecture Review
+
+Two parallel review passes (Auth/Security + CLI/Data-Model/Test). Overall
+verdict: **PASS** with three concerns surfaced, all resolved below.
+
+### Auth / Security review (7 areas)
+
+| # | Area | Rating | Notes |
+|---|------|--------|-------|
+| 1 | `CodexAuthMissingError` as direct `Exception` subclass | PASS | Sibling pattern preserves structural CLI routing per `precall-env-validation.md` + `llm-cli-exit-code-taxonomy.md`. |
+| 2 | Strict-OR `CODEX_API_KEY` / `OPENAI_API_KEY` (DEC-003) | PASS w/ note | Cross-key confusion (operator sets `OPENAI_API_KEY` for grading + selects Codex) surfaces late at `codex exec` invoke time as classified `error_category="auth"` — not silent leakage. Acceptable late-surface UX. |
+| 3 | Defense-in-depth at `CodexHarness.invoke` | PASS | Subprocess auth failure surfaces via `_classify_codex_failure` keyword classifier; no hang risk. Pre-call guard is first line of defense, in-loop classifier is second. |
+| 4 | `shutil.which` PATH-manipulation threat | PASS | Standard CLI threat model; PATH is operator-controlled. Same shape as existing `_claude_cli_is_available`. |
+| 5 | Stderr scrubbing covers `CODEX_API_KEY=` patterns | PASS | `_AUTH_LEAK_PATTERNS` in `_harnesses/_codex.py` already includes both `OPENAI_API_KEY=` and `CODEX_API_KEY=` plus the `_API_KEY_REGEX` bare-token catch. Post-#151 redaction surface complete. |
+| 6 | `_AUTH_LEAK_PATTERNS` completeness | PASS | All five anchor patterns present (api_key, Authorization, OPENAI_API_KEY=, CODEX_API_KEY=, CODEX_HOME=). |
+| 7 | Announcement notice avoids value interpolation | PASS | `_AUTO_CODEX_ANNOUNCEMENT` will be a `Final[str]` constant (no `.format(value=...)` calls), parallel to existing `_IMPLICIT_NO_API_KEY_ANNOUNCEMENT`. Names only, no values. |
+
+### CLI / Data-Model / Test review (10 areas)
+
+| # | Area | Rating | Notes |
+|---|------|--------|-------|
+| 1 | `EvalSpec.harness: str = "auto"` + skip-if-default `to_dict` | PASS | No generic `dataclasses.fields(EvalSpec)` consumers; `lint.py` uses `asdict()` only on issue dataclasses, not `EvalSpec`. Round-trip stays minimal-diff for pre-#151 specs. |
+| 2 | `SkillSpec.run(harness_name_override=)` keyword arg | PASS | Existing overrides: `timeout_override`, `env_override`, `sync_tasks_override`. Adding a fourth override-style kwarg sits at the readability high-water mark but stays under the cliff. |
+| 3 | `construct_harness(name)` location | **CONCERN → DEC-009** | Plan didn't pin file. Resolved: `_harnesses/__init__.py::construct_harness(name) -> Harness` with deferred per-call imports of `_claude_code` and `_codex` modules per `back-compat-shim-discipline.md` Pattern 3 (avoids circular import; `__init__.py` is already imported by both submodules at protocol-class load). |
+| 4 | `--harness` flag scope (4 commands, not 9) | PASS | Skill-execution surface only. Sub-question: does `cli/grade.py --baseline` arm propagate the resolved harness to BOTH the with-skill and without-skill `spec.run` calls? Answer below. |
+| 5 | `_harness_choice` argparse type validator | PASS | Sibling of `_transport_choice`/`_provider_choice`; literal three-set; rejects unknown values at argparse time (exit 2). |
+| 6 | `shutil.which` in pure resolver layer | PASS w/ precedent note | Existing `resolve_transport`/`resolve_grading_provider` are PATH-free. #151's `resolve_harness` is the first four-layer resolver to read PATH. Acceptable per plan's reasoning (PATH is contract, not state) and matches `_claude_cli_is_available` precedent. Document the precedent in the rule update. |
+| 7 | Test surface ~31 tests | PASS | Schema (5) + resolver (10) + env (3) + auth (4) + announcement (3) + CLI integration (4) + round-trip (2). Plus ~2 fixture-honors-spec tests = 33 total. |
+| 8 | Pytest fixture extension (DEC-005) | PASS | Spec-field honoring is automatic via `spec.run()` invoking the resolver under the hood. No kwarg added; fixture surface stable. |
+| 9 | Live-runner test gating | PASS | Existing `CLAUDITOR_RUN_LIVE`-gated tests in `tests/test_bundled_review_skill.py` use the default Anthropic harness; #151 changes nothing for them. A new live-Codex test is out of scope (no live Codex CI today). |
+| 10 | Auto-resolve `claude`-first preference | PASS | Pre-existing operators are on Anthropic; defaulting to claude-code preserves zero-friction upgrade. Codex-only operators set `CLAUDITOR_HARNESS=codex` once. |
+
+### Concerns resolved
+
+**Concern A — `CodexAuthMissingError` location (CLI/data review #3 + auth review #1).**
+Resolved: the **exception class** lives in `_providers/__init__.py` next
+to `AnthropicAuthMissingError` and `OpenAIAuthMissingError` (preserves
+class-identity invariant per `back-compat-shim-discipline.md` Pattern 2);
+the **helper function** `check_codex_auth(cmd_name)` lives in
+`_providers/_auth.py` (co-located with `check_any_auth_available`,
+`check_openai_auth`). Tracked as **DEC-010** below.
+
+**Concern B — Announcement fires from wrapper, not pure resolver
+(CLI/data review #3 / Auth review #7).** Resolved: the
+`announce_auto_codex_harness()` call lives in the **CLI wrapper**
+`_resolve_harness()` (which already owns stderr + `SystemExit(2)` per
+`pure-compute-vs-io-split.md`), NOT in the pure
+`_providers.resolve_harness()`. The pure helper returns a tuple
+`(name: str, auto_resolved_to: str | None)` so the wrapper knows when to
+fire the notice; the pure helper itself never touches stderr. Tracked as
+**DEC-011** below.
+
+**Concern C — `construct_harness()` placement (CLI/data review #3).**
+Resolved: `_harnesses/__init__.py::construct_harness(name: str) -> Harness`
+with deferred per-call imports. The two existing harnesses both import
+from `_harnesses/__init__.py` (the `Harness` protocol and `InvokeResult`),
+so eager imports of `_claude_code`/`_codex` from `__init__.py` would
+circular-import. Deferred import inside the function body matches the
+back-compat-shim Pattern 3 already used by `call_model` in
+`_providers/__init__.py`. Tracked as **DEC-012** below.
+
+**Minor note D — Harness-name case-sensitivity.** Validator rejects case
+variants (`"ClaudeCode"`, `"CodeX"`) loudly. Already implied by literal-set
+membership; called out explicitly to forestall future "did you mean
+case-insensitive?" PRs. No new DEC needed (DEC-008 covers this).
+
+**Minor note E — `--baseline` arm of `grade`.** The resolved harness
+propagates to BOTH the primary skill run AND the baseline skill run
+(both go through `spec.run` with the same `harness_name_override`).
+Per DEC-013 below.
+
+### Phase 2 additional decisions
+
+- **DEC-009 (Concern C):** `construct_harness(name: str) -> Harness` lives
+  in `_harnesses/__init__.py` with deferred per-call imports of
+  `_claude_code` and `_codex` modules (back-compat-shim-discipline Pattern 3
+  applied). Raises `ValueError` for unknown names (mirrors `call_model`
+  dispatcher shape).
+- **DEC-010 (Concern A):** `CodexAuthMissingError` lives in
+  `_providers/__init__.py` (sibling of the existing two
+  `*AuthMissingError` classes; direct subclass of `Exception`, NOT of
+  any shared parent). The auth-check helper `check_codex_auth(cmd_name)`
+  lives in `_providers/_auth.py` co-located with the other
+  `check_*_auth` helpers. The dispatcher `check_provider_auth` does NOT
+  grow a Codex branch (Codex is a HARNESS, not a PROVIDER — different
+  axis); the CLI seam directly calls `check_codex_auth(cmd_name)` when
+  the resolved harness is `"codex"`.
+- **DEC-011 (Concern B):** Pure resolver
+  `_providers.resolve_harness(cli, env, spec) -> tuple[str, str | None]`
+  returns `(resolved_name, auto_resolved_to)` where the second element is
+  `"codex"` when auto picked codex, `None` otherwise. The CLI wrapper
+  `_resolve_harness(args, eval_spec=None)` reads the tuple and calls
+  `announce_auto_codex_harness()` when the second element is `"codex"`.
+  Pure helper stays I/O-free (except `shutil.which` for PATH lookup,
+  per CLI/data review #6 precedent note).
+- **DEC-012:** Auth-check ordering — when `harness="codex"` resolves
+  (whether via auto or explicit), `check_codex_auth(cmd_name)` fires
+  AFTER `--dry-run` early-return AND BEFORE `spec.run()` invocation, at
+  the same CLI seam where `check_provider_auth(provider, cmd_name)`
+  already fires for grader auth. Both checks fire (provider auth +
+  harness auth) in the four skill-execution commands when the harness is
+  codex, since both subsystems are exercised. Order: provider auth
+  first, harness auth second (so a missing `ANTHROPIC_API_KEY` for
+  grading is reported before a missing `CODEX_API_KEY` for execution).
+- **DEC-013:** `--baseline` arm of `grade` propagates the resolved
+  harness to BOTH the primary skill run AND the baseline run. The
+  baseline executes the same skill without the eval spec but uses the
+  same harness — running the baseline under a different harness would
+  defeat the purpose (an A/B comparison must isolate the variable). No
+  separate `--baseline-harness` flag.
+
+---
+
+---
+
+## Refinement Log
+
+All open concerns resolved during architecture review (see DEC-009 through
+DEC-013 above). No additional questions surfaced. Total decisions: 13
+(DEC-001 through DEC-013).
+
+---
+
+## Detailed Breakdown
+
+Stories ordered by natural dependency: schema → pure resolver → auth helper
+→ CLI plumbing → SkillSpec.run integration → fixture extension → docs +
+quality gate + patterns memory.
+
+### US-001 — `EvalSpec.harness` field + load-time validator
+
+**Description:** Add `harness: str = "auto"` field to `EvalSpec` dataclass
+with literal-set membership validation in `from_dict`. Conditional emission
+in `to_dict` (skip when value equals default `"auto"`).
+
+**Traces to:** DEC-001, DEC-008.
+
+**Acceptance criteria:**
+- `EvalSpec.harness` field declared with `str = "auto"` default
+- `from_dict` validates against `{"claude-code", "codex", "auto"}`,
+  rejects bool, non-string, and unknown literal values with
+  `ValueError` message naming the allowed set
+- `to_dict` emits `"harness"` key only when value differs from `"auto"`
+- Round-trip `from_dict(to_dict(spec))` preserves both default-`"auto"`
+  and explicit-`"codex"` shapes
+- `uv run pytest tests/test_schemas.py -k harness` passes
+- `uv run ruff check src/ tests/` clean
+
+**Done when:** Schema validator unit tests cover all 5 cases (default,
+each of 3 literals explicitly, invalid-string rejection, bool rejection,
+null rejection). `to_dict` skip-if-default path is tested for both `"auto"`
+(skipped) and `"codex"` (emitted).
+
+**Files:**
+- `src/clauditor/schemas.py` — add field at the EvalSpec dataclass
+  (sibling of `transport`, line ~307); validator block in `from_dict`
+  (sibling of transport block, ~740-760); `to_dict` skip-if-default
+  emission (sibling of ~959).
+- `tests/test_schemas.py` — add `TestEvalSpecHarness` test class
+  (~5 tests).
+
+**Depends on:** none
+
+---
+
+### US-002 — Pure `resolve_harness` helper + `construct_harness` dispatcher
+
+**Description:** Add the pure four-layer resolver
+`resolve_harness(cli, env, spec) -> tuple[str, str | None]` in
+`_providers/__init__.py` (precedent: `resolve_transport`,
+`resolve_grading_provider`). Add the `construct_harness(name) -> Harness`
+dispatcher in `_harnesses/__init__.py` with deferred per-call imports of
+the two harness submodules.
+
+**Traces to:** DEC-002, DEC-009, DEC-011.
+
+**Acceptance criteria:**
+- `resolve_harness(cli, env, spec)` returns
+  `(resolved_name, auto_resolved_to)`:
+  - When `cli` is non-`None` non-`"auto"`: returns `(cli, None)`
+  - When CLI is unset, env layer wins; whitespace-only env normalizes
+    to `None`
+  - When all four layers are `None` or `"auto"`: PATH lookup runs
+    (`claude` first, then `codex`); returns `(picked, picked)` when
+    auto-selection succeeds; raises `ValueError` if neither found, with
+    a message naming `--harness=<name>`, `CLAUDITOR_HARNESS=<name>`,
+    and the `'harness'` field in `eval.json`
+  - When precedence resolves to a non-`"auto"` value, `auto_resolved_to`
+    is always `None` (no announcement should fire)
+  - Invalid values from any layer raise `ValueError` with the literal
+    set named
+- `construct_harness(name)` returns `ClaudeCodeHarness()` for
+  `"claude-code"`, `CodexHarness()` for `"codex"`; raises `ValueError`
+  for any other input (including `"auto"` — auto must be resolved
+  before construction)
+- Both helpers are pure (no stderr, no `sys.exit`)
+- Both fully unit-tested
+
+**TDD:** Write failing tests first, in this order:
+- `resolve_harness` returns explicit cli value
+- `resolve_harness` whitespace-empty env normalizes to None
+- `resolve_harness` spec falls through when cli + env are None
+- `resolve_harness` default `"auto"` triggers PATH lookup
+- `resolve_harness` auto-resolves to `claude-code` when `claude` on PATH
+- `resolve_harness` auto-resolves to `codex` when only `codex` on PATH;
+  returns `auto_resolved_to="codex"`
+- `resolve_harness` raises ValueError when neither on PATH
+- `resolve_harness` raises ValueError on unknown literal (per layer)
+- `construct_harness("claude-code")` returns ClaudeCodeHarness
+- `construct_harness("codex")` returns CodexHarness
+- `construct_harness("auto")` and `construct_harness("unknown")` raise
+
+**Done when:** ~12 unit tests pass; coverage on the new functions is
+100%. `resolve_harness` and `construct_harness` are importable from
+their canonical paths.
+
+**Files:**
+- `src/clauditor/_providers/__init__.py` — add `resolve_harness`
+  alongside `resolve_transport` and `resolve_grading_provider`.
+  `shutil.which` is the only non-pure call; it's already a precedent
+  (see `_claude_cli_is_available`).
+- `src/clauditor/_harnesses/__init__.py` — add `construct_harness`
+  with deferred per-call imports of `_claude_code` and `_codex` modules
+  (back-compat-shim-discipline Pattern 3).
+- `tests/test_providers.py` (or new `tests/test_resolve_harness.py`) —
+  pure-resolver tests with `monkeypatch.setattr(shutil, "which", ...)`
+  for PATH stubbing.
+- `tests/test_harnesses.py` (or sibling) — `construct_harness` tests.
+
+**Depends on:** US-001 (need the spec field shape stable so that the
+spec-layer parameter type-checks)
+
+---
+
+### US-003 — `check_codex_auth` + `CodexAuthMissingError` + announcement family
+
+**Description:** Add the three pre-call auth pieces: the exception class
+in `_providers/__init__.py`, the helper function in `_providers/_auth.py`,
+and the auto→codex announcement family member.
+
+**Traces to:** DEC-003, DEC-007, DEC-010, DEC-011.
+
+**Acceptance criteria:**
+- `CodexAuthMissingError` declared at `_providers/__init__.py`,
+  direct subclass of `Exception` (NOT of `AnthropicAuthMissingError`
+  or any shared parent)
+- `check_codex_auth(cmd_name: str) -> None` in `_providers/_auth.py`:
+  - Returns silently when `CODEX_API_KEY` OR `OPENAI_API_KEY` is set
+    (both checked via whitespace-trimmed non-empty)
+  - Raises `CodexAuthMissingError` with a message naming both env vars
+    and a pointer to `https://platform.openai.com/api-keys`
+- `_announced_auto_codex_harness: bool = False` module-level flag
+  + `_AUTO_CODEX_ANNOUNCEMENT: Final[str] = "..."` constant in
+  `_providers/_auth.py` (auth-coupled home; matches existing pattern)
+- `announce_auto_codex_harness()` public helper — print-and-flip;
+  one-shot per process; emits a notice naming `CODEX_API_KEY` and
+  `OPENAI_API_KEY` (env-var names only, never values)
+- Class-identity test: import `CodexAuthMissingError` from both
+  `_providers` and `_providers._auth` (re-export); assert
+  `from_a is from_b` (per `back-compat-shim-discipline.md` Pattern 2)
+- Tests for the auth helper cover: only `CODEX_API_KEY` set, only
+  `OPENAI_API_KEY` set, both set, neither set (raises),
+  whitespace-only values treated as unset
+- Tests for the announcement: fires once per process, the
+  `monkeypatch.setattr(..., False)` autouse-fixture pattern resets
+  between tests
+
+**TDD:** Write failing tests first for the auth helper (4 cases) and the
+announcement (one-shot + reset).
+
+**Done when:** ~9 unit tests pass; class-identity invariant verified; the
+announcement family member integrates with the existing test reset
+pattern in `tests/test_providers_auth.py`.
+
+**Files:**
+- `src/clauditor/_providers/__init__.py` — `CodexAuthMissingError`
+  class declaration + re-export.
+- `src/clauditor/_providers/_auth.py` — `check_codex_auth`,
+  `_announced_auto_codex_harness`, `_AUTO_CODEX_ANNOUNCEMENT`,
+  `announce_auto_codex_harness`.
+- `tests/test_providers_auth.py` — extend existing test classes with
+  `TestCheckCodexAuth` and `TestAnnounceAutoCodexHarness`.
+
+**Depends on:** none (parallel-safe with US-001 and US-002)
+
+---
+
+### US-004 — `_harness_choice` argparse validator + `_resolve_harness` CLI wrapper
+
+**Description:** Add the CLI-side helpers in `cli/__init__.py`. The
+argparse `type=` validator rejects malformed values at parse time; the
+wrapper threads CLI/env/spec through the pure resolver and routes errors
++ fires the announcement.
+
+**Traces to:** DEC-002, DEC-006, DEC-007, DEC-011.
+
+**Acceptance criteria:**
+- `_harness_choice(value: str) -> str` argparse-type callable parallels
+  `_transport_choice` and `_provider_choice`. Rejects unknown values
+  with `argparse.ArgumentTypeError` (argparse maps to exit 2 for free).
+- `_resolve_harness(args, eval_spec=None) -> str`:
+  - Reads `getattr(args, "harness", None)` for CLI layer
+  - Reads `os.environ.get("CLAUDITOR_HARNESS")` for env layer; strips
+    whitespace; whitespace-only normalizes to None
+  - Reads `eval_spec.harness` for spec layer (when `eval_spec` is
+    non-None); treats `None` AND `"auto"` as fall-through
+  - Calls `clauditor._providers.resolve_harness(cli, env, spec)`
+  - On `ValueError` from the pure helper: prints `f"ERROR: {exc}"` to
+    stderr, raises `SystemExit(2)`
+  - On success: if pure helper returned non-None
+    `auto_resolved_to == "codex"`, calls
+    `announce_auto_codex_harness()` BEFORE returning the resolved name
+  - Returns the resolved name (string)
+- `_resolve_harness` wrapper accepts `eval_spec=None` cleanly so
+  `cli/run.py` (no spec) Just Works
+- Wrapper is fully unit-tested with `monkeypatch.setattr` patching
+  `clauditor._providers.resolve_harness` (canonical seam) and
+  `clauditor._providers._auth.announce_auto_codex_harness`
+
+**TDD:** Tests written first for: each precedence layer wins correctly,
+invalid env raises SystemExit(2) with stderr message, announcement fires
+when auto-resolves to codex AND not when auto-resolves to claude-code.
+
+**Done when:** ~8 unit tests pass; `_resolve_harness` is a one-call
+swap-in for any CLI seam.
+
+**Files:**
+- `src/clauditor/cli/__init__.py` — `_harness_choice` (sibling of
+  `_transport_choice` ~44-56) and `_resolve_harness` (sibling of
+  `_resolve_grader_transport` ~77-107).
+- `tests/test_cli_helpers.py` (or sibling) — `TestHarnessChoice`,
+  `TestResolveHarness`.
+
+**Depends on:** US-002 (pure resolver), US-003 (announcement helper)
+
+---
+
+### US-005 — Wire `--harness` flag into `validate`/`grade`/`capture`/`run`
+
+**Description:** Add `--harness {claude-code,codex,auto}` argparse argument
+to the four skill-execution CLI commands; thread the resolved harness
+name through to `SkillSpec.run` (via the new
+`harness_name_override` kwarg added in US-006). Wire `check_codex_auth`
+at each seam after the existing `check_provider_auth` call.
+
+**Traces to:** DEC-006, DEC-012, DEC-013.
+
+**Acceptance criteria:**
+- Each of `cli/validate.py`, `cli/grade.py`, `cli/capture.py`,
+  `cli/run.py` adds `--harness` argument with
+  `type=_harness_choice`, `default=None`,
+  `choices=("claude-code", "codex", "auto")`,
+  help text matching the existing `--transport` template
+- Each command resolves
+  `harness_name = _resolve_harness(args, spec.eval_spec)` after spec
+  load (or `_resolve_harness(args, None)` for `cli/run.py`)
+- Each command, AFTER `--dry-run` early-return AND AFTER
+  `check_provider_auth(...)`, calls `check_codex_auth("validate")`
+  (etc.) when `harness_name == "codex"`. Catches
+  `CodexAuthMissingError`, prints to stderr, returns exit 2.
+- The resolved `harness_name` threads into `spec.run(...)` as
+  `harness_name_override=harness_name` (US-006). For `cli/run.py`
+  which constructs `SkillRunner` directly, the resolved name passes
+  through to `construct_harness(harness_name)` and the result is
+  passed as `SkillRunner(harness=...)`.
+- `cli/grade.py --baseline` arm propagates the SAME resolved harness
+  to BOTH the primary and baseline `spec.run` calls (DEC-013).
+- Smoke tests: `clauditor validate --harness codex <skill>` succeeds
+  on a Codex-installed env (mocked subprocess); fails with
+  `CodexAuthMissingError` exit 2 when both env vars unset.
+
+**Done when:** integration tests verify all four commands accept the
+flag, route to the correct harness, and propagate auth failures correctly.
+~6 integration tests.
+
+**Files:**
+- `src/clauditor/cli/validate.py` — add argparse block + resolver call
+  + auth check + thread to spec.run.
+- `src/clauditor/cli/grade.py` — same; both `spec.run` arms get the
+  override; baseline arm shares the resolved harness.
+- `src/clauditor/cli/capture.py` — same.
+- `src/clauditor/cli/run.py` — add argparse block; this command
+  constructs `SkillRunner` directly, so the integration is
+  `runner = SkillRunner(harness=construct_harness(harness_name))`.
+- `tests/test_cli_*.py` — add per-command smoke tests.
+
+**Depends on:** US-001, US-002, US-003, US-004, US-006
+
+---
+
+### US-006 — `SkillSpec.run` `harness_name_override` kwarg
+
+**Description:** Add the keyword-only override on `SkillSpec.run` and the
+internal resolution that calls `construct_harness(name)` to materialize
+the harness instance, then passes it to `SkillRunner.run` via the
+existing `harness=` kwarg path.
+
+**Traces to:** DEC-004.
+
+**Acceptance criteria:**
+- `SkillSpec.run` signature gains
+  `harness_name_override: str | None = None` after `*,` (keyword-only,
+  parallels `timeout_override`, `env_override`, `sync_tasks_override`)
+- When `harness_name_override` is non-None: `SkillSpec.run` calls
+  `construct_harness(harness_name_override)` and constructs an ad-hoc
+  `SkillRunner(...)` with that harness, OR — if `self.runner` already
+  exists with the right harness — reuses it. (Recommended: when
+  override is non-None, construct a fresh `SkillRunner` with the same
+  config but the new harness; the construction cost is negligible.)
+- When `harness_name_override` is None: existing behavior unchanged
+  (`self.runner` used as-is, default `ClaudeCodeHarness`)
+- Tests cover override-applied path AND override-omitted path
+- `tests/test_spec.py` test class `TestSkillSpecRunHarnessOverride`
+
+**Done when:** ~3 unit tests pass; the override is the canonical seam
+for the CLI to inject harness selection without duplicating the
+fallback-to-spec-field logic.
+
+**Files:**
+- `src/clauditor/spec.py` — `SkillSpec.run` signature + body.
+- `tests/test_spec.py` — `TestSkillSpecRunHarnessOverride`.
+
+**Depends on:** US-002 (`construct_harness`)
+
+---
+
+### US-007 — Pytest fixture honors `eval_spec.harness` automatically
+
+**Description:** Per DEC-005 (Q5=C), no new fixture kwarg. The fixture
+factories pass `harness_name_override=eval_spec.harness` (when set and
+non-`"auto"`) into `spec.run`. Auto-resolution still fires when needed.
+
+**Traces to:** DEC-005.
+
+**Acceptance criteria:**
+- `clauditor_spec` factory threads
+  `harness_name_override=spec.eval_spec.harness` into
+  `spec.run` when the spec field is non-`"auto"` (so `"auto"` and
+  unset still defer to the resolver's auto path)
+- Tests verify a Codex-spec eval.json picks up the harness without a
+  fixture-side kwarg
+- Live-runner tests untouched (default `claude-code` path)
+
+**Done when:** ~2 fixture tests pass.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py` — extend fixture factory bodies.
+- `tests/test_pytest_plugin.py` — add `TestFixtureHonorsHarness`.
+
+**Depends on:** US-006
+
+---
+
+### US-008 — Update `.claude/rules/spec-cli-precedence.md`
+
+**Description:** Per ticket acceptance criterion #4, add `harness` as the
+sixth four-layer-precedence canonical implementation in the rule's
+"Canonical implementations" section. Document the precedent of
+`shutil.which` in the pure resolver layer (first such case).
+
+**Traces to:** ticket acceptance criterion #4.
+
+**Acceptance criteria:**
+- New `### Four-layer precedence — harness (#151)` subsection in
+  `.claude/rules/spec-cli-precedence.md` matching the structure of the
+  existing "transport" and "grading_provider" anchors
+- Lists CLI flag, env var, spec field, default
+- Notes the auto-resolution PATH-lookup behavior and that this is the
+  first four-layer resolver to read PATH from the pure layer
+- Cross-references `harness-protocol-shape.md`,
+  `centralized-sdk-call.md` (announcement family), and
+  `precall-env-validation.md`
+- Trace line at the bottom of the subsection: "Traces to DEC-001
+  through DEC-013 of `plans/super/151-harness-precedence.md`."
+
+**Done when:** the rule renders cleanly; an author opening
+`spec-cli-precedence.md` finds `harness` listed alongside `transport`
+and `grading_provider`.
+
+**Files:**
+- `.claude/rules/spec-cli-precedence.md` — new subsection.
+
+**Depends on:** US-001 through US-007 (rule should reflect what shipped)
+
+---
+
+### US-009 — Quality Gate
+
+**Description:** Run code reviewer 4 times across the full changeset,
+fixing every real bug found each pass. Run CodeRabbit review if
+available. Verify project quality gates pass.
+
+**Acceptance criteria:**
+- 4 passes of `code-reviewer` agent across the diff; all real findings
+  resolved (false positives documented inline if any)
+- CodeRabbit review run (if PR is open); all findings addressed
+- `uv run ruff check src/ tests/` clean
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes
+  with ≥80% coverage gate enforced
+- Coverage on new code (`resolve_harness`, `construct_harness`,
+  `_resolve_harness`, `check_codex_auth`,
+  `announce_auto_codex_harness`, `EvalSpec.harness` validator) ≥ 90%
+
+**Done when:** all gates green; no real findings from any review pass.
+
+**Depends on:** US-001 through US-008
+
+---
+
+### US-010 — Patterns & Memory
+
+**Description:** Update `.claude/rules/` and `MEMORY.md` with patterns
+discovered during #151 implementation. Specifically: the
+"PATH-lookup-in-pure-resolver" precedent (first four-layer resolver to
+read PATH), the "harness vs provider — different axis" clarification
+(harness is NOT a provider; auth dispatcher does NOT grow a Codex branch).
+
+**Acceptance criteria:**
+- If new patterns surfaced, write them up as `.claude/rules/*.md`
+  entries OR extend existing rules
+- If no new patterns surfaced (unlikely given the cross-axis
+  clarification needed), document the absence in the rule's "When this
+  rule does NOT apply" section
+- Update `MEMORY.md` index entries if new rule files are added
+
+**Done when:** any patterns from this ticket are durable and
+discoverable.
+
+**Depends on:** US-009
+
+---
+
+## Beads Manifest
+
+_(populated after devolve)_

--- a/plans/super/151-harness-precedence.md
+++ b/plans/super/151-harness-precedence.md
@@ -4,7 +4,7 @@
 
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/151
 - **Branch:** `feature/151-harness-precedence`
-- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/151-harness-precedence`
+- **Worktree:** `worktrees/clauditor/151-harness-precedence` (relative)
 - **PR:** https://github.com/wjduenow/clauditor/pull/166
 - **Phase:** devolved
 - **Epic:** clauditor-66i
@@ -1014,7 +1014,7 @@ discoverable.
 ## Beads Manifest
 
 - **Epic:** `clauditor-66i` — #151: Multi-harness EvalSpec.harness four-layer precedence
-- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/151-harness-precedence`
+- **Worktree:** `worktrees/clauditor/151-harness-precedence` (relative)
 - **PR:** https://github.com/wjduenow/clauditor/pull/166
 
 | Bead | Story | Depends on |

--- a/plans/super/151-harness-precedence.md
+++ b/plans/super/151-harness-precedence.md
@@ -6,8 +6,8 @@
 - **Branch:** `feature/151-harness-precedence`
 - **Worktree:** `/home/wesd/Projects/worktrees/clauditor/151-harness-precedence`
 - **PR:** https://github.com/wjduenow/clauditor/pull/166
-- **Phase:** published
-- **Epic:** _(pending devolve)_
+- **Phase:** devolved
+- **Epic:** clauditor-66i
 - **Sessions:** 1 (2026-05-03)
 - **Total decisions:** 13 (DEC-001 through DEC-013)
 - **Stories:** 8 implementation + Quality Gate + Patterns & Memory = 10
@@ -1013,4 +1013,22 @@ discoverable.
 
 ## Beads Manifest
 
-_(populated after devolve)_
+- **Epic:** `clauditor-66i` — #151: Multi-harness EvalSpec.harness four-layer precedence
+- **Worktree:** `/home/wesd/Projects/worktrees/clauditor/151-harness-precedence`
+- **PR:** https://github.com/wjduenow/clauditor/pull/166
+
+| Bead | Story | Depends on |
+|---|---|---|
+| `clauditor-66i.1` | US-001: EvalSpec.harness field + validator | — |
+| `clauditor-66i.2` | US-002: resolve_harness + construct_harness | US-001 |
+| `clauditor-66i.3` | US-003: check_codex_auth + announcement | — |
+| `clauditor-66i.4` | US-004: _harness_choice + _resolve_harness wrapper | US-002, US-003 |
+| `clauditor-66i.5` | US-005: Wire --harness into 4 CLI commands | US-001..4, US-006 |
+| `clauditor-66i.6` | US-006: SkillSpec.run harness_name_override kwarg | US-002 |
+| `clauditor-66i.7` | US-007: Pytest fixture honors eval_spec.harness | US-006 |
+| `clauditor-66i.8` | US-008: Update spec-cli-precedence.md | US-005, US-007 |
+| `clauditor-66i.9` | US-009: Quality Gate (code-reviewer x4 + CodeRabbit) | US-008 |
+| `clauditor-66i.10` | US-010: Patterns & Memory | US-009 |
+
+**Ready to start (no blockers):** `clauditor-66i.1` (US-001),
+`clauditor-66i.3` (US-003) — parallel-safe.

--- a/src/clauditor/_harnesses/__init__.py
+++ b/src/clauditor/_harnesses/__init__.py
@@ -26,7 +26,7 @@ from typing import ClassVar, Protocol, runtime_checkable
 
 from clauditor.runner import InvokeResult
 
-__all__ = ["Harness", "InvokeResult"]
+__all__ = ["Harness", "InvokeResult", "construct_harness"]
 
 
 @runtime_checkable
@@ -102,3 +102,70 @@ class Harness(Protocol):
         analogous to how all harnesses accept ``model`` on ``invoke``.
         """
         ...
+
+
+def construct_harness(name: str) -> Harness:
+    """Construct a :class:`Harness` instance from its literal name.
+
+    DEC-009 / DEC-012 of ``plans/super/151-harness-precedence.md``.
+    Thin dispatcher mirroring the shape of
+    :func:`clauditor._providers.call_model` (the provider-axis
+    dispatcher in ``_providers/__init__.py``). The pure resolver
+    :func:`clauditor._providers.resolve_harness` returns a literal
+    name; this helper turns the name into the concrete harness
+    instance.
+
+    Uses **deferred per-call imports** for ``_claude_code`` and
+    ``_codex`` per ``.claude/rules/back-compat-shim-discipline.md``
+    Pattern 3. Both submodules import ``Harness`` and
+    ``InvokeResult`` from this ``__init__.py`` at protocol-class
+    load time, so an eager top-level ``from clauditor._harnesses
+    import _claude_code`` here would circular-import. Deferring
+    inside the function body breaks the cycle without sacrificing
+    test-patchability — patches that target
+    ``clauditor._harnesses._claude_code.ClaudeCodeHarness`` (or the
+    codex sibling) still take effect because the lookup happens at
+    call time against the module object.
+
+    The dispatcher rejects ``"auto"`` explicitly: callers must
+    resolve auto via :func:`~clauditor._providers.resolve_harness`
+    before constructing. Letting ``"auto"`` through here would
+    couple the harness package to PATH lookup, which belongs in
+    the resolver layer (one seam per concern).
+
+    Args:
+        name: One of ``"claude-code"`` or ``"codex"``. ``"auto"``
+            and unknown values raise.
+
+    Returns:
+        A concrete :class:`Harness` instance with default
+        construction kwargs (``claude_bin="claude"`` /
+        ``codex_bin="codex"``, ``model=None``,
+        ``allow_hang_heuristic=True`` for Claude Code).
+
+    Raises:
+        ValueError: ``name`` is ``"auto"`` (not yet resolved) or
+            any unknown literal.
+    """
+    if name == "claude-code":
+        # Deferred import: ``_claude_code`` imports ``Harness`` and
+        # ``InvokeResult`` from this module at load time, so an
+        # eager top-level import here would circular-import.
+        from clauditor._harnesses import _claude_code as _claude_code_mod
+
+        return _claude_code_mod.ClaudeCodeHarness()
+    if name == "codex":
+        # Same deferred-import shape.
+        from clauditor._harnesses import _codex as _codex_mod
+
+        return _codex_mod.CodexHarness()
+    if name == "auto":
+        raise ValueError(
+            "construct_harness: 'auto' must be resolved before "
+            "construction — call clauditor._providers.resolve_harness "
+            "first to pick a concrete harness name."
+        )
+    raise ValueError(
+        f"construct_harness: unknown harness {name!r} — "
+        "expected 'claude-code' or 'codex'"
+    )

--- a/src/clauditor/_harnesses/_claude_code.py
+++ b/src/clauditor/_harnesses/_claude_code.py
@@ -59,28 +59,61 @@ _monotonic = time.monotonic
 _API_KEY_ENV_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY")
 
 
+# Harness-aware strip set: when the skill subprocess runs under the
+# Codex harness, ``OPENAI_API_KEY`` is one of the two valid Codex auth
+# env vars (along with ``CODEX_API_KEY``). Stripping it would launch
+# the Codex subprocess without usable auth, breaking ``capture`` /
+# ``run`` / ``validate`` / ``grade`` whenever the operator passed
+# ``--no-api-key`` (or ``--transport cli`` triggered the implicit
+# strip) AND relied on ``OPENAI_API_KEY`` rather than
+# ``CODEX_API_KEY``. The Anthropic-only set preserves the
+# ``--no-api-key`` invariant for the Anthropic side (the operator
+# wanted Anthropic-key-less subscription auth) while leaving Codex
+# auth intact. Copilot review feedback on PR #166.
+_API_KEY_ENV_VARS_ANTHROPIC_ONLY = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+
 def env_without_api_key(
     base_env: dict[str, str] | None = None,
+    *,
+    harness_name: str | None = None,
 ) -> dict[str, str]:
     """Return a new env dict with provider auth env vars removed.
 
     Pure, non-mutating helper per
     ``.claude/rules/non-mutating-scrub.md``. When ``base_env`` is
     ``None``, reads from ``os.environ``. Always returns a new dict
-    (never mutates the input). Strips ``ANTHROPIC_API_KEY``,
-    ``ANTHROPIC_AUTH_TOKEN``, and ``OPENAI_API_KEY``; preserves every
-    other key (including ``ANTHROPIC_BASE_URL``, ``OPENAI_BASE_URL``,
-    ``OPENAI_ORG_ID``, and ``OPENAI_PROJECT_ID``).
+    (never mutates the input).
 
-    ``OPENAI_API_KEY`` is included for parity with the Anthropic
-    stripping when grading via OpenAI under ``--transport cli``: a
-    skill subprocess could spawn a child that calls the OpenAI API,
-    so the operator's quota must not be implicitly delegated to an
-    untrusted skill (DEC-008 of
+    Default behavior (``harness_name`` unset or ``"claude-code"``):
+    strips ``ANTHROPIC_API_KEY``, ``ANTHROPIC_AUTH_TOKEN``, and
+    ``OPENAI_API_KEY``; preserves every other key (including
+    ``ANTHROPIC_BASE_URL``, ``OPENAI_BASE_URL``, ``OPENAI_ORG_ID``,
+    and ``OPENAI_PROJECT_ID``).
+
+    ``OPENAI_API_KEY`` is included in the default strip set for parity
+    with the Anthropic stripping when grading via OpenAI under
+    ``--transport cli``: a skill subprocess could spawn a child that
+    calls the OpenAI API, so the operator's quota must not be
+    implicitly delegated to an untrusted skill (DEC-008 of
     ``plans/super/145-openai-provider.md``).
+
+    ``harness_name="codex"`` (Copilot review feedback on PR #166):
+    preserve ``OPENAI_API_KEY`` so the Codex subprocess retains valid
+    auth. The Codex harness uses ``CODEX_API_KEY`` (preferred) or
+    ``OPENAI_API_KEY``; stripping the latter would launch Codex
+    without usable auth even though :func:`check_codex_auth` accepted
+    it from ``os.environ``. Anthropic env vars are still stripped
+    because Codex does not need them and a leaked Anthropic key
+    inside an untrusted subprocess is undesirable.
     """
     source = base_env if base_env is not None else os.environ
-    return {k: v for k, v in source.items() if k not in _API_KEY_ENV_VARS}
+    strip_set = (
+        _API_KEY_ENV_VARS_ANTHROPIC_ONLY
+        if harness_name == "codex"
+        else _API_KEY_ENV_VARS
+    )
+    return {k: v for k, v in source.items() if k not in strip_set}
 
 
 # Soft cap applied to stream-json ``result`` text surfaced on

--- a/src/clauditor/_providers/__init__.py
+++ b/src/clauditor/_providers/__init__.py
@@ -100,6 +100,40 @@ class OpenAIAuthMissingError(Exception):
     """
 
 
+class CodexAuthMissingError(Exception):
+    """Raised when no usable Codex authentication path is available.
+
+    Thrown by :func:`check_codex_auth` when neither ``CODEX_API_KEY``
+    nor ``OPENAI_API_KEY`` is set (both checked via whitespace-trimmed
+    non-empty). Codex accepts either env var — ``CODEX_API_KEY`` is
+    the harness-native name; ``OPENAI_API_KEY`` is honored as a
+    fallback because Codex's underlying transport ultimately routes
+    to OpenAI.
+
+    DEC-003 / DEC-010 of ``plans/super/151-harness-precedence.md``:
+    Codex is a HARNESS axis, not a PROVIDER axis. The
+    :func:`check_provider_auth` dispatcher does NOT grow a Codex
+    branch — the CLI seam directly calls :func:`check_codex_auth`
+    when the resolved harness is ``"codex"``. The exception class
+    lives here next to its siblings to preserve the class-identity
+    invariant per ``.claude/rules/back-compat-shim-discipline.md``
+    Pattern 2: every ``except CodexAuthMissingError`` ladder catches
+    the same class object regardless of which module raised it.
+
+    Distinct from :class:`AnthropicAuthMissingError` AND
+    :class:`OpenAIAuthMissingError` by design: the CLI layer routes
+    ``CodexAuthMissingError`` to exit 2 (pre-call input-validation
+    error per ``.claude/rules/llm-cli-exit-code-taxonomy.md``) — the
+    same exit code the other auth-missing classes route to, but via
+    a structurally distinct ``except`` branch.
+
+    Subclass of :class:`Exception` directly, NOT of
+    :class:`AnthropicAuthMissingError`, :class:`OpenAIAuthMissingError`,
+    or any helper-error class — a common ancestor would defeat the
+    structural-routing invariant every CLI dispatcher depends on.
+    """
+
+
 # Re-export the auth-helper surface from ``_auth.py``. Imported AFTER
 # ``AnthropicAuthMissingError`` is defined so ``_auth.py``'s deferred
 # / direct ``from clauditor._providers import AnthropicAuthMissingError``
@@ -126,16 +160,21 @@ class OpenAIAuthMissingError(Exception):
 from clauditor._providers._auth import (  # noqa: E402, I001
     _AUTH_MISSING_TEMPLATE,
     _AUTH_MISSING_TEMPLATE_KEY_ONLY,
+    _AUTO_CODEX_ANNOUNCEMENT,
     _CALL_ANTHROPIC_DEPRECATION_NOTICE,
+    _CODEX_AUTH_MISSING_TEMPLATE,
     _IMPLICIT_NO_API_KEY_ANNOUNCEMENT,
     _OPENAI_AUTH_MISSING_TEMPLATE,
     _api_key_is_set,
     _claude_cli_is_available,
+    _codex_api_key_is_set,
     _openai_api_key_is_set,
+    announce_auto_codex_harness,
     announce_call_anthropic_deprecation,
     announce_implicit_no_api_key,
     check_any_auth_available,
     check_api_key_only,
+    check_codex_auth,
     check_openai_auth,
     check_provider_auth,
 )
@@ -476,15 +515,18 @@ __all__ = [
     "AnthropicHelperError",
     "AnthropicResult",
     "ClaudeCLIError",
+    "CodexAuthMissingError",
     "ModelResult",
     "OpenAIAuthMissingError",
     "OpenAIHelperError",
+    "announce_auto_codex_harness",
     "announce_call_anthropic_deprecation",
     "announce_implicit_no_api_key",
     "call_anthropic",
     "call_model",
     "check_any_auth_available",
     "check_api_key_only",
+    "check_codex_auth",
     "check_openai_auth",
     "check_provider_auth",
     "infer_provider_from_model",
@@ -497,10 +539,13 @@ __all__ = [
     # flag is deliberately absent — see the import comment above.
     "_AUTH_MISSING_TEMPLATE",
     "_AUTH_MISSING_TEMPLATE_KEY_ONLY",
+    "_AUTO_CODEX_ANNOUNCEMENT",
     "_CALL_ANTHROPIC_DEPRECATION_NOTICE",
+    "_CODEX_AUTH_MISSING_TEMPLATE",
     "_IMPLICIT_NO_API_KEY_ANNOUNCEMENT",
     "_OPENAI_AUTH_MISSING_TEMPLATE",
     "_api_key_is_set",
     "_claude_cli_is_available",
+    "_codex_api_key_is_set",
     "_openai_api_key_is_set",
 ]

--- a/src/clauditor/_providers/__init__.py
+++ b/src/clauditor/_providers/__init__.py
@@ -19,6 +19,7 @@ class object regardless of which module raised it.
 from __future__ import annotations
 
 import re
+import shutil
 from typing import Any, Literal, cast
 
 # Anthropic-default grading model used when ``grading_model`` is unset
@@ -40,6 +41,14 @@ _ANTHROPIC_DEFAULT_GRADING_MODEL: Literal["claude-sonnet-4-6"] = "claude-sonnet-
 _VALID_GRADING_PROVIDER_VALUES: frozenset[str] = frozenset(
     ("anthropic", "openai", "auto")
 )
+
+# Valid harness values across all four precedence layers (CLI override,
+# env override, spec field, default). ``"auto"`` is the default; the
+# resolver picks ``"claude-code"`` first when the ``claude`` binary is
+# on PATH and falls back to ``"codex"`` when only the ``codex`` binary
+# is available (DEC-001 / DEC-002 of
+# ``plans/super/151-harness-precedence.md``).
+_VALID_HARNESS_VALUES: tuple[str, ...] = ("claude-code", "codex", "auto")
 
 # Regex for OpenAI o-series reasoning models (``o1``, ``o4-mini``,
 # ``o3-pro``, ...). The pattern matches a leading ``o`` followed by
@@ -510,6 +519,148 @@ def resolve_grading_model(eval_spec: Any, provider: str) -> str:
     )
 
 
+def _validate_harness_value(value: str, layer: str) -> None:
+    """Raise ``ValueError`` when ``value`` is outside the literal set.
+
+    ``layer`` is a human-readable name of the precedence layer
+    (``"CLI --harness"``, ``"CLAUDITOR_HARNESS"``, or
+    ``"EvalSpec.harness"``) interpolated into the message so a CLI
+    caller routing the failure to exit 2 can name the layer the
+    operator should fix.
+    """
+    if value not in _VALID_HARNESS_VALUES:
+        raise ValueError(
+            f"{layer} must be one of 'claude-code', 'codex', 'auto', "
+            f"got {value!r}"
+        )
+
+
+def resolve_harness(
+    cli_override: str | None,
+    env_override: str | None,
+    spec_value: str | None,
+) -> tuple[str, str | None]:
+    """Pick the winning harness via four-layer precedence.
+
+    DEC-001 / DEC-002 / DEC-009 / DEC-011 of
+    ``plans/super/151-harness-precedence.md``. Pure helper per
+    ``.claude/rules/pure-compute-vs-io-split.md``: reads no env /
+    filesystem state directly — all three precedence inputs are
+    passed in. The CLI seam ``_resolve_harness`` (US-004) is
+    responsible for reading ``os.environ["CLAUDITOR_HARNESS"]``
+    (with whitespace normalization) and passing the result as
+    ``env_override``.
+
+    The single I/O concession is :func:`shutil.which` for PATH
+    lookup when the resolved value is ``"auto"`` — this is the
+    first four-layer resolver in clauditor that touches PATH from
+    the pure layer (precedent: ``_claude_cli_is_available`` in
+    ``_providers/_auth.py``). PATH is treated as contract, not
+    state — operators set it once at session start, and the
+    resolver's read is idempotent within a process.
+
+    Precedence (highest → lowest): CLI override > env override >
+    spec value > default ``"auto"``. A layer is "set" when its
+    value is non-``None`` AND non-``"auto"``: an explicit
+    ``"auto"`` at any layer is equivalent to "no preference at
+    this layer", so the chain falls through to the next layer.
+    This matches operator intuition — passing ``--harness=auto``
+    on the CLI should mean "let the auto branch decide", not
+    "the literal string auto wins over my env var".
+
+    When the winning value (or the fall-through default) is
+    ``"auto"``, the resolver runs PATH lookup:
+
+    - ``shutil.which("claude")`` is checked first → return
+      ``("claude-code", None)`` when found.
+    - Otherwise ``shutil.which("codex")`` → return
+      ``("codex", "codex")``. The second tuple element flags the
+      auto-resolution path so the CLI wrapper can fire
+      ``announce_auto_codex_harness()``.
+    - Neither found → raise ``ValueError`` naming all three
+      escape hatches (CLI flag, env var, spec field) so the
+      CLI's exit-2 message tells the operator how to fix it.
+
+    When the winning value is ``"claude-code"`` or ``"codex"``
+    explicitly (a non-``"auto"`` literal at any precedence
+    layer), the resolver returns ``(value, None)`` — no PATH
+    lookup, no announcement. Operators who pinned a harness
+    accept the responsibility of having the binary available.
+
+    Args:
+        cli_override: Value from the ``--harness`` argparse flag
+            (``None`` when the flag was not passed).
+        env_override: Value of ``os.environ["CLAUDITOR_HARNESS"]``
+            (or ``None`` when unset / whitespace-only — the CLI
+            seam normalizes whitespace-only env values to ``None``
+            before calling this helper). For defense-in-depth this
+            helper also strips and treats empty as ``None``.
+        spec_value: Value of ``EvalSpec.harness`` (or ``None``
+            when no eval spec is attached). The spec dataclass
+            defaults to ``"auto"`` so most callers pass that
+            literal here, which falls through to the default
+            branch identically.
+
+    Returns:
+        ``(name, auto_resolved_to)`` where ``name`` is one of
+        ``{"claude-code", "codex"}`` and ``auto_resolved_to`` is
+        ``"codex"`` when the auto branch picked codex (so the
+        CLI wrapper knows to fire
+        ``announce_auto_codex_harness``), and ``None`` in every
+        other case (explicit literal at any layer, or auto
+        picked claude-code).
+
+    Raises:
+        ValueError: A non-``None`` precedence layer holds an
+            invalid value, OR the resolved value is ``"auto"``
+            and neither ``claude`` nor ``codex`` is on PATH.
+    """
+    # Defensive whitespace-strip on env_override: the CLI wrapper
+    # is supposed to normalize whitespace-only env to ``None``,
+    # but a non-CLI caller (a future direct invocation, a test)
+    # might pass a raw env value. Strip-then-empty-check keeps
+    # the resolver robust either way.
+    if env_override is not None:
+        stripped_env = env_override.strip()
+        env_override = stripped_env if stripped_env != "" else None
+
+    if cli_override is not None and cli_override != "auto":
+        _validate_harness_value(cli_override, "CLI --harness")
+        return (cli_override, None)
+    if env_override is not None and env_override != "auto":
+        _validate_harness_value(env_override, "CLAUDITOR_HARNESS")
+        return (env_override, None)
+    if spec_value is not None and spec_value != "auto":
+        _validate_harness_value(spec_value, "EvalSpec.harness")
+        return (spec_value, None)
+
+    # Validate any explicit ``"auto"`` value too — guards against a
+    # future caller passing a non-string sentinel by mistake. The
+    # resolver still falls through to the auto branch below.
+    if cli_override is not None:
+        _validate_harness_value(cli_override, "CLI --harness")
+    if env_override is not None:
+        _validate_harness_value(env_override, "CLAUDITOR_HARNESS")
+    if spec_value is not None:
+        _validate_harness_value(spec_value, "EvalSpec.harness")
+
+    # Auto branch: prefer claude-code when the claude CLI is on
+    # PATH (zero-friction upgrade for pre-#151 Anthropic operators
+    # per DEC-002 / Phase-2 review note 10), fall back to codex
+    # when only the codex CLI is available.
+    if shutil.which("claude") is not None:
+        return ("claude-code", None)
+    if shutil.which("codex") is not None:
+        return ("codex", "codex")
+    raise ValueError(
+        "harness=auto: neither 'claude' nor 'codex' is on PATH. "
+        "Install one of the harness CLIs, or pin a harness "
+        "explicitly via --harness=<name> (claude-code or codex), "
+        "the CLAUDITOR_HARNESS=<name> env var, or the 'harness' "
+        "field in eval.json."
+    )
+
+
 __all__ = [
     "AnthropicAuthMissingError",
     "AnthropicHelperError",
@@ -532,6 +683,7 @@ __all__ = [
     "infer_provider_from_model",
     "resolve_grading_model",
     "resolve_grading_provider",
+    "resolve_harness",
     "resolve_transport",
     # Private surface re-exported for back-compat with the
     # ``clauditor._anthropic`` shim and for tests that introspect

--- a/src/clauditor/_providers/_auth.py
+++ b/src/clauditor/_providers/_auth.py
@@ -409,8 +409,9 @@ _announced_auto_codex_harness: bool = False
 _AUTO_CODEX_ANNOUNCEMENT: Final[str] = (
     "clauditor: auto-resolved harness to 'codex' (claude CLI not on "
     "PATH; codex CLI present). Codex needs CODEX_API_KEY or "
-    "OPENAI_API_KEY exported. Pin --harness=claude-code or "
-    "CLAUDITOR_HARNESS=claude-code to override."
+    "OPENAI_API_KEY exported. If you want Claude Code instead, "
+    "install the claude CLI and then pin --harness=claude-code (or "
+    "CLAUDITOR_HARNESS=claude-code)."
 )
 
 
@@ -461,8 +462,7 @@ _CODEX_AUTH_MISSING_TEMPLATE = (
     "key. Get a key at https://platform.openai.com/api-keys, then\n"
     "export CODEX_API_KEY=... (preferred) or OPENAI_API_KEY=... and\n"
     "re-run.\n"
-    "Commands that don't need a key: validate, capture, run, lint, init,\n"
-    "badge, audit, trend."
+    "Commands that don't need a key: lint, init, badge, audit, trend."
 )
 
 

--- a/src/clauditor/_providers/_auth.py
+++ b/src/clauditor/_providers/_auth.py
@@ -381,6 +381,157 @@ def check_provider_auth(provider: str, cmd_name: str) -> None:
     )
 
 
+# DEC-007 / DEC-010 (#151 US-003): one-shot stderr announcement when
+# the four-layer harness resolver auto-resolves to ``"codex"`` (i.e. no
+# explicit CLI flag, env var, or spec field; ``claude`` not on PATH;
+# ``codex`` on PATH). Flipped to ``True`` after the first emission per
+# Python process. Co-located with the other one-shot announcement flags
+# (:data:`_announced_implicit_no_api_key`,
+# :data:`_announced_call_anthropic_deprecation`) per
+# ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+# announcements — an emerging family". The notice is auth-coupled (it
+# names ``CODEX_API_KEY`` / ``OPENAI_API_KEY``) so this module is the
+# right home rather than ``_providers/_anthropic.py`` (transport-coupled
+# notices live there). Tests reset via the
+# ``monkeypatch.setattr(..., False)`` autouse fixture pattern,
+# targeting the canonical flag location at
+# ``clauditor._providers._auth._announced_auto_codex_harness``.
+_announced_auto_codex_harness: bool = False
+
+
+# DEC-007 / DEC-011 (#151 US-003): the auto→codex announcement emitted
+# on the first auto-resolution per Python process. Names env-var names
+# only (NEVER interpolates values) per Auth review #7 of the plan. Two
+# durable substrings tests pin: ``CODEX_API_KEY`` and ``OPENAI_API_KEY``
+# — the env-var names users must export to authenticate Codex. The
+# remainder of the message is stylistic copy and may be edited without
+# churning tests.
+_AUTO_CODEX_ANNOUNCEMENT: Final[str] = (
+    "clauditor: auto-resolved harness to 'codex' (claude CLI not on "
+    "PATH; codex CLI present). Codex needs CODEX_API_KEY or "
+    "OPENAI_API_KEY exported. Pin --harness=claude-code or "
+    "CLAUDITOR_HARNESS=claude-code to override."
+)
+
+
+def announce_auto_codex_harness() -> None:
+    """Emit the auto→codex harness notice to stderr once per process.
+
+    DEC-007 / DEC-011 (#151 US-003). Called by the CLI wrapper
+    ``_resolve_harness`` (US-004) when the four-layer harness resolver
+    returns ``auto_resolved_to == "codex"`` — i.e. no explicit CLI
+    flag, env var, or spec field forced the choice; ``claude`` is not
+    on PATH; ``codex`` is. The one-shot module flag
+    :data:`_announced_auto_codex_harness` ensures a single
+    announcement per Python process regardless of how many subsequent
+    CLI commands resolve under the same conditions.
+
+    Same shape as :func:`announce_implicit_no_api_key` (#95 US-002)
+    and :func:`announce_call_anthropic_deprecation` (#144 US-007):
+    public helper, print-and-flip, one-shot per process. Tests reset
+    via ``monkeypatch.setattr`` on the canonical flag location.
+
+    Per ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+    announcements — an emerging family", the helper lives in
+    ``_providers/_auth.py`` because the notice is auth-coupled (it
+    names ``CODEX_API_KEY`` / ``OPENAI_API_KEY``). Transport-coupled
+    notices live in ``_providers/_anthropic.py``.
+    """
+    global _announced_auto_codex_harness
+    if _announced_auto_codex_harness:
+        return
+    print(_AUTO_CODEX_ANNOUNCEMENT, file=sys.stderr)
+    _announced_auto_codex_harness = True
+
+
+# DEC-003 / DEC-010 (#151 US-003): message template for
+# :func:`check_codex_auth`, the strict-OR pre-flight guard for the
+# Codex harness. Mirrors :data:`_OPENAI_AUTH_MISSING_TEMPLATE` in shape
+# — single ``{cmd_name}`` interpolation, naming the env-var names
+# users must export, and listing the commands that don't require auth
+# so users see the escape hatch.
+#
+# Three durable substrings tests pin: ``CODEX_API_KEY`` and
+# ``OPENAI_API_KEY`` (the two env-var names Codex accepts), plus
+# ``platform.openai.com`` (the canonical place to obtain a key —
+# Codex's underlying transport routes to OpenAI).
+_CODEX_AUTH_MISSING_TEMPLATE = (
+    "ERROR: Neither CODEX_API_KEY nor OPENAI_API_KEY is set.\n"
+    "clauditor {cmd_name} runs the codex harness, which needs an API\n"
+    "key. Get a key at https://platform.openai.com/api-keys, then\n"
+    "export CODEX_API_KEY=... (preferred) or OPENAI_API_KEY=... and\n"
+    "re-run.\n"
+    "Commands that don't need a key: validate, capture, run, lint, init,\n"
+    "badge, audit, trend."
+)
+
+
+def _codex_api_key_is_set() -> bool:
+    """Return True when ``CODEX_API_KEY`` is present and non-empty.
+
+    Whitespace-only values count as absent — same shape as
+    :func:`_api_key_is_set` for ``ANTHROPIC_API_KEY`` and
+    :func:`_openai_api_key_is_set` for ``OPENAI_API_KEY``. Codex's
+    own "could not resolve authentication" path triggers on these
+    shapes, and the pre-flight guard's whole point is to catch the
+    failure with an actionable message upstream.
+    """
+    value = os.environ.get("CODEX_API_KEY")
+    return value is not None and value.strip() != ""
+
+
+def check_codex_auth(cmd_name: str) -> None:
+    """Pre-flight guard: raise if neither Codex env var is set.
+
+    DEC-003 / DEC-010 of ``plans/super/151-harness-precedence.md``.
+    Pure helper raising :class:`CodexAuthMissingError` when
+    ``CODEX_API_KEY`` AND ``OPENAI_API_KEY`` are both absent, empty,
+    or whitespace-only. Strict-OR semantics: at least one of the two
+    env vars must be set (non-empty after whitespace trimming). There
+    is no CLI-fallback branch — Codex has no documented "subscription
+    only" auth analog like Claude Pro/Max.
+
+    Codex is a HARNESS axis, not a PROVIDER axis (DEC-010): the
+    :func:`check_provider_auth` dispatcher is unchanged; the CLI seam
+    directly calls :func:`check_codex_auth` when the resolved harness
+    is ``"codex"``.
+
+    Pure function per ``.claude/rules/pure-compute-vs-io-split.md``:
+    reads ``os.environ`` only; does NOT print to stderr, does NOT call
+    ``sys.exit``, does NOT log. The CLI wrapper catches
+    :class:`CodexAuthMissingError` (a direct subclass of
+    :class:`Exception`, NOT :class:`AnthropicAuthMissingError`,
+    :class:`OpenAIAuthMissingError`, or any helper-error class) and
+    maps it to ``return 2`` per
+    ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+
+    Args:
+        cmd_name: Subcommand label (e.g. ``"grade"``, ``"validate"``,
+            ``"capture"``, ``"run"``) interpolated into the error
+            message so users see ``clauditor grade`` for immediately
+            actionable UX.
+
+    Raises:
+        CodexAuthMissingError: when neither ``CODEX_API_KEY`` nor
+            ``OPENAI_API_KEY`` is set (both checked via whitespace-
+            trimmed non-empty). Message contains the three durable
+            substrings (``CODEX_API_KEY``, ``OPENAI_API_KEY``,
+            ``platform.openai.com``) and the interpolated command
+            name.
+    """
+    if _codex_api_key_is_set() or _openai_api_key_is_set():
+        return None
+    # Local import to avoid a module-load circular hazard analogous to
+    # ``AnthropicAuthMissingError`` (defined in ``_providers/__init__``
+    # so both the auth helpers and the SDK seam reference it). At call
+    # time the parent package is fully initialized.
+    from clauditor._providers import CodexAuthMissingError
+
+    raise CodexAuthMissingError(
+        _CODEX_AUTH_MISSING_TEMPLATE.format(cmd_name=cmd_name)
+    )
+
+
 def check_api_key_only(cmd_name: str) -> None:
     """Strict pre-flight guard: raise if ``ANTHROPIC_API_KEY`` is missing.
 

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -79,9 +79,12 @@ def _harness_choice(value: str) -> str:
 
     DEC-002 / DEC-011 of ``plans/super/151-harness-precedence.md``.
     Mirrors :func:`_transport_choice` and :func:`_provider_choice` shape —
-    shared across the LLM-mediated commands so help text and error
-    messages stay consistent. argparse maps the
-    ``ArgumentTypeError`` to a clean exit 2 at parse time per
+    shared across the skill-execution commands (``validate``, ``grade``,
+    ``capture``, ``run``) where ``--harness`` is wired, so help text and
+    error messages stay consistent. (The LLM-mediated grader commands
+    use ``--transport`` / ``--grading-provider`` instead; ``--harness``
+    governs the skill subprocess, not the grading SDK call.) argparse
+    maps the ``ArgumentTypeError`` to a clean exit 2 at parse time per
     ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
     """
     if value not in ("claude-code", "codex", "auto"):

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -74,6 +74,83 @@ def _provider_choice(value: str) -> str:
     return value
 
 
+def _harness_choice(value: str) -> str:
+    """argparse type: accept one of ``"claude-code"``, ``"codex"``, ``"auto"``.
+
+    DEC-002 / DEC-011 of ``plans/super/151-harness-precedence.md``.
+    Mirrors :func:`_transport_choice` and :func:`_provider_choice` shape —
+    shared across the LLM-mediated commands so help text and error
+    messages stay consistent. argparse maps the
+    ``ArgumentTypeError`` to a clean exit 2 at parse time per
+    ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    """
+    if value not in ("claude-code", "codex", "auto"):
+        raise argparse.ArgumentTypeError(
+            f"must be one of 'claude-code', 'codex', 'auto', got {value!r}"
+        )
+    return value
+
+
+def _resolve_harness(args: argparse.Namespace, eval_spec=None) -> str:
+    """Resolve harness using four-layer precedence.
+
+    DEC-002 / DEC-006 / DEC-007 / DEC-011 of
+    ``plans/super/151-harness-precedence.md``. CLI flag >
+    ``CLAUDITOR_HARNESS`` env > ``EvalSpec.harness`` > default
+    ``"auto"``. Whitespace-only env values normalize to ``None`` so
+    they are treated as unset, matching the parallel
+    :func:`_resolve_grader_transport` and
+    :func:`_resolve_grading_provider` shape.
+
+    The pure resolver :func:`clauditor._providers.resolve_harness`
+    treats an explicit ``"auto"`` at any precedence layer as
+    fall-through to the next layer (so a user passing
+    ``--harness=auto`` is asking the auto branch to decide, not
+    pinning the literal string ``"auto"`` over their env var).
+    When the auto branch picks ``"codex"`` (because ``claude`` is
+    not on PATH but ``codex`` is) the second tuple element returned
+    by the pure helper equals ``"codex"`` and this wrapper fires
+    :func:`clauditor._providers._auth.announce_auto_codex_harness`
+    BEFORE returning the resolved name. Explicit non-``"auto"``
+    selections at any layer (and auto resolving to ``"claude-code"``)
+    do NOT fire the announcement.
+
+    ``eval_spec`` is the loaded ``EvalSpec`` (or ``None`` when the
+    calling command has no eval spec — e.g. ``run``). The wrapper
+    accepts ``getattr(args, "harness", None)`` defensively so call
+    sites that have not (yet) registered ``--harness`` on their
+    subparser still resolve cleanly.
+
+    Raises ``SystemExit(2)`` on any ``ValueError`` from the pure
+    resolver (invalid env / spec value, or ``"auto"`` resolution
+    when neither ``claude`` nor ``codex`` is on PATH). Printing the
+    error to stderr before exit centralizes the routing per
+    ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    """
+    import os
+
+    from clauditor._providers import resolve_harness
+    from clauditor._providers._auth import announce_auto_codex_harness
+
+    cli_value = getattr(args, "harness", None)
+    env_value = os.environ.get("CLAUDITOR_HARNESS")
+    if env_value is not None and env_value.strip() == "":
+        env_value = None
+    spec_value = eval_spec.harness if eval_spec is not None else None
+
+    try:
+        name, auto_resolved_to = resolve_harness(
+            cli_value, env_value, spec_value
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    if auto_resolved_to == "codex":
+        announce_auto_codex_harness()
+    return name
+
+
 def _resolve_grader_transport(args: argparse.Namespace, eval_spec=None) -> str:
     """Resolve grader transport using four-layer precedence.
 

--- a/src/clauditor/cli/capture.py
+++ b/src/clauditor/cli/capture.py
@@ -135,7 +135,11 @@ def cmd_capture(args: argparse.Namespace) -> int:
         try:
             check_codex_auth("capture")
         except CodexAuthMissingError as exc:
-            print(f"ERROR: {exc}", file=sys.stderr)
+            # Template already starts with "ERROR: " — print verbatim
+            # to avoid a doubled "ERROR: ERROR: " prefix (matches the
+            # AnthropicAuthMissingError / OpenAIAuthMissingError
+            # handlers in cli/grade.py).
+            print(str(exc), file=sys.stderr)
             return 2
 
     # When the resolved harness is the default ``claude-code``, preserve

--- a/src/clauditor/cli/capture.py
+++ b/src/clauditor/cli/capture.py
@@ -130,6 +130,28 @@ def cmd_capture(args: argparse.Namespace) -> int:
     # "auto"; no eval spec for capture). Fail fast if the resolved
     # harness is "codex" and Codex auth is missing. ``capture`` has no
     # provider-grader axis, so harness auth is the only pre-call check.
+    #
+    # ``--claude-bin`` precedence (CodeRabbit review feedback on PR
+    # #166): when the operator explicitly passed ``--claude-bin``, they
+    # have signalled intent to run Claude Code. Treat that as
+    # equivalent to pinning ``--harness=claude-code`` UNLESS they
+    # explicitly pinned ``--harness=codex`` (in which case the
+    # explicit ``--harness`` wins — operator-intent layers are siblings,
+    # but ``--harness`` is the more specific knob). Without this guard,
+    # ``capture --claude-bin /custom/claude`` would silently auto-resolve
+    # to ``codex`` (or hard-fail with "neither claude nor codex on PATH")
+    # whenever ``claude`` was not on PATH, even though the operator
+    # supplied a custom Claude binary.
+    if (
+        getattr(args, "claude_bin", None) is not None
+        and getattr(args, "harness", None) != "codex"
+    ):
+        # Force the claude-code branch by pinning ``args.harness`` BEFORE
+        # the resolver fires. Argparse normalizes the attribute, so
+        # rewriting it here is structural — ``_resolve_harness`` reads
+        # ``args.harness`` first and that value will now be
+        # ``"claude-code"``.
+        args.harness = "claude-code"
     harness_name = _resolve_harness(args, None)
     if harness_name == "codex":
         try:
@@ -154,8 +176,14 @@ def cmd_capture(args: argparse.Namespace) -> int:
         runner = SkillRunner(harness=construct_harness(harness_name))
     # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
     # to the runner. Defaults are both None (today's behavior).
+    #
+    # ``harness_name`` is threaded into ``env_without_api_key`` so the
+    # codex branch preserves ``OPENAI_API_KEY`` (Copilot review feedback
+    # on PR #166): otherwise ``--no-api-key`` would launch the Codex
+    # subprocess without usable auth even though :func:`check_codex_auth`
+    # accepted it.
     env_override: dict[str, str] | None = (
-        env_without_api_key()
+        env_without_api_key(harness_name=harness_name)
         if getattr(args, "no_api_key", False)
         else None
     )

--- a/src/clauditor/cli/capture.py
+++ b/src/clauditor/cli/capture.py
@@ -6,7 +6,12 @@ import argparse
 import sys
 from pathlib import Path
 
+from clauditor._harnesses import construct_harness
 from clauditor._harnesses._claude_code import env_without_api_key
+from clauditor._providers import (
+    CodexAuthMissingError,
+    check_codex_auth,
+)
 from clauditor.capture_provenance import write_capture_provenance
 from clauditor.runner import (
     SkillRunner,
@@ -18,7 +23,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``capture`` subparser."""
     # Shared argparse type helpers live in the package __init__; import
     # lazily to avoid a circular import at module load time.
-    from clauditor.cli import _positive_int
+    from clauditor.cli import _harness_choice, _positive_int
 
     p_capture = subparsers.add_parser(
         "capture",
@@ -76,6 +81,19 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     p_capture.add_argument(
+        "--harness",
+        type=_harness_choice,
+        default=None,
+        choices=("claude-code", "codex", "auto"),
+        help=(
+            "Override the harness selection: 'claude-code' (Anthropic "
+            "Claude CLI), 'codex' (OpenAI Codex CLI), or 'auto' (prefer "
+            "claude-code when available). Three-layer precedence (no "
+            "spec layer): this flag > CLAUDITOR_HARNESS env > default "
+            "'auto'."
+        ),
+    )
+    p_capture.add_argument(
         "skill_args",
         nargs="*",
         help="Arguments to pass to the skill (put after `--`)",
@@ -93,7 +111,7 @@ def cmd_capture(args: argparse.Namespace) -> int:
 
     # Shared helper lives in ``clauditor.cli`` (package __init__). Import
     # lazily to avoid a circular import at module load.
-    from clauditor.cli import _render_skill_error
+    from clauditor.cli import _render_skill_error, _resolve_harness
 
     skill_name = args.skill.lstrip("/")
     skill_args = " ".join(args.skill_args) if args.skill_args else ""
@@ -107,7 +125,29 @@ def cmd_capture(args: argparse.Namespace) -> int:
             f"{out_path.stem}-{stamp}{out_path.suffix}"
         )
 
-    runner = SkillRunner(claude_bin=args.claude_bin or "claude")
+    # #151 US-005 / DEC-006 / DEC-012: resolve harness via the four-layer
+    # precedence helper (CLI flag > CLAUDITOR_HARNESS env > default
+    # "auto"; no eval spec for capture). Fail fast if the resolved
+    # harness is "codex" and Codex auth is missing. ``capture`` has no
+    # provider-grader axis, so harness auth is the only pre-call check.
+    harness_name = _resolve_harness(args, None)
+    if harness_name == "codex":
+        try:
+            check_codex_auth("capture")
+        except CodexAuthMissingError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    # When the resolved harness is the default ``claude-code``, preserve
+    # the historical ``--claude-bin`` override path so existing call
+    # sites are unaffected. For non-default harnesses, ``--claude-bin``
+    # is silently ignored (Codex has its own CLI binary). Constructing
+    # via ``construct_harness`` for non-default reuses the dispatcher
+    # logic and keeps the wiring uniform with ``SkillSpec.run``.
+    if harness_name == "claude-code":
+        runner = SkillRunner(claude_bin=args.claude_bin or "claude")
+    else:
+        runner = SkillRunner(harness=construct_harness(harness_name))
     # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
     # to the runner. Defaults are both None (today's behavior).
     env_override: dict[str, str] | None = (

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 def _resolve_grade_env_override(
     args: argparse.Namespace,
+    harness_name: str | None = None,
 ) -> tuple[dict[str, str] | None, bool]:
     """Decide the skill-subprocess env override and notice-firing bit.
 
@@ -61,6 +62,13 @@ def _resolve_grade_env_override(
 
     Whitespace-only env values are treated as absent (matching
     :func:`clauditor._anthropic._api_key_is_set`).
+
+    ``harness_name`` (Copilot review feedback on PR #166): threaded
+    into :func:`env_without_api_key` so the codex branch preserves
+    ``OPENAI_API_KEY`` (otherwise ``--no-api-key`` or the
+    ``--transport cli`` implicit-strip coupling would launch the Codex
+    subprocess without usable auth even though :func:`check_codex_auth`
+    accepted it from ``os.environ``).
     """
     from clauditor.cli import should_strip_api_key_for_skill_subprocess
 
@@ -73,7 +81,7 @@ def _resolve_grade_env_override(
     auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or ""
     key_was_present = bool(api_key.strip() or auth_token.strip())
     env_override = (
-        env_without_api_key()
+        env_without_api_key(harness_name=harness_name)
         if (explicit_strip or implicit_strip)
         else None
     )
@@ -594,7 +602,9 @@ def _run_skill_variants(
     # Copilot feedback on duplication). Traces to DEC-001, DEC-003,
     # DEC-006, DEC-007, DEC-008, DEC-009 of
     # plans/super/95-subscription-auth-flag.md.
-    env_override, should_announce = _resolve_grade_env_override(args)
+    env_override, should_announce = _resolve_grade_env_override(
+        args, harness_name=harness_name
+    )
     if should_announce:
         announce_implicit_no_api_key()
     timeout_override = getattr(args, "timeout", None)
@@ -807,7 +817,9 @@ def _write_workspace_sidecars(
         # lockstep by construction. The ``should_announce`` return is
         # deliberately ignored here — the primary arm already fired the
         # notice (and the helper is idempotent per US-002 regardless).
-        env_override, _ = _resolve_grade_env_override(args)
+        env_override, _ = _resolve_grade_env_override(
+            args, harness_name=harness_name
+        )
         # Tier 1.5 of GitHub #103: when --sync-tasks fires, the
         # baseline arm must also run synchronously so the delta
         # compares like-for-like. spec.runner.run_raw (used by the

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -13,8 +13,10 @@ from clauditor import history
 from clauditor._harnesses._claude_code import env_without_api_key
 from clauditor._providers import (
     AnthropicAuthMissingError,
+    CodexAuthMissingError,
     OpenAIAuthMissingError,
     announce_implicit_no_api_key,
+    check_codex_auth,
     check_provider_auth,
 )
 from clauditor.assertions import AssertionSet, run_assertions
@@ -84,6 +86,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     # Shared argparse type helpers live in the package __init__; import
     # lazily to avoid a circular import at module load time.
     from clauditor.cli import (
+        _harness_choice,
         _positive_int,
         _provider_choice,
         _transport_choice,
@@ -247,6 +250,19 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
             "EvalSpec.grading_provider > default 'auto'."
         ),
     )
+    p_grade.add_argument(
+        "--harness",
+        type=_harness_choice,
+        default=None,
+        choices=("claude-code", "codex", "auto"),
+        help=(
+            "Override the harness selection: 'claude-code' (Anthropic "
+            "Claude CLI), 'codex' (OpenAI Codex CLI), or 'auto' (prefer "
+            "claude-code when available). Four-layer precedence: this "
+            "flag > CLAUDITOR_HARNESS env > EvalSpec.harness > default "
+            "'auto'."
+        ),
+    )
 
 
 def _load_and_validate_grade_args(
@@ -357,7 +373,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
     # The resolved provider is threaded down through every grader
     # entry point per #146 US-006 (orchestrators no longer re-read
     # ``eval_spec.grading_provider``).
-    from clauditor.cli import _resolve_grading_provider
+    from clauditor.cli import _resolve_grading_provider, _resolve_harness
 
     provider = _resolve_grading_provider(args, spec.eval_spec)
     try:
@@ -368,6 +384,34 @@ def cmd_grade(args: argparse.Namespace) -> int:
     except OpenAIAuthMissingError as exc:
         print(str(exc), file=sys.stderr)
         return 2
+
+    # #151 US-005 / DEC-006 / DEC-012: resolve harness via the four-layer
+    # precedence helper, then fail fast if the resolved harness is
+    # "codex" and Codex auth is missing. Auth-check ordering: provider
+    # auth FIRST (already above) so a missing ANTHROPIC_API_KEY for
+    # grading is reported before a missing CODEX_API_KEY for execution;
+    # harness auth SECOND. Both fire when applicable. Guard lands BEFORE
+    # allocate_iteration so we do not leave an abandoned
+    # iteration-N-tmp/ staging dir behind when the guard fires. Skipped
+    # when the entire run is captured-text (``--output`` AND no
+    # ``--variance`` AND no ``--baseline``) because no subprocess fires
+    # — the auto-resolve PATH check would otherwise be a hostile UX
+    # regression for the captured-output workflow.
+    needs_subprocess = (
+        not args.output
+        or bool(args.variance)
+        or bool(getattr(args, "baseline", False))
+    )
+    if needs_subprocess:
+        harness_name: str | None = _resolve_harness(args, spec.eval_spec)
+        if harness_name == "codex":
+            try:
+                check_codex_auth("grade")
+            except CodexAuthMissingError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 2
+    else:
+        harness_name = None
 
     # #146 US-006 / DEC-004: pick the per-provider default model when
     # the spec's ``grading_model`` is unset. ``args.model`` (if the
@@ -430,6 +474,7 @@ def cmd_grade(args: argparse.Namespace) -> int:
             spec=spec,
             model=model,
             provider=provider,
+            harness_name=harness_name,
             clauditor_dir=clauditor_dir,
             workspace=workspace,
         )
@@ -512,6 +557,7 @@ def _run_skill_variants(
     spec: SkillSpec,
     workspace: IterationWorkspace,
     n_variance: int,
+    harness_name: str | None,
 ) -> tuple[
     list[tuple[str, list[dict]]],
     list[SkillResult | None],
@@ -581,6 +627,7 @@ def _run_skill_variants(
             timeout_override=timeout_override,
             env_override=env_override,
             sync_tasks_override=sync_tasks_override,
+            harness_name_override=harness_name,
         )
         if not primary_skill_result.succeeded_cleanly:
             print(
@@ -613,6 +660,7 @@ def _run_skill_variants(
             timeout_override=timeout_override,
             env_override=env_override,
             sync_tasks_override=sync_tasks_override,
+            harness_name_override=harness_name,
         )
         if not variance_result.succeeded_cleanly:
             print(
@@ -699,6 +747,7 @@ def _write_workspace_sidecars(
     model: str,
     transport: str = "auto",
     provider: str = "anthropic",
+    harness_name: str | None = None,
 ) -> Benchmark | None:
     """Write grading/assertions/extraction/baseline/benchmark sidecars.
 
@@ -774,6 +823,7 @@ def _write_workspace_sidecars(
             provider=provider,
             env_override=env_override,
             timeout_override=timeout_override,
+            harness_name=harness_name,
         )
 
     return None
@@ -921,6 +971,7 @@ def _write_baseline_and_benchmark(
     provider: str = "anthropic",
     env_override: dict[str, str] | None = None,
     timeout_override: int | None = None,
+    harness_name: str | None = None,
 ) -> Benchmark | None:
     """Run the baseline phase and compute+persist the benchmark delta.
 
@@ -941,6 +992,7 @@ def _write_baseline_and_benchmark(
         provider=provider,
         env_override=env_override,
         timeout_override=timeout_override,
+        harness_name=harness_name,
     )
 
     # #28 US-002: compute the pair-run benchmark delta and persist
@@ -998,6 +1050,7 @@ def _run_baseline_phase(
     provider: str = "anthropic",
     env_override: dict[str, str] | None = None,
     timeout_override: int | None = None,
+    harness_name: str | None = None,
 ) -> tuple[GradingReport, SkillResult]:
     """Run the baseline (no skill prefix) and persist sidecars.
 
@@ -1010,10 +1063,19 @@ def _run_baseline_phase(
     ``--baseline`` run (otherwise the baseline subprocess would bypass
     the flags, defeating their intent).
 
+    ``harness_name`` (#151 US-005 / DEC-013): the resolved harness name
+    must match the primary arm's harness so the A/B comparison isolates
+    the variable. When non-default, materialize a fresh
+    :class:`SkillRunner` with the override harness for the baseline
+    invocation (mirrors :meth:`SkillSpec.run`'s
+    ``harness_name_override`` shape).
+
     Returns ``(GradingReport, SkillResult)`` so the caller can feed
     them to :func:`clauditor.benchmark.compute_benchmark`.
     """
+    from clauditor._harnesses import construct_harness
     from clauditor.baseline import compute_baseline
+    from clauditor.runner import SkillRunner
     from clauditor.workspace import stage_inputs
 
     test_args = spec.eval_spec.test_args or ""
@@ -1026,7 +1088,23 @@ def _run_baseline_phase(
         stage_inputs(baseline_run_dir, sources)
         effective_cwd = baseline_run_dir / "inputs"
     print(f"Running baseline (no skill prefix) {test_args}...")
-    baseline_result = spec.runner.run_raw(
+
+    # #151 US-005 / DEC-013: when a non-default harness was resolved,
+    # materialize a fresh ``SkillRunner`` with that harness so the
+    # baseline runs under the same harness as the primary. Constructing
+    # a new runner (rather than mutating ``spec.runner.harness``) avoids
+    # mutating shared state across calls. ``harness_name`` is ``None``
+    # only on captured-output runs that never reach this path; treat
+    # ``"claude-code"`` and ``None`` the same way (preserve historical
+    # ``spec.runner`` behavior).
+    baseline_runner = spec.runner
+    if harness_name is not None and harness_name != "claude-code":
+        baseline_runner = SkillRunner(
+            project_dir=spec.runner.project_dir,
+            timeout=spec.runner.timeout,
+            harness=construct_harness(harness_name),
+        )
+    baseline_result = baseline_runner.run_raw(
         test_args,
         cwd=effective_cwd,
         env=env_override,
@@ -1114,6 +1192,7 @@ def _cmd_grade_with_workspace(
     spec: SkillSpec,
     model: str,
     provider: str,
+    harness_name: str | None,
     clauditor_dir: Path,
     workspace: IterationWorkspace,
 ) -> int:
@@ -1129,7 +1208,7 @@ def _cmd_grade_with_workspace(
         skill_output_total,
         skill_duration_total,
         error_rc,
-    ) = _run_skill_variants(args, spec, workspace, n_variance)
+    ) = _run_skill_variants(args, spec, workspace, n_variance, harness_name)
     if error_rc is not None:
         return error_rc
 
@@ -1187,6 +1266,7 @@ def _cmd_grade_with_workspace(
             model=model,
             transport=grader_transport,
             provider=provider,
+            harness_name=harness_name,
         )
         _write_timing_and_finalize(
             workspace=workspace,

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -408,7 +408,11 @@ def cmd_grade(args: argparse.Namespace) -> int:
             try:
                 check_codex_auth("grade")
             except CodexAuthMissingError as exc:
-                print(f"ERROR: {exc}", file=sys.stderr)
+                # Template already starts with "ERROR: " — print verbatim
+                # to avoid a doubled "ERROR: ERROR: " prefix (matches the
+                # AnthropicAuthMissingError / OpenAIAuthMissingError
+                # handlers in cli/grade.py).
+                print(str(exc), file=sys.stderr)
                 return 2
     else:
         harness_name = None

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -95,7 +95,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         try:
             check_codex_auth("run")
         except CodexAuthMissingError as exc:
-            print(f"ERROR: {exc}", file=sys.stderr)
+            # Template already starts with "ERROR: " — print verbatim
+            # to avoid a doubled "ERROR: ERROR: " prefix (matches the
+            # AnthropicAuthMissingError / OpenAIAuthMissingError
+            # handlers in cli/grade.py).
+            print(str(exc), file=sys.stderr)
             return 2
 
     project_dir = (

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -115,8 +115,14 @@ def cmd_run(args: argparse.Namespace) -> int:
     # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
     # to the runner. Defaults are both None (today's behavior; runner
     # falls back to its own ``self.timeout`` default of 300s).
+    #
+    # ``harness_name`` is threaded into ``env_without_api_key`` so the
+    # codex branch preserves ``OPENAI_API_KEY`` (Copilot review feedback
+    # on PR #166): otherwise ``--no-api-key`` would launch the Codex
+    # subprocess without usable auth even though :func:`check_codex_auth`
+    # accepted it.
     env_override: dict[str, str] | None = (
-        env_without_api_key()
+        env_without_api_key(harness_name=harness_name)
         if getattr(args, "no_api_key", False)
         else None
     )

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -6,7 +6,12 @@ import argparse
 import sys
 from pathlib import Path
 
+from clauditor._harnesses import construct_harness
 from clauditor._harnesses._claude_code import env_without_api_key
+from clauditor._providers import (
+    CodexAuthMissingError,
+    check_codex_auth,
+)
 from clauditor.runner import (
     SkillRunner,
     env_with_sync_tasks,
@@ -17,7 +22,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``run`` subparser."""
     # Shared argparse type helpers live in the package __init__; import
     # lazily to avoid a circular import at module load time.
-    from clauditor.cli import _positive_int
+    from clauditor.cli import _harness_choice, _positive_int
 
     p_run = subparsers.add_parser("run", help="Run a skill and print output")
     p_run.add_argument("skill", help="Skill name (e.g., find-kid-activities)")
@@ -58,6 +63,19 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
             "caveats."
         ),
     )
+    p_run.add_argument(
+        "--harness",
+        type=_harness_choice,
+        default=None,
+        choices=("claude-code", "codex", "auto"),
+        help=(
+            "Override the harness selection: 'claude-code' (Anthropic "
+            "Claude CLI), 'codex' (OpenAI Codex CLI), or 'auto' (prefer "
+            "claude-code when available). Three-layer precedence (no "
+            "spec layer): this flag > CLAUDITOR_HARNESS env > default "
+            "'auto'."
+        ),
+    )
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -65,11 +83,31 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Shared helper lives in ``clauditor.cli`` (package __init__). Import
     # lazily to avoid a circular import at module load: ``clauditor.cli``
     # imports this module to register the subparser.
-    from clauditor.cli import _render_skill_error
+    from clauditor.cli import _render_skill_error, _resolve_harness
 
-    runner = SkillRunner(
-        project_dir=Path(args.project_dir) if args.project_dir else Path.cwd(),
+    # #151 US-005 / DEC-006 / DEC-012: resolve harness via the four-layer
+    # precedence helper. ``run`` has no eval spec, so the spec layer is
+    # skipped (eval_spec=None). Fail fast if the resolved harness is
+    # "codex" and Codex auth is missing. ``run`` has no provider-grader
+    # axis, so harness auth is the only pre-call check.
+    harness_name = _resolve_harness(args, None)
+    if harness_name == "codex":
+        try:
+            check_codex_auth("run")
+        except CodexAuthMissingError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    project_dir = (
+        Path(args.project_dir) if args.project_dir else Path.cwd()
     )
+    if harness_name == "claude-code":
+        runner = SkillRunner(project_dir=project_dir)
+    else:
+        runner = SkillRunner(
+            project_dir=project_dir,
+            harness=construct_harness(harness_name),
+        )
     # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags through
     # to the runner. Defaults are both None (today's behavior; runner
     # falls back to its own ``self.timeout`` default of 300s).

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -188,7 +188,11 @@ def cmd_validate(args: argparse.Namespace) -> int:
             try:
                 check_codex_auth("validate")
             except CodexAuthMissingError as exc:
-                print(f"ERROR: {exc}", file=sys.stderr)
+                # Template already starts with "ERROR: " — print verbatim
+                # to avoid a doubled "ERROR: ERROR: " prefix (matches the
+                # AnthropicAuthMissingError / OpenAIAuthMissingError
+                # handlers in cli/grade.py).
+                print(str(exc), file=sys.stderr)
                 return 2
 
         clauditor_dir = resolve_clauditor_dir()

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -8,6 +8,10 @@ import sys
 from pathlib import Path
 
 from clauditor._harnesses._claude_code import env_without_api_key
+from clauditor._providers import (
+    CodexAuthMissingError,
+    check_codex_auth,
+)
 from clauditor.assertions import run_assertions
 from clauditor.paths import resolve_clauditor_dir
 from clauditor.runner import SkillResult
@@ -22,7 +26,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``validate`` subparser."""
     # Shared argparse type helpers live in the package __init__; import
     # lazily to avoid a circular import at module load time.
-    from clauditor.cli import _positive_int
+    from clauditor.cli import _harness_choice, _positive_int
 
     p_validate = subparsers.add_parser(
         "validate", help="Run Layer 1 assertions against a skill's output"
@@ -76,6 +80,19 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     p_validate.add_argument(
+        "--harness",
+        type=_harness_choice,
+        default=None,
+        choices=("claude-code", "codex", "auto"),
+        help=(
+            "Override the harness selection: 'claude-code' (Anthropic "
+            "Claude CLI), 'codex' (OpenAI Codex CLI), or 'auto' (prefer "
+            "claude-code when available). Four-layer precedence: this "
+            "flag > CLAUDITOR_HARNESS env > EvalSpec.harness > default "
+            "'auto'."
+        ),
+    )
+    p_validate.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -104,6 +121,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
         _print_failing_transcript_slice,
         _relative_to_repo,
         _render_skill_error,
+        _resolve_harness,
         _write_run_dir,
     )
 
@@ -124,6 +142,12 @@ def cmd_validate(args: argparse.Namespace) -> int:
     workspace: IterationWorkspace | None = None
     workspace_rel: str | None = None
     iteration_index: int | None = None
+    # ``harness_name`` is resolved only on the live-run path. The
+    # ``--output`` branch reads a captured file and never invokes a
+    # subprocess, so the four-layer resolver (which raises if neither
+    # ``claude`` nor ``codex`` is on PATH under the default ``"auto"``)
+    # would be a hostile UX regression for the captured-output workflow.
+    harness_name: str | None = None
 
     if args.output:
         # Validate against a pre-captured output file. This path is
@@ -150,6 +174,23 @@ def cmd_validate(args: argparse.Namespace) -> int:
         # Live-run path: allocate an iteration workspace, run the skill
         # into ``workspace.tmp_path / run-0``, persist sidecars, and
         # finalize atomically. On any exception, abort the staging dir.
+        #
+        # #151 US-005 / DEC-006 / DEC-012: resolve harness via the
+        # four-layer precedence helper (CLI flag > CLAUDITOR_HARNESS env
+        # > EvalSpec.harness > default "auto"), then fail fast if the
+        # resolved harness is "codex" and Codex auth is missing. Guard
+        # lands BEFORE allocate_iteration so we do not leave an
+        # abandoned iteration-N-tmp/ staging dir behind when the guard
+        # fires. ``validate`` has no provider-grader axis, so harness
+        # auth is the only pre-call check.
+        harness_name = _resolve_harness(args, spec.eval_spec)
+        if harness_name == "codex":
+            try:
+                check_codex_auth("validate")
+            except CodexAuthMissingError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 2
+
         clauditor_dir = resolve_clauditor_dir()
         try:
             workspace = allocate_iteration(clauditor_dir, spec.skill_name)
@@ -179,6 +220,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 sync_tasks_override=(
                     True if getattr(args, "sync_tasks", False) else None
                 ),
+                harness_name_override=harness_name,
             )
             if not skill_result.succeeded_cleanly:
                 print(

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -212,8 +212,14 @@ def cmd_validate(args: argparse.Namespace) -> int:
             # vars via ``env_without_api_key``; ``--timeout`` wins over
             # spec/default per DEC-002. Both default to None (today's
             # behavior).
+            #
+            # ``harness_name`` is threaded into ``env_without_api_key``
+            # so the codex branch preserves ``OPENAI_API_KEY`` (Copilot
+            # review feedback on PR #166): otherwise ``--no-api-key``
+            # would launch the Codex subprocess without usable auth
+            # even though :func:`check_codex_auth` accepted it.
             env_override = (
-                env_without_api_key()
+                env_without_api_key(harness_name=harness_name)
                 if getattr(args, "no_api_key", False)
                 else None
             )

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -183,12 +183,28 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
         # override as ``None`` so ``SkillSpec.run`` falls through to
         # ``self.runner`` (the resolver's auto path is the CLI seam's
         # responsibility, not the fixture's).
+        #
+        # Same-harness skip (CodeRabbit review feedback on PR #166):
+        # when the spec's harness already matches the runner's current
+        # harness (e.g. spec sets ``harness="claude-code"`` and the
+        # fixture's base ``runner`` is ``ClaudeCodeHarness`` with a
+        # custom ``--clauditor-claude-bin``), do NOT request an override
+        # — ``SkillSpec.run`` would otherwise reconstruct a fresh runner
+        # via ``construct_harness("claude-code")`` and lose the fixture's
+        # configured Claude binary. ``SkillSpec.run`` itself also has
+        # a same-harness skip layer; this fixture-side check is
+        # defense-in-depth and avoids the unnecessary override-path
+        # entry in the closure below.
         spec_harness_override: str | None = None
         if (
             spec.eval_spec is not None
             and spec.eval_spec.harness != "auto"
         ):
-            spec_harness_override = spec.eval_spec.harness
+            current_harness_name = getattr(
+                getattr(runner, "harness", None), "name", None
+            )
+            if spec.eval_spec.harness != current_harness_name:
+                spec_harness_override = spec.eval_spec.harness
         if (
             has_input_files
             or fixture_env_override is not None

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -175,7 +175,25 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
         has_input_files = (
             spec.eval_spec is not None and bool(spec.eval_spec.input_files)
         )
-        if has_input_files or fixture_env_override is not None:
+        # US-007 (#151) / DEC-005: when ``eval_spec.harness`` is set to
+        # a concrete value (``"claude-code"`` or ``"codex"``), thread it
+        # to ``SkillSpec.run`` as ``harness_name_override`` so the
+        # spec-author preference is honored automatically — no new
+        # fixture kwarg per DEC-005. ``"auto"`` (and unset) leaves the
+        # override as ``None`` so ``SkillSpec.run`` falls through to
+        # ``self.runner`` (the resolver's auto path is the CLI seam's
+        # responsibility, not the fixture's).
+        spec_harness_override: str | None = None
+        if (
+            spec.eval_spec is not None
+            and spec.eval_spec.harness != "auto"
+        ):
+            spec_harness_override = spec.eval_spec.harness
+        if (
+            has_input_files
+            or fixture_env_override is not None
+            or spec_harness_override is not None
+        ):
             original_run = spec.run
             default_run_dir = tmp_path / f"clauditor_run_{id(spec)}"
 
@@ -185,6 +203,7 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                 run_dir: Path | None = None,
                 env_override: dict[str, str] | None = None,
                 timeout_override: int | None = None,
+                harness_name_override: str | None = None,
             ):
                 effective_run_dir = run_dir
                 if has_input_files and effective_run_dir is None:
@@ -201,12 +220,26 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                     if env_override is not None
                     else fixture_env_override
                 )
-                if effective_env is not None or timeout_override is not None:
+                # US-007 (#151) / DEC-005: caller-provided
+                # ``harness_name_override=`` (operator intent) wins over
+                # the spec-field default (author intent), mirroring the
+                # ``env_override`` / ``timeout_override`` precedence.
+                effective_harness = (
+                    harness_name_override
+                    if harness_name_override is not None
+                    else spec_harness_override
+                )
+                if (
+                    effective_env is not None
+                    or timeout_override is not None
+                    or effective_harness is not None
+                ):
                     return original_run(
                         args,
                         run_dir=effective_run_dir,
                         env_override=effective_env,
                         timeout_override=timeout_override,
+                        harness_name_override=effective_harness,
                     )
                 return original_run(args, run_dir=effective_run_dir)
 

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -305,6 +305,18 @@ class EvalSpec:
     # string / bool values rejected per
     # ``.claude/rules/constant-with-type-info.md``.
     transport: str = "auto"
+    # DEC-001 / DEC-008 of #151: per-spec harness selector for the
+    # skill subprocess. One of ``"claude-code"``, ``"codex"``, or
+    # ``"auto"``. The default ``"auto"`` resolves to the harness
+    # whose CLI is on PATH (subscription-first); explicit
+    # ``"claude-code"`` / ``"codex"`` pin a specific harness.
+    # Four-layer precedence per ``.claude/rules/spec-cli-precedence.md``:
+    # CLI ``--harness`` > ``CLAUDITOR_HARNESS`` env > this field >
+    # default ``"auto"``. Validated at load time against the literal
+    # set; non-string / bool / unknown-string values rejected per
+    # ``.claude/rules/constant-with-type-info.md``. The pure resolver
+    # + ``construct_harness`` dispatcher live in US-002 of #151.
+    harness: str = "auto"
     # Tier 1.5 of GitHub #103: when ``True``, clauditor sets
     # ``CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`` in the skill
     # subprocess env, forcing ``Task(run_in_background=true)`` calls
@@ -759,6 +771,37 @@ class EvalSpec:
                 )
             transport = raw_transport
 
+        # DEC-001 / DEC-008 of #151: optional per-spec harness selector.
+        # Missing → default ``"auto"`` (back-compat). Must be a non-bool
+        # string in the literal set ``{"claude-code", "codex", "auto"}``.
+        # Explicit ``null`` is rejected (use omission for default).
+        # Bool guard first per ``.claude/rules/constant-with-type-info.md``.
+        harness: str = "auto"
+        if "harness" in data:
+            raw_harness = data["harness"]
+            if raw_harness is None:
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    "'harness' must be one of "
+                    "'claude-code', 'codex', 'auto', got null "
+                    "(omit the key to use the default 'auto')"
+                )
+            if isinstance(raw_harness, bool) or not isinstance(
+                raw_harness, str
+            ):
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    f"'harness' must be a string, got "
+                    f"{type(raw_harness).__name__} {raw_harness!r}"
+                )
+            if raw_harness not in ("claude-code", "codex", "auto"):
+                raise ValueError(
+                    f"EvalSpec(skill_name={skill_name!r}): "
+                    "'harness' must be one of 'claude-code', 'codex', "
+                    f"'auto', got {raw_harness!r}"
+                )
+            harness = raw_harness
+
         # Tier 1.5 of GitHub #103: optional per-spec sync-tasks
         # opt-in. Missing → default ``False``. Must be a real bool
         # per ``.claude/rules/constant-with-type-info.md`` — a
@@ -882,6 +925,7 @@ class EvalSpec:
             allow_hang_heuristic=allow_hang_heuristic,
             timeout=timeout,
             transport=transport,
+            harness=harness,
             sync_tasks=sync_tasks,
             grading_provider=grading_provider,
         )
@@ -957,6 +1001,11 @@ class EvalSpec:
             # DEC-012 of #86: emit only on non-default. Omission at
             # load time means default "auto" per from_dict.
             result["transport"] = self.transport
+        if self.harness != "auto":
+            # DEC-001 / DEC-008 of #151: emit only on non-default.
+            # Omission at load time means default ``"auto"`` per
+            # from_dict.
+            result["harness"] = self.harness
         if self.sync_tasks:
             # Tier 1.5 of GitHub #103: emit only on non-default.
             # Omission at load time means default ``False``.

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -234,15 +234,30 @@ class SkillSpec:
         # shared state across calls; construction cost is negligible.
         # ``construct_harness`` rejects ``"auto"`` — callers must resolve
         # it through :func:`clauditor._providers.resolve_harness` first.
+        #
+        # Same-harness skip (Copilot / CodeRabbit review feedback on PR
+        # #166): when ``harness_name_override`` matches the harness the
+        # existing ``self.runner`` already uses, reuse the runner. This
+        # preserves any harness-specific configuration carried by that
+        # runner (notably the pytest plugin's ``--clauditor-claude-bin``
+        # which lives on ``self.runner.harness.claude_bin``). Constructing
+        # a fresh ``SkillRunner`` with the default ``construct_harness``
+        # call would silently swap that custom binary back to ``"claude"``.
         if harness_name_override is not None:
-            from clauditor._harnesses import construct_harness
-
-            override_harness = construct_harness(harness_name_override)
-            active_runner = SkillRunner(
-                project_dir=self.runner.project_dir,
-                timeout=self.runner.timeout,
-                harness=override_harness,
+            current_harness_name = getattr(
+                getattr(self.runner, "harness", None), "name", None
             )
+            if current_harness_name == harness_name_override:
+                active_runner = self.runner
+            else:
+                from clauditor._harnesses import construct_harness
+
+                override_harness = construct_harness(harness_name_override)
+                active_runner = SkillRunner(
+                    project_dir=self.runner.project_dir,
+                    timeout=self.runner.timeout,
+                    harness=override_harness,
+                )
         else:
             active_runner = self.runner
 

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -130,6 +130,7 @@ class SkillSpec:
         timeout_override: int | None = None,
         env_override: dict[str, str] | None = None,
         sync_tasks_override: bool | None = None,
+        harness_name_override: str | None = None,
     ) -> SkillResult:
         """Run the skill and return captured output.
 
@@ -138,6 +139,14 @@ class SkillSpec:
         If ``run_dir`` is provided and the eval spec declares non-empty
         ``input_files``, those files are staged into ``run_dir / "inputs"``
         and the subprocess runs with that directory as its CWD.
+
+        ``harness_name_override`` (US-006 / DEC-004 of #151): when non-
+        ``None``, materialize a fresh :class:`SkillRunner` with the
+        named harness via :func:`clauditor._harnesses.construct_harness`
+        and use it for this call. ``"auto"`` is rejected by
+        ``construct_harness``; callers must resolve auto via
+        :func:`clauditor._providers.resolve_harness` before passing.
+        When ``None`` (default), ``self.runner`` is used as-is.
         """
         run_args = (
             args
@@ -218,7 +227,26 @@ class SkillSpec:
                     f"{exc}"
                 ) from exc
 
-        result = self.runner.run(
+        # US-006 / DEC-004 of #151: when the caller (typically the CLI
+        # seam) has resolved a concrete harness name, materialize a fresh
+        # ``SkillRunner`` with that harness. Constructing a new runner
+        # (rather than mutating ``self.runner.harness``) avoids mutating
+        # shared state across calls; construction cost is negligible.
+        # ``construct_harness`` rejects ``"auto"`` — callers must resolve
+        # it through :func:`clauditor._providers.resolve_harness` first.
+        if harness_name_override is not None:
+            from clauditor._harnesses import construct_harness
+
+            override_harness = construct_harness(harness_name_override)
+            active_runner = SkillRunner(
+                project_dir=self.runner.project_dir,
+                timeout=self.runner.timeout,
+                harness=override_harness,
+            )
+        else:
+            active_runner = self.runner
+
+        result = active_runner.run(
             self.skill_name,
             run_args,
             cwd=effective_cwd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -733,12 +733,25 @@ def _force_api_transport_in_tests(monkeypatch):
     ``TestStderrAnnouncement`` in ``tests/test_providers_anthropic.py``)
     re-patch ``shutil.which`` inside the test body to override this
     default.
+
+    #151 US-005: pin ``CLAUDITOR_HARNESS=claude-code`` so the harness
+    resolver short-circuits before hitting the auto-PATH-lookup branch.
+    ``shutil.which`` is a module-level attribute on the singleton
+    ``shutil`` module, so patching ``_anthropic.shutil.which`` globally
+    affects every reader (including
+    :func:`clauditor._providers.resolve_harness`'s PATH lookup) — the
+    harness auto-resolver would otherwise raise on every test under
+    the ``"auto"`` default. Tests that exercise codex resolution, the
+    no-binary-on-PATH error path, or the ``CLAUDITOR_HARNESS`` env-var
+    layer specifically use ``monkeypatch.setenv`` /
+    ``monkeypatch.delenv`` inside the test body to override.
     """
     import clauditor._anthropic as _anthropic
 
     monkeypatch.setattr(
         _anthropic.shutil, "which", lambda name: None
     )
+    monkeypatch.setenv("CLAUDITOR_HARNESS", "claude-code")
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8099,6 +8099,12 @@ class TestCmdValidateHarness:
         assert rc == 2
         err = capsys.readouterr().err
         assert "CODEX_API_KEY" in err
+        # Regression guard: stderr must NOT contain a doubled
+        # ``"ERROR: ERROR: "`` prefix. The Codex template already
+        # starts with ``"ERROR: "`` so the CLI handler must use
+        # ``print(str(exc), ...)`` (matches Anthropic / OpenAI
+        # auth-missing handlers), not ``f"ERROR: {exc}"``.
+        assert "ERROR: ERROR:" not in err
         assert spec.run.call_count == 0
 
 
@@ -8244,6 +8250,8 @@ class TestCmdGradeHarness:
         assert rc == 2
         err = capsys.readouterr().err
         assert "CODEX_API_KEY" in err
+        # Regression guard: no doubled ``"ERROR: ERROR: "`` prefix.
+        assert "ERROR: ERROR:" not in err
         assert spec.run.call_count == 0
         assert mock_grade.await_count == 0
 
@@ -8273,6 +8281,8 @@ class TestCmdCaptureHarness:
         assert rc == 2
         err = capsys.readouterr().err
         assert "CODEX_API_KEY" in err
+        # Regression guard: no doubled ``"ERROR: ERROR: "`` prefix.
+        assert "ERROR: ERROR:" not in err
         assert mock_runner_cls.call_count == 0
 
 
@@ -8298,6 +8308,8 @@ class TestCmdRunHarness:
         assert rc == 2
         err = capsys.readouterr().err
         assert "CODEX_API_KEY" in err
+        # Regression guard: no doubled ``"ERROR: ERROR: "`` prefix.
+        assert "ERROR: ERROR:" not in err
         assert mock_runner_cls.call_count == 0
 
     def test_run_with_harness_codex_constructs_codex_harness(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8692,14 +8692,14 @@ class TestCmdGradeHarness:
                 ["grade", "skill.md", "--harness", "codex", "--baseline"]
             )
 
-        # Whatever the final exit code (delta gate may or may not
-        # pass), the baseline arm must have called
-        # ``construct_harness("codex")`` — that's the DEC-013
-        # invariant. ``construct_harness`` is also called inside
-        # ``SkillSpec.run`` (from US-006), but here ``spec.run`` is a
-        # mock so that path is bypassed; the only call therefore comes
-        # from the baseline arm.
-        assert rc in (0, 1), f"unexpected rc {rc}"
+        # Tightened from ``rc in (0, 1)`` per CodeRabbit review feedback
+        # on PR #166: assert deterministic success (``rc == 0``) so a
+        # future regression in the baseline flow surfaces here rather
+        # than being masked by a permissive ladder. ``construct_harness``
+        # is also called inside ``SkillSpec.run`` (from US-006), but
+        # here ``spec.run`` is a mock so that path is bypassed; the
+        # codex call therefore only comes from the baseline arm.
+        assert rc == 0, f"baseline propagation regression: rc={rc}"
         codex_calls = [
             c for c in mock_construct.call_args_list
             if c.args and c.args[0] == "codex"
@@ -8745,6 +8745,92 @@ class TestCmdGradeHarness:
         assert mock_grade.await_count == 0
 
 
+class TestCmdCaptureClaudeBinPrecedence:
+    """CodeRabbit review feedback on PR #166: ``--claude-bin`` is an
+    explicit operator-intent signal that the operator wants the Claude
+    branch. Treat it as equivalent to pinning ``--harness=claude-code``
+    UNLESS the operator explicitly pinned ``--harness=codex``. Without
+    this guard, ``capture --claude-bin /custom/claude`` would auto-
+    resolve to ``codex`` (or hard-fail) when ``claude`` is not on PATH,
+    silently breaking back-compat for existing ``capture`` users.
+    """
+
+    def test_capture_claude_bin_forces_claude_code_branch(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--claude-bin /custom/claude`` without ``--harness`` should
+        resolve to the Claude branch even when the auto-resolver would
+        otherwise pick codex (e.g. ``claude`` not on PATH but ``codex``
+        is). The custom binary path threads through to the constructed
+        ``SkillRunner``.
+        """
+        monkeypatch.chdir(tmp_path)
+        # Override the autouse fixture: unset CLAUDITOR_HARNESS so the
+        # CLI flag layer is what drives precedence, NOT the env var.
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="captured output",
+            skill_name="my-skill",
+            duration_seconds=0.5,
+        )
+
+        with patch(
+            "clauditor.cli.capture.SkillRunner", return_value=mock_runner
+        ) as mock_runner_cls:
+            rc = main(
+                [
+                    "capture",
+                    "my-skill",
+                    "--claude-bin",
+                    "/custom/claude",
+                    "--out",
+                    str(tmp_path / "out.txt"),
+                ]
+            )
+
+        assert rc == 0
+        # SkillRunner constructed exactly once with the custom claude_bin.
+        assert mock_runner_cls.call_count == 1
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert kwargs.get("claude_bin") == "/custom/claude"
+
+    def test_capture_explicit_harness_codex_still_wins_over_claude_bin(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """When the operator explicitly pins ``--harness=codex``, that
+        more-specific signal wins over ``--claude-bin``. The Codex auth
+        guard fires (with no Codex key set, exits 2). Defends the
+        precedence direction: explicit ``--harness`` > implicit
+        ``--claude-bin``.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with patch("clauditor.cli.capture.SkillRunner") as mock_runner_cls:
+            rc = main(
+                [
+                    "capture",
+                    "my-skill",
+                    "--harness",
+                    "codex",
+                    "--claude-bin",
+                    "/custom/claude",
+                    "--out",
+                    str(tmp_path / "out.txt"),
+                ]
+            )
+
+        # Codex auth missing → exit 2; SkillRunner never constructed.
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "CODEX_API_KEY" in err
+        assert mock_runner_cls.call_count == 0
+
+
 class TestCmdCaptureHarness:
     """#151 US-005: ``cmd_capture`` resolves harness via three-layer
     precedence (no spec layer) and dispatches Codex auth.
@@ -8773,6 +8859,49 @@ class TestCmdCaptureHarness:
         # Regression guard: no doubled ``"ERROR: ERROR: "`` prefix.
         assert "ERROR: ERROR:" not in err
         assert mock_runner_cls.call_count == 0
+
+    def test_capture_with_harness_codex_constructs_codex_harness(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--harness codex`` + ``CODEX_API_KEY`` set →
+        ``SkillRunner`` is constructed via ``construct_harness("codex")``
+        (the non-default branch in ``cmd_capture``). Sibling to the
+        ``cmd_run`` codex-success test; covers the
+        ``runner = SkillRunner(harness=construct_harness(...))`` line
+        that the keys-missing test cannot reach.
+        """
+        from clauditor._harnesses._codex import CodexHarness
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CODEX_API_KEY", "ck-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="codex captured", skill_name="my-skill",
+            duration_seconds=0.7,
+        )
+
+        with patch(
+            "clauditor.cli.capture.SkillRunner", return_value=mock_runner
+        ) as mock_runner_cls:
+            rc = main(
+                [
+                    "capture",
+                    "my-skill",
+                    "--harness",
+                    "codex",
+                    "--out",
+                    str(tmp_path / "out.txt"),
+                ]
+            )
+
+        assert rc == 0
+        # SkillRunner constructed exactly once with a CodexHarness via
+        # the non-default branch.
+        assert mock_runner_cls.call_count == 1
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert isinstance(kwargs["harness"], CodexHarness)
 
 
 class TestCmdRunHarness:
@@ -8829,3 +8958,39 @@ class TestCmdRunHarness:
         assert mock_runner_cls.call_count == 1
         kwargs = mock_runner_cls.call_args.kwargs
         assert isinstance(kwargs["harness"], CodexHarness)
+
+    def test_run_codex_no_api_key_preserves_openai_api_key(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Copilot review feedback on PR #166: ``run --harness codex
+        --no-api-key`` must NOT strip ``OPENAI_API_KEY`` from the
+        subprocess env. Stripping it would launch the Codex subprocess
+        without usable auth even though ``check_codex_auth`` accepted
+        it from ``os.environ``. ``--no-api-key`` is intended to strip
+        Anthropic auth (subscription auth path); Codex auth env vars
+        must be preserved.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="codex output", skill_name="my-skill",
+            duration_seconds=1.0,
+        )
+
+        with patch(
+            "clauditor.cli.run.SkillRunner", return_value=mock_runner
+        ):
+            rc = main(["run", "my-skill", "--harness", "codex", "--no-api-key"])
+
+        assert rc == 0
+        # The env_override threaded through to runner.run must preserve
+        # OPENAI_API_KEY so the codex subprocess still has auth.
+        env_override = mock_runner.run.call_args.kwargs.get("env")
+        assert env_override is not None
+        assert env_override.get("OPENAI_API_KEY") == "sk-openai"
+        # Anthropic auth IS still stripped (Codex doesn't need it).
+        assert "ANTHROPIC_API_KEY" not in env_override

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8006,3 +8006,325 @@ class TestResolveGradingProvider:
         eval_spec = _FakeEvalSpecForProviderResolver(grading_provider="openai")
         result = _resolve_grading_provider(args, eval_spec)
         assert result == "openai"
+
+
+class TestCLIHarnessFlag:
+    """#151 US-005: ``--harness {claude-code,codex,auto}`` argparse flag.
+
+    Each of the four skill-execution commands (``validate``, ``grade``,
+    ``capture``, ``run``) accepts ``--harness`` with the shared
+    ``_harness_choice`` validator. Invalid values exit 2 at argparse
+    time per ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            ["validate", "skill.md", "--harness", "bogus"],
+            ["grade", "skill.md", "--harness", "bogus"],
+            ["capture", "my-skill", "--harness", "bogus"],
+            ["run", "my-skill", "--harness", "bogus"],
+        ],
+    )
+    def test_invalid_harness_exits_2(self, cmd, capsys):
+        """Invalid ``--harness bogus`` rejected by argparse with exit 2."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(cmd)
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "must be one of" in err or "invalid" in err.lower()
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            ["validate", "--help"],
+            ["grade", "--help"],
+            ["capture", "--help"],
+            ["run", "--help"],
+        ],
+    )
+    def test_four_commands_advertise_harness_in_help(self, cmd, capsys):
+        """Each of the four commands advertises ``--harness`` in help text."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(cmd)
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "--harness" in out
+
+
+class TestCmdValidateHarness:
+    """#151 US-005: ``cmd_validate`` resolves harness and dispatches Codex auth."""
+
+    def test_validate_with_harness_codex_passes_when_key_set(
+        self, tmp_path, monkeypatch
+    ):
+        """``--harness codex`` + ``CODEX_API_KEY`` set → live-run path
+        threads ``harness_name_override="codex"`` into ``spec.run``.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("CODEX_API_KEY", "ck-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="hello world output", duration_seconds=1.5,
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--harness", "codex"])
+
+        assert rc == 0
+        spec.run.assert_called_once()
+        # DEC-013 / US-006: the resolved harness is threaded through.
+        kwargs = spec.run.call_args.kwargs
+        assert kwargs.get("harness_name_override") == "codex"
+
+    def test_validate_with_harness_codex_exits_2_when_keys_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--harness codex`` with both Codex env vars unset → exit 2
+        with stderr mentioning ``CODEX_API_KEY``. ``spec.run`` is never
+        invoked because the auth guard fires before subprocess launch.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(output="ignored")
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--harness", "codex"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "CODEX_API_KEY" in err
+        assert spec.run.call_count == 0
+
+
+class TestCmdGradeHarness:
+    """#151 US-005 / DEC-013: ``cmd_grade`` resolves harness, threads it
+    through to BOTH primary and baseline ``spec.run`` calls.
+    """
+
+    def test_grade_with_harness_codex_passes_when_key_set(
+        self, tmp_path, monkeypatch
+    ):
+        """``--harness codex`` + ``CODEX_API_KEY`` set → primary
+        ``spec.run`` is invoked with ``harness_name_override="codex"``.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CODEX_API_KEY", "ck-test")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="hello world output", duration_seconds=1.5,
+        )
+        report = make_grading_report(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--harness", "codex"])
+
+        assert rc == 0
+        assert spec.run.call_count >= 1
+        # Every primary/variance ``spec.run`` call gets the override.
+        for call in spec.run.call_args_list:
+            assert call.kwargs.get("harness_name_override") == "codex"
+
+    def test_grade_baseline_propagates_codex_harness_to_baseline_runner(
+        self, tmp_path, monkeypatch
+    ):
+        """DEC-013: ``--baseline --harness codex`` must use the same
+        Codex harness for both the primary and baseline arms (the A/B
+        comparison must isolate the variable).
+
+        The baseline arm calls ``baseline_runner.run_raw(...)`` rather
+        than ``spec.run(...)``. Verify ``construct_harness("codex")``
+        was invoked for the baseline phase — confirming the resolved
+        harness propagated to the without-skill arm.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CODEX_API_KEY", "ck-test")
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="hello world output", duration_seconds=1.5,
+        )
+        # spec.runner mirrors the primary harness so the baseline path
+        # has a project_dir / timeout to copy into the override runner.
+        spec.runner = MagicMock()
+        spec.runner.project_dir = tmp_path
+        spec.runner.timeout = 300
+
+        report = make_grading_report(passed=True)
+        baseline_reports = MagicMock()
+        baseline_reports.grading_report = report
+        baseline_reports.skill_result = make_skill_result(
+            output="baseline output", duration_seconds=1.0,
+        )
+        baseline_reports.to_json_map = lambda: {}
+
+        # ``construct_harness`` is imported lazily inside
+        # ``_run_baseline_phase`` (deferred per
+        # ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3),
+        # so the canonical patch seam is the source module.
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+            patch(
+                "clauditor._harnesses.construct_harness"
+            ) as mock_construct,
+            patch(
+                "clauditor.baseline.compute_baseline",
+                return_value=baseline_reports,
+            ),
+        ):
+            mock_construct.return_value = MagicMock()
+            rc = main(
+                ["grade", "skill.md", "--harness", "codex", "--baseline"]
+            )
+
+        # Whatever the final exit code (delta gate may or may not
+        # pass), the baseline arm must have called
+        # ``construct_harness("codex")`` — that's the DEC-013
+        # invariant. ``construct_harness`` is also called inside
+        # ``SkillSpec.run`` (from US-006), but here ``spec.run`` is a
+        # mock so that path is bypassed; the only call therefore comes
+        # from the baseline arm.
+        assert rc in (0, 1), f"unexpected rc {rc}"
+        codex_calls = [
+            c for c in mock_construct.call_args_list
+            if c.args and c.args[0] == "codex"
+        ]
+        assert len(codex_calls) >= 1, (
+            "Baseline arm did not call construct_harness('codex'); "
+            "DEC-013 requires the resolved harness to propagate to "
+            "both arms."
+        )
+
+    def test_grade_with_harness_codex_exits_2_when_keys_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--harness codex`` with both Codex env vars unset → exit 2
+        with stderr mentioning ``CODEX_API_KEY``. ``allocate_iteration``
+        is never reached because the auth guard fires upstream.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(output="ignored")
+        report = make_grading_report(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ) as mock_grade,
+        ):
+            rc = main(["grade", "skill.md", "--harness", "codex"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "CODEX_API_KEY" in err
+        assert spec.run.call_count == 0
+        assert mock_grade.await_count == 0
+
+
+class TestCmdCaptureHarness:
+    """#151 US-005: ``cmd_capture`` resolves harness via three-layer
+    precedence (no spec layer) and dispatches Codex auth.
+    """
+
+    def test_capture_with_harness_codex_exits_2_when_keys_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--harness codex`` with both Codex env vars unset → exit 2
+        with stderr mentioning ``CODEX_API_KEY``. ``SkillRunner`` is
+        never constructed because the guard fires upstream.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with patch("clauditor.cli.capture.SkillRunner") as mock_runner_cls:
+            rc = main(
+                ["capture", "my-skill", "--harness", "codex", "--out",
+                 str(tmp_path / "out.txt")]
+            )
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "CODEX_API_KEY" in err
+        assert mock_runner_cls.call_count == 0
+
+
+class TestCmdRunHarness:
+    """#151 US-005: ``cmd_run`` resolves harness via three-layer
+    precedence (no spec layer) and dispatches Codex auth.
+    """
+
+    def test_run_with_harness_codex_exits_2_when_keys_missing(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--harness codex`` with both Codex env vars unset → exit 2
+        with stderr mentioning ``CODEX_API_KEY``. ``SkillRunner`` is
+        never constructed.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with patch("clauditor.cli.run.SkillRunner") as mock_runner_cls:
+            rc = main(["run", "my-skill", "--harness", "codex"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "CODEX_API_KEY" in err
+        assert mock_runner_cls.call_count == 0
+
+    def test_run_with_harness_codex_constructs_codex_harness(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``--harness codex`` + ``CODEX_API_KEY`` set →
+        ``SkillRunner`` is constructed with a ``CodexHarness`` instance.
+        """
+        from clauditor._harnesses._codex import CodexHarness
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CODEX_API_KEY", "ck-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="codex output", skill_name="my-skill",
+            duration_seconds=1.0,
+        )
+
+        with patch(
+            "clauditor.cli.run.SkillRunner", return_value=mock_runner
+        ) as mock_runner_cls:
+            rc = main(["run", "my-skill", "--harness", "codex"])
+
+        assert rc == 0
+        # SkillRunner constructed exactly once with a CodexHarness.
+        assert mock_runner_cls.call_count == 1
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert isinstance(kwargs["harness"], CodexHarness)

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import argparse
 
+import pytest
+
 
 class TestShouldStripApiKeyForSkillSubprocess:
     """Regression tests for ``should_strip_api_key_for_skill_subprocess``.
@@ -121,3 +123,299 @@ class TestShouldStripApiKeyForSkillSubprocess:
 
         args = argparse.Namespace()  # no transport attribute at all
         assert should_strip_api_key_for_skill_subprocess(args) is False
+
+
+class TestHarnessChoice:
+    """Tests for the ``_harness_choice`` argparse type validator.
+
+    Sibling to :class:`TestTransportChoice` patterns in ``test_cli.py``.
+    Traces to DEC-002 / DEC-011 of
+    ``plans/super/151-harness-precedence.md``.
+    """
+
+    @pytest.mark.parametrize("value", ["claude-code", "codex", "auto"])
+    def test_accepts_each_valid_literal(self, value):
+        """Each of the three valid literals returns unchanged."""
+        from clauditor.cli import _harness_choice
+
+        assert _harness_choice(value) == value
+
+    @pytest.mark.parametrize(
+        "value", ["claude", "openai", "", "Claude-Code", " codex", "anthropic"]
+    )
+    def test_rejects_invalid_value(self, value):
+        """Anything outside the three-literal set raises
+        ``ArgumentTypeError`` with a "must be one of" message.
+        argparse maps this to exit 2 at parse time.
+        """
+        from clauditor.cli import _harness_choice
+
+        with pytest.raises(
+            argparse.ArgumentTypeError, match="must be one of"
+        ):
+            _harness_choice(value)
+
+
+class TestResolveHarness:
+    """Tests for the ``_resolve_harness`` four-layer precedence wrapper.
+
+    Sibling to :class:`TestResolveGraderTransport` in ``test_cli.py``.
+    Patches the canonical seam ``clauditor._providers.resolve_harness``
+    and the announcement helper
+    ``clauditor._providers._auth.announce_auto_codex_harness`` per
+    ``.claude/rules/back-compat-shim-discipline.md`` Pattern 3.
+
+    Traces to DEC-002 / DEC-006 / DEC-007 / DEC-011 of
+    ``plans/super/151-harness-precedence.md``.
+    """
+
+    def test_cli_value_passed_through(self, monkeypatch):
+        """``args.harness`` is forwarded to the pure resolver as
+        ``cli_override``. This is an integration sanity check —
+        the pure resolver decides precedence; the wrapper just
+        plumbs through."""
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        captured: dict = {}
+
+        def fake_resolve(cli, env, spec):
+            captured["cli"] = cli
+            captured["env"] = env
+            captured["spec"] = spec
+            return ("codex", None)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness="codex")
+        result = _resolve_harness(args, None)
+        assert result == "codex"
+        assert captured["cli"] == "codex"
+        assert captured["env"] is None
+        assert captured["spec"] is None
+
+    def test_env_value_read_when_cli_unset(self, monkeypatch):
+        """When ``args.harness`` is None, env is forwarded to the
+        pure resolver as ``env_override``."""
+        monkeypatch.setenv("CLAUDITOR_HARNESS", "codex")
+        captured: dict = {}
+
+        def fake_resolve(cli, env, spec):
+            captured["cli"] = cli
+            captured["env"] = env
+            captured["spec"] = spec
+            return ("codex", None)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness=None)
+        result = _resolve_harness(args, None)
+        assert result == "codex"
+        assert captured["cli"] is None
+        assert captured["env"] == "codex"
+
+    def test_whitespace_only_env_normalizes_to_none(self, monkeypatch):
+        """``CLAUDITOR_HARNESS='   '`` is treated as unset (passed as
+        ``None`` to the pure resolver)."""
+        monkeypatch.setenv("CLAUDITOR_HARNESS", "   ")
+        captured: dict = {}
+
+        def fake_resolve(cli, env, spec):
+            captured["env"] = env
+            return ("claude-code", None)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness=None)
+        _resolve_harness(args, None)
+        assert captured["env"] is None
+
+    def test_spec_value_read_when_cli_and_env_unset(self, monkeypatch):
+        """When CLI + env are both unset, ``eval_spec.harness`` is
+        forwarded as ``spec_value``."""
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        captured: dict = {}
+
+        def fake_resolve(cli, env, spec):
+            captured["spec"] = spec
+            return ("codex", None)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        eval_spec = argparse.Namespace(harness="codex")
+        args = argparse.Namespace(harness=None)
+        result = _resolve_harness(args, eval_spec)
+        assert result == "codex"
+        assert captured["spec"] == "codex"
+
+    def test_eval_spec_none_falls_through_cleanly(self, monkeypatch):
+        """``eval_spec=None`` (e.g. ``cli/run.py`` path) does not
+        raise. ``spec_value`` is forwarded as ``None``."""
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        captured: dict = {}
+
+        def fake_resolve(cli, env, spec):
+            captured["spec"] = spec
+            return ("claude-code", None)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness=None)
+        result = _resolve_harness(args, None)
+        assert result == "claude-code"
+        assert captured["spec"] is None
+
+    def test_args_without_harness_attr_falls_back_to_none(
+        self, monkeypatch
+    ):
+        """``args`` missing ``harness`` attribute → ``cli=None``.
+
+        Defensive: ``getattr(args, "harness", None)`` so call sites
+        that have not yet registered ``--harness`` (e.g. cli/run.py
+        before US-005) still work.
+        """
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        captured: dict = {}
+
+        def fake_resolve(cli, env, spec):
+            captured["cli"] = cli
+            return ("claude-code", None)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace()  # no `harness` attribute
+        result = _resolve_harness(args, None)
+        assert result == "claude-code"
+        assert captured["cli"] is None
+
+    def test_value_error_routes_to_systemexit_2(
+        self, monkeypatch, capsys
+    ):
+        """``ValueError`` from the pure resolver → stderr ``ERROR:``
+        line + ``SystemExit(2)`` per
+        ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
+        """
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+
+        def fake_resolve(cli, env, spec):
+            raise ValueError("harness=auto: neither claude nor codex on PATH")
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness=None)
+        with pytest.raises(SystemExit) as exc_info:
+            _resolve_harness(args, None)
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "ERROR:" in captured.err
+        assert "neither claude nor codex" in captured.err
+
+    def test_announce_fired_when_auto_resolved_to_codex(
+        self, monkeypatch
+    ):
+        """When the pure resolver returns
+        ``auto_resolved_to == "codex"``, the wrapper fires
+        ``announce_auto_codex_harness`` BEFORE returning."""
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+
+        def fake_resolve(cli, env, spec):
+            return ("codex", "codex")
+
+        announce_calls: list[int] = []
+
+        def fake_announce():
+            announce_calls.append(1)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        monkeypatch.setattr(
+            "clauditor._providers._auth.announce_auto_codex_harness",
+            fake_announce,
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness=None)
+        result = _resolve_harness(args, None)
+        assert result == "codex"
+        assert announce_calls == [1]
+
+    def test_announce_not_fired_when_auto_resolved_to_claude_code(
+        self, monkeypatch
+    ):
+        """When the auto branch picks ``"claude-code"`` (i.e.
+        ``auto_resolved_to is None`` per the pure resolver's
+        contract), no announcement fires."""
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+
+        def fake_resolve(cli, env, spec):
+            return ("claude-code", None)
+
+        announce_calls: list[int] = []
+
+        def fake_announce():
+            announce_calls.append(1)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        monkeypatch.setattr(
+            "clauditor._providers._auth.announce_auto_codex_harness",
+            fake_announce,
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness=None)
+        result = _resolve_harness(args, None)
+        assert result == "claude-code"
+        assert announce_calls == []
+
+    def test_announce_not_fired_when_explicit_codex(
+        self, monkeypatch
+    ):
+        """When an explicit non-``"auto"`` value at any layer
+        selects ``codex`` (``auto_resolved_to is None``), the
+        announcement does NOT fire — operators who pin a harness
+        accept the binary-availability responsibility silently."""
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+
+        def fake_resolve(cli, env, spec):
+            return ("codex", None)
+
+        announce_calls: list[int] = []
+
+        def fake_announce():
+            announce_calls.append(1)
+
+        monkeypatch.setattr(
+            "clauditor._providers.resolve_harness", fake_resolve
+        )
+        monkeypatch.setattr(
+            "clauditor._providers._auth.announce_auto_codex_harness",
+            fake_announce,
+        )
+        from clauditor.cli import _resolve_harness
+
+        args = argparse.Namespace(harness="codex")
+        result = _resolve_harness(args, None)
+        assert result == "codex"
+        assert announce_calls == []

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -358,6 +358,15 @@ class TestValidateVerboseInvocation:
         # fails the literal-set validator. Pin to ``None`` so the
         # resolver falls through to the env-var layer.
         args.harness = None
+        # CodeRabbit review feedback on PR #166: pin the other
+        # ``cmd_validate``-read attributes to defaults so the test
+        # exercises the default branch. ``MagicMock`` returns truthy
+        # MagicMock instances for un-pinned attrs which would silently
+        # toggle ``--no-api-key`` / ``--sync-tasks`` and produce a
+        # non-default ``--timeout``.
+        args.no_api_key = False
+        args.sync_tasks = False
+        args.timeout = None
         args.verbose = True
         args.no_transcript = False
 
@@ -449,6 +458,13 @@ class TestValidateVerboseInvocation:
         # fails the literal-set validator. Pin to ``None`` so the
         # resolver falls through to the env-var layer.
         args.harness = None
+        # CodeRabbit review feedback on PR #166: pin the other
+        # ``cmd_validate``-read attributes to defaults so the test
+        # exercises the default branch (see comment on the analogous
+        # block above).
+        args.no_api_key = False
+        args.sync_tasks = False
+        args.timeout = None
         args.verbose = False
         args.no_transcript = False
 

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -353,6 +353,11 @@ class TestValidateVerboseInvocation:
         args.eval = str(eval_path)
         args.output = None
         args.json = False
+        # #151 US-005: ``_resolve_harness`` reads ``args.harness``.
+        # MagicMock returns a fresh MagicMock for any attribute, which
+        # fails the literal-set validator. Pin to ``None`` so the
+        # resolver falls through to the env-var layer.
+        args.harness = None
         args.verbose = True
         args.no_transcript = False
 
@@ -361,6 +366,12 @@ class TestValidateVerboseInvocation:
             spec.skill_name = "demo"
             spec.eval_spec = MagicMock()
             spec.eval_spec.test_args = ""
+            # #151 US-005: ``_resolve_harness`` reads ``eval_spec.harness``.
+            # MagicMock returns a fresh MagicMock for any attribute access,
+            # which fails the literal-set validator. Pin to ``None`` so the
+            # resolver falls through to the env-var layer (autouse fixture
+            # pins ``CLAUDITOR_HARNESS=claude-code``).
+            spec.eval_spec.harness = None
             spec.eval_spec.assertions = [
                 MagicMock(
                     name="a1",
@@ -433,6 +444,11 @@ class TestValidateVerboseInvocation:
         args.eval = None
         args.output = None
         args.json = False
+        # #151 US-005: ``_resolve_harness`` reads ``args.harness``.
+        # MagicMock returns a fresh MagicMock for any attribute, which
+        # fails the literal-set validator. Pin to ``None`` so the
+        # resolver falls through to the env-var layer.
+        args.harness = None
         args.verbose = False
         args.no_transcript = False
 
@@ -441,6 +457,12 @@ class TestValidateVerboseInvocation:
             spec.skill_name = "demo"
             spec.eval_spec = MagicMock()
             spec.eval_spec.test_args = ""
+            # #151 US-005: ``_resolve_harness`` reads ``eval_spec.harness``.
+            # MagicMock returns a fresh MagicMock for any attribute access,
+            # which fails the literal-set validator. Pin to ``None`` so the
+            # resolver falls through to the env-var layer (autouse fixture
+            # pins ``CLAUDITOR_HARNESS=claude-code``).
+            spec.eval_spec.harness = None
             spec.eval_spec.assertions = []
             spec.run.return_value = fake_skill_result
             from_file.return_value = spec

--- a/tests/test_harnesses_construct.py
+++ b/tests/test_harnesses_construct.py
@@ -1,0 +1,86 @@
+"""Tests for #151 US-002 :func:`clauditor._harnesses.construct_harness`.
+
+Covers DEC-009 / DEC-012 of ``plans/super/151-harness-precedence.md``:
+the literal-name dispatcher with deferred per-call imports of
+``_claude_code`` and ``_codex`` per
+``.claude/rules/back-compat-shim-discipline.md`` Pattern 3. Pure
+helper — construction only, no I/O.
+
+``isinstance`` checks resolve ``ClaudeCodeHarness`` /
+``CodexHarness`` via the module attribute at test-method invocation
+time, NOT via top-of-file ``from`` imports. ``tests/test_runner.py``
+and ``tests/test_codex_harness.py`` ``importlib.reload`` the
+``_claude_code`` / ``_codex`` submodules during their own collection;
+a top-of-file ``from clauditor._harnesses._claude_code import
+ClaudeCodeHarness`` here would bind a stale pre-reload class object
+that ``construct_harness``'s deferred import no longer resolves to.
+Looking up ``_claude_code_mod.ClaudeCodeHarness`` at test time
+re-resolves through the live module attribute, matching the canonical
+class ``construct_harness`` returns.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import clauditor._harnesses._claude_code as _claude_code_mod
+import clauditor._harnesses._codex as _codex_mod
+from clauditor._harnesses import Harness, construct_harness
+
+
+class TestConstructHarness:
+    def test_construct_claude_code_returns_claude_code_harness(self) -> None:
+        harness = construct_harness("claude-code")
+        # Re-resolve through the module attribute at call time — see the
+        # module docstring for why the top-of-file ``from`` import would
+        # bind a stale class object after sibling-test reloads.
+        assert isinstance(harness, _claude_code_mod.ClaudeCodeHarness)
+        # Protocol drift-guard: still satisfies the structural Harness.
+        assert isinstance(harness, Harness)
+        assert harness.name == "claude-code"
+
+    def test_construct_codex_returns_codex_harness(self) -> None:
+        harness = construct_harness("codex")
+        assert isinstance(harness, _codex_mod.CodexHarness)
+        assert isinstance(harness, Harness)
+        assert harness.name == "codex"
+
+    def test_construct_auto_raises(self) -> None:
+        """``"auto"`` must be resolved before construction (DEC-009)."""
+        with pytest.raises(ValueError) as exc_info:
+            construct_harness("auto")
+        msg = str(exc_info.value)
+        # Message points the caller at the resolver layer.
+        assert "auto" in msg
+        assert "resolve_harness" in msg
+
+    def test_construct_unknown_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            construct_harness("unknown-harness")
+        msg = str(exc_info.value)
+        assert "'unknown-harness'" in msg
+        # Names the acceptable set so the error message is actionable.
+        assert "claude-code" in msg
+        assert "codex" in msg
+
+    def test_construct_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError):
+            construct_harness("")
+
+    def test_construct_case_sensitive(self) -> None:
+        """Case variants rejected — mirrors resolver's literal-set."""
+        with pytest.raises(ValueError):
+            construct_harness("Claude-Code")
+
+    def test_returns_default_constructed_instances(self) -> None:
+        """Default kwargs: ``claude_bin="claude"`` / ``codex_bin="codex"``."""
+        cc = construct_harness("claude-code")
+        assert isinstance(cc, _claude_code_mod.ClaudeCodeHarness)
+        assert cc.claude_bin == "claude"
+        assert cc.model is None
+        assert cc.allow_hang_heuristic is True
+
+        cx = construct_harness("codex")
+        assert isinstance(cx, _codex_mod.CodexHarness)
+        assert cx.codex_bin == "codex"
+        assert cx.model is None

--- a/tests/test_providers_auth.py
+++ b/tests/test_providers_auth.py
@@ -892,3 +892,289 @@ class TestOpenAiApiKeyIsSet:
 
         monkeypatch.setenv("OPENAI_API_KEY", "   \t\n")
         assert _openai_api_key_is_set() is False
+
+
+class TestCheckCodexAuth:
+    """Unit tests for the Codex pre-flight auth guard (US-003 / DEC-003 / DEC-010).
+
+    Pins DEC-003 of ``plans/super/151-harness-precedence.md``: strict-OR
+    pre-flight guard raising :class:`CodexAuthMissingError` when neither
+    ``CODEX_API_KEY`` nor ``OPENAI_API_KEY`` is set (both checked via
+    whitespace-trimmed non-empty). No CLI-fallback branch — Codex has no
+    documented "subscription only" auth analog like Claude Pro/Max.
+
+    Codex is a HARNESS axis, not a PROVIDER axis (DEC-010): the
+    :func:`check_provider_auth` dispatcher is unchanged; the CLI seam
+    directly calls :func:`check_codex_auth` when the resolved harness
+    is ``"codex"``.
+    """
+
+    def test_only_codex_api_key_set_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert check_codex_auth("grade") is None
+
+    def test_only_openai_api_key_set_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        assert check_codex_auth("grade") is None
+
+    def test_both_keys_set_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        assert check_codex_auth("grade") is None
+
+    def test_neither_key_set_raises_with_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            CodexAuthMissingError,
+            check_codex_auth,
+        )
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(CodexAuthMissingError) as exc_info:
+            check_codex_auth("grade")
+        message = str(exc_info.value)
+        # DEC-003 / DEC-010 durable substrings.
+        assert "CODEX_API_KEY" in message
+        assert "OPENAI_API_KEY" in message
+        assert "platform.openai.com" in message
+        # Command-name interpolation.
+        assert "clauditor grade" in message
+
+    def test_both_empty_strings_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            CodexAuthMissingError,
+            check_codex_auth,
+        )
+
+        monkeypatch.setenv("CODEX_API_KEY", "")
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        with pytest.raises(CodexAuthMissingError):
+            check_codex_auth("grade")
+
+    def test_both_whitespace_only_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Whitespace-only values are treated as unset for both env vars."""
+        from clauditor._providers import (
+            CodexAuthMissingError,
+            check_codex_auth,
+        )
+
+        monkeypatch.setenv("CODEX_API_KEY", "   \t\n")
+        monkeypatch.setenv("OPENAI_API_KEY", "  ")
+        with pytest.raises(CodexAuthMissingError):
+            check_codex_auth("grade")
+
+    def test_codex_whitespace_openai_set_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Strict-OR: whitespace-only CODEX_API_KEY but valid OPENAI_API_KEY
+        passes — at least one env var is set."""
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.setenv("CODEX_API_KEY", "   ")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        assert check_codex_auth("grade") is None
+
+    def test_cmd_name_interpolation_validate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from clauditor._providers import (
+            CodexAuthMissingError,
+            check_codex_auth,
+        )
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(CodexAuthMissingError) as exc_info:
+            check_codex_auth("validate")
+        assert "clauditor validate" in str(exc_info.value)
+
+    def test_codex_auth_missing_error_is_direct_exception_subclass(
+        self,
+    ) -> None:
+        """DEC-010 + ``.claude/rules/llm-cli-exit-code-taxonomy.md``:
+        ``CodexAuthMissingError`` is a direct subclass of
+        :class:`Exception`, NOT of :class:`AnthropicAuthMissingError`,
+        :class:`OpenAIAuthMissingError`, or any helper-error class. A
+        common ancestor would defeat the structural-routing invariant
+        CLI dispatchers depend on.
+        """
+        from clauditor._providers import (
+            AnthropicAuthMissingError,
+            CodexAuthMissingError,
+            OpenAIAuthMissingError,
+        )
+
+        assert not issubclass(CodexAuthMissingError, AnthropicAuthMissingError)
+        assert not issubclass(CodexAuthMissingError, OpenAIAuthMissingError)
+        # And the converse — the existing classes do not inherit from Codex.
+        assert not issubclass(AnthropicAuthMissingError, CodexAuthMissingError)
+        assert not issubclass(OpenAIAuthMissingError, CodexAuthMissingError)
+        # Direct base is Exception.
+        assert CodexAuthMissingError.__bases__ == (Exception,)
+
+    def test_constant_substrings(self) -> None:
+        """Prose-presence check on the message template."""
+        from clauditor._providers import _CODEX_AUTH_MISSING_TEMPLATE
+
+        assert "CODEX_API_KEY" in _CODEX_AUTH_MISSING_TEMPLATE
+        assert "OPENAI_API_KEY" in _CODEX_AUTH_MISSING_TEMPLATE
+        assert "platform.openai.com" in _CODEX_AUTH_MISSING_TEMPLATE
+        assert "{cmd_name}" in _CODEX_AUTH_MISSING_TEMPLATE
+
+    def test_codex_auth_missing_error_class_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per ``.claude/rules/back-compat-shim-discipline.md`` Pattern 2:
+        the ``CodexAuthMissingError`` instance raised by
+        :func:`check_codex_auth` (which imports the class locally from
+        ``clauditor._providers`` inside the function body) MUST be an
+        instance of the same class object users import from
+        ``clauditor._providers``. Defining the class twice (e.g. a
+        local re-declaration in ``_auth.py``) would silently break
+        ``except CodexAuthMissingError`` at any call site that imported
+        from the canonical seam.
+        """
+        from clauditor._providers import (
+            CodexAuthMissingError,
+            check_codex_auth,
+        )
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(CodexAuthMissingError) as exc_info:
+            check_codex_auth("grade")
+        # The raised instance must be an exact instance of the canonical
+        # class, not a same-named-but-distinct re-declaration.
+        assert type(exc_info.value) is CodexAuthMissingError
+
+
+class TestCheckProviderAuthCodexUnchanged:
+    """Regression: per DEC-010, ``check_provider_auth`` does NOT grow a
+    Codex branch. Codex is a HARNESS axis, not a PROVIDER axis. Calling
+    ``check_provider_auth("codex", ...)`` must still raise ``ValueError``
+    (unknown provider) — the CLI seam directly calls
+    :func:`check_codex_auth` when the resolved harness is ``"codex"``.
+    """
+
+    def test_codex_provider_string_raises_value_error(self) -> None:
+        from clauditor._providers import check_provider_auth
+
+        with pytest.raises(ValueError) as exc_info:
+            check_provider_auth("codex", "grade")
+        assert "unknown provider" in str(exc_info.value)
+        assert "'codex'" in str(exc_info.value)
+
+
+class TestAnnounceAutoCodexHarness:
+    """DEC-007 / DEC-011 (#151 US-003): one-shot stderr notice emitted
+    on the first auto→codex resolution per Python process.
+
+    Parallel to :class:`TestAnnounceImplicitNoApiKey` and
+    :class:`TestCallAnthropicDeprecationAnnouncement` — same autouse-
+    reset pattern; same one-shot-per-process contract. Tests pin two
+    durable substrings (``CODEX_API_KEY``, ``OPENAI_API_KEY``) per
+    ``.claude/rules/precall-env-validation.md``'s durable-substring
+    discipline so stylistic copy edits don't churn tests.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_announcement_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every test starts with the one-shot flag set to False."""
+        monkeypatch.setattr(
+            "clauditor._providers._auth._announced_auto_codex_harness",
+            False,
+        )
+
+    def test_first_call_emits_announcement(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from clauditor._providers import announce_auto_codex_harness
+
+        announce_auto_codex_harness()
+        captured = capsys.readouterr()
+        from clauditor._providers import _AUTO_CODEX_ANNOUNCEMENT
+
+        assert _AUTO_CODEX_ANNOUNCEMENT in captured.err
+
+    def test_second_call_silent(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from clauditor._providers import announce_auto_codex_harness
+
+        announce_auto_codex_harness()
+        # Drain the first emission.
+        capsys.readouterr()
+        announce_auto_codex_harness()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_constant_names_codex_env_var(self) -> None:
+        """First durable substring — users must see ``CODEX_API_KEY``
+        so they know which env var Codex prefers."""
+        from clauditor._providers import _AUTO_CODEX_ANNOUNCEMENT
+
+        assert "CODEX_API_KEY" in _AUTO_CODEX_ANNOUNCEMENT
+
+    def test_constant_names_openai_env_var(self) -> None:
+        """Second durable substring — users must see ``OPENAI_API_KEY``
+        so they know the fallback env var Codex accepts."""
+        from clauditor._providers import _AUTO_CODEX_ANNOUNCEMENT
+
+        assert "OPENAI_API_KEY" in _AUTO_CODEX_ANNOUNCEMENT
+
+    def test_constant_does_not_interpolate_values(self) -> None:
+        """Auth review #7 (#151): the announcement names env-var names
+        only; it MUST NOT interpolate values. A leaked secret in the
+        constant would surface in the test text — fail closed."""
+        from clauditor._providers import _AUTO_CODEX_ANNOUNCEMENT
+
+        # No format placeholders for values.
+        assert "{value" not in _AUTO_CODEX_ANNOUNCEMENT
+        # No literal "sk-" prefixed tokens (canonical OpenAI/Codex key
+        # shape).
+        assert "sk-" not in _AUTO_CODEX_ANNOUNCEMENT
+
+    def test_autouse_fixture_resets_flag_between_tests_first_half(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """First test of a pair — proves first-call emission works."""
+        from clauditor._providers import announce_auto_codex_harness
+
+        announce_auto_codex_harness()
+        captured = capsys.readouterr()
+        assert captured.err != ""
+
+    def test_autouse_fixture_resets_flag_between_tests_second_half(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Second test of the pair — if the autouse fixture did not
+        reset the flag, this test would see silence (the flag would
+        still be ``True`` from the first test). Seeing an emission
+        here proves the fixture reset works."""
+        from clauditor._providers import announce_auto_codex_harness
+
+        announce_auto_codex_harness()
+        captured = capsys.readouterr()
+        assert captured.err != ""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -281,6 +281,9 @@ class TestClauditorSpecInputFiles:
         mock_spec = MagicMock(spec=SkillSpec)
         mock_eval_spec = MagicMock()
         mock_eval_spec.input_files = []
+        # US-007 (#151): set harness="auto" so the spec-field-honoring
+        # branch does NOT wrap (matches the default for unset specs).
+        mock_eval_spec.harness = "auto"
         mock_spec.eval_spec = mock_eval_spec
         original_run = mock_spec.run
 
@@ -315,6 +318,9 @@ class TestClauditorSpecInputFiles:
         mock_spec = MagicMock(spec=SkillSpec)
         mock_eval_spec = MagicMock()
         mock_eval_spec.input_files = ["/abs/path/sales.csv"]
+        # US-007 (#151): "auto" harness — the wrapping happens here
+        # because of input_files, not because of a non-auto harness.
+        mock_eval_spec.harness = "auto"
         mock_spec.eval_spec = mock_eval_spec
         original_run = mock_spec.run
         original_run.return_value = "RESULT"
@@ -851,6 +857,9 @@ class TestClauditorNoApiKeyOption:
         mock_spec = MagicMock(spec=SkillSpec)
         mock_eval_spec = MagicMock()
         mock_eval_spec.input_files = []
+        # US-007 (#151): set harness="auto" so the spec-field-honoring
+        # branch does NOT wrap (preserves pre-US-007 behavior here).
+        mock_eval_spec.harness = "auto"
         mock_spec.eval_spec = mock_eval_spec
         original_run = mock_spec.run
 
@@ -1824,3 +1833,120 @@ class TestFixtureModelOverrideThreading:
         ):
             with pytest.raises(ValueError, match="unknown provider"):
                 _dispatch_fixture_auth_guard(eval_spec, "grader")
+
+
+class TestFixtureHonorsHarness:
+    """US-007 (#151) / DEC-005: ``clauditor_spec`` fixture honors
+    ``eval_spec.harness`` automatically — no new fixture kwarg.
+
+    A spec author who writes ``"harness": "codex"`` in eval.json gets
+    the Codex harness when they run ``spec.run()`` from a fixture,
+    without the test having to pass any kwarg. ``"auto"`` (and unset)
+    falls through to the default runner so the resolver's auto path
+    can fire at the CLI seam — the fixture itself does not auto-resolve.
+    """
+
+    def _request(self):
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 300,
+                "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
+            }[opt]
+        )
+        return request
+
+    def test_codex_spec_threads_harness_override(self, tmp_path):
+        """``eval_spec.harness == "codex"`` threads
+        ``harness_name_override="codex"`` into ``original_run``.
+
+        DEC-005: spec-author intent (``"codex"``) is honored
+        automatically when ``spec.run()`` is called from the fixture.
+        """
+        from clauditor.spec import SkillSpec
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "codex"
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+        original_run.return_value = "RESULT"
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # Wrapping happened because the spec declares a non-auto harness
+        assert result.run is not original_run
+
+        ret = result.run()
+        assert ret == "RESULT"
+        original_run.assert_called_once()
+        call_kwargs = original_run.call_args.kwargs
+        assert call_kwargs.get("harness_name_override") == "codex"
+
+    def test_auto_spec_does_not_override_harness(self, tmp_path):
+        """``eval_spec.harness == "auto"`` (or unset) leaves the
+        wrapper unattached so ``spec.run`` is called verbatim — the
+        resolver's auto path is the CLI seam's responsibility.
+        """
+        from clauditor.spec import SkillSpec
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "auto"
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # No wrapping — the spec field is "auto" AND there are no
+        # other reasons (no input_files, no --clauditor-no-api-key).
+        assert result.run is original_run
+
+    def test_caller_harness_override_wins_over_spec(self, tmp_path):
+        """Caller-provided ``harness_name_override=`` (operator intent)
+        wins over ``eval_spec.harness`` (author intent), mirroring the
+        ``env_override`` / ``timeout_override`` precedence shape.
+        """
+        from clauditor.spec import SkillSpec
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "codex"
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+        original_run.return_value = "RESULT"
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # Caller passes "claude-code" — should override the spec's "codex".
+        result.run(harness_name_override="claude-code")
+        assert (
+            original_run.call_args.kwargs.get("harness_name_override")
+            == "claude-code"
+        )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1950,3 +1950,38 @@ class TestFixtureHonorsHarness:
             original_run.call_args.kwargs.get("harness_name_override")
             == "claude-code"
         )
+
+    def test_same_harness_spec_does_not_force_override(self, tmp_path):
+        """CodeRabbit review feedback on PR #166: when
+        ``eval_spec.harness`` matches the runner's current harness
+        (default ``"claude-code"`` for the fixture-built runner), the
+        plugin must NOT thread ``harness_name_override="claude-code"``
+        through to ``SkillSpec.run``. Otherwise ``SkillSpec.run`` would
+        reconstruct a fresh ``SkillRunner`` via
+        ``construct_harness("claude-code")``, dropping any custom
+        ``--clauditor-claude-bin`` carried by the fixture's runner.
+        """
+        from clauditor.spec import SkillSpec
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        # Spec declares the same harness the fixture-built runner already
+        # uses (the default ``ClaudeCodeHarness``).
+        mock_eval_spec.harness = "claude-code"
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = mock_spec.run
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+
+        # No wrapping — the spec's harness matches the runner's
+        # current harness AND there are no other reasons for wrapping
+        # (no input_files, no --clauditor-no-api-key).
+        assert result.run is original_run

--- a/tests/test_resolve_harness.py
+++ b/tests/test_resolve_harness.py
@@ -1,0 +1,222 @@
+"""Tests for #151 US-002 pure helper :func:`resolve_harness`.
+
+Covers DEC-001 / DEC-002 / DEC-009 / DEC-011 of
+``plans/super/151-harness-precedence.md``: four-layer precedence
+(CLI > env > spec > default ``"auto"``), PATH-based auto resolution
+preferring ``claude-code`` over ``codex``, ``auto_resolved_to``
+flag for the CLI wrapper's announcement, and structurally-routed
+``ValueError`` on per-layer invalid values plus the no-binary-on-PATH
+case.
+
+Pure helper per ``.claude/rules/pure-compute-vs-io-split.md`` — only
+``shutil.which`` is touched (PATH lookup), and tests pin it via
+``monkeypatch.setattr`` on ``clauditor._providers.shutil``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import clauditor._providers as _providers_mod
+from clauditor._providers import resolve_harness
+
+
+def _patch_which(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    claude: str | None,
+    codex: str | None,
+) -> None:
+    """Pin ``shutil.which`` results for ``"claude"`` and ``"codex"``.
+
+    The pure :func:`resolve_harness` calls ``shutil.which`` from the
+    ``clauditor._providers`` module's import binding; patching there
+    is the canonical seam.
+    """
+
+    def _fake_which(name: str) -> str | None:
+        if name == "claude":
+            return claude
+        if name == "codex":
+            return codex
+        return None
+
+    monkeypatch.setattr(_providers_mod.shutil, "which", _fake_which)
+
+
+class TestPrecedence:
+    """Four-layer precedence: CLI > env > spec > default auto."""
+
+    def test_cli_explicit_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLI=codex beats env=claude-code beats spec=auto."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex="/usr/bin/codex")
+        name, auto_to = resolve_harness(
+            cli_override="codex",
+            env_override="claude-code",
+            spec_value="auto",
+        )
+        assert name == "codex"
+        assert auto_to is None
+
+    def test_env_falls_through_when_cli_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLI=None → env=codex wins over spec/default."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex="/usr/bin/codex")
+        name, auto_to = resolve_harness(
+            cli_override=None,
+            env_override="codex",
+            spec_value="claude-code",
+        )
+        assert name == "codex"
+        assert auto_to is None
+
+    def test_spec_falls_through_when_cli_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLI=None, env=None → spec=codex wins."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex="/usr/bin/codex")
+        name, auto_to = resolve_harness(
+            cli_override=None,
+            env_override=None,
+            spec_value="codex",
+        )
+        assert name == "codex"
+        assert auto_to is None
+
+    def test_default_auto_when_all_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All layers unset → auto branch with claude on PATH wins."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        name, auto_to = resolve_harness(
+            cli_override=None,
+            env_override=None,
+            spec_value=None,
+        )
+        assert name == "claude-code"
+        assert auto_to is None
+
+    def test_cli_auto_falls_through_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit CLI=auto is treated as no preference at this layer."""
+        _patch_which(monkeypatch, claude=None, codex="/usr/bin/codex")
+        name, auto_to = resolve_harness(
+            cli_override="auto",
+            env_override="codex",
+            spec_value=None,
+        )
+        assert name == "codex"
+        assert auto_to is None
+
+    def test_spec_auto_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """spec='auto' default falls through to PATH-based auto branch."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        name, auto_to = resolve_harness(
+            cli_override=None,
+            env_override=None,
+            spec_value="auto",
+        )
+        assert name == "claude-code"
+        assert auto_to is None
+
+    def test_whitespace_only_env_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Whitespace-only env_override falls through (defense-in-depth)."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        name, auto_to = resolve_harness(
+            cli_override=None,
+            env_override="   ",
+            spec_value=None,
+        )
+        assert name == "claude-code"
+        assert auto_to is None
+
+
+class TestAutoBranch:
+    """PATH-based auto resolution: claude first, codex fallback."""
+
+    def test_auto_picks_claude_code_when_claude_on_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``claude`` on PATH → claude-code wins (no announcement)."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex="/usr/bin/codex")
+        name, auto_to = resolve_harness(None, None, None)
+        assert name == "claude-code"
+        # auto_resolved_to is None when claude wins — no announcement.
+        assert auto_to is None
+
+    def test_auto_picks_codex_when_only_codex_on_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only codex available → returns auto_resolved_to='codex'."""
+        _patch_which(monkeypatch, claude=None, codex="/usr/bin/codex")
+        name, auto_to = resolve_harness(None, None, None)
+        assert name == "codex"
+        # Flag set so the CLI wrapper fires announce_auto_codex_harness.
+        assert auto_to == "codex"
+
+    def test_auto_raises_when_neither_on_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Neither binary → ValueError naming all three escape hatches."""
+        _patch_which(monkeypatch, claude=None, codex=None)
+        with pytest.raises(ValueError) as exc_info:
+            resolve_harness(None, None, None)
+        msg = str(exc_info.value)
+        # Must name all three escape hatches per DEC-002.
+        assert "--harness" in msg
+        assert "CLAUDITOR_HARNESS" in msg
+        assert "eval.json" in msg or "'harness'" in msg
+        # Acceptable name set named in the message.
+        assert "claude-code" in msg
+        assert "codex" in msg
+
+
+class TestInvalidValues:
+    """Per-layer invalid-value rejection (DEC-008 literal-set membership)."""
+
+    def test_invalid_cli_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        with pytest.raises(ValueError) as exc_info:
+            resolve_harness("unknown", None, None)
+        msg = str(exc_info.value)
+        assert "CLI --harness" in msg
+        assert "claude-code" in msg
+        assert "codex" in msg
+        assert "auto" in msg
+        assert "'unknown'" in msg
+
+    def test_invalid_env_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        with pytest.raises(ValueError) as exc_info:
+            resolve_harness(None, "ClaudeCode", None)
+        msg = str(exc_info.value)
+        assert "CLAUDITOR_HARNESS" in msg
+        assert "'ClaudeCode'" in msg
+
+    def test_invalid_spec_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        with pytest.raises(ValueError) as exc_info:
+            resolve_harness(None, None, "wat")
+        msg = str(exc_info.value)
+        assert "EvalSpec.harness" in msg
+        assert "'wat'" in msg
+
+    def test_case_sensitive_rejection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Case variants are rejected loudly (Minor note D)."""
+        _patch_which(monkeypatch, claude="/usr/bin/claude", codex=None)
+        with pytest.raises(ValueError):
+            resolve_harness("CodeX", None, None)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3327,6 +3327,48 @@ class TestEnvWithoutApiKey:
         assert "ANTHROPIC_API_KEY" in base
         assert base["FOO"] == "bar"
 
+    def test_codex_harness_preserves_openai_api_key(self):
+        """Copilot review feedback on PR #166: when the skill subprocess
+        runs under the Codex harness, ``OPENAI_API_KEY`` is one of the
+        two valid Codex auth env vars and MUST be preserved. Stripping
+        it would launch the Codex subprocess without usable auth even
+        though :func:`check_codex_auth` accepted it from ``os.environ``.
+
+        Anthropic env vars are still stripped because Codex does not
+        need them.
+        """
+        base = {
+            "OPENAI_API_KEY": "sk-openai",
+            "CODEX_API_KEY": "ck-codex",
+            "ANTHROPIC_API_KEY": "sk-ant",
+            "ANTHROPIC_AUTH_TOKEN": "tok-ant",
+            "PATH": "/usr/bin",
+        }
+        result = env_without_api_key(base, harness_name="codex")
+        # OpenAI/Codex auth preserved (Codex needs them).
+        assert result["OPENAI_API_KEY"] == "sk-openai"
+        assert result["CODEX_API_KEY"] == "ck-codex"
+        # Anthropic auth still stripped (Codex does not need them).
+        assert "ANTHROPIC_API_KEY" not in result
+        assert "ANTHROPIC_AUTH_TOKEN" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_claude_code_harness_strips_openai_api_key(self):
+        """Default behavior preserved for the claude-code harness:
+        ``OPENAI_API_KEY`` is stripped alongside the Anthropic vars.
+        Explicit ``harness_name="claude-code"`` matches the
+        no-kwarg default — defends DEC-008 of #145 by re-asserting it.
+        """
+        base = {
+            "OPENAI_API_KEY": "sk-openai",
+            "ANTHROPIC_API_KEY": "sk-ant",
+            "PATH": "/usr/bin",
+        }
+        result = env_without_api_key(base, harness_name="claude-code")
+        assert "OPENAI_API_KEY" not in result
+        assert "ANTHROPIC_API_KEY" not in result
+        assert result["PATH"] == "/usr/bin"
+
 
 class TestEnvWithSyncTasks:
     """Pure-unit tests for :func:`clauditor.runner.env_with_sync_tasks`.

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2146,6 +2146,115 @@ class TestEvalSpecTransport:
         assert "transport" not in round_tripped
 
 
+class TestEvalSpecHarness:
+    """US-001 / DEC-001 / DEC-008 of #151: ``EvalSpec.harness`` parsing
+    in ``from_dict``.
+
+    Default ``"auto"`` preserves back-compat. The literal set
+    ``{"claude-code", "codex", "auto"}`` is enforced at load time;
+    non-string, bool, null, and unknown-literal values are rejected
+    with a ``ValueError`` per
+    ``.claude/rules/constant-with-type-info.md``. ``to_dict`` omits
+    the key when value equals the default ``"auto"`` (matches the
+    ``transport`` skip-if-default pattern).
+    """
+
+    def test_missing_defaults_to_auto(self, tmp_path):
+        """No ``harness`` key → ``.harness == "auto"`` (back-compat)."""
+        data = {"skill_name": "s"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.harness == "auto"
+
+    def test_valid_claude_code_loads(self, tmp_path):
+        """``{"harness": "claude-code"}`` loads with ``.harness == "claude-code"``."""
+        data = {"skill_name": "s", "harness": "claude-code"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.harness == "claude-code"
+
+    def test_valid_codex_loads(self, tmp_path):
+        """``{"harness": "codex"}`` loads with ``.harness == "codex"``."""
+        data = {"skill_name": "s", "harness": "codex"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.harness == "codex"
+
+    def test_valid_auto_loads(self, tmp_path):
+        """``{"harness": "auto"}`` loads with ``.harness == "auto"``."""
+        data = {"skill_name": "s", "harness": "auto"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        assert spec.harness == "auto"
+
+    def test_invalid_string_rejects(self, tmp_path):
+        """Unknown literal string (e.g. ``"raw-api"``) rejected with a
+        ``must be one of`` error that names the allowed values.
+        """
+        data = {"skill_name": "s", "harness": "raw-api"}
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"'harness' must be one of 'claude-code', 'codex', "
+                r"'auto', got 'raw-api'"
+            ),
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_non_string_rejects(self, tmp_path):
+        """Non-string (e.g. int 42) rejected with a type error."""
+        data = {"skill_name": "s", "harness": 42}
+        with pytest.raises(
+            ValueError,
+            match=r"'harness' must be a string, got int 42",
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_bool_rejects(self, tmp_path):
+        """Bool guard per ``.claude/rules/constant-with-type-info.md``:
+        ``isinstance(True, str)`` is False but we still want a distinct
+        error path that names the type.
+        """
+        data = {"skill_name": "s", "harness": True}
+        with pytest.raises(
+            ValueError,
+            match=r"'harness' must be a string, got bool True",
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_null_rejects(self, tmp_path):
+        """Explicit null is rejected — authors should omit the key
+        to get the default ``"auto"``, not write ``null`` explicitly.
+        """
+        data = {"skill_name": "s", "harness": None}
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"'harness' must be one of 'claude-code', 'codex', "
+                r"'auto', got null"
+            ),
+        ):
+            EvalSpec.from_dict(data, spec_dir=tmp_path)
+
+    def test_round_trip_non_default(self, tmp_path):
+        """Non-default harness round-trips through to_dict / from_dict."""
+        data = {"skill_name": "s", "harness": "codex"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        round_tripped = spec.to_dict()
+        assert round_tripped.get("harness") == "codex"
+        # End-to-end: re-load preserves value.
+        spec2 = EvalSpec.from_dict(round_tripped, spec_dir=tmp_path)
+        assert spec2.harness == "codex"
+
+    def test_round_trip_default_omits_key(self, tmp_path):
+        """Default ``"auto"`` is omitted from ``to_dict`` output to
+        keep diffs minimal (matches ``transport`` pattern).
+        """
+        data = {"skill_name": "s"}
+        spec = EvalSpec.from_dict(data, spec_dir=tmp_path)
+        round_tripped = spec.to_dict()
+        assert "harness" not in round_tripped
+        # End-to-end: re-load yields the default again.
+        spec2 = EvalSpec.from_dict(round_tripped, spec_dir=tmp_path)
+        assert spec2.harness == "auto"
+
+
 class TestEvalSpecGradingModel:
     """US-003 / DEC-004a of #146: ``EvalSpec.grading_model`` nullable
     migration.

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1366,3 +1366,52 @@ class TestSkillSpecRunHarnessOverride:
         msg = str(exc_info.value)
         assert "auto" in msg
         assert "resolve_harness" in msg
+
+    def test_same_harness_override_reuses_existing_runner(
+        self, tmp_skill_file
+    ):
+        """CodeRabbit / Copilot review feedback on PR #166: when the
+        override matches the harness already wired into ``self.runner``,
+        ``SkillSpec.run`` MUST reuse that runner rather than construct a
+        fresh one. Constructing a fresh runner via ``construct_harness``
+        would silently swap out custom harness configuration (notably
+        the pytest plugin's ``--clauditor-claude-bin`` value carried on
+        the existing ``ClaudeCodeHarness.claude_bin``).
+        """
+        from clauditor._harnesses._claude_code import ClaudeCodeHarness
+        from clauditor.runner import SkillRunner
+
+        skill_path = tmp_skill_file("override-skill")
+        # Build a runner with a custom-binary ClaudeCodeHarness — this
+        # simulates the pytest plugin's ``--clauditor-claude-bin``.
+        custom_harness = ClaudeCodeHarness(claude_bin="/custom/claude")
+        runner = SkillRunner(
+            project_dir=skill_path.parent, harness=custom_harness
+        )
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+
+        # Patch SkillRunner construction in spec.py to FAIL the test
+        # if the same-harness branch ever falls through to construction.
+        with patch("clauditor.spec.SkillRunner") as mock_runner_cls:
+            mock_runner_cls.side_effect = AssertionError(
+                "spec.run constructed a fresh SkillRunner when it should "
+                "have reused the existing same-harness runner"
+            )
+            # Patch the runner's invoke flow so the test doesn't shell
+            # out — return a canned SkillResult by patching the harness
+            # invoke method on the existing runner.
+            with patch.object(runner, "run") as mock_run:
+                mock_run.return_value = SkillResult(
+                    output="from-existing-runner",
+                    exit_code=0,
+                    skill_name="override-skill",
+                    args="",
+                )
+                spec.run(harness_name_override="claude-code")
+
+        # No new SkillRunner was constructed (would have raised).
+        assert mock_runner_cls.call_count == 0
+        # The original harness (with its custom claude_bin) is still
+        # the one wired into spec.runner.
+        assert spec.runner.harness is custom_harness
+        assert spec.runner.harness.claude_bin == "/custom/claude"

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1215,3 +1215,154 @@ class TestSystemPromptResolution:
         assert spec.skill_name in msg
         assert str(skill_path) in msg
         assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+class TestSkillSpecRunHarnessOverride:
+    """US-006 / DEC-004 of #151: ``SkillSpec.run`` accepts a
+    keyword-only ``harness_name_override: str | None``. When non-
+    ``None``, materialize a fresh :class:`SkillRunner` with the named
+    harness (constructed via
+    :func:`clauditor._harnesses.construct_harness`) and use it for
+    this call. When ``None``, ``self.runner`` is used as-is.
+
+    Tests construct a real :class:`SkillRunner` carrying a
+    :class:`MockHarness` so we can observe which harness ended up
+    handling ``invoke``. The override path must NOT mutate
+    ``self.runner`` — the spec's own runner stays bound to its
+    original harness.
+    """
+
+    @staticmethod
+    def _build_runner_with_mock_harness(project_dir):
+        from clauditor._harnesses._mock import MockHarness
+        from clauditor.runner import SkillRunner
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir=project_dir, harness=mock)
+        return runner, mock
+
+    def test_no_override_uses_existing_runner(
+        self, tmp_skill_file, mock_runner
+    ):
+        """Override omitted → ``self.runner`` is the one called."""
+        skill_path = tmp_skill_file("override-skill")
+        runner = mock_runner(output="from-existing-runner")
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        result = spec.run(args="--arg")
+
+        # The spec's own runner is the only one called.
+        runner.run.assert_called_once()
+        # Identity check: ``self.runner`` is unchanged.
+        assert spec.runner is runner
+        assert result.output == "from-existing-runner"
+
+    def test_override_constructs_codex_harness(
+        self, tmp_skill_file
+    ):
+        """``harness_name_override="codex"`` → fresh ``SkillRunner``
+        wired with a :class:`CodexHarness`. The spec's own runner is
+        NOT mutated (still has the original harness)."""
+        from clauditor._harnesses import _codex as _codex_mod
+
+        skill_path = tmp_skill_file("override-skill")
+        runner, original_mock = self._build_runner_with_mock_harness(
+            skill_path.parent
+        )
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+
+        # Patch ``SkillRunner`` *within* the spec module so we can
+        # observe the construction call AND avoid actually invoking
+        # the codex subprocess.
+        with patch("clauditor.spec.SkillRunner") as mock_runner_cls:
+            constructed = mock_runner_cls.return_value
+            constructed.run.return_value = SkillResult(
+                output="from-override",
+                exit_code=0,
+                skill_name="override-skill",
+                args="",
+            )
+            spec.run(harness_name_override="codex")
+
+        # The spec module constructed exactly one fresh runner with
+        # the override harness.
+        assert mock_runner_cls.call_count == 1
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert isinstance(kwargs["harness"], _codex_mod.CodexHarness)
+        # Project dir + timeout mirrored from the original runner.
+        assert kwargs["project_dir"] == runner.project_dir
+        assert kwargs["timeout"] == runner.timeout
+
+        # The fresh runner is what handled the call — not the
+        # original.
+        constructed.run.assert_called_once()
+        # Original runner's harness is untouched (no mutation).
+        assert spec.runner is runner
+        assert spec.runner.harness is original_mock
+
+    def test_override_constructs_claude_code_harness(
+        self, tmp_skill_file
+    ):
+        """``harness_name_override="claude-code"`` → fresh ``SkillRunner``
+        wired with a :class:`ClaudeCodeHarness`."""
+        from clauditor._harnesses import _claude_code as _claude_code_mod
+
+        skill_path = tmp_skill_file("override-skill")
+        runner, _original_mock = self._build_runner_with_mock_harness(
+            skill_path.parent
+        )
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+
+        with patch("clauditor.spec.SkillRunner") as mock_runner_cls:
+            constructed = mock_runner_cls.return_value
+            constructed.run.return_value = SkillResult(
+                output="from-override",
+                exit_code=0,
+                skill_name="override-skill",
+                args="",
+            )
+            spec.run(harness_name_override="claude-code")
+
+        assert mock_runner_cls.call_count == 1
+        kwargs = mock_runner_cls.call_args.kwargs
+        assert isinstance(
+            kwargs["harness"], _claude_code_mod.ClaudeCodeHarness
+        )
+
+    def test_override_invalid_name_propagates_value_error(
+        self, tmp_skill_file
+    ):
+        """Unknown harness name → ``construct_harness`` raises
+        ``ValueError``; ``SkillSpec.run`` does NOT swallow or reshape
+        it. The CLI wrapper (US-004) handles its own validation
+        upstream."""
+        skill_path = tmp_skill_file("override-skill")
+        runner, _original_mock = self._build_runner_with_mock_harness(
+            skill_path.parent
+        )
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+
+        with pytest.raises(ValueError) as exc_info:
+            spec.run(harness_name_override="bogus")
+
+        msg = str(exc_info.value)
+        assert "bogus" in msg
+
+    def test_override_auto_propagates_value_error(
+        self, tmp_skill_file
+    ):
+        """``"auto"`` is rejected by ``construct_harness`` — callers
+        must resolve auto via ``resolve_harness`` BEFORE calling
+        ``spec.run``. The error propagates unchanged."""
+        skill_path = tmp_skill_file("override-skill")
+        runner, _original_mock = self._build_runner_with_mock_harness(
+            skill_path.parent
+        )
+        spec = SkillSpec(skill_path=skill_path, eval_spec=None, runner=runner)
+
+        with pytest.raises(ValueError) as exc_info:
+            spec.run(harness_name_override="auto")
+
+        msg = str(exc_info.value)
+        assert "auto" in msg
+        assert "resolve_harness" in msg


### PR DESCRIPTION
## Summary

Super plan for [#151](https://github.com/wjduenow/clauditor/issues/151) — multi-harness `EvalSpec.harness` field with four-layer precedence (CLI > env > spec > default), `--harness` CLI flag on the four skill-execution commands, `CLAUDITOR_HARNESS` env var, `_resolve_harness()` shared helper, per-harness `check_codex_auth` guard, and a one-time `auto → codex` stderr announcement.

**Phase:** detailing (awaiting approval)
**Decisions:** 13 (DEC-001 through DEC-013)
**Stories:** 8 implementation + Quality Gate + Patterns & Memory = 10

## Plan document

See [`plans/super/151-harness-precedence.md`](../blob/feature/151-harness-precedence/plans/super/151-harness-precedence.md) for the full plan, including:

- Discovery (codebase findings, applicable rules, ticket parsing)
- Phase 1 scoping decisions (DEC-001 through DEC-008)
- Architecture review (auth/security pass + CLI/data-model/test pass)
- Phase 2 decisions resolving 3 review concerns (DEC-009 through DEC-013)
- 10-story breakdown with acceptance criteria, files, and dependency graph

## Key design choices

- **Field default:** `harness: str = "auto"` with `to_dict` skip-if-default (DEC-001) — direct match to ticket text, minimal-diff round-trip on pre-#151 specs.
- **Auto-resolution:** `shutil.which("claude")` first, then `shutil.which("codex")`; hard-fail with three-escape-hatch error message if neither found (DEC-002).
- **`check_codex_auth`:** strict-OR of `CODEX_API_KEY` / `OPENAI_API_KEY`; no CLI-on-PATH fallback (DEC-003).
- **`SkillSpec.run`:** new `harness_name_override: str | None = None` keyword arg; harness construction via new `_harnesses.construct_harness(name)` dispatcher (DEC-004, DEC-009).
- **Pure resolver returns tuple:** `resolve_harness() -> (name, auto_resolved_to)` so the CLI wrapper (not the pure layer) owns the announcement firing per `pure-compute-vs-io-split.md` (DEC-011).
- **Auth dispatcher unchanged:** `check_provider_auth` does NOT grow a Codex branch — Codex is a HARNESS axis, not a PROVIDER axis (DEC-010).
- **`--baseline` arm of `grade`:** propagates the same resolved harness to both runs; no separate `--baseline-harness` flag (DEC-013).

## Story dependency graph

```
US-001 ──┐
US-002 ──┼── US-004 ──┐
US-003 ──┘            ├── US-005 ──┐
                      │            │
            US-006 ───┴── US-007 ──┴── US-008 ── US-009 ── US-010
```

US-001, US-002, US-003 can run in parallel. US-005 is the integration story.

## Dependencies

- Blocked by [#148](https://github.com/wjduenow/clauditor/issues/148) (CLOSED — Harness protocol extracted)
- Blocked by [#149](https://github.com/wjduenow/clauditor/issues/149) (CLOSED — CodexHarness shipped)
- Blocks [#152](https://github.com/wjduenow/clauditor/issues/152)

## Next steps

1. Review the plan in this PR
2. Approve to proceed to devolve (beads creation + Ralph execution)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--harness {claude-code,codex,auto}` CLI flag to validate, grade, capture, and run commands.
  * Added `harness` field to skill evaluation specs for declaring harness preference.
  * Added `CLAUDITOR_HARNESS` environment variable for harness selection.
  * Implemented four-layer harness precedence: CLI flag > environment variable > spec field > default.
  * Added fail-fast authentication checks when Codex harness is selected without credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->