### PR TITLE
#152: Multi-harness sidecar harness field (plan)

### DIFF
--- a/.claude/rules/harness-protocol-shape.md
+++ b/.claude/rules/harness-protocol-shape.md
@@ -84,6 +84,26 @@ identity. Class-level so the value is immutable per harness type — no
 instance variance. `ClaudeCodeHarness.name = "claude-code"`,
 `MockHarness.name = "mock"`, `CodexHarness.name = "codex"`.
 
+#### Sidecar identity (post-#152)
+
+`Harness.name` is now load-bearing for on-disk sidecar identity, not
+just an observability label. `SkillRunner._invoke` reads
+`self.harness.name` at `SkillResult` construction time and stamps it
+onto `SkillResult.harness`; downstream sidecar emitters
+(`assertions.json` v2, `extraction.json` v4, `grading.json` v4,
+`history.jsonl` v3) thread that string through verbatim into the
+`harness` field on each persisted record. Audit aggregation then
+groups by the 4-tuple `(harness, provider, layer, id)` so two runs
+of the same skill under different harnesses (e.g. `claude-code` vs
+`codex`) produce distinct buckets rather than averaging across
+them. See `.claude/rules/json-schema-version.md` "Schema version
+bumps for #152" for the persisted-side contract. Practical
+consequence for harness implementers: the `name` ClassVar is now a
+public-data identifier — choose it carefully, do not change it
+without considering the legacy-read defaults that downstream loaders
+already key on (`"claude-code"` is the default for missing-field
+reads).
+
 ### Why `invoke` accepts `subject: str | None = None`
 
 `subject` is an optional human-readable label (e.g. `"L2 extraction"`)

--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -157,8 +157,8 @@ skill subprocess. The harness identity is materialized once by #151's
 resolver, stamped onto `SkillResult.harness` at `SkillRunner._invoke`
 construction time (US-001), and threaded into every downstream sidecar
 emitter from there. The field name deliberately omits the `_source`
-suffix that `provider_source` carries: `provider_source` records a
-per-call API/CLI transport choice, while `harness` records what
+suffix that `provider_source` carries: `provider_source` records which
+provider backend served the grader call, while `harness` records what
 materially ran the skill — they are conceptually distinct, and the name
 keeps them visually distinguishable on disk per DEC-001 of
 `plans/super/152-sidecar-harness-field.md`.

--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -149,6 +149,134 @@ Writers and readers (post-#147):
 - `src/clauditor/history.py::append_record` (keyword-only `provider=`) /
   `read_records` (defaults missing `provider` to `"anthropic"`).
 
+### Schema version bumps for #152 (`harness` field)
+
+`#152` added `harness` — the harness-axis sibling to `provider_source` —
+recording which harness CLI (`"claude-code"` or `"codex"` today) ran the
+skill subprocess. The harness identity is materialized once by #151's
+resolver, stamped onto `SkillResult.harness` at `SkillRunner._invoke`
+construction time (US-001), and threaded into every downstream sidecar
+emitter from there. The field name deliberately omits the `_source`
+suffix that `provider_source` carries: `provider_source` records a
+per-call API/CLI transport choice, while `harness` records what
+materially ran the skill — they are conceptually distinct, and the name
+keeps them visually distinguishable on disk per DEC-001 of
+`plans/super/152-sidecar-harness-field.md`.
+
+Five schema bumps shipped together in #152:
+
+- **`assertions.json` v1 → v2** — adds top-level `harness` field
+  (sibling-of-`schema_version` placement per DEC-003). Unlike
+  `extraction.json` / `grading.json`, the L1 sidecar previously had no
+  provider/harness axis at all (L1 makes no LLM call) — #152 is the
+  first bump on this file.
+- **`extraction.json` v3 → v4** — adds `harness` sibling to the
+  existing `provider_source` field (DEC-004).
+- **`grading.json` v3 → v4** — same shape as `extraction.json`
+  (DEC-004).
+- **`history.jsonl` v2 → v3** — adds top-level `harness` field per
+  record. `harness=` becomes a mandatory keyword-only parameter on
+  `append_record` (mirroring the post-#147 `provider=` mandatory-
+  keyword shape). `read_records` defaults missing `harness` to
+  `"claude-code"` for legacy v1/v2 lines so pre-#152 history stays
+  readable. Per DEC-005, the history bump lands in lockstep with the
+  sidecar bumps so #153 can refuse mixed-harness history at `trend`
+  time without a follow-up version skew.
+- **audit `render_json` output v2 → v3** — adds top-level
+  `harnesses_seen: list[str]` array (sorted, deduped) sibling to the
+  existing `providers_seen[]`, and each `assertions[]` entry gains a
+  `"harness": str` field (DEC-010). Mirrors the #147 audit JSON
+  v1 → v2 bump exactly.
+
+`MAX_SCHEMA_VERSION` map post-#152:
+`{"assertions.json": 2, "extraction.json": 4, "grading.json": 4}`.
+`history.py` post-#152: `SCHEMA_VERSION = 3`,
+`_ACCEPTED_SCHEMA_VERSIONS = frozenset({1, 2, 3})`.
+
+`BlindReport` deliberately stays at `schema_version: 1` per DEC-014 —
+`compare --blind` takes two pre-captured outputs as inputs, so there is
+no skill execution at judge time and no harness axis to record. The
+harness that produced each captured output is recorded in *that
+capture's* sidecars, not on the blind-judge result.
+
+**L1 placeholder inversion (DEC-008).** L1 audit rows now carry a real
+`harness` value (sourced from `assertions.json` v2) but keep the
+`provider: "anthropic"` placeholder from #147 — L1 makes no LLM call,
+so provider is genuinely "no value." The two surfaces handle the
+placeholder differently:
+
+- **Stdout / Markdown renderers** show the L1 `provider` cell as `"—"`
+  (em-dash) so the column structure stays uniform across L1/L2/L3 rows
+  while signaling honestly that no provider attribution exists.
+- **Audit JSON output (`render_json` v3)** retains the literal
+  `"anthropic"` placeholder string so downstream JSON consumers see a
+  fixed-shape value rather than a glyph that would force string-
+  comparison branching.
+
+The new pure helper
+`src/clauditor/audit.py::_harness_or_default` — sibling of
+`_provider_or_default` — handles defensive read of malformed v2/v4
+sidecars (non-string truthy values, empty strings) and supplies the
+`"claude-code"` default for v1/v2/v3 legacy reads with no `harness`
+field. Both helpers are pure (no I/O, no logging) per
+`.claude/rules/pure-compute-vs-io-split.md`.
+
+`IterationRecord` and `AuditAggregate` both gained
+`harness: str = "claude-code"` (DEC-006), mirroring the
+`provider: str = "anthropic"` default introduced in #147. The `aggregate()`
+grouping key widens from the 3-tuple `(provider, layer, id)` to the
+4-tuple `(harness, provider, layer, id)` per DEC-007 — same `(provider,
+layer, id)` under different harnesses now produces two distinct buckets
+rather than averaging across harnesses. `apply_thresholds` and the
+three renderers were updated in lockstep to consume the 4-tuple key.
+
+The pytest fixtures `clauditor_grader` and `clauditor_triggers` auto-
+populate `harness` from `EvalSpec.harness` resolution (the same
+resolver path the CLI uses), threading it into `spec.run(
+harness_name_override=...)` and onto the resulting `GradingReport`.
+`clauditor_blind_compare` is unaffected (no harness axis at blind-judge
+time per DEC-014).
+
+Writers and readers (post-#152):
+
+- `src/clauditor/runner.py::SkillResult.harness` — the foundational
+  field; populated from `SkillRunner._invoke` reading
+  `self.harness.name` (the `Harness.name` ClassVar per
+  `.claude/rules/harness-protocol-shape.md`). Default `"claude-code"`
+  keeps direct-construct test fixtures green.
+- `src/clauditor/cli/grade.py::_write_assertions_sidecar` — accepts a
+  `harness: str = "claude-code"` parameter; stamps
+  `{"schema_version": 2, "harness": <name>, ...}` (canonical key
+  order). The production call site in `_write_workspace_sidecars`
+  threads the resolved harness name through.
+- `src/clauditor/grader.py::ExtractionReport.to_json` /
+  `ExtractionReport.from_json` — emits `schema_version: 4` with
+  `"harness"` placed after `"provider_source"` to mirror the
+  provider-sibling shape; reader defaults missing `harness` to
+  `"claude-code"` for v1/v2/v3 reads.
+- `src/clauditor/quality_grader.py::GradingReport.to_json` /
+  `GradingReport.from_json` — same shape as `ExtractionReport`.
+- `src/clauditor/audit.py::IterationRecord` /
+  `src/clauditor/audit.py::AuditAggregate` — both carry the
+  `harness: str = "claude-code"` field.
+- `src/clauditor/audit.py::aggregate` — 4-tuple grouping key
+  `(harness, provider, layer, id)`.
+- `src/clauditor/audit.py::_records_from_assertions` /
+  `_records_from_extraction` / `_records_from_grading` — all read
+  through `_harness_or_default(data.get("harness"))` so legacy v1/v2/v3
+  reads default cleanly.
+- `src/clauditor/audit.py::_harness_or_default` — pure defensive-read
+  helper, sibling of `_provider_or_default`.
+- `src/clauditor/audit.py::render_stdout_table` /
+  `render_markdown` / `render_json` — all surface the harness
+  dimension (HARNESS column leftmost in stdout/markdown;
+  `harnesses_seen[]` + per-entry `harness` in JSON v3).
+- `src/clauditor/history.py::SCHEMA_VERSION` (= 3) /
+  `_ACCEPTED_SCHEMA_VERSIONS` (= `frozenset({1, 2, 3})`) /
+  `append_record` (mandatory keyword-only `harness=`; rejects blank
+  and `"auto"`) / `read_records` (defaults missing `harness` to
+  `"claude-code"` for v1/v2 reads).
+
 ## When this rule applies
 
 Any new persisted JSON file whose shape may evolve. Internal-only debug

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -460,17 +460,17 @@ Exits 1 when a regression is detected (assertion that previously passed now fail
 
 ### `audit`
 
-Aggregate per-assertion pass rates across the most recent N iteration workspaces. Surfaces assertions that are flaky, never fire, or fail to discriminate between the with-skill and baseline arms. Aggregates are grouped by `(provider, layer, id)` so mixed-provider history (Anthropic and OpenAI grading runs under the same skill) renders as separate rows rather than averaging across providers.
+Aggregate per-assertion pass rates across the most recent N iteration workspaces. Surfaces assertions that are flaky, never fire, or fail to discriminate between the with-skill and baseline arms. Aggregates are grouped by `(harness, provider, layer, id)` so mixed-harness or mixed-provider history (e.g. Claude Code and Codex runs, or Anthropic and OpenAI grading runs, under the same skill) renders as separate rows rather than averaging across harnesses or providers.
 
 | Flag | Purpose |
 | ---- | ------- |
 | `--last N` | Consider the last `N` iteration directories (default 20). |
 | `--min-fail-rate FLOAT` | Flag assertions whose fail rate is at least this value (0.0–1.0). |
 | `--min-discrimination FLOAT` | Flag assertions whose with-vs-baseline pass-rate delta is below this value. |
-| `--json` | Emit a machine-readable JSON report instead of the table. The JSON output is `schema_version: 2` (per #147), with each `assertions[]` entry carrying a `provider` field and a top-level `providers_seen: [...]` array sorted alphabetically — JSON consumers can detect mixed history without iterating the entries. |
+| `--json` | Emit a machine-readable JSON report instead of the table. The JSON output is `schema_version: 3` (per #152), with each `assertions[]` entry carrying `harness` and `provider` fields and top-level `harnesses_seen: [...]` and `providers_seen: [...]` arrays sorted alphabetically — JSON consumers can detect mixed history without iterating the entries. |
 | `--output-dir PATH` | Directory to write audit reports. |
 
-The default text and Markdown renderers add a leftmost `PROVIDER` column (~11 chars wide) and sort by `(provider, layer, id)`. L1 assertions carry a placeholder `"anthropic"` provider — L1 has no LLM call to attribute, and the honest harness-axis bump for `assertions.json` lives in #152.
+The default text and Markdown renderers add leftmost `HARNESS` and `PROVIDER` columns and sort by `(harness, provider, layer, id)`. L1 audit rows now show a real HARNESS value (sourced from `assertions.json` v2) alongside the existing PROVIDER column, which renders as `—` (em-dash) for L1 rows since L1 makes no LLM call. Audit JSON output bumped to `schema_version: 3` with a new top-level `harnesses_seen[]` array and per-entry `harness` field; for JSON-output honesty the L1 `provider` field still emits `"anthropic"` (the #147 placeholder) so downstream consumers see a fixed-shape value rather than an em-dash glyph.
 
 ### `trend`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -591,7 +591,7 @@ Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 3,
   "command": "grade",
   "ts": "2026-04-13T15:00:00+00:00",
   "skill": "find-restaurants",
@@ -599,6 +599,8 @@ Every `clauditor grade`, `extract`, and `validate` run appends a JSON line to `.
   "workspace_path": ".clauditor/iteration-4/find-restaurants",
   "pass_rate": 0.83,
   "mean_score": 0.75,
+  "provider": "anthropic",
+  "harness": "claude-code",
   "metrics": {
     "skill":   {"input_tokens": 1200, "output_tokens": 800},
     "quality": {"input_tokens": 900,  "output_tokens": 350},

--- a/plans/super/152-sidecar-harness-field.md
+++ b/plans/super/152-sidecar-harness-field.md
@@ -5,8 +5,30 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/152
 - **Branch:** `feature/152-sidecar-harness-field`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/152-sidecar-harness-field`
-- **Phase:** published
+- **Phase:** devolved
 - **PR:** https://github.com/wjduenow/clauditor/pull/167
+
+## Beads manifest
+
+- **Epic:** `clauditor-8zd` — #152: Multi-harness sidecar harness field
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/152-sidecar-harness-field`
+- **Branch:** `feature/152-sidecar-harness-field`
+
+| Story | Bead ID | Depends on |
+|---|---|---|
+| US-001 — SkillResult.harness field | `clauditor-gfo` | (foundation) |
+| US-002 — assertions.json v1 → v2 | `clauditor-ynm` | gfo |
+| US-003 — ExtractionReport v3 → v4 | `clauditor-oth` | gfo |
+| US-004 — GradingReport v3 → v4 | `clauditor-8fd` | gfo |
+| US-005 — IterationRecord/AuditAggregate + 4-tuple grouping | `clauditor-ycl` | ynm, oth, 8fd |
+| US-006 — Renderers + render_json v3 + harnesses_seen[] | `clauditor-db9` | ycl |
+| US-007 — history.jsonl v2 → v3 | `clauditor-e0b` | gfo |
+| US-008 — Pytest fixtures auto-populate harness | `clauditor-ptd` | gfo, 8fd |
+| US-009 — Docs (rule + cli-reference) | `clauditor-k4n` | ynm, oth, 8fd, ycl, db9, e0b, ptd |
+| Quality Gate — code review ×4 + CodeRabbit | `clauditor-mdp` | k4n, db9, e0b, ptd |
+| Patterns & Memory | `clauditor-8n6` | mdp |
+
+Initial ready queue (no active blockers): **`clauditor-gfo`** (US-001 foundation).
 - **Sessions:** 1 (2026-05-03)
 - **Depends on:** #147 (CLOSED — provider_source field, MAX_SCHEMA_VERSION map), #151 (CLOSED — EvalSpec.harness + four-layer precedence + construct_harness)
 - **Blocks:** #153 (cross-{harness,provider} grouping refusal in audit/trend/compare)

--- a/plans/super/152-sidecar-harness-field.md
+++ b/plans/super/152-sidecar-harness-field.md
@@ -5,7 +5,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/152
 - **Branch:** `feature/152-sidecar-harness-field`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/152-sidecar-harness-field`
-- **Phase:** detailing
+- **Phase:** published
+- **PR:** https://github.com/wjduenow/clauditor/pull/167
 - **Sessions:** 1 (2026-05-03)
 - **Depends on:** #147 (CLOSED — provider_source field, MAX_SCHEMA_VERSION map), #151 (CLOSED — EvalSpec.harness + four-layer precedence + construct_harness)
 - **Blocks:** #153 (cross-{harness,provider} grouping refusal in audit/trend/compare)

--- a/plans/super/152-sidecar-harness-field.md
+++ b/plans/super/152-sidecar-harness-field.md
@@ -1,0 +1,558 @@
+# 152 — Multi-harness sidecar: add harness field to L1/L2/L3 sidecars
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/152
+- **Branch:** `feature/152-sidecar-harness-field`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/152-sidecar-harness-field`
+- **Phase:** detailing
+- **Sessions:** 1 (2026-05-03)
+- **Depends on:** #147 (CLOSED — provider_source field, MAX_SCHEMA_VERSION map), #151 (CLOSED — EvalSpec.harness + four-layer precedence + construct_harness)
+- **Blocks:** #153 (cross-{harness,provider} grouping refusal in audit/trend/compare)
+- **Related rule:** `.claude/rules/json-schema-version.md` — explicitly names #152 as the assertions.json harness-axis bump
+
+## Discovery
+
+### Ticket summary
+
+Mirror of #147 on the harness axis. Sidecars must record which harness produced
+the output so audit/trend doesn't average across non-comparable runs.
+
+In scope:
+- `assertions.json` schema_version 1 → 2, add top-level `harness: str = "claude-code"`
+- `extraction.json` schema_version 3 → 4, add `harness` field (sibling to existing `provider_source`)
+- `grading.json` schema_version 3 → 4, add `harness` field (sibling to `provider_source`)
+- Audit loader accepts all prior versions; defaults missing `harness` to `"claude-code"` for legacy reads
+- `clauditor audit` groups by `(harness, provider, layer, id)` (was 3-tuple, becomes 4-tuple)
+- L1 audit table gets a `harness` column where it doesn't have a `provider` one
+- Update `.claude/rules/json-schema-version.md` "Schema version bumps" section
+
+Out of scope (per ticket):
+- Sandbox-mode / system-prompt-source / reasoning-token capture (#154)
+- Cross-{harness,provider} averaging refusal in trend/compare (#153)
+- Harness-axis bump on `history.jsonl` — ticket is silent; flagged as scoping question
+
+### Codebase landscape (post-#147, post-#151)
+
+**Sidecar writers:**
+- `src/clauditor/quality_grader.py::GradingReport` (lines 75–104) — dataclass at v3 with `provider_source: str = "anthropic"`. `to_json` at lines 129–168 stamps `schema_version: 3` first; `from_json` at 171–209 defaults missing `provider_source` to `"anthropic"` for v1/v2 reads.
+- `src/clauditor/grader.py::ExtractionReport` (lines 86–145) — same shape, v3, `provider_source` field; `to_json` at 153–185, `from_json` at 188–227.
+- `src/clauditor/cli/grade.py::_write_assertions_sidecar` (lines 876–941) — assertions.json is **inline-built** (no dataclass), currently emits v1 with shape `{"schema_version": 1, "skill", "iteration", "runs": [...]}`.
+
+**Audit loader (`src/clauditor/audit.py`):**
+- `MAX_SCHEMA_VERSION` map (lines 52–56): `{"assertions.json": 1, "extraction.json": 3, "grading.json": 3}`. Per-#147 DEC-008 a future bump is "one-number-per-file edit."
+- `_is_accepted_version` (lines 59–87) and `_check_schema_version` (107–129) enforce the range check + stderr warn-and-skip.
+- `IterationRecord` (lines 157–177) has `provider: str = "anthropic"` placeholder (added #147 line 176). No `harness` field.
+- `AuditAggregate` (lines 180–198) carries `provider: str = "anthropic"` (line 198). No `harness` field.
+- `aggregate()` grouping (lines 445–509) uses `(provider, layer, id)` 3-tuple key (line 463).
+- `_records_from_assertions` (242–276) — sets `provider="anthropic"` placeholder per #147 DEC-002.
+- `_records_from_extraction` (279–313) — reads `provider_source` via `_provider_or_default(data.get("provider_source"))` (line 297).
+- `_records_from_grading` (316–353) — same provider read pattern (line 333).
+
+**History (`src/clauditor/history.py`):**
+- `SCHEMA_VERSION = 2`, `_ACCEPTED_SCHEMA_VERSIONS = frozenset({1, 2})` (post-#147).
+- `append_record` (lines 127–197) takes mandatory `provider: str` keyword; rejects `"auto"`. No `harness` field today.
+- v1 reads default missing `provider` to `"anthropic"`.
+
+**Harness propagation (post-#151):**
+- `SkillSpec.run(harness_name_override: str | None = None, ...)` materializes a fresh `SkillRunner` via `construct_harness()` (spec.py 246–262) when override is set; reuses runner otherwise.
+- `SkillResult` (runner.py 54–101) has **no `harness` field today**. Comment at line 69 explicitly warns: "runtime-only — do not serialize to sidecars without bumping schema_version".
+- CLI grade.py resolves harness via `_resolve_harness(args, spec.eval_spec)` (lines 384/414) per #151 four-layer precedence; threads to `spec.run(..., harness_name_override=harness_name)` (lines 644/677).
+- The harness identity at sidecar-emit time is currently only on the active runner's `runner.harness.name`; not surfaced on `SkillResult`.
+
+**Test bumps required:**
+- `tests/test_audit.py:93,115,129,264` — assertions.json v1 fixtures → v2 (or assert defaulted-on-read).
+- `tests/test_cli_auth_guard.py:181`, `tests/test_cli_lint.py:504` — v1 assertions samples.
+- `tests/test_grader.py:1648,1819` — extraction/grading v3 → v4.
+- `tests/test_grader.py:1670,1840,1859` — legacy v1/v2 read tests stay; add v3 legacy default-on-read tests.
+- ~10 sites total across audit + grader + cli tests.
+
+### Convention-rule constraints (from `.claude/rules/`)
+
+Directly applicable:
+1. **`json-schema-version.md`** — anchor rule. Use `MAX_SCHEMA_VERSION` map (DEC-008 pattern); writers stamp `schema_version` as first key; loaders default missing field on legacy reads. Rule explicitly names #152 as the assertions.json harness-axis bump.
+2. **`pure-compute-vs-io-split.md`** — sidecar `to_json` stays on dataclass; audit grouping stays pure (no I/O in `aggregate`).
+3. **`back-compat-shim-discipline.md`** — Pattern 2 (class identity) — no new shim added in #152, but if any field is moved across modules, add identity test.
+4. **`sidecar-during-staging.md`** — assertions.json / extraction.json / grading.json all written inside `workspace.tmp_path` before `workspace.finalize()`. Already enforced; #152 must not break.
+5. **`spec-cli-precedence.md`** — Four-layer precedence — harness (#151) is the resolution path; #152 only consumes the resolved harness name; no new precedence layer.
+6. **`harness-protocol-shape.md`** — The string written into sidecars is `Harness.name` (ClassVar). Use the canonical attribute, not a synthesized string.
+7. **`centralized-sdk-call.md`** + **`multi-provider-dispatch.md`** — harness ≠ provider per #151 DEC-010. Sidecar grouping by `(harness, provider, layer, id)` is two orthogonal dimensions; do not merge.
+
+Read but not applicable:
+- `constant-with-type-info.md` (no new KeySpec mixed-type field)
+- `eval-spec-stable-ids.md` (sidecar metadata, not per-entry id)
+- `pre-llm-contract-hard-validate.md` (no LLM output)
+- `permissive-parser-strict-validator.md` (sidecars are clauditor-authored)
+- `data-vs-asserter-split.md` (no new helper class)
+
+No `workflow-project.md` exists.
+
+### #147 canonical pattern to mirror
+
+#147's structural moves that #152 will replay:
+- **DEC-001 (field naming)** — `provider_source` was the on-disk byte-identical field name. For #152 the field is just `harness` (no `_source` suffix; harness identity is materialized by #151, not a "source" choice the user makes mid-call).
+- **DEC-002 (L1 placeholder)** — #147 left L1 at v1 with `IterationRecord.provider="anthropic"` placeholder. #152 inverts this: assertions.json bumps to v2 because L1 *can* be honestly stamped (the harness ran the skill that produced the output being asserted on). After #152, the L1 placeholder for `provider` remains (no LLM call) but `harness` is real.
+- **DEC-008 (MAX_SCHEMA_VERSION map)** — already in place; #152 is a one-number-per-file edit.
+- **DEC-012 (history bump)** — #147 bumped history v1→v2 alongside sidecars; #152 should consider the parallel v2→v3 bump (open question DEC-S3 below).
+- **US-001 / US-003 shape** — sidecar writer + reader bump per file, then `IterationRecord` / `AuditAggregate` field, then grouping-key widen, then renderer column, then tests.
+
+## Scoping questions for the user
+
+DEC-S1 — **How should the harness name reach sidecar emitters?**
+- **(A)** Add a `harness: str` field to `SkillResult` dataclass (runtime-only mirror of how provider_source lives on the orchestrator return). Sidecar emitters read `result.harness`. Cleanest seam; one place to populate; matches the existing pattern of "everything the sidecar needs lives on the result the orchestrator returns."
+- **(B)** Thread the resolved `harness_name` separately into each sidecar write call. Avoids touching `SkillResult` (which has the "do not serialize without bumping schema_version" comment), but spreads the concern across multiple call sites.
+- **(C)** Read `runner.harness.name` from the active runner inside the writers. Tightest coupling to runner; brittle if the runner is reused across calls.
+
+DEC-S2 — **`assertions.json`: top-level harness or per-run within `runs[]`?**
+- **(A)** Top-level field, mirroring `extraction.json` / `grading.json`'s `provider_source` placement. Simplest; one harness per command invocation today (no per-rep harness override).
+- **(B)** Per-run inside each entry of `runs[]`. Forward-compat for #155 (pytest fixtures parametrize harness across runs in one command), but premature today.
+
+DEC-S3 — **Bump `history.jsonl` v2 → v3 in this ticket, or defer?**
+- **(A)** Bump in #152: add `harness` field, mandatory keyword on `append_record`, default missing → `"claude-code"` for legacy reads. Keeps sidecar + history axes in lockstep (#147 did both).
+- **(B)** Defer: ticket scope is silent on history; only #153 (which depends on #152) needs `trend` to detect mixed harness from history.
+- Recommendation: (A) — locks the axes together and avoids a tiny follow-up later.
+
+DEC-S4 — **`IterationRecord.harness` and `AuditAggregate.harness` default value?**
+- **(A)** `harness: str = "claude-code"` default — mirrors `provider: str = "anthropic"` from #147 and matches the legacy-read default.
+- **(B)** Required (no default) — forces every record-builder site to pass it explicitly.
+- Recommendation: (A) for consistency with #147; constructors at the record-builder sites still pass it explicitly.
+
+DEC-S5 — **L1 audit-table column treatment.**
+- Ticket says: "L1 audit gets a `harness` column where it didn't have a `provider` one." Confirming the renderer model:
+  - L1 row gets a real `harness` column (sourced from assertions.json v2)
+  - L1 row gets either no `provider` cell or a placeholder ("—" / "—") — which?
+- **(A)** Show "—" or empty in the provider column for L1 rows (visually grouped, but null-call-out).
+- **(B)** Hide the provider column entirely if the iteration set has only L1 records.
+- Recommendation: (A) — matches markdown-table semantics where columns are stable across rows.
+
+DEC-S6 — **Pytest plugin / fixture surface.** The pytest fixtures (`clauditor_grader`, `clauditor_blind_compare`) build `GradingReport`s in tests. Do those fixtures need to populate `harness` on the report (and threaded through), or can tests construct the field directly when needed?
+- **(A)** Fixtures populate `harness` from `EvalSpec.harness` resolution (mirror of how `provider` flows through). Fixture callers don't have to think about it.
+- **(B)** Add `harness` to fixture factory kwargs; default to `"claude-code"`; require explicit pass when testing non-default harness.
+- Recommendation: (A) — closes the loop with how the production CLI seam threads it.
+
+## Discovery answers (confirmed 2026-05-03)
+
+DEC-S1=A — `harness: str` on `SkillResult`. DEC-S2=A — top-level on assertions.json. DEC-S3=A — bump history.jsonl v2→v3 in this ticket. DEC-S4=A — defaults `"claude-code"`. DEC-S5=A — L1 provider cell shows "—" placeholder. DEC-S6=A — fixtures auto-populate `harness` from `EvalSpec.harness` resolution.
+
+## Architecture review
+
+| Area                        | Rating  | Headline finding |
+|-----------------------------|---------|------------------|
+| Schema migration safety     | PASS    | `MAX_SCHEMA_VERSION` map + `_is_accepted_version` already absorb per-file bumps; legacy default-on-read mirrors #147 exactly. |
+| Aggregation grouping widen  | CONCERN | 5 call sites consume the 3-tuple key (`apply_thresholds`, three renderers, `AuditAggregate` ctor); all reachable, mechanical. |
+| `SkillResult.harness` field | PASS    | Runtime-only; `runner.harness.name` available at construction in `SkillRunner.run`. The "do not serialize without bumping" comment refers to observation fields, not adopted-for-sidecar fields. |
+| `history.jsonl` v3 bump     | PASS    | Three `append_record` call sites identified; mandatory-keyword pattern mirrors #147's provider rollout. |
+| L1 placeholder inversion    | PASS    | `provider="anthropic"` placeholder remains correct (no LLM call); only `harness` moves from placeholder to real-from-v2-sidecar. |
+| `_write_assertions_sidecar` | PASS    | Inline writer at `cli/grade.py:876-941`; called from `_grade_primary_arm` at line 789 with `harness_name` already in scope at line 414. |
+| Existing test coverage map  | PASS    | 11 schema-literal sites + 35 history sites + 16 cli sites + 8 ctor sites + 5 grouping-tuple sites = ~75 total mechanical updates. No blind spots. |
+| New test cases needed       | PASS    | Six suites well-scoped: round-trip v4, legacy default-on-read, grouping splits on harness, renderer columns, history v3, fixture auto-population. |
+| Coverage gate (80%)         | PASS    | New branches mirror provider's #147 branches; existing test discipline covers them. |
+| Pytester coverage hazard    | PASS    | No `runpytest_inprocess + mock.patch + cov` combos planned; tests are pure round-trips. |
+| Audit renderers             | PASS    | Three renderers (stdout/markdown/JSON) take a HARNESS column cleanly; column order open as DEC-A1 below. |
+| Audit JSON output schema    | CONCERN | `render_json` returns its own `schema_version: 2` (post-#147); needs v3 bump for harness. Open as DEC-A2 below. |
+| Other audit consumers       | PASS    | `clauditor badge` reads sidecars directly (per-iteration singleton; unaffected). `compare`/`trend` out of scope per ticket but cleanly compatible. |
+| Stderr observability        | PASS    | `_check_schema_version` warning text is parameterized by `MAX_SCHEMA_VERSION`; future-proof. |
+| Documentation               | CONCERN | `.claude/rules/json-schema-version.md` needs a "Schema version bumps for #152" section. `docs/cli-reference.md:473` already namedrops #152 — needs a sentence about the column. Open as DEC-A3 below. |
+| Dual-version external-schema rule | PASS | Doesn't apply — sidecars are clauditor-internal; badge pair already correctly split. |
+
+**Master rating: PASS** (no blockers). Three concerns landed as refinement questions DEC-A1, DEC-A2, DEC-A3 below.
+
+## Refinement questions (architecture concerns)
+
+**DEC-A1 — Audit-table column order.** Where does `HARNESS` slot in the renderer's column sequence?
+- (A) `HARNESS | PROVIDER | LAYER | ID | ...` — harness leftmost; matches the grouping-key tuple order `(harness, provider, layer, id)` declared in the ticket.
+- (B) `PROVIDER | HARNESS | LAYER | ID | ...` — harness between provider and layer; preserves existing `PROVIDER` lead column from #147.
+- Recommendation: (A) — keys-tuple order matches reading order; "harness" is the higher-level dispatch axis (it determines which provider's data even exists). Also makes `audit_json` entries' field order intuitive.
+
+**DEC-A2 — Audit JSON output (`render_json`) schema bump.** The audit's own JSON output (not sidecars) is currently `schema_version: 2`. With `harness` becoming a field on every entry:
+- (A) Bump to `schema_version: 3`. Add to top-level `harnesses_seen[]` array (sibling of existing `providers_seen[]`). Each `assertions[]` entry gains `harness` field.
+- (B) Stay at v2 with optional `harness` key. Backward-permissive but semantically dishonest (the field is mandatory, not optional, in v3 sidecars).
+- Recommendation: (A) — explicit bump, sibling top-level array, mandatory per entry. Mirrors #147's audit JSON v1→v2 bump exactly.
+
+**DEC-A3 — Documentation footprint.** Which docs absolutely must update in this ticket vs. follow-on?
+- (A) Mandatory in #152: `.claude/rules/json-schema-version.md` "Schema version bumps for #152" section; `docs/cli-reference.md:473` audit description sentence.
+- (B) Also include: README.md "Three Layers of Validation" mention if any; `docs/audit-reference.md` if exists (scout: doesn't exist).
+- Recommendation: (A) — strict footprint matching the rule's anchor pattern; no speculative doc work.
+
+## Architecture answers (confirmed 2026-05-03)
+
+DEC-A1=A — HARNESS leftmost column. DEC-A2=A — `render_json` bumps to v3 with `harnesses_seen[]`. DEC-A3=A — strict doc footprint.
+
+## Refinement log — formal decisions
+
+**DEC-001 — Field name on disk: `harness` (no `_source` suffix).**
+*Rationale:* #147 used `provider_source` because the operator chose between API/CLI/auto transports per call. `harness` identity is materialized once by #151's resolver; the field records what ran the skill, not a "source" choice. Keeps the field name visually distinct from `provider_source`.
+
+**DEC-002 — `harness` reaches sidecar emitters via `SkillResult.harness: str` (DEC-S1=A).**
+*Rationale:* Mirrors how `provider_source` flows on grader returns. `SkillRunner._invoke` reads `self.harness.name` (the `Harness.name` ClassVar per `harness-protocol-shape.md`) at SkillResult construction. The "runtime-only — do not serialize" comment in `runner.py:69` governs observation fields like `api_key_source`/`harness_metadata`; `harness` is now an adopted-for-sidecar field, deliberately serialized.
+
+**DEC-003 — `assertions.json` carries `harness` as a top-level field (DEC-S2=A), v1 → v2.**
+*Rationale:* One harness per command invocation today. Matches `provider_source` placement in `extraction.json` / `grading.json`. Per-run harness within `runs[]` is premature — when #155 lands per-rep harness parametrization, the field can be additionally placed inside `runs[]` entries without removing the top-level (or migrated cleanly to v3 then).
+
+**DEC-004 — `extraction.json` v3 → v4 and `grading.json` v3 → v4 add `harness` sibling to `provider_source`.**
+*Rationale:* Mirrors #147 DEC-001 placement. Loaders default missing `harness` to `"claude-code"` for legacy v1/v2/v3 reads; `provider_source` defaults to `"anthropic"` for v1/v2 reads (preserved).
+
+**DEC-005 — `history.jsonl` v2 → v3 in this ticket (DEC-S3=A).** Adds top-level `harness` per record; `harness=` becomes mandatory keyword on `append_record`. Legacy v1/v2 reads default missing `harness` to `"claude-code"`.
+*Rationale:* Locks the harness axis in lockstep with sidecar bumps; mirrors #147's parallel history v1→v2 bump (DEC-012 of #147). Avoids a tiny follow-up immediately before #153 needs `trend` to refuse mixed-harness history.
+
+**DEC-006 — `IterationRecord.harness: str = "claude-code"` and `AuditAggregate.harness: str = "claude-code"` (DEC-S4=A).**
+*Rationale:* Mirrors `provider: str = "anthropic"` from #147. Default keeps legacy-default-on-read semantics consistent. Production record-builder sites still pass it explicitly (per #147 precedent).
+
+**DEC-007 — Audit grouping key widens from `(provider, layer, id)` to `(harness, provider, layer, id)` 4-tuple.**
+*Rationale:* Honest grouping per ticket. Same `id` under different harnesses produces two distinct `AuditAggregate` buckets; this is the load-bearing test. Five downstream consumers (apply_thresholds + three renderers + the dataclass field add) are all reachable in one synchronized PR.
+
+**DEC-008 — L1 audit row shows `harness` real, `provider` "—" placeholder (DEC-S5=A).**
+*Rationale:* L1 makes no LLM call — provider is genuinely "no value." The em-dash placeholder cell preserves the column structure in markdown/stdout tables (rendering invariant: every column appears on every row regardless of layer). For audit JSON output (post-DEC-A2 v3), L1 entries emit `"provider": "anthropic"` (the placeholder per #147 DEC-002 stays unchanged) AND `"harness": <real>` from the v2 sidecar.
+
+**DEC-009 — Audit-table column order: `HARNESS | PROVIDER | LAYER | ID | ...` (DEC-A1=A).**
+*Rationale:* Matches the grouping-key tuple order. Harness is the higher-level dispatch axis (it determines which provider's data even exists for a given run).
+
+**DEC-010 — Audit JSON output (`render_json`) bumps `schema_version: 2` → `3` (DEC-A2=A).** Adds top-level `harnesses_seen[]` array (sibling to existing `providers_seen[]`). Each `assertions[]` entry gains a `"harness": str` field.
+*Rationale:* Audit's own JSON is a separate schema from the sidecars it aggregates. Mirrors the #147 audit JSON v1→v2 bump exactly.
+
+**DEC-011 — Pytest fixtures auto-populate `harness` from `EvalSpec.harness` resolution (DEC-S6=A).**
+*Rationale:* `clauditor_grader` and `clauditor_blind_compare` fixtures resolve provider via `_resolve_fixture_provider` (post-#162); harness mirrors the same shape via the resolver from #151. Fixture callers don't have to think about it.
+
+**DEC-012 — Strict documentation footprint (DEC-A3=A).** Two doc updates only:
+- `.claude/rules/json-schema-version.md` — new section "Schema version bumps for #152" (parallel to existing "#86" and "#147" sections); documents per-file bumps and the `harnesses_seen[]` audit JSON addition.
+- `docs/cli-reference.md` — one sentence on `audit` describing the new HARNESS column and the v3 audit JSON output (line ~473 already namedrops #152, expand it).
+
+No README change; `docs/audit-reference.md` does not exist.
+
+**DEC-013 — Schema-bump isolation: extract `assertions.json` writer into a tiny dataclass (DEC-internal).**
+*Rationale (architectural pre-flight):* `assertions.json` is currently inline-built in `_write_assertions_sidecar` (cli/grade.py:876–941). Bumping it to v2 via inline edits is fine for one bump, but the field will be re-bumped in #154 (sandbox-mode/system-prompt-source) and possibly again. Per `pure-compute-vs-io-split.md`'s "json-schema-version anchor", the writers that own `schema_version` should be a `to_json` method on a dataclass. **Decision: DEFER the dataclass extraction; bump v1→v2 in-place as inline JSON.** Rationale to defer: in-place is one PR; extraction is a separate refactor that doesn't change wire behavior, and the inline shape is small enough to bump again next time. Track as a follow-up issue if #154 also touches it.
+
+**DEC-014 — `BlindReport` is OUT of scope for #152.**
+*Rationale:* `compare --blind` takes two pre-captured outputs as inputs (no skill execution at judge time → no harness axis). The harness that produced each captured output is recorded in *that capture's own sidecars*, not on the blind-judge result. Separately, `BlindReport.to_json` at `quality_grader.py:270` is still at `schema_version: 1` and deliberately does not serialize `provider_source` (line 260 comment); that is a #147 follow-up gap — also out of scope here.
+
+### Schema-version table (target state after #152)
+
+| Artifact | Current (dev) | After #152 | Touched by #152 |
+|---|---|---|---|
+| `assertions.json` | v1 | **v2** | yes — adds top-level `harness` |
+| `extraction.json` | v3 | **v4** | yes — adds `harness` sibling to `provider_source` |
+| `grading.json` | v3 | **v4** | yes — adds `harness` sibling to `provider_source` |
+| `history.jsonl` | v2 | **v3** | yes — adds top-level `harness`; mandatory `harness=` keyword on `append_record` |
+| audit `render_json` output | v2 | **v3** | yes — adds top-level `harnesses_seen[]` + per-entry `harness` |
+| `BlindReport` JSON | v1 | (stays v1) | NO — no harness axis at blind-judge time |
+
+`MAX_SCHEMA_VERSION` map post-#152: `{"assertions.json": 2, "extraction.json": 4, "grading.json": 4}`.
+
+`history.py` post-#152: `SCHEMA_VERSION = 3`, `_ACCEPTED_SCHEMA_VERSIONS = frozenset({1, 2, 3})`.
+
+## Open questions (none)
+
+All blockers and concerns resolved.
+
+## Detailed breakdown — stories
+
+Validation command per `CLAUDE.md`: `uv run ruff check src/ tests/ && uv run pytest --cov=clauditor --cov-report=term-missing`. Every story's "Acceptance Criteria" includes a clean run of this command.
+
+---
+
+### US-001 — `SkillResult.harness: str` field + populate at runner construction
+
+**Description.** Add a `harness: str` field to `SkillResult` and populate it from the active runner's `harness.name` ClassVar at the point `SkillResult` is constructed in `SkillRunner._invoke` / `SkillRunner.run`. This is the foundation: every sidecar emitter downstream reads `result.harness` to get the value to stamp.
+
+**Traces to:** DEC-002.
+
+**Files:**
+- `src/clauditor/runner.py` — add `harness: str` field to `SkillResult` dataclass (lines 54–101); populate in `SkillRunner._invoke` (or wherever `SkillResult(...)` is constructed) by reading `self.harness.name` per `harness-protocol-shape.md`.
+- Update the "runtime-only — do not serialize" comment at line 69 to clarify that `harness` is an adopted-for-sidecar field, distinct from observation-only fields (`api_key_source`, `harness_metadata`).
+
+**TDD:**
+- `tests/test_runner.py::TestSkillResult::test_harness_field_present_with_default` — direct dataclass construction; default `"claude-code"`.
+- `tests/test_runner.py::TestSkillRunner::test_invoke_populates_harness_from_active_harness` — uses `MockHarness` (name="mock") via `SkillRunner(harness=MockHarness(...))`; `SkillResult.harness == "mock"`.
+- `tests/test_runner.py::TestSkillRunner::test_invoke_populates_harness_claude_code_default` — default `ClaudeCodeHarness` produces `result.harness == "claude-code"`.
+
+**Acceptance criteria:**
+- `SkillResult.harness: str` exists with default `"claude-code"`.
+- After any `SkillRunner.run`/`_invoke` call, `result.harness == runner.harness.name`.
+- `uv run ruff check src/ tests/ && uv run pytest --cov=clauditor --cov-report=term-missing` passes (≥80% coverage).
+
+**Done when:** All three TDD tests pass; existing tests still pass (no `SkillResult(...)` direct constructions break — default kwarg keeps them green).
+
+**Depends on:** none (foundation).
+
+---
+
+### US-002 — `assertions.json` v1 → v2 with top-level `harness` field
+
+**Description.** Bump the inline-built `assertions.json` writer to `schema_version: 2`, adding a top-level `harness` field. Thread the value from the `SkillResult.harness` field (US-001) at the call site.
+
+**Traces to:** DEC-003, DEC-006 (sidecar wire-format), DEC-013.
+
+**Files:**
+- `src/clauditor/cli/grade.py::_write_assertions_sidecar` (lines 876–941) — accept new `harness: str` parameter; stamp `"schema_version": 2` (line 930) and add top-level `"harness": harness` key (canonical key order: `schema_version`, `harness`, then existing fields).
+- Call site at `cli/grade.py:789` (inside `_grade_primary_arm`) — pass `harness=result.harness` (or equivalent, post-US-001).
+- `src/clauditor/audit.py::MAX_SCHEMA_VERSION` — bump `"assertions.json"` from `1` to `2` (lines 52–56). Loader behavior is forward-compat; no other audit changes here (US-005 owns the record-builder default-on-read).
+
+**TDD:**
+- `tests/test_cli_grade.py::TestWriteAssertionsSidecar::test_emits_schema_version_2` — stamps v2 first key.
+- `tests/test_cli_grade.py::TestWriteAssertionsSidecar::test_includes_harness_field` — top-level `harness` from caller value.
+- `tests/test_cli_grade.py::TestWriteAssertionsSidecar::test_harness_passed_through_unchanged` — caller passes `"codex"`, payload stamps `"codex"`.
+
+**Acceptance criteria:**
+- `assertions.json` payload starts with `{"schema_version": 2, "harness": "<name>", ...}`.
+- `MAX_SCHEMA_VERSION["assertions.json"] == 2`.
+- All `tests/test_audit.py` v1 fixture sites updated (4 sites: `93,115,129,264`) — either bumped to v2-with-harness or kept as v1 to assert legacy default-on-read (split decision in test).
+- `tests/test_cli_auth_guard.py:181` and `tests/test_cli_lint.py:504` — bumped to v2 OR refactored to test legacy default explicitly.
+- Validation command passes.
+
+**Done when:** All three TDD tests pass; `_grade_primary_arm` integration test still emits assertions.json successfully end-to-end.
+
+**Depends on:** US-001.
+
+---
+
+### US-003 — `ExtractionReport` v3 → v4 with `harness` field
+
+**Description.** Add `harness: str = "claude-code"` field to `ExtractionReport`; bump `to_json` to v4; extend `from_json` to accept v1/v2/v3/v4 with default-on-read for missing `harness`. Orchestrator-side: `extract_and_grade` / `extract_and_report` pass `harness=skill_result.harness` to the report constructor.
+
+**Traces to:** DEC-004, DEC-006.
+
+**Files:**
+- `src/clauditor/grader.py::ExtractionReport` (lines 86–145) — add `harness: str = "claude-code"` field after `provider_source`.
+- `ExtractionReport.to_json` (lines 153–185) — emit `"schema_version": 4` (was 3) and `"harness": self.harness` field (place after `provider_source` to mirror provider sibling).
+- `ExtractionReport.from_json` (lines 188–227) — add v4 branch reading `harness`; v1/v2/v3 reads default missing `harness` to `"claude-code"`.
+- `src/clauditor/audit.py::MAX_SCHEMA_VERSION` — bump `"extraction.json"` from `3` to `4`.
+- `extract_and_grade` / `extract_and_report` orchestrators in `grader.py` — pass `harness=skill_result.harness` to `ExtractionReport(...)` construction.
+
+**TDD:**
+- `tests/test_grader.py::TestExtractionReport::test_to_json_emits_v4_with_harness`.
+- `tests/test_grader.py::TestExtractionReport::test_from_json_v4_round_trip`.
+- `tests/test_grader.py::TestExtractionReport::test_from_json_v3_defaults_harness_to_claude_code`.
+- `tests/test_grader.py::TestExtractionReport::test_from_json_v1_v2_legacy_still_load`.
+
+**Acceptance criteria:**
+- `ExtractionReport.to_json()` first key `schema_version: 4`; includes `"harness": ...`.
+- v3 sidecar (no harness) round-trips through `from_json` with `report.harness == "claude-code"`.
+- `MAX_SCHEMA_VERSION["extraction.json"] == 4`.
+- Existing v3 round-trip tests at `tests/test_grader.py:1648,1819` updated to v4 or split into legacy reads.
+- Validation command passes.
+
+**Done when:** All four TDD tests pass; orchestrator tests for `extract_and_*` produce a report with non-empty `harness`.
+
+**Depends on:** US-001.
+
+---
+
+### US-004 — `GradingReport` v3 → v4 with `harness` field
+
+**Description.** Same shape as US-003, mirrored on `GradingReport`.
+
+**Traces to:** DEC-004, DEC-006.
+
+**Files:**
+- `src/clauditor/quality_grader.py::GradingReport` (lines 75–104) — add `harness: str = "claude-code"`.
+- `GradingReport.to_json` (lines 129–168) — emit `"schema_version": 4` and `"harness"` field after `provider_source`.
+- `GradingReport.from_json` (lines 171–209) — v4 branch + v1/v2/v3 default-on-read for missing `harness`.
+- `src/clauditor/audit.py::MAX_SCHEMA_VERSION` — bump `"grading.json"` from `3` to `4`.
+- `grade_quality` orchestrator in `quality_grader.py` — pass `harness=skill_result.harness` to `GradingReport(...)`.
+
+**TDD:**
+- `tests/test_quality_grader.py::TestGradingReport::test_to_json_emits_v4_with_harness`.
+- `tests/test_quality_grader.py::TestGradingReport::test_from_json_v4_round_trip`.
+- `tests/test_quality_grader.py::TestGradingReport::test_from_json_v3_defaults_harness_to_claude_code`.
+- `tests/test_quality_grader.py::TestGradingReport::test_from_json_v1_v2_legacy_still_load`.
+
+**Acceptance criteria:**
+- `GradingReport.to_json()` first key `schema_version: 4`; includes `"harness"`.
+- v3 sidecar round-trips with default `harness="claude-code"`.
+- `MAX_SCHEMA_VERSION["grading.json"] == 4`.
+- Existing v3 tests at `tests/test_quality_grader.py:360,404,483` updated.
+- Validation command passes.
+
+**Done when:** All four TDD tests pass; `grade_quality` orchestrator tests produce a report with non-empty `harness`.
+
+**Depends on:** US-001.
+
+---
+
+### US-005 — Audit `IterationRecord` + `AuditAggregate` `harness` field; grouping key widened to 4-tuple
+
+**Description.** Add `harness: str = "claude-code"` to `IterationRecord` and `AuditAggregate`. Widen `aggregate()`'s grouping key from `(provider, layer, id)` to `(harness, provider, layer, id)`. Update `_records_from_assertions` (read v2 sidecar's harness; default "claude-code" for v1), `_records_from_extraction` and `_records_from_grading` (read v4 sidecars' harness; default for v1/v2/v3). Update `apply_thresholds` to consume the 4-tuple key.
+
+**Traces to:** DEC-006, DEC-007, DEC-008.
+
+**Files:**
+- `src/clauditor/audit.py::IterationRecord` (lines 157–177) — add `harness: str = "claude-code"`.
+- `src/clauditor/audit.py::AuditAggregate` (lines 180–198) — add `harness: str = "claude-code"`.
+- `_records_from_assertions` (lines 242–276) — read `data.get("harness", "claude-code")`; pass into `IterationRecord(harness=...)`.
+- `_records_from_extraction` (lines 279–313) — read `data.get("harness", "claude-code")`.
+- `_records_from_grading` (lines 316–353) — read `data.get("harness", "claude-code")`.
+- `aggregate()` (lines 445–509) — change grouping key from 3-tuple to 4-tuple `(harness, provider, layer, id)` (line 463).
+- `apply_thresholds` and any other consumer of the aggregate dict's keys — adapt to 4-tuple (~5 sites total per architecture review).
+
+**TDD:**
+- `tests/test_audit.py::TestAggregate::test_grouping_splits_on_harness` — same `(provider, layer, id)` under different harnesses produces TWO distinct `AuditAggregate` buckets (load-bearing).
+- `tests/test_audit.py::TestRecordsFromAssertions::test_reads_harness_from_v2_sidecar`.
+- `tests/test_audit.py::TestRecordsFromAssertions::test_defaults_harness_for_v1_legacy`.
+- `tests/test_audit.py::TestRecordsFromExtraction::test_reads_harness_from_v4_sidecar` + legacy default sibling.
+- `tests/test_audit.py::TestRecordsFromGrading::test_reads_harness_from_v4_sidecar` + legacy default sibling.
+- `tests/test_audit.py::TestApplyThresholds::test_handles_four_tuple_keys` — function still works after key widening.
+
+**Acceptance criteria:**
+- `IterationRecord.harness` and `AuditAggregate.harness` exist with default `"claude-code"`.
+- Aggregate grouping key is 4-tuple `(harness, provider, layer, id)`.
+- Records from v1/v2/v3 legacy sidecars default `harness="claude-code"`.
+- All existing 3-tuple-iteration tests in `test_audit.py` (~5 sites near lines 313–335) updated to 4-tuple.
+- Validation command passes.
+
+**Done when:** Load-bearing grouping-split test passes; all `_records_from_*` default-on-read tests pass.
+
+**Depends on:** US-002, US-003, US-004.
+
+---
+
+### US-006 — Audit renderers: HARNESS column + audit JSON v3 with `harnesses_seen[]`
+
+**Description.** Update `render_stdout_table`, `render_markdown`, and `render_json` to surface the harness dimension. Column order leftmost: `HARNESS | PROVIDER | LAYER | ID | ...` (DEC-009). For L1 rows, the provider cell renders as `"—"` em-dash placeholder (DEC-008). The audit's own JSON output schema bumps from `2` to `3` and gains a top-level `harnesses_seen[]` array sibling to the existing `providers_seen[]` (DEC-010).
+
+**Traces to:** DEC-008, DEC-009, DEC-010.
+
+**Files:**
+- `src/clauditor/audit.py::render_stdout_table` (lines 670–689) — add `HARNESS` column leftmost; render L1 provider as `"—"`.
+- `src/clauditor/audit.py::render_markdown` (lines 692–773) — add `harness` column to per-layer detail tables; same `"—"` for L1 provider.
+- `src/clauditor/audit.py::render_json` (line 814) — bump `schema_version` from `2` to `3`; add top-level `harnesses_seen: list[str]` (sorted, deduped); each `assertions[]` entry gains `"harness": str` field.
+
+**TDD:**
+- `tests/test_audit.py::TestRenderStdoutTable::test_includes_harness_column_leftmost`.
+- `tests/test_audit.py::TestRenderStdoutTable::test_l1_row_shows_em_dash_for_provider`.
+- `tests/test_audit.py::TestRenderMarkdown::test_per_layer_table_includes_harness_column`.
+- `tests/test_audit.py::TestRenderJson::test_schema_version_3`.
+- `tests/test_audit.py::TestRenderJson::test_includes_harnesses_seen_array`.
+- `tests/test_audit.py::TestRenderJson::test_per_entry_harness_field`.
+
+**Acceptance criteria:**
+- All three renderers emit a HARNESS column / field.
+- `render_json()` first key is `schema_version: 3`; top-level `harnesses_seen` populated.
+- L1 stdout/markdown rows show `"—"` (em-dash) in provider column.
+- Validation command passes.
+
+**Done when:** All six TDD tests pass; existing renderer tests updated to handle the new column.
+
+**Depends on:** US-005.
+
+---
+
+### US-007 — `history.jsonl` v2 → v3: `harness` field; mandatory `harness=` keyword on `append_record`
+
+**Description.** Bump `history.py::SCHEMA_VERSION` to `3`; widen `_ACCEPTED_SCHEMA_VERSIONS` to `{1, 2, 3}`. Add `harness: str` as a mandatory keyword-only parameter on `append_record` (mirrors the post-#147 `provider=` mandatory-keyword pattern). Update production call sites in `cli/grade.py` and `cli/extract.py` (and any others discovered) to pass the resolved harness name. `read_records` defaults missing `harness` to `"claude-code"` for v1/v2 reads.
+
+**Traces to:** DEC-005.
+
+**Files:**
+- `src/clauditor/history.py::SCHEMA_VERSION` — `2` → `3`.
+- `src/clauditor/history.py::_ACCEPTED_SCHEMA_VERSIONS` — `frozenset({1, 2})` → `frozenset({1, 2, 3})`.
+- `src/clauditor/history.py::append_record` (lines 127–197) — add mandatory keyword-only `harness: str`; reject blank/whitespace-only; reject `"auto"` (mirroring provider validation); add `"harness": harness` to the record template (lines 181–192).
+- `src/clauditor/history.py::read_records` — when reading v1/v2 records, default missing `harness` to `"claude-code"`.
+- Production call sites — every `append_record(...)` in `src/` gains `harness=harness_name`. Per architecture review there are 3 production sites; update each.
+
+**TDD:**
+- `tests/test_history.py::TestAppendRecord::test_v3_writes_harness_field`.
+- `tests/test_history.py::TestAppendRecord::test_harness_keyword_required` — missing `harness=` raises `TypeError`.
+- `tests/test_history.py::TestAppendRecord::test_harness_blank_rejected`.
+- `tests/test_history.py::TestAppendRecord::test_harness_auto_rejected`.
+- `tests/test_history.py::TestReadRecords::test_v2_legacy_defaults_harness_to_claude_code`.
+- `tests/test_history.py::TestReadRecords::test_v3_round_trip`.
+
+**Acceptance criteria:**
+- `SCHEMA_VERSION == 3`; `_ACCEPTED_SCHEMA_VERSIONS == {1, 2, 3}`.
+- v3 record contains `"harness": <name>`.
+- v1/v2 reads default `harness="claude-code"` per record.
+- All ~51 test-side `append_record` call sites compile (mostly auto-resolve via `harness=` default in fixtures, or explicit pass at integration sites).
+- Validation command passes.
+
+**Done when:** All six TDD tests pass; integration tests for `cli grade` / `cli extract` still write history end-to-end.
+
+**Depends on:** US-001 (call sites need a resolved harness name; #151 already provides resolution at the CLI seam).
+
+---
+
+### US-008 — Pytest fixtures auto-populate `harness`
+
+**Description.** The grader-related fixtures (`clauditor_grader`, `clauditor_triggers`) auto-populate `harness` from `EvalSpec.harness` resolution, mirroring the post-#162 provider flow. `clauditor_blind_compare` is unaffected (no harness axis at blind-judge time per DEC-014).
+
+**Traces to:** DEC-011.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py::clauditor_grader` factory — resolve harness from `eval_spec.harness` (use the same resolver path the CLI uses); thread into `spec.run(harness_name_override=...)` and into the resulting `GradingReport`.
+- `src/clauditor/pytest_plugin.py::clauditor_triggers` factory — same.
+- `clauditor_blind_compare` — verify no change needed.
+
+**TDD:**
+- `tests/test_pytest_plugin.py::TestClauditorGrader::test_uses_harness_from_eval_spec`.
+- `tests/test_pytest_plugin.py::TestClauditorGrader::test_defaults_harness_to_claude_code_when_eval_spec_unset`.
+- `tests/test_pytest_plugin.py::TestClauditorTriggers::test_uses_harness_from_eval_spec`.
+
+**Acceptance criteria:**
+- Fixture-produced `GradingReport.harness` reflects the spec's resolved harness.
+- No fixture-caller code changes required for default `"claude-code"` behavior.
+- Validation command passes.
+
+**Done when:** All three TDD tests pass.
+
+**Depends on:** US-001, US-004.
+
+---
+
+### US-009 — Documentation: rule + cli-reference updates
+
+**Description.** Add a "Schema version bumps for #152" section to `.claude/rules/json-schema-version.md` documenting the per-file bumps (assertions 1→2, extraction 3→4, grading 3→4, history 2→3, audit `render_json` 2→3) and the `harnesses_seen[]` audit-output addition. Update the existing namedrop of #152 in `docs/cli-reference.md:473` to a sentence describing the HARNESS column and the v3 audit JSON shape.
+
+**Traces to:** DEC-012.
+
+**Files:**
+- `.claude/rules/json-schema-version.md` — append new "Schema version bumps for #152" section after the existing #147 section. Document each of the five bumps + the `MAX_SCHEMA_VERSION` map updates + L1 placeholder inversion (harness real, provider "—") + audit JSON v3 shape.
+- `docs/cli-reference.md` — at line ~473 (the audit subsection), expand the namedrop to a sentence: "L1 audit rows now show a real HARNESS value (sourced from `assertions.json` v2) alongside the existing PROVIDER column, which renders as '—' for L1 rows since L1 makes no LLM call."
+
+**TDD:** Not applicable (text-only).
+
+**Acceptance criteria:**
+- New rule section exists with all five bumps documented; cross-links to canonical implementations.
+- `cli-reference.md` audit section reads cleanly post-update.
+- `tests/test_bundled_skill.py` doesn't regress (the bundled skill SKILL.md doesn't reference these docs directly).
+- Validation command passes (doc edits are markdown; ruff/pytest still green).
+
+**Done when:** Both files updated; no markdown formatting regressions.
+
+**Depends on:** US-001 through US-008 (doc reflects the implemented behavior).
+
+---
+
+### Quality Gate
+
+**Description.** Run code-reviewer four times across the full changeset (each pass fixes any real bugs found); run CodeRabbit if available. The full validation command must pass after all fixes.
+
+**Files:** Any file flagged by review; tests.
+
+**Acceptance criteria:**
+- Four code-reviewer passes complete with no remaining real bugs.
+- CodeRabbit pass complete with no remaining real bugs.
+- `uv run ruff check src/ tests/ && uv run pytest --cov=clauditor --cov-report=term-missing` passes ≥80% coverage.
+- All changes committed.
+
+**Done when:** All gates green; no outstanding review findings.
+
+**Depends on:** US-001 through US-009.
+
+---
+
+### Patterns & Memory
+
+**Description.** Update `.claude/rules/` and memory with patterns learned. Likely candidates:
+- `json-schema-version.md` — already updated by US-009; verify the rule's "Canonical implementation" section names the new code anchors (US-002–US-007).
+- Consider whether the "harness adopted-for-sidecar field on `SkillResult`" pattern deserves a note (small enough to fold into `harness-protocol-shape.md` rather than a new rule).
+- Memory: any session-level insights worth persisting (probably none — this is a structural mirror of #147).
+
+**Files:** `.claude/rules/*.md`, `~/.claude/projects/.../memory/*.md` if applicable.
+
+**Acceptance criteria:**
+- Rules updated to reflect new canonical implementation anchors for #152.
+- No new rule files created unless a genuinely new pattern emerged.
+- All changes committed.
+
+**Done when:** Rules accurately point at #152's code; rule-refresh discipline (per `.claude/rules/rule-refresh-vs-delete.md`) honored.
+
+**Depends on:** Quality Gate.

--- a/plans/super/152-sidecar-harness-field.md
+++ b/plans/super/152-sidecar-harness-field.md
@@ -112,7 +112,7 @@ No `workflow-project.md` exists.
 
 ### #147 canonical pattern to mirror
 
-#147's structural moves that #152 will replay:
+Issue #147's structural moves that #152 will replay:
 - **DEC-001 (field naming)** — `provider_source` was the on-disk byte-identical field name. For #152 the field is just `harness` (no `_source` suffix; harness identity is materialized by #151, not a "source" choice the user makes mid-call).
 - **DEC-002 (L1 placeholder)** — #147 left L1 at v1 with `IterationRecord.provider="anthropic"` placeholder. #152 inverts this: assertions.json bumps to v2 because L1 *can* be honestly stamped (the harness ran the skill that produced the output being asserted on). After #152, the L1 placeholder for `provider` remains (no LLM call) but `harness` is real.
 - **DEC-008 (MAX_SCHEMA_VERSION map)** — already in place; #152 is a one-number-per-file edit.

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -700,15 +700,23 @@ def _fmt_disc(value: float | None) -> str:
 
 
 def _sorted_verdicts(verdicts: list[AuditVerdict]) -> list[AuditVerdict]:
-    """Sort verdicts by ``(provider, layer, id)`` for stable rendering.
+    """Sort verdicts by ``(harness, provider, layer, id)`` for stable rendering.
 
     DEC-004 (#147): all three render paths share the same sort order so
     a reader scanning ``stdout`` / markdown / JSON in succession sees
     rows in the same sequence. ``apply_thresholds`` already returns
     verdicts in this order today, but renderers re-sort defensively in
     case a caller hands in a list constructed differently.
+
+    US-006 (#152): widened the sort key to include ``harness`` (first)
+    so mixed-harness audits render all-claude-code rows before
+    all-codex rows; within a harness, the existing ``(provider, layer,
+    id)`` ordering preserves pre-#152 row sequence for single-harness
+    audits.
     """
-    return sorted(verdicts, key=lambda v: (v.provider, v.layer, v.id))
+    return sorted(
+        verdicts, key=lambda v: (v.harness, v.provider, v.layer, v.id)
+    )
 
 
 def _providers_seen(verdicts: list[AuditVerdict]) -> list[str]:
@@ -721,23 +729,54 @@ def _providers_seen(verdicts: list[AuditVerdict]) -> list[str]:
     return sorted({v.provider for v in verdicts})
 
 
-def render_stdout_table(verdicts: list[AuditVerdict]) -> str:
-    """Compact table: provider, layer, id, with%, verdict.
+def _harnesses_seen(verdicts: list[AuditVerdict]) -> list[str]:
+    """Return the sorted list of distinct harnesses across ``verdicts``.
 
-    DEC-004 (#147): leftmost ``PROVIDER`` column (~11 chars wide) so a
-    mixed-provider audit shows which provider's SDK produced each
-    grouped result. Sort order: ``(provider, layer, id)``.
+    DEC-010 (#152): the audit-output JSON v3 carries a top-level
+    ``harnesses_seen`` array (sibling to ``providers_seen``) so JSON
+    consumers can detect mixed-harness history without iterating
+    ``assertions[]``.
+    """
+    return sorted({v.harness for v in verdicts})
+
+
+# DEC-008 (#152): em-dash (U+2014) is the stdout/markdown placeholder
+# rendered in L1 rows' PROVIDER column. L1 makes no LLM call so
+# "anthropic" is a placeholder, not a real value — the em-dash makes
+# the absence visible to humans. The on-disk JSON output keeps the
+# ``"provider": "anthropic"`` placeholder for downstream consumers
+# (semantically honest for mixed-layer aggregation).
+_L1_PROVIDER_DISPLAY = "—"
+
+
+def render_stdout_table(verdicts: list[AuditVerdict]) -> str:
+    """Compact table: harness, provider, layer, id, with%, verdict.
+
+    DEC-009 (#152): leftmost ``HARNESS`` column (~11 chars wide), then
+    ``PROVIDER`` (~11 chars wide), then layer/id/with%/verdict. Column
+    order matches the grouping-key tuple order
+    ``(harness, provider, layer, id)``.
+
+    DEC-008 (#152): L1 rows render the PROVIDER cell as ``"—"``
+    (em-dash, U+2014) since L1 makes no LLM call. L2/L3 rows render
+    the real provider value.
     """
     header = (
-        f"{'PROVIDER':<11} {'LAYER':<6} {'ID':<40} "
+        f"{'HARNESS':<11} {'PROVIDER':<11} {'LAYER':<6} {'ID':<40} "
         f"{'WITH%':>8} {'VERDICT':<24}"
     )
     lines = [header, "-" * len(header)]
     for v in _sorted_verdicts(verdicts):
         agg = v.aggregate
         with_pct = _fmt_pct(agg.with_pass_rate) if agg else "-"
+        # DEC-008: L1 PROVIDER cell shows em-dash placeholder; L2/L3
+        # render the real provider value.
+        provider_display = (
+            _L1_PROVIDER_DISPLAY if v.layer == "L1" else v.provider
+        )
         lines.append(
-            f"{v.provider[:11]:<11} {v.layer:<6} {v.id[:40]:<40} "
+            f"{v.harness[:11]:<11} {provider_display[:11]:<11} "
+            f"{v.layer:<6} {v.id[:40]:<40} "
             f"{with_pct:>8} {v.verdict.value:<24}"
         )
     return "\n".join(lines)
@@ -800,22 +839,31 @@ def render_markdown(
             lines.append("_No data._")
             lines.append("")
             continue
-        # DEC-004 (#147): leftmost ``provider`` column so mixed-provider
-        # audits show which provider's SDK produced each row.
+        # DEC-009 (#152): leftmost ``harness`` column, then ``provider``
+        # so mixed-harness/mixed-provider audits show both dimensions.
+        # DEC-008 (#152): L1 rows render provider as ``—`` (em-dash,
+        # U+2014) since L1 makes no LLM call. L2/L3 rows render the
+        # real provider value. Provider cell is NOT backtick-quoted
+        # for L1 because the em-dash is a typographic placeholder, not
+        # a code identifier.
         lines.append(
-            "| provider | id | runs | with% | baseline% | "
+            "| harness | provider | id | runs | with% | baseline% | "
             "discrimination | verdict |"
         )
         lines.append(
-            "|----------|----|------|-------|-----------|"
+            "|---------|----------|----|------|-------|-----------|"
             "----------------|---------|"
         )
         for v in layer_rows:
             agg = v.aggregate
             if agg is None:
                 continue
+            if v.layer == "L1":
+                provider_cell = _L1_PROVIDER_DISPLAY
+            else:
+                provider_cell = f"`{_md_escape(v.provider)}`"
             lines.append(
-                f"| `{_md_escape(v.provider)}` | "
+                f"| `{_md_escape(v.harness)}` | {provider_cell} | "
                 f"`{_md_escape(v.id)}` | {agg.total_with_runs} | "
                 f"{_fmt_pct(agg.with_pass_rate)} | "
                 f"{_fmt_pct(agg.baseline_pass_rate)} | "
@@ -841,8 +889,18 @@ def render_json(
     new ``provider`` field on each ``assertions[]`` entry. DEC-010
     (#147): adds a top-level ``providers_seen`` array (sorted
     alphabetically) so JSON consumers can detect mixed-provider history
-    without iterating ``assertions[]``. Sort order across ``assertions``
-    matches the stdout/markdown renderers: ``(provider, layer, id)``.
+    without iterating ``assertions[]``.
+
+    DEC-010 (#152): ``schema_version`` bumped from 2 to 3 to signal the
+    new ``harness`` field on each ``assertions[]`` entry plus the new
+    top-level ``harnesses_seen`` array (sibling to ``providers_seen``).
+    Sort order across ``assertions`` matches the stdout/markdown
+    renderers: ``(harness, provider, layer, id)``.
+
+    DEC-008 (#152): L1 entries keep ``"provider": "anthropic"``
+    placeholder in the JSON output (the em-dash is stdout/markdown
+    only) — keeps mixed-layer JSON aggregation semantically honest for
+    downstream consumers.
     """
     sorted_verdicts = _sorted_verdicts(verdicts)
     assertions_list: list[dict] = []
@@ -850,6 +908,7 @@ def render_json(
         agg = v.aggregate
         assertions_list.append(
             {
+                "harness": v.harness,
                 "provider": v.provider,
                 "layer": v.layer,
                 "id": v.id,
@@ -865,11 +924,12 @@ def render_json(
             }
         )
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "skill": skill,
         "timestamp": timestamp,
         "iterations": iterations_analyzed,
         "thresholds": dict(thresholds),
         "providers_seen": _providers_seen(verdicts),
+        "harnesses_seen": _harnesses_seen(verdicts),
         "assertions": assertions_list,
     }

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -824,8 +824,16 @@ def render_markdown(
     else:
         for v in flagged:
             reasons = "; ".join(v.reasons) if v.reasons else v.verdict.value
+            # #152 N2: include harness in the bullet so mixed-harness
+            # audits don't produce visually identical bullets for the
+            # same (layer, id) under different harnesses. Provider is
+            # included for L2/L3 only — L1's "anthropic" placeholder
+            # would just add noise.
+            head = f"{v.layer} {v.harness}"
+            if v.layer in ("L2", "L3"):
+                head = f"{head}/{v.provider}"
             lines.append(
-                f"- **{v.layer} `{_md_escape(v.id)}`** — "
+                f"- **{head} `{_md_escape(v.id)}`** — "
                 f"{_md_escape(reasons)}"
             )
     lines.append("")

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -52,7 +52,7 @@ from clauditor.paths import resolve_clauditor_dir
 MAX_SCHEMA_VERSION: dict[str, int] = {
     "assertions.json": 1,
     "extraction.json": 3,
-    "grading.json": 3,
+    "grading.json": 4,
 }
 
 

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -50,7 +50,7 @@ from clauditor.paths import resolve_clauditor_dir
 # filename rather than re-listing the accepted set. See DEC-008 in
 # ``plans/super/147-sidecar-provider-field.md``.
 MAX_SCHEMA_VERSION: dict[str, int] = {
-    "assertions.json": 1,
+    "assertions.json": 2,
     "extraction.json": 3,
     "grading.json": 3,
 }

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -104,6 +104,21 @@ def _provider_or_default(value: object) -> str:
     return "anthropic"
 
 
+def _harness_or_default(value: object) -> str:
+    """Return ``value`` when it is a non-blank ``str``, else ``"claude-code"``.
+
+    US-005 (#152): mirror of :func:`_provider_or_default` for the
+    harness axis. Defends the three ``_records_from_*`` helpers
+    against malformed v2/v4 sidecars that store ``harness`` as a
+    non-string. Defaults to ``"claude-code"`` per DEC-006 so legacy
+    v1/v2/v3 reads (with no ``harness`` field) and malformed reads
+    both produce structurally-string-typed aggregate keys.
+    """
+    if isinstance(value, str) and value.strip():
+        return value
+    return "claude-code"
+
+
 def _check_schema_version(
     data: dict, *, iteration_dir: Path | str, filename: str
 ) -> bool:
@@ -166,6 +181,14 @@ class IterationRecord:
     has no LLM call to attribute, but ``IterationRecord`` keeps a
     uniform shape across layers so audit grouping does not have to
     branch by layer.
+
+    US-005 (#152): the ``harness`` field records which harness CLI
+    produced the underlying skill output. Loaded from the v2
+    assertions / v4 grading-and-extraction sidecars' ``harness``
+    field; defaults to ``"claude-code"`` for legacy reads per DEC-006.
+    Unlike ``provider`` (which carries an ``"anthropic"`` placeholder
+    for L1), ``harness`` is real for every layer because every layer's
+    underlying skill ran through some harness.
     """
 
     iteration: int
@@ -174,17 +197,24 @@ class IterationRecord:
     passed: bool
     with_skill: bool  # True for primary, False for baseline sidecar
     provider: str = "anthropic"
+    harness: str = "claude-code"
 
 
 @dataclass
 class AuditAggregate:
-    """Aggregate pass-rate statistics for one ``(provider, layer, id)`` triple.
+    """Aggregate stats for one ``(harness, provider, layer, id)`` key.
 
-    US-003 (#147): keyed by ``(provider, layer, id)`` so mixed-provider
-    history (the same eval run under both Anthropic and OpenAI) groups
-    into separate aggregates instead of being averaged together. The
-    ``provider`` field defaults to ``"anthropic"`` to keep direct
-    constructor calls in tests working without per-test edits.
+    US-003 (#147): added the ``provider`` dimension so mixed-provider
+    history (the same eval run under both Anthropic and OpenAI)
+    groups into separate aggregates instead of being averaged
+    together.
+
+    US-005 (#152): added the ``harness`` dimension so mixed-harness
+    history (the same eval run under both Claude Code and Codex)
+    groups separately too. Aggregate dict keys are now 4-tuples
+    ``(harness, provider, layer, id)`` per DEC-007. The ``harness``
+    field defaults to ``"claude-code"`` to keep direct constructor
+    calls in tests working without per-test edits.
     """
 
     layer: str
@@ -196,6 +226,7 @@ class AuditAggregate:
     baseline_fails: int
     baseline_pass_rate: float | None
     provider: str = "anthropic"
+    harness: str = "claude-code"
 
     @property
     def discrimination(self) -> float | None:
@@ -253,11 +284,14 @@ def _records_from_assertions(
         return []
     records: list[IterationRecord] = []
     # DEC-002 (#147): L1 records carry ``provider="anthropic"`` as a
-    # placeholder. Assertions sidecars stay at schema_version=1 (no
-    # ``provider_source`` field — L1 has no LLM call to attribute), but
+    # placeholder. Assertions sidecars carry no ``provider_source``
+    # field even at v2 — L1 has no LLM call to attribute, but
     # ``IterationRecord`` keeps a uniform shape across layers so the
-    # ``aggregate()`` group key is always 3-tuple. The honest harness
-    # dimension lands in #152.
+    # ``aggregate()`` group key is always uniform.
+    # US-005 (#152): assertions.json bumped to v2 with a top-level
+    # ``harness`` field. Read it through the defensive helper; v1
+    # legacy reads default to ``"claude-code"`` per DEC-006.
+    harness = _harness_or_default(data.get("harness"))
     for run in data.get("runs", []) or []:
         for result in run.get("results", []) or []:
             rid = result.get("id")
@@ -271,6 +305,7 @@ def _records_from_assertions(
                     passed=bool(result.get("passed", False)),
                     with_skill=with_skill,
                     provider="anthropic",
+                    harness=harness,
                 )
             )
     return records
@@ -295,6 +330,9 @@ def _records_from_extraction(
     # ``1`` or ``True`` (which a malformed v3 sidecar could carry) so
     # downstream sorting/rendering never sees a non-string provider.
     provider = _provider_or_default(data.get("provider_source"))
+    # US-005 (#152): extraction.json bumped to v4 with ``harness``
+    # field; v1/v2/v3 reads default to ``"claude-code"`` per DEC-006.
+    harness = _harness_or_default(data.get("harness"))
     for field_id, entries in (data.get("fields") or {}).items():
         for entry in entries or []:
             if "passed" not in entry:
@@ -308,6 +346,7 @@ def _records_from_extraction(
                     passed=passed,
                     with_skill=with_skill,
                     provider=provider,
+                    harness=harness,
                 )
             )
     return records
@@ -331,6 +370,9 @@ def _records_from_grading(
     # ``provider_source``; v1/v2 reads default to ``"anthropic"``.
     # ``_provider_or_default`` rejects non-string truthy values.
     provider = _provider_or_default(data.get("provider_source"))
+    # US-005 (#152): grading.json bumped to v4 with ``harness`` field;
+    # v1/v2/v3 reads default to ``"claude-code"`` per DEC-006.
+    harness = _harness_or_default(data.get("harness"))
     for result in data.get("results", []) or []:
         # DEC-001 / #25: L3 results are keyed by their stable spec id.
         # Drop records missing an ``id`` entirely — falling back to the
@@ -348,6 +390,7 @@ def _records_from_grading(
                 passed=bool(result.get("passed", False)),
                 with_skill=with_skill,
                 provider=provider,
+                harness=harness,
             )
         )
     return records
@@ -444,23 +487,28 @@ def load_iterations(
 
 def aggregate(
     records: list[IterationRecord],
-) -> dict[tuple[str, str, str], AuditAggregate]:
-    """Group records by ``(provider, layer, id)`` and compute pass rates.
+) -> dict[tuple[str, str, str, str], AuditAggregate]:
+    """Group records by ``(harness, provider, layer, id)`` and compute pass rates.
 
     US-003 (#147): expanded the grouping key from ``(layer, id)`` to
-    ``(provider, layer, id)`` so mixed-provider history (the same eval
-    run under both Anthropic and OpenAI) groups separately. Pre-#147
-    history (no ``provider_source`` on disk) defaults every record's
-    provider to ``"anthropic"`` and produces a single bucket per
-    ``(layer, id)`` keyed under ``("anthropic", layer, id)``, so
-    single-provider audit reports keep their pre-#147 shape.
+    ``(provider, layer, id)`` so mixed-provider history groups
+    separately.
+
+    US-005 (#152): expanded the grouping key further to
+    ``(harness, provider, layer, id)`` so mixed-harness history (the
+    same eval run under both Claude Code and Codex) groups separately
+    too. Pre-#152 history (no ``harness`` on disk) defaults every
+    record's harness to ``"claude-code"`` and produces a single bucket
+    per ``(provider, layer, id)`` keyed under
+    ``("claude-code", provider, layer, id)``, so single-harness audit
+    reports keep their pre-#152 shape.
 
     With-skill and baseline records are tallied separately so callers
     can compare them (see :attr:`AuditAggregate.discrimination`).
     """
-    buckets: dict[tuple[str, str, str], dict[str, int]] = {}
+    buckets: dict[tuple[str, str, str, str], dict[str, int]] = {}
     for r in records:
-        key = (r.provider, r.layer, r.id)
+        key = (r.harness, r.provider, r.layer, r.id)
         bucket = buckets.setdefault(
             key,
             {
@@ -479,8 +527,8 @@ def aggregate(
             if not r.passed:
                 bucket["baseline_fails"] += 1
 
-    result: dict[tuple[str, str, str], AuditAggregate] = {}
-    for (provider, layer, rid), b in buckets.items():
+    result: dict[tuple[str, str, str, str], AuditAggregate] = {}
+    for (harness, provider, layer, rid), b in buckets.items():
         with_total = b["with_total"]
         baseline_total = b["baseline_total"]
         with_pass_rate = (
@@ -495,7 +543,7 @@ def aggregate(
             )
         else:
             baseline_pass_rate = None
-        result[(provider, layer, rid)] = AuditAggregate(
+        result[(harness, provider, layer, rid)] = AuditAggregate(
             layer=layer,
             id=rid,
             total_with_runs=with_total,
@@ -505,6 +553,7 @@ def aggregate(
             baseline_fails=b["baseline_fails"],
             baseline_pass_rate=baseline_pass_rate,
             provider=provider,
+            harness=harness,
         )
     return result
 
@@ -518,11 +567,13 @@ def aggregate(
 class AuditVerdict:
     """A threshold classification over one :class:`AuditAggregate`.
 
-    US-003 (#147): the ``provider`` field carries through from the
-    underlying :class:`AuditAggregate`'s 3-tuple key so renderers
-    (US-004) can surface the provider dimension in the audit output.
-    Defaults to ``"anthropic"`` so direct test fixture constructions
-    that predate #147 keep working without per-test edits.
+    US-003 (#147): added the ``provider`` field so renderers can
+    surface the provider dimension in the audit output.
+
+    US-005 (#152): added the ``harness`` field so renderers (US-006)
+    can surface the harness dimension. Defaults to ``"claude-code"``
+    so direct test fixture constructions that predate #152 keep
+    working without per-test edits.
     """
 
     layer: str
@@ -531,6 +582,7 @@ class AuditVerdict:
     reasons: list[str] = field(default_factory=list)
     aggregate: AuditAggregate | None = None
     provider: str = "anthropic"
+    harness: str = "claude-code"
 
     @property
     def is_flagged(self) -> bool:
@@ -538,7 +590,7 @@ class AuditVerdict:
 
 
 def apply_thresholds(
-    aggregates: dict[tuple[str, str, str], AuditAggregate],
+    aggregates: dict[tuple[str, str, str, str], AuditAggregate],
     *,
     min_fail_rate: float,
     min_discrimination: float,
@@ -564,11 +616,12 @@ def apply_thresholds(
     preserved on disk; only the verdict stream filters them out.
     """
     verdicts: list[AuditVerdict] = []
-    # US-003 (#147): unpack the 3-tuple ``(provider, layer, id)`` key
-    # produced by :func:`aggregate`. ``sorted`` orders provider first so
-    # an audit report renders all-anthropic rows across all layers
-    # before openai rows; layer/id break ties within a provider.
-    for (provider, layer, rid), agg in sorted(aggregates.items()):
+    # US-005 (#152): unpack the 4-tuple ``(harness, provider, layer,
+    # id)`` key produced by :func:`aggregate`. ``sorted`` orders
+    # harness first, then provider, then layer, then id — so an audit
+    # report renders all-claude-code rows before all-codex rows, and
+    # within a harness all-anthropic rows before openai rows.
+    for (harness, provider, layer, rid), agg in sorted(aggregates.items()):
         if agg.total_with_runs == 0:
             continue
         reasons: list[str] = []
@@ -613,6 +666,7 @@ def apply_thresholds(
                 reasons=reasons,
                 aggregate=agg,
                 provider=provider,
+                harness=harness,
             )
         )
     return verdicts

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -51,7 +51,7 @@ from clauditor.paths import resolve_clauditor_dir
 # ``plans/super/147-sidecar-provider-field.md``.
 MAX_SCHEMA_VERSION: dict[str, int] = {
     "assertions.json": 1,
-    "extraction.json": 3,
+    "extraction.json": 4,
     "grading.json": 3,
 }
 

--- a/src/clauditor/baseline.py
+++ b/src/clauditor/baseline.py
@@ -31,6 +31,7 @@ __all__ = [
 ]
 
 _SCHEMA_VERSION = 1
+_ASSERTIONS_SCHEMA_VERSION = 2  # #152 US-002: assertions.json carries `harness`
 
 
 @dataclass
@@ -71,8 +72,15 @@ class BaselineReports:
         files["baseline.json"] = json.dumps(meta, indent=2) + "\n"
 
         # baseline_assertions.json — Layer 1
+        # #152 US-002 / B2: bump v1 -> v2 with top-level harness so the
+        # baseline arm of `clauditor grade --baseline --harness codex`
+        # records the codex baseline output honestly. Without this the
+        # audit reader's `_harness_or_default` would silently default
+        # the missing field to "claude-code" and group codex baseline
+        # data under the wrong harness key.
         assertions_payload = {
-            "schema_version": _SCHEMA_VERSION,
+            "schema_version": _ASSERTIONS_SCHEMA_VERSION,
+            "harness": self.skill_result.harness,
             "skill": self.skill_name,
             "iteration": self.iteration,
             **self.assertion_set.to_json(),

--- a/src/clauditor/baseline.py
+++ b/src/clauditor/baseline.py
@@ -128,6 +128,7 @@ def compute_baseline(
                 eval_spec,
                 skill_name=skill_name,
                 provider=provider,
+                harness=skill_result.harness,
             )
         )
 

--- a/src/clauditor/baseline.py
+++ b/src/clauditor/baseline.py
@@ -139,6 +139,7 @@ def compute_baseline(
             model,
             thresholds=eval_spec.grade_thresholds,
             provider=provider,
+            harness=skill_result.harness,
         )
     )
 

--- a/src/clauditor/cli/__init__.py
+++ b/src/clauditor/cli/__init__.py
@@ -336,6 +336,7 @@ def _append_validate_history(
     skill_result: SkillResult | None,
     iteration: int | None,
     workspace_path: str | None,
+    harness_name: str | None = None,
 ) -> None:
     """Append a ``command="validate"`` row to ``history.jsonl``.
 
@@ -343,6 +344,12 @@ def _append_validate_history(
     so failed live validates stay visible to trend/audit tooling. On the
     failure path ``iteration`` / ``workspace_path`` are ``None`` (the
     workspace was aborted) and ``pass_rate`` is ``0.0``.
+
+    ``harness_name`` is the resolved skill harness (``"claude-code"`` or
+    ``"codex"``) per #152 DEC-005. When ``None``, falls back to
+    ``skill_result.harness`` (US-001) and finally to ``"claude-code"``
+    so non-live-run paths still produce a record with a concrete
+    harness value.
     """
     from clauditor.metrics import TokenUsage, build_metrics
 
@@ -355,6 +362,12 @@ def _append_validate_history(
         skill=skill_tokens,
         duration_seconds=skill_duration,
     )
+    if harness_name is None:
+        harness_name = (
+            getattr(skill_result, "harness", "claude-code")
+            if skill_result is not None
+            else "claude-code"
+        )
     try:
         history.append_record(
             skill=skill_name,
@@ -368,6 +381,7 @@ def _append_validate_history(
             # placeholder per #147 DEC-002 / DEC-012 so history records
             # carry a valid value downstream consumers can group on.
             provider="anthropic",
+            harness=harness_name,
             iteration=iteration,
             workspace_path=workspace_path,
         )

--- a/src/clauditor/cli/extract.py
+++ b/src/clauditor/cli/extract.py
@@ -234,6 +234,18 @@ def cmd_extract(args: argparse.Namespace) -> int:
         duration_seconds=skill_duration,
         grader=grader_tokens,
     )
+    # #152 US-007: ``harness`` is a mandatory keyword on
+    # ``append_record``. When the skill ran live (no ``--output``), read
+    # the harness off the ``SkillResult`` populated by US-001. When the
+    # output was pre-captured, fall back to ``"claude-code"`` (the
+    # default harness) since the captured file carries no harness
+    # provenance and downstream consumers rely on a guaranteed-present
+    # value.
+    harness_name = (
+        getattr(skill_result, "harness", "claude-code")
+        if skill_result is not None
+        else "claude-code"
+    )
     try:
         history.append_record(
             skill=spec.skill_name,
@@ -242,6 +254,7 @@ def cmd_extract(args: argparse.Namespace) -> int:
             metrics=metrics_dict,
             command="extract",
             provider=provider,
+            harness=harness_name,
         )
     except Exception as e:  # pragma: no cover - defensive
         print(f"WARNING: failed to append history: {e}", file=sys.stderr)

--- a/src/clauditor/cli/extract.py
+++ b/src/clauditor/cli/extract.py
@@ -237,15 +237,20 @@ def cmd_extract(args: argparse.Namespace) -> int:
     # #152 US-007: ``harness`` is a mandatory keyword on
     # ``append_record``. When the skill ran live (no ``--output``), read
     # the harness off the ``SkillResult`` populated by US-001. When the
-    # output was pre-captured, fall back to ``"claude-code"`` (the
-    # default harness) since the captured file carries no harness
-    # provenance and downstream consumers rely on a guaranteed-present
-    # value.
-    harness_name = (
-        getattr(skill_result, "harness", "claude-code")
-        if skill_result is not None
-        else "claude-code"
-    )
+    # output was pre-captured, use ``eval_spec.harness`` when it pins a
+    # concrete harness (not ``"auto"``), otherwise fall back to
+    # ``"claude-code"`` (the default). The spec field is the best
+    # available signal for pre-captured output; the captured file itself
+    # carries no harness provenance.
+    if skill_result is not None:
+        harness_name = getattr(skill_result, "harness", "claude-code")
+    elif (
+        spec.eval_spec is not None
+        and spec.eval_spec.harness not in ("auto", None)
+    ):
+        harness_name = spec.eval_spec.harness
+    else:
+        harness_name = "claude-code"
     try:
         history.append_record(
             skill=spec.skill_name,

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -1366,6 +1366,7 @@ def _cmd_grade_with_workspace(
         benchmark=benchmark,
         metrics_dict=metrics_dict,
         provider=provider,
+        harness_name=harness_name,
     )
 
     # Determine exit code
@@ -1392,6 +1393,7 @@ def _report_grade_to_user(
     benchmark: Benchmark | None,
     metrics_dict: dict,
     provider: str,
+    harness_name: str | None,
 ) -> None:
     """Emit the grade report, diff/baseline delta blocks, and history row.
 
@@ -1434,6 +1436,7 @@ def _report_grade_to_user(
             primary_report=primary_report,
             metrics_dict=metrics_dict,
             provider=provider,
+            harness_name=harness_name,
         )
 
 
@@ -1573,12 +1576,19 @@ def _append_grade_history_record(
     primary_report: GradingReport,
     metrics_dict: dict,
     provider: str,
+    harness_name: str | None,
 ) -> None:
     """Append a ``command="grade"`` row to ``history.jsonl`` (US-006).
 
     ``provider`` is the resolved grading provider (``"anthropic"`` or
     ``"openai"``) per #147 DEC-012; threaded down from ``cmd_grade``'s
     four-layer ``_resolve_grading_provider`` resolution.
+
+    ``harness_name`` is the resolved skill harness (``"claude-code"`` or
+    ``"codex"``) per #152 DEC-005; threaded down from ``cmd_grade``'s
+    ``_resolve_harness`` call. ``None`` collapses to ``"claude-code"``
+    (the default harness) so non-live-run paths still produce a record
+    with a concrete harness value.
     """
     from clauditor.cli import _relative_to_repo
 
@@ -1591,6 +1601,7 @@ def _append_grade_history_record(
             metrics=metrics_dict,
             command="grade",
             provider=provider,
+            harness=harness_name or "claude-code",
             iteration=workspace.iteration,
             workspace_path=workspace_rel,
         )

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -797,6 +797,17 @@ def _write_workspace_sidecars(
     )
 
     if spec.eval_spec.sections:
+        # #152 US-003: pass the harness that produced the underlying
+        # skill output so the sidecar honestly records which harness
+        # produced the text being extracted. Falls back to
+        # ``"claude-code"`` (the ``ExtractionReport.harness`` default)
+        # for ``--output`` mode where every entry of
+        # ``skill_results`` is ``None``.
+        harness_for_extraction = "claude-code"
+        for sr in skill_results:
+            if sr is not None:
+                harness_for_extraction = sr.harness
+                break
         _write_extraction_sidecar(
             skill_dir,
             primary_text,
@@ -804,6 +815,7 @@ def _write_workspace_sidecars(
             model,
             transport=transport,
             provider=provider,
+            harness=harness_for_extraction,
         )
 
     if getattr(args, "baseline", False):
@@ -949,6 +961,7 @@ def _write_extraction_sidecar(
     transport: str = "auto",
     *,
     provider: str = "anthropic",
+    harness: str = "claude-code",
 ) -> None:
     """Run Layer 2 schema extraction and persist ``extraction.json``.
 
@@ -956,6 +969,11 @@ def _write_extraction_sidecar(
     the surrounding ``cmd_grade`` invocation. Passed through verbatim
     so OpenAI-graded skills don't fall back to ``extract_and_report``'s
     Anthropic-default model (CodeRabbit finding on PR #164).
+
+    ``harness`` is the name of the harness that produced
+    ``primary_text`` (read off the originating ``SkillResult.harness``
+    by the caller). Persisted into ``extraction.json`` at
+    ``schema_version=4`` per #152 US-003 / DEC-004.
     """
     import asyncio
 
@@ -969,6 +987,7 @@ def _write_extraction_sidecar(
             skill_name=spec.skill_name,
             transport=transport,
             provider=provider,
+            harness=harness,
         )
     )
     (skill_dir / "extraction.json").write_text(

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -1176,11 +1176,26 @@ def _grade_all_runs(
     transport: str = "auto",
     *,
     provider: str = "anthropic",
+    skill_results: list[SkillResult | None] | None = None,
 ) -> list[GradingReport]:
-    """Grade every run's output concurrently and return the per-run reports."""
+    """Grade every run's output concurrently and return the per-run reports.
+
+    ``skill_results`` is a parallel list to ``run_outputs``; when
+    provided, each entry's ``harness`` value flows into the matching
+    :class:`GradingReport.harness` so the on-disk ``grading.json`` v4
+    sidecar (#152) records which harness produced the output. Captured
+    ``--output`` runs land as ``None`` in ``skill_results``; those
+    fall back to the ``"claude-code"`` default.
+    """
     import asyncio
 
     from clauditor.quality_grader import grade_quality
+
+    def _harness_for(idx: int) -> str:
+        if skill_results is None:
+            return "claude-code"
+        result = skill_results[idx] if idx < len(skill_results) else None
+        return result.harness if result is not None else "claude-code"
 
     async def _grade_all() -> list[GradingReport]:
         return list(
@@ -1193,8 +1208,9 @@ def _grade_all_runs(
                         thresholds=spec.eval_spec.grade_thresholds,
                         transport=transport,
                         provider=provider,
+                        harness=_harness_for(idx),
                     )
-                    for text, _ev in run_outputs
+                    for idx, (text, _ev) in enumerate(run_outputs)
                 ]
             )
         )
@@ -1234,7 +1250,12 @@ def _cmd_grade_with_workspace(
 
     primary_text = run_outputs[0][0]
     reports = _grade_all_runs(
-        run_outputs, spec, model, transport=grader_transport, provider=provider
+        run_outputs,
+        spec,
+        model,
+        transport=grader_transport,
+        provider=provider,
+        skill_results=skill_results,
     )
     primary_report = reports[0]
 

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -786,6 +786,16 @@ def _write_workspace_sidecars(
         primary_report.to_json(), encoding="utf-8"
     )
 
+    # #152 US-002: stamp the harness on assertions.json. Single harness
+    # per command invocation (DEC-S2=A), so we read it from the first
+    # SkillResult — which has been populated from ``Harness.name`` since
+    # US-001. In ``--output`` mode there is no SkillResult; fall back to
+    # the resolved ``harness_name`` (or its default of ``"claude-code"``)
+    # so the field is always present.
+    if skill_results and skill_results[0] is not None:
+        assertions_harness = skill_results[0].harness
+    else:
+        assertions_harness = harness_name or "claude-code"
     _write_assertions_sidecar(
         args=args,
         spec=spec,
@@ -794,6 +804,7 @@ def _write_workspace_sidecars(
         run_outputs=run_outputs,
         verbose=verbose,
         no_transcript=no_transcript,
+        harness=assertions_harness,
     )
 
     if spec.eval_spec.sections:
@@ -882,6 +893,7 @@ def _write_assertions_sidecar(
     run_outputs: list[tuple[str, list[dict]]],
     verbose: bool,
     no_transcript: bool,
+    harness: str = "claude-code",
 ) -> None:
     """Run L1 assertions per run, write ``assertions.json``, emit slices.
 
@@ -889,6 +901,14 @@ def _write_assertions_sidecar(
     auditor can jump from a failing row to the stream-json that
     produced it (US-004). Under ``verbose`` mode, failing-run transcript
     slices are printed to stderr (US-007).
+
+    ``harness`` (#152 US-002 / DEC-003): name of the harness that
+    produced the runs (one harness per command invocation per
+    DEC-S2=A). Stamped at the top level of ``assertions.json`` under
+    the ``harness`` key (schema_version 2). Defaults to ``"claude-code"``
+    so direct callers without the field stay green (the production
+    call site in ``_write_workspace_sidecars`` always passes the
+    resolved value).
     """
     from clauditor.cli import _print_failing_transcript_slice, _relative_to_repo
 
@@ -926,8 +946,12 @@ def _write_assertions_sidecar(
                     idx, run_outputs[idx][1], sys.stderr
                 )
 
+    # #152 US-002: schema_version bumped 1 → 2 with a top-level
+    # ``harness`` field. Canonical key order: schema_version, harness,
+    # skill, iteration, runs (per DEC-003 / DEC-013).
     assertions_payload = {
-        "schema_version": 1,
+        "schema_version": 2,
+        "harness": harness,
         "skill": spec.skill_name,
         "iteration": workspace.iteration,
         "runs": [

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -287,8 +287,18 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
                 shutil.rmtree(skill_dir / "run-0", ignore_errors=True)
 
+            # #152 US-002 / B1: assertions.json carries the resolved
+            # harness identity. Live runs read from ``skill_result.harness``
+            # (US-001's runtime field); the ``--output`` mode falls back
+            # to the resolved CLI harness name (or default ``"claude-code"``).
+            harness_for_sidecar = (
+                skill_result.harness
+                if skill_result is not None
+                else (harness_name or "claude-code")
+            )
             assertions_payload = {
-                "schema_version": 1,
+                "schema_version": 2,
+                "harness": harness_for_sidecar,
                 "skill": spec.skill_name,
                 "iteration": workspace.iteration,
                 "runs": [{"run": 0, **results.to_json()}],

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -248,6 +248,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
                     skill_result=skill_result,
                     iteration=None,
                     workspace_path=None,
+                    harness_name=harness_name,
                 )
                 return 1
             output = skill_result.output
@@ -314,6 +315,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
         skill_result=skill_result,
         iteration=iteration_index,
         workspace_path=workspace_rel,
+        harness_name=harness_name,
     )
 
     if args.json:

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -288,17 +288,15 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 shutil.rmtree(skill_dir / "run-0", ignore_errors=True)
 
             # #152 US-002 / B1: assertions.json carries the resolved
-            # harness identity. Live runs read from ``skill_result.harness``
-            # (US-001's runtime field); the ``--output`` mode falls back
-            # to the resolved CLI harness name (or default ``"claude-code"``).
-            harness_for_sidecar = (
-                skill_result.harness
-                if skill_result is not None
-                else (harness_name or "claude-code")
-            )
+            # harness identity from ``skill_result.harness`` (US-001's
+            # runtime field). This branch is the live-run path
+            # (``args.output`` is False), so ``skill_result`` is
+            # always set by the ``spec.run`` call above; ``--output``
+            # mode reaches a separate branch that does NOT write a
+            # workspace sidecar.
             assertions_payload = {
                 "schema_version": 2,
-                "harness": harness_for_sidecar,
+                "harness": skill_result.harness,
                 "skill": spec.skill_name,
                 "iteration": workspace.iteration,
                 "runs": [{"run": 0, **results.to_json()}],

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -92,11 +92,12 @@ class ExtractionReport:
     .. code-block:: json
 
         {
-          "schema_version": 3,
+          "schema_version": 4,
           "skill_name": "...",
           "model": "...",
           "transport_source": "api",
           "provider_source": "anthropic",
+          "harness": "claude-code",
           "input_tokens": 0,
           "output_tokens": 0,
           "parse_errors": [],
@@ -121,10 +122,15 @@ class ExtractionReport:
     ``plans/super/86-claude-cli-transport.md``). ``provider_source``
     records which provider backend produced the response —
     ``"anthropic"`` or ``"openai"`` (added in v3 per DEC-001 /
-    DEC-006 of ``plans/super/147-sidecar-provider-field.md``). The
-    audit loader accepts ``{1, 2, 3}`` and defaults missing
-    ``transport_source`` to ``"api"`` and missing ``provider_source``
-    to ``"anthropic"`` when reading legacy v1/v2 sidecars.
+    DEC-006 of ``plans/super/147-sidecar-provider-field.md``).
+    ``harness`` records which skill harness produced the underlying
+    skill output that was extracted — ``"claude-code"`` (current
+    default) or ``"codex"`` (#149+) (added in v4 per DEC-004 /
+    DEC-006 of ``plans/super/152-sidecar-harness-field.md``). The
+    audit loader accepts ``{1, 2, 3, 4}`` and defaults missing
+    ``transport_source`` to ``"api"``, missing ``provider_source``
+    to ``"anthropic"``, and missing ``harness`` to ``"claude-code"``
+    when reading legacy v1/v2/v3 sidecars.
     """
 
     skill_name: str
@@ -139,10 +145,18 @@ class ExtractionReport:
     # response — ``"anthropic"`` (current) or ``"openai"`` (#145+).
     # Persisted into ``extraction.json`` at ``schema_version=3`` per
     # DEC-001 / DEC-006 of ``plans/super/147-sidecar-provider-field.md``.
-    # The audit loader accepts ``{1, 2, 3}`` and defaults missing
+    # The audit loader accepts ``{1, 2, 3, 4}`` and defaults missing
     # ``provider_source`` to ``"anthropic"`` when reading legacy v1/v2
     # sidecars.
     provider_source: str = "anthropic"
+    # ``harness`` records which skill harness produced the underlying
+    # skill output extracted by Layer 2 — ``"claude-code"`` (current
+    # default) or ``"codex"`` (#149+). Persisted into
+    # ``extraction.json`` at ``schema_version=4`` per DEC-004 /
+    # DEC-006 of ``plans/super/152-sidecar-harness-field.md``. The
+    # audit loader defaults missing ``harness`` to ``"claude-code"``
+    # when reading legacy v1/v2/v3 sidecars.
+    harness: str = "claude-code"
 
     @property
     def passed(self) -> bool:
@@ -153,13 +167,14 @@ class ExtractionReport:
     def to_json(self) -> str:
         """Serialize the report to a JSON string.
 
-        Emits ``schema_version: 3`` as the first key per
-        ``.claude/rules/json-schema-version.md``. Version 3 adds the
-        ``provider_source`` field on disk (v2 added
-        ``transport_source``); the audit loader accepts ``{1, 2, 3}``
-        and defaults missing ``transport_source`` to ``"api"`` and
-        missing ``provider_source`` to ``"anthropic"`` when reading
-        legacy v1/v2 sidecars.
+        Emits ``schema_version: 4`` as the first key per
+        ``.claude/rules/json-schema-version.md``. Version 4 adds the
+        ``harness`` field on disk (v3 added ``provider_source``, v2
+        added ``transport_source``); the audit loader accepts
+        ``{1, 2, 3, 4}`` and defaults missing ``transport_source`` to
+        ``"api"``, missing ``provider_source`` to ``"anthropic"``, and
+        missing ``harness`` to ``"claude-code"`` when reading legacy
+        v1/v2/v3 sidecars.
         """
         by_id: dict[str, list[dict]] = {}
         # Pre-populate every declared field id with an empty list so the
@@ -172,11 +187,12 @@ class ExtractionReport:
                 {k: v for k, v in r.to_dict().items() if k != "field_id"}
             )
         payload = {
-            "schema_version": 3,
+            "schema_version": 4,
             "skill_name": self.skill_name,
             "model": self.model,
             "transport_source": self.transport_source,
             "provider_source": self.provider_source,
+            "harness": self.harness,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "parse_errors": list(self.parse_errors),
@@ -188,10 +204,12 @@ class ExtractionReport:
     def from_json(cls, text: str) -> ExtractionReport:
         """Deserialize an ExtractionReport from a JSON string.
 
-        Tolerates schema versions ``1``, ``2``, and ``3``. A missing
-        ``transport_source`` defaults to ``"api"`` so pre-#86 sidecars
-        load cleanly; a missing ``provider_source`` defaults to
-        ``"anthropic"`` so pre-#147 sidecars load cleanly.
+        Tolerates schema versions ``1``, ``2``, ``3``, and ``4``. A
+        missing ``transport_source`` defaults to ``"api"`` so pre-#86
+        sidecars load cleanly; a missing ``provider_source`` defaults
+        to ``"anthropic"`` so pre-#147 sidecars load cleanly; a
+        missing ``harness`` defaults to ``"claude-code"`` so
+        pre-#152 sidecars load cleanly.
         """
         data = json.loads(text)
         results: list[FieldExtractionResult] = []
@@ -224,6 +242,7 @@ class ExtractionReport:
             provider_source=str(
                 data.get("provider_source") or "anthropic"
             ),
+            harness=str(data.get("harness") or "claude-code"),
         )
 
 
@@ -238,6 +257,7 @@ def build_extraction_report(
     parse_errors: list[str] | None = None,
     transport_source: str = "api",
     provider_source: str = "anthropic",
+    harness: str = "claude-code",
 ) -> ExtractionReport:
     """Build a field-id-keyed ``ExtractionReport`` from extracted output.
 
@@ -327,6 +347,7 @@ def build_extraction_report(
         declared_field_ids=declared_field_ids,
         transport_source=transport_source,
         provider_source=provider_source,
+        harness=harness,
     )
 
 
@@ -748,6 +769,7 @@ def build_extraction_report_from_text(
     output_tokens: int,
     transport_source: str = "api",
     provider_source: str = "anthropic",
+    harness: str = "claude-code",
 ) -> ExtractionReport:
     """Parse ``response_text`` into an :class:`ExtractionReport`.
 
@@ -770,6 +792,7 @@ def build_extraction_report_from_text(
             parse_errors=["grader returned no text blocks"],
             transport_source=transport_source,
             provider_source=provider_source,
+            harness=harness,
         )
 
     parse = parse_extraction_response(response_text, eval_spec)
@@ -789,6 +812,7 @@ def build_extraction_report_from_text(
             parse_errors=[err.message for err in parse.parse_errors],
             transport_source=transport_source,
             provider_source=provider_source,
+            harness=harness,
         )
     return build_extraction_report(
         parse.extracted,
@@ -800,6 +824,7 @@ def build_extraction_report_from_text(
         parse_errors=[err.message for err in parse.parse_errors],
         transport_source=transport_source,
         provider_source=provider_source,
+        harness=harness,
     )
 
 
@@ -924,6 +949,7 @@ async def extract_and_report(
     skill_name: str = "",
     transport: str = "auto",
     provider: str = "anthropic",
+    harness: str = "claude-code",
 ) -> ExtractionReport:
     """Layer 2 wrapper that returns a field-id-keyed :class:`ExtractionReport`.
 
@@ -961,4 +987,5 @@ async def extract_and_report(
         output_tokens=output_tokens,
         transport_source=source,
         provider_source=last_provider,
+        harness=harness,
     )

--- a/src/clauditor/history.py
+++ b/src/clauditor/history.py
@@ -8,9 +8,10 @@ block characters.
 
 Each record is a JSON object with the following top-level keys:
 
-- ``schema_version``: int, ``2`` (current). v1 records are still readable
-  for back-compat — ``read_records`` defaults their missing ``provider``
-  to ``"anthropic"`` per #147 DEC-012.
+- ``schema_version``: int, ``3`` (current). v1 and v2 records are still
+  readable for back-compat — ``read_records`` defaults their missing
+  ``provider`` to ``"anthropic"`` (per #147 DEC-012) and missing
+  ``harness`` to ``"claude-code"`` (per #152 DEC-005).
 - ``command``: one of ``"grade"``, ``"extract"``, ``"validate"``
 - ``ts``: ISO-8601 UTC timestamp
 - ``skill``: skill name
@@ -22,6 +23,10 @@ Each record is a JSON object with the following top-level keys:
 - ``provider``: str — which model provider's SDK served the grading call
   (``"anthropic"`` or ``"openai"``). Required (keyword-only) on
   ``append_record``; defaults to ``"anthropic"`` on legacy v1 reads.
+- ``harness``: str — which harness ran the skill subprocess
+  (``"claude-code"`` or ``"codex"``). Required (keyword-only) on
+  ``append_record``; defaults to ``"claude-code"`` on legacy v1/v2
+  reads (#152 DEC-005).
 
 ``iteration`` and ``workspace_path`` are always written, even when
 ``None``, so the on-disk record shape is predictable.
@@ -73,11 +78,13 @@ def _default_path() -> Path:
 
 
 SPARK_GLYPHS = "_.-=#"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
-# v1 records are still readable; ``read_records`` defaults missing
-# ``provider`` to ``"anthropic"`` for legacy lines per #147 DEC-012.
-_ACCEPTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1, 2})
+# v1 and v2 records are still readable; ``read_records`` defaults
+# missing ``provider`` to ``"anthropic"`` for legacy lines (#147
+# DEC-012) and missing ``harness`` to ``"claude-code"`` for v1/v2
+# lines (#152 DEC-005).
+_ACCEPTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1, 2, 3})
 
 _FLOCK_UNSUPPORTED_WARNED = False
 
@@ -132,6 +139,7 @@ def append_record(
     *,
     command: Literal["grade", "extract", "validate"],
     provider: str,
+    harness: str,
     path: Path | None = None,
     iteration: int | None = None,
     workspace_path: str | None = None,
@@ -149,6 +157,11 @@ def append_record(
     provider's SDK served the grading call (``"anthropic"`` or
     ``"openai"``). Per #147 DEC-012 this field is mandatory on writes;
     legacy v1 reads default to ``"anthropic"``.
+
+    ``harness`` is required (keyword-only) and identifies which harness
+    ran the skill subprocess (``"claude-code"`` or ``"codex"``). Per
+    #152 DEC-005 this field is mandatory on writes; legacy v1/v2 reads
+    default to ``"claude-code"``.
 
     Concurrent appends from multiple processes are serialized via an
     ``fcntl.flock`` exclusive lock on ``<history_parent>/.lock`` so each
@@ -175,6 +188,22 @@ def append_record(
             "provider must be a resolved provider name "
             "(use 'anthropic' or 'openai', not 'auto')"
         )
+    # Defense in depth: ``harness`` should already be a resolved harness
+    # name (one of ``"claude-code"`` / ``"codex"``) by the time it
+    # reaches this seam — the CLI plumbs it through ``_resolve_harness``
+    # per #151's four-layer precedence. Mirror the provider validation
+    # shape: reject the unresolved sentinel ``"auto"`` and any
+    # blank/non-string so a future caller that bypasses the resolver
+    # cannot corrupt ``trend``/``audit`` grouping semantics.
+    if not isinstance(harness, str) or not harness.strip():
+        raise ValueError(
+            f"harness must be a non-blank string; got {harness!r}"
+        )
+    if harness == "auto":
+        raise ValueError(
+            "harness must be a resolved harness name "
+            "(use 'claude-code' or 'codex', not 'auto')"
+        )
     if path is None:
         path = _default_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -189,6 +218,7 @@ def append_record(
         "iteration": iteration,
         "workspace_path": workspace_path,
         "provider": provider,
+        "harness": harness,
     }
     line = json.dumps(record) + "\n"
     lock_path = path.parent / ".lock"
@@ -200,9 +230,10 @@ def append_record(
 def _check_schema_version(data: dict, source: Path, lineno: int) -> bool:
     """Return ``True`` if ``data`` has an accepted schema version.
 
-    Per #147 DEC-012, both v1 and v2 records are accepted; v1 records are
-    legacy and have ``provider`` defaulted in :func:`read_records`. Records
-    with a mismatched version are skipped with a stderr warning per
+    Per #147 DEC-012 / #152 DEC-005, v1, v2, and v3 records are accepted;
+    v1/v2 records are legacy and have ``provider`` (v1) and ``harness``
+    (v1/v2) defaulted in :func:`read_records`. Records with a mismatched
+    version are skipped with a stderr warning per
     ``.claude/rules/json-schema-version.md``.
     """
     version = data.get("schema_version")
@@ -264,6 +295,11 @@ def read_records(
             # treat the field as guaranteed-present per DEC-012.
             if "provider" not in record:
                 record["provider"] = "anthropic"
+            # v1/v2 records (pre-#152) lack ``harness``. Default to
+            # ``"claude-code"`` so downstream consumers can treat the
+            # field as guaranteed-present per #152 DEC-005.
+            if "harness" not in record:
+                record["harness"] = "claude-code"
             records.append(record)
     return records
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -447,11 +447,17 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
             or spec.eval_spec.grading_model
             or resolve_grading_model(spec.eval_spec, provider)
         )
-        harness = "claude-code"
         if output is None:
             result = spec.run()
             output = result.output
             harness = result.harness
+        elif (
+            spec.eval_spec is not None
+            and spec.eval_spec.harness not in ("auto", None)
+        ):
+            harness = spec.eval_spec.harness
+        else:
+            harness = "claude-code"
         return asyncio.run(
             grade_quality(
                 output,

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -447,11 +447,19 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
             or spec.eval_spec.grading_model
             or resolve_grading_model(spec.eval_spec, provider)
         )
+        harness = "claude-code"
         if output is None:
             result = spec.run()
             output = result.output
+            harness = result.harness
         return asyncio.run(
-            grade_quality(output, spec.eval_spec, model, provider=provider)
+            grade_quality(
+                output,
+                spec.eval_spec,
+                model,
+                provider=provider,
+                harness=harness,
+            )
         )
 
     return _factory

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -102,6 +102,17 @@ class GradingReport:
     # ``provider_source`` to ``"anthropic"`` when reading legacy v1/v2
     # sidecars.
     provider_source: str = "anthropic"
+    # ``harness`` records which skill harness produced the underlying
+    # output this report grades — ``"claude-code"`` (default) or
+    # ``"codex"`` (#149+). Populated from :class:`SkillResult.harness`
+    # by orchestrators that have a SkillResult in scope; defaults to
+    # ``"claude-code"`` for direct callers (mainly tests). Persisted
+    # into ``grading.json`` at ``schema_version=4`` per DEC-004 /
+    # DEC-006 of ``plans/super/152-sidecar-harness-field.md``. The
+    # audit loader accepts ``{1, 2, 3, 4}`` and defaults missing
+    # ``harness`` to ``"claude-code"`` when reading legacy v1/v2/v3
+    # sidecars.
+    harness: str = "claude-code"
 
     @property
     def passed(self) -> bool:
@@ -129,20 +140,22 @@ class GradingReport:
     def to_json(self) -> str:
         """Serialize the report to a JSON string.
 
-        Emits ``schema_version: 3`` as the first key per
-        ``.claude/rules/json-schema-version.md``. Version 3 adds the
-        ``provider_source`` field on disk (v2 added
-        ``transport_source``); the audit loader accepts ``{1, 2, 3}``
-        and defaults missing ``transport_source`` to ``"api"`` and
-        missing ``provider_source`` to ``"anthropic"`` when reading
-        legacy v1/v2 sidecars.
+        Emits ``schema_version: 4`` as the first key per
+        ``.claude/rules/json-schema-version.md``. Version 4 adds the
+        ``harness`` field on disk (v3 added ``provider_source``, v2
+        added ``transport_source``); the audit loader accepts
+        ``{1, 2, 3, 4}`` and defaults missing ``transport_source`` to
+        ``"api"``, missing ``provider_source`` to ``"anthropic"``,
+        and missing ``harness`` to ``"claude-code"`` when reading
+        legacy sidecars.
         """
         data = {
-            "schema_version": 3,
+            "schema_version": 4,
             "skill_name": self.skill_name,
             "model": self.model,
             "transport_source": self.transport_source,
             "provider_source": self.provider_source,
+            "harness": self.harness,
             "duration_seconds": self.duration_seconds,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
@@ -171,10 +184,12 @@ class GradingReport:
     def from_json(cls, data: str) -> GradingReport:
         """Deserialize a GradingReport from a JSON string.
 
-        Tolerates schema versions ``1``, ``2``, and ``3``. A missing
-        ``transport_source`` defaults to ``"api"`` so pre-#86 sidecars
-        load cleanly; a missing ``provider_source`` defaults to
-        ``"anthropic"`` so pre-#147 sidecars load cleanly.
+        Tolerates schema versions ``1``, ``2``, ``3``, and ``4``. A
+        missing ``transport_source`` defaults to ``"api"`` so pre-#86
+        sidecars load cleanly; a missing ``provider_source`` defaults
+        to ``"anthropic"`` so pre-#147 sidecars load cleanly; a
+        missing ``harness`` defaults to ``"claude-code"`` so pre-#152
+        sidecars load cleanly.
         """
         parsed = json.loads(data)
         results = [
@@ -206,6 +221,7 @@ class GradingReport:
             provider_source=str(
                 parsed.get("provider_source") or "anthropic"
             ),
+            harness=str(parsed.get("harness") or "claude-code"),
         )
 
     def summary(self) -> str:
@@ -1031,6 +1047,7 @@ def _grading_failure_report(
     reasoning: str,
     transport_source: str = "api",
     provider_source: str = "anthropic",
+    harness: str = "claude-code",
 ) -> GradingReport:
     """Build a failed :class:`GradingReport` for a parse/alignment failure.
 
@@ -1056,6 +1073,7 @@ def _grading_failure_report(
         output_tokens=output_tokens,
         transport_source=transport_source,
         provider_source=provider_source,
+        harness=harness,
     )
 
 
@@ -1070,6 +1088,7 @@ def build_grading_report(
     output_tokens: int,
     transport_source: str = "api",
     provider_source: str = "anthropic",
+    harness: str = "claude-code",
 ) -> GradingReport:
     """Parse ``response_text`` into a :class:`GradingReport`.
 
@@ -1094,6 +1113,7 @@ def build_grading_report(
         "output_tokens": output_tokens,
         "transport_source": transport_source,
         "provider_source": provider_source,
+        "harness": harness,
     }
     if not response_text:
         return _grading_failure_report(
@@ -1136,6 +1156,7 @@ def build_grading_report(
         output_tokens=output_tokens,
         transport_source=transport_source,
         provider_source=provider_source,
+        harness=harness,
     )
 
 
@@ -1163,6 +1184,7 @@ async def grade_quality(
     transport: str = "auto",
     *,
     provider: str = "anthropic",
+    harness: str = "claude-code",
 ) -> GradingReport:
     """Layer 3: Grade skill output against rubric criteria using an LLM.
 
@@ -1254,6 +1276,7 @@ async def grade_quality(
         output_tokens=total_output_tokens,
         transport_source=last_source,
         provider_source=last_provider,
+        harness=harness,
     )
 
 

--- a/src/clauditor/runner.py
+++ b/src/clauditor/runner.py
@@ -66,7 +66,18 @@ class SkillResult:
     args: str
     duration_seconds: float = 0.0
     error: str | None = None
-    # runtime-only — do not serialize to sidecars without bumping schema_version
+    # #152 US-001 / DEC-002: name of the harness that produced this
+    # result, populated from the active ``Harness.name`` ClassVar at
+    # ``SkillRunner._invoke`` construction time. Default
+    # ``"claude-code"`` keeps existing direct-construction call sites
+    # (tests, fixtures) green. **Adopted-for-sidecar field**: every
+    # downstream sidecar emitter (assertions.json v2, plus future
+    # extraction.json / grading.json bumps) reads this value to stamp
+    # the harness axis. Distinct from observation-only fields below
+    # (``error_category``, ``api_key_source``, ``harness_metadata``)
+    # which remain runtime-only — do not serialize to sidecars without
+    # bumping schema_version.
+    harness: str = "claude-code"
     error_category: (
         Literal[
             "rate_limit",
@@ -428,6 +439,10 @@ class SkillRunner:
             args=args,
             duration_seconds=invoke.duration_seconds,
             error=invoke.error,
+            # #152 US-001 / DEC-002: stamp the active harness's name
+            # ClassVar so every downstream sidecar emitter can read
+            # ``result.harness`` to get the harness axis value.
+            harness=harness_for_call.name,
             error_category=invoke.error_category,
             input_tokens=invoke.input_tokens,
             output_tokens=invoke.output_tokens,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -301,7 +301,7 @@ class TestAggregate:
             for i in range(1, 5)
         ]
         agg = aggregate(records)
-        entry = agg[("anthropic", "L1", "a")]
+        entry = agg[("claude-code", "anthropic", "L1", "a")]
         assert entry.total_with_runs == 4
         assert entry.with_fails == 1
         assert entry.with_pass_rate == 0.75
@@ -316,7 +316,7 @@ class TestAggregate:
             IterationRecord(2, "L1", "a", passed=True, with_skill=False),
         ]
         agg = aggregate(records)
-        entry = agg[("anthropic", "L1", "a")]
+        entry = agg[("claude-code", "anthropic", "L1", "a")]
         assert entry.with_pass_rate == 1.0
         assert entry.baseline_pass_rate == 0.5
         assert entry.discrimination == pytest.approx(0.5)
@@ -326,7 +326,7 @@ class TestAggregate:
             IterationRecord(1, "L1", "a", passed=True, with_skill=True),
         ]
         agg = aggregate(records)
-        assert agg[("anthropic", "L1", "a")].discrimination is None
+        assert agg[("claude-code", "anthropic", "L1", "a")].discrimination is None
 
     def test_groups_by_layer_and_id(self) -> None:
         records = [
@@ -334,10 +334,10 @@ class TestAggregate:
             IterationRecord(1, "L3", "shared", passed=False, with_skill=True),
         ]
         agg = aggregate(records)
-        assert ("anthropic", "L1", "shared") in agg
-        assert ("anthropic", "L3", "shared") in agg
-        assert agg[("anthropic", "L1", "shared")].with_pass_rate == 1.0
-        assert agg[("anthropic", "L3", "shared")].with_pass_rate == 0.0
+        assert ("claude-code", "anthropic", "L1", "shared") in agg
+        assert ("claude-code", "anthropic", "L3", "shared") in agg
+        assert agg[("claude-code", "anthropic", "L1", "shared")].with_pass_rate == 1.0
+        assert agg[("claude-code", "anthropic", "L3", "shared")].with_pass_rate == 0.0
 
 
 # --------------------------------------------------------------------------- #
@@ -429,7 +429,11 @@ def _agg(
 
 class TestApplyThresholds:
     def test_threshold_flags_100_percent_pass(self) -> None:
-        aggs = {("anthropic", "L1", "a"): _agg(with_runs=20, with_fails=0)}
+        aggs = {
+            ("claude-code", "anthropic", "L1", "a"): _agg(
+                with_runs=20, with_fails=0
+            )
+        }
         verdicts = apply_thresholds(
             aggs, min_fail_rate=0.0, min_discrimination=0.05
         )
@@ -439,7 +443,11 @@ class TestApplyThresholds:
 
     def test_threshold_flags_zero_failures(self) -> None:
         # 100% pass is the priority reason, but zero-failures still in reasons.
-        aggs = {("anthropic", "L1", "a"): _agg(with_runs=5, with_fails=0)}
+        aggs = {
+            ("claude-code", "anthropic", "L1", "a"): _agg(
+                with_runs=5, with_fails=0
+            )
+        }
         verdicts = apply_thresholds(
             aggs, min_fail_rate=0.0, min_discrimination=0.05
         )
@@ -450,7 +458,7 @@ class TestApplyThresholds:
     ) -> None:
         # With-rate 0.8, baseline 0.78 → discrimination 0.02 < 0.05
         aggs = {
-            ("anthropic", "L1", "a"): _agg(
+            ("claude-code", "anthropic", "L1", "a"): _agg(
                 with_runs=10,
                 with_fails=2,
                 baseline_runs=50,
@@ -465,7 +473,7 @@ class TestApplyThresholds:
     def test_threshold_passes_discriminating_assertion(self) -> None:
         # with 0.75 pass, baseline 0.25 pass → 0.5 discrimination, keeps.
         aggs = {
-            ("anthropic", "L1", "a"): _agg(
+            ("claude-code", "anthropic", "L1", "a"): _agg(
                 with_runs=4,
                 with_fails=1,
                 baseline_runs=4,
@@ -481,7 +489,11 @@ class TestApplyThresholds:
     def test_threshold_override_via_cli_args(self) -> None:
         # 95% pass, not 100%; default 0.0 min_fail_rate wouldn't flag,
         # but 0.1 min_fail_rate (threshold 0.9) flags it.
-        aggs = {("anthropic", "L1", "a"): _agg(with_runs=20, with_fails=1)}
+        aggs = {
+            ("claude-code", "anthropic", "L1", "a"): _agg(
+                with_runs=20, with_fails=1
+            )
+        }
         lax = apply_thresholds(
             aggs, min_fail_rate=0.0, min_discrimination=0.05
         )
@@ -505,8 +517,8 @@ class TestRenderers:
         )
         return apply_thresholds(
             {
-                ("anthropic", "L1", "always_pass"): flagged,
-                ("anthropic", "L2", "sometimes"): kept,
+                ("claude-code", "anthropic", "L1", "always_pass"): flagged,
+                ("claude-code", "anthropic", "L2", "sometimes"): kept,
             },
             min_fail_rate=0.0,
             min_discrimination=0.05,
@@ -1164,9 +1176,11 @@ class TestAuditL3StableId:
         assert len(l3) == 2
         assert {r.id for r in l3} == {"quality"}
         agg = aggregate(records)
-        assert ("anthropic", "L3", "quality") in agg
+        assert ("claude-code", "anthropic", "L3", "quality") in agg
         # One pass, one fail → 0.5 with_pass_rate.
-        assert agg[("anthropic", "L3", "quality")].with_pass_rate == pytest.approx(0.5)
+        assert agg[
+            ("claude-code", "anthropic", "L3", "quality")
+        ].with_pass_rate == pytest.approx(0.5)
 
     def test_loader_skips_unknown_schema_version(
         self, tmp_path: Path
@@ -1265,7 +1279,7 @@ class TestFix12Fix13:
             baseline_pass_rate=None,
         )
         verdicts = apply_thresholds(
-            {("anthropic", "L1", "a|b"): agg},
+            {("claude-code", "anthropic", "L1", "a|b"): agg},
             min_fail_rate=0.0,
             min_discrimination=0.05,
         )
@@ -1303,8 +1317,8 @@ class TestFix12Fix13:
         )
         verdicts = apply_thresholds(
             {
-                ("anthropic", "L1", "live"): primary_only,
-                ("anthropic", "L1", "stale"): baseline_only,
+                ("claude-code", "anthropic", "L1", "live"): primary_only,
+                ("claude-code", "anthropic", "L1", "stale"): baseline_only,
             },
             min_fail_rate=0.0,
             min_discrimination=0.05,
@@ -1540,12 +1554,12 @@ class TestProviderDimension:
             ),
         ]
         agg = aggregate(records)
-        assert ("anthropic", "L3", "x") in agg
-        assert ("openai", "L3", "x") in agg
-        assert agg[("anthropic", "L3", "x")].with_pass_rate == 0.5
-        assert agg[("openai", "L3", "x")].with_pass_rate == 1.0
-        assert agg[("anthropic", "L3", "x")].provider == "anthropic"
-        assert agg[("openai", "L3", "x")].provider == "openai"
+        assert ("claude-code", "anthropic", "L3", "x") in agg
+        assert ("claude-code", "openai", "L3", "x") in agg
+        assert agg[("claude-code", "anthropic", "L3", "x")].with_pass_rate == 0.5
+        assert agg[("claude-code", "openai", "L3", "x")].with_pass_rate == 1.0
+        assert agg[("claude-code", "anthropic", "L3", "x")].provider == "anthropic"
+        assert agg[("claude-code", "openai", "L3", "x")].provider == "openai"
 
     def test_aggregate_single_provider_history_unchanged_shape(
         self,
@@ -1557,15 +1571,15 @@ class TestProviderDimension:
             IterationRecord(2, "L1", "a", passed=False, with_skill=True),
         ]
         agg = aggregate(records)
-        assert list(agg.keys()) == [("anthropic", "L1", "a")]
-        assert agg[("anthropic", "L1", "a")].with_pass_rate == 0.5
+        assert list(agg.keys()) == [("claude-code", "anthropic", "L1", "a")]
+        assert agg[("claude-code", "anthropic", "L1", "a")].with_pass_rate == 0.5
 
     def test_apply_thresholds_consumes_three_tuple_key(self) -> None:
         """``apply_thresholds`` must unpack the new 3-tuple key without
         raising and must propagate ``provider`` into the resulting
         ``AuditVerdict``."""
         aggs = {
-            ("openai", "L3", "x"): AuditAggregate(
+            ("claude-code", "openai", "L3", "x"): AuditAggregate(
                 layer="L3",
                 id="x",
                 total_with_runs=20,
@@ -1610,8 +1624,8 @@ class TestProviderDimension:
             provider="openai",
         )
         aggs = {
-            ("openai", "L3", "x"): openai_agg,
-            ("anthropic", "L3", "x"): anthropic_agg,
+            ("claude-code", "openai", "L3", "x"): openai_agg,
+            ("claude-code", "anthropic", "L3", "x"): anthropic_agg,
         }
         verdicts = apply_thresholds(
             aggs, min_fail_rate=0.0, min_discrimination=0.05
@@ -1641,8 +1655,8 @@ class TestProviderDimension:
             "s", last=5, clauditor_dir=clauditor_dir
         )
         agg = aggregate(records)
-        assert ("anthropic", "L3", "x") in agg
-        assert ("openai", "L3", "x") in agg
+        assert ("claude-code", "anthropic", "L3", "x") in agg
+        assert ("claude-code", "openai", "L3", "x") in agg
         assert len(agg) == 2
 
     def test_v2_sidecar_defaults_provider_to_anthropic(
@@ -1678,7 +1692,7 @@ class TestProviderDimension:
         assert len(records) == 1
         assert records[0].provider == "anthropic"
         agg = aggregate(records)
-        assert ("anthropic", "L3", "x") in agg
+        assert ("claude-code", "anthropic", "L3", "x") in agg
 
 
 class TestProviderOrDefault:
@@ -1756,7 +1770,7 @@ class TestProviderOrDefault:
         assert len(records) == 1
         assert records[0].provider == "anthropic"
         agg = aggregate(records)
-        assert ("anthropic", "L3", "x") in agg
+        assert ("claude-code", "anthropic", "L3", "x") in agg
 
 
 class TestRenderProviderColumn:
@@ -1810,9 +1824,9 @@ class TestRenderProviderColumn:
         )
         return apply_thresholds(
             {
-                ("openai", "L3", "x"): openai_l3,
-                ("anthropic", "L3", "x"): ant_l3,
-                ("anthropic", "L1", "ant_only"): ant_l1,
+                ("claude-code", "openai", "L3", "x"): openai_l3,
+                ("claude-code", "anthropic", "L3", "x"): ant_l3,
+                ("claude-code", "anthropic", "L1", "ant_only"): ant_l1,
             },
             min_fail_rate=0.0,
             min_discrimination=0.05,
@@ -1832,7 +1846,7 @@ class TestRenderProviderColumn:
             provider="anthropic",
         )
         return apply_thresholds(
-            {("anthropic", "L3", "x"): ant},
+            {("claude-code", "anthropic", "L3", "x"): ant},
             min_fail_rate=0.0,
             min_discrimination=0.05,
         )
@@ -1902,10 +1916,14 @@ class TestRenderProviderColumn:
         )
         verdicts = apply_thresholds(
             {
-                ("zebra", "L3", "x"): agg_factory("L3", "x", "zebra"),
-                ("openai", "L3", "x"): agg_factory("L3", "x", "openai"),
-                ("alpha", "L3", "x"): agg_factory("L3", "x", "alpha"),
-                ("anthropic", "L3", "x"): agg_factory("L3", "x", "anthropic"),
+                ("claude-code", "zebra", "L3", "x"):
+                    agg_factory("L3", "x", "zebra"),
+                ("claude-code", "openai", "L3", "x"):
+                    agg_factory("L3", "x", "openai"),
+                ("claude-code", "alpha", "L3", "x"):
+                    agg_factory("L3", "x", "alpha"),
+                ("claude-code", "anthropic", "L3", "x"):
+                    agg_factory("L3", "x", "anthropic"),
             },
             min_fail_rate=0.0,
             min_discrimination=0.05,
@@ -2052,7 +2070,7 @@ class TestRenderProviderColumn:
             provider="a" * 30,
         )
         verdicts = apply_thresholds(
-            {("a" * 30, "L3", "x"): long_provider_agg},
+            {("claude-code", "a" * 30, "L3", "x"): long_provider_agg},
             min_fail_rate=0.0,
             min_discrimination=0.05,
         )
@@ -2062,3 +2080,458 @@ class TestRenderProviderColumn:
         assert body.startswith("a" * 11)
         # And there is whitespace after — the column is bounded.
         assert body[11] == " "
+
+
+# --------------------------------------------------------------------------- #
+# US-005 (#152) — harness dimension                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _write_assertions_v2(
+    skill_dir: Path,
+    *,
+    rid: str,
+    passed: bool,
+    harness: str | None,
+) -> None:
+    """Write an assertions.json with optional v2 ``harness`` field.
+
+    When ``harness`` is None, emit a v1 sidecar (no ``harness`` key) so
+    the loader's default-on-read branch fires.
+    """
+    payload: dict = {
+        "schema_version": 2 if harness is not None else 1,
+        "skill": "s",
+        "iteration": 1,
+        "runs": [
+            {
+                "run": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "results": [
+                    {
+                        "id": rid,
+                        "name": rid,
+                        "passed": passed,
+                        "message": "",
+                        "kind": "custom",
+                        "evidence": None,
+                        "raw_data": None,
+                    },
+                ],
+            },
+        ],
+    }
+    if harness is not None:
+        payload["harness"] = harness
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "assertions.json").write_text(
+        json.dumps(payload, indent=2)
+    )
+
+
+def _write_grading_v4(
+    skill_dir: Path,
+    *,
+    rid: str,
+    passed: bool,
+    harness: str | None,
+    provider_source: str = "anthropic",
+) -> None:
+    """Write a v4 grading.json with optional ``harness`` field."""
+    payload: dict = {
+        "schema_version": 4 if harness is not None else 3,
+        "skill_name": "s",
+        "model": "claude-sonnet-4-6",
+        "provider_source": provider_source,
+        "results": [
+            {
+                "id": rid,
+                "criterion": rid,
+                "passed": passed,
+                "score": 1.0 if passed else 0.0,
+                "evidence": "",
+                "reasoning": "",
+            },
+        ],
+    }
+    if harness is not None:
+        payload["harness"] = harness
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "grading.json").write_text(
+        json.dumps(payload, indent=2)
+    )
+
+
+def _write_extraction_v4(
+    skill_dir: Path,
+    *,
+    field_id: str,
+    passed: bool,
+    harness: str | None,
+    provider_source: str = "anthropic",
+) -> None:
+    """Write a v4 extraction.json with optional ``harness`` field."""
+    payload: dict = {
+        "schema_version": 4 if harness is not None else 3,
+        "skill_name": "s",
+        "model": "haiku",
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "parse_errors": [],
+        "provider_source": provider_source,
+        "fields": {
+            field_id: [
+                {
+                    "field_name": field_id,
+                    "section": "s",
+                    "tier": "primary",
+                    "entry_index": 0,
+                    "required": True,
+                    "passed": passed,
+                    "presence_passed": passed,
+                    "format_passed": None,
+                    "evidence": "",
+                },
+            ],
+        },
+    }
+    if harness is not None:
+        payload["harness"] = harness
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "extraction.json").write_text(
+        json.dumps(payload, indent=2)
+    )
+
+
+class TestHarnessOrDefault:
+    """US-005 (#152): defense-in-depth helper guards malformed sidecars
+    that store ``harness`` as a non-string. Mirrors the
+    ``_provider_or_default`` shape — same defensive contract, same
+    ``"claude-code"`` default per DEC-006.
+    """
+
+    def test_valid_string_passes_through(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default("claude-code") == "claude-code"
+        assert _harness_or_default("codex") == "codex"
+
+    def test_none_falls_back_to_claude_code(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default(None) == "claude-code"
+
+    def test_empty_string_falls_back(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default("") == "claude-code"
+
+    def test_whitespace_only_falls_back(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default("   ") == "claude-code"
+
+    def test_int_falls_back(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default(1) == "claude-code"
+        assert _harness_or_default(0) == "claude-code"
+
+    def test_bool_falls_back(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default(True) == "claude-code"
+        assert _harness_or_default(False) == "claude-code"
+
+    def test_list_falls_back(self) -> None:
+        from clauditor.audit import _harness_or_default
+        assert _harness_or_default([]) == "claude-code"
+        assert _harness_or_default(["codex"]) == "claude-code"
+
+
+class TestHarnessDimension:
+    """US-005 (#152): ``IterationRecord`` / ``AuditAggregate`` carry
+    ``harness``; aggregation groups by 4-tuple
+    ``(harness, provider, layer, id)`` so mixed-harness history splits
+    cleanly. Pre-#152 history (v1 assertions, v3 grading/extraction
+    without ``harness``) defaults to ``"claude-code"`` per DEC-006.
+    """
+
+    def test_iteration_record_defaults_harness_to_claude_code(self) -> None:
+        rec = IterationRecord(
+            iteration=1,
+            layer="L3",
+            id="x",
+            passed=True,
+            with_skill=True,
+        )
+        assert rec.harness == "claude-code"
+
+    def test_iteration_record_explicit_harness(self) -> None:
+        rec = IterationRecord(
+            iteration=1,
+            layer="L3",
+            id="x",
+            passed=True,
+            with_skill=True,
+            harness="codex",
+        )
+        assert rec.harness == "codex"
+
+    def test_audit_aggregate_defaults_harness_to_claude_code(self) -> None:
+        agg = AuditAggregate(
+            layer="L3",
+            id="x",
+            total_with_runs=1,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+        )
+        assert agg.harness == "claude-code"
+
+    def test_grouping_splits_on_harness(self) -> None:
+        """Load-bearing: same ``(provider, layer, id)`` under different
+        harnesses produces TWO distinct ``AuditAggregate`` buckets keyed
+        on ``(claude-code, anthropic, L3, x)`` and
+        ``(codex, anthropic, L3, x)``.
+        """
+        records = [
+            IterationRecord(
+                1, "L3", "x", passed=True, with_skill=True,
+                provider="anthropic", harness="claude-code",
+            ),
+            IterationRecord(
+                2, "L3", "x", passed=False, with_skill=True,
+                provider="anthropic", harness="claude-code",
+            ),
+            IterationRecord(
+                3, "L3", "x", passed=True, with_skill=True,
+                provider="anthropic", harness="codex",
+            ),
+            IterationRecord(
+                4, "L3", "x", passed=True, with_skill=True,
+                provider="anthropic", harness="codex",
+            ),
+        ]
+        agg = aggregate(records)
+        assert ("claude-code", "anthropic", "L3", "x") in agg
+        assert ("codex", "anthropic", "L3", "x") in agg
+        assert (
+            agg[("claude-code", "anthropic", "L3", "x")].with_pass_rate
+            == 0.5
+        )
+        assert (
+            agg[("codex", "anthropic", "L3", "x")].with_pass_rate == 1.0
+        )
+        assert (
+            agg[("claude-code", "anthropic", "L3", "x")].harness
+            == "claude-code"
+        )
+        assert agg[("codex", "anthropic", "L3", "x")].harness == "codex"
+
+    def test_aggregate_single_harness_history_unchanged_shape(self) -> None:
+        """Single-harness history continues to render the single
+        bucket (default ``"claude-code"`` harness)."""
+        records = [
+            IterationRecord(1, "L1", "a", passed=True, with_skill=True),
+            IterationRecord(2, "L1", "a", passed=False, with_skill=True),
+        ]
+        agg = aggregate(records)
+        assert list(agg.keys()) == [
+            ("claude-code", "anthropic", "L1", "a"),
+        ]
+        assert agg[
+            ("claude-code", "anthropic", "L1", "a")
+        ].with_pass_rate == 0.5
+
+
+class TestRecordsFromAssertionsHarness:
+    """US-005 (#152): assertions.json bumped to v2 with ``harness`` field.
+    Records read from v2 sidecars carry the harness; v1 reads default
+    to ``"claude-code"`` per DEC-006.
+    """
+
+    def test_reads_harness_from_v2_sidecar(self, tmp_path: Path) -> None:
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_assertions_v2(
+            skill_dir, rid="has_header", passed=True, harness="codex"
+        )
+        records, skipped = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert skipped == 0
+        assert len(records) == 1
+        assert records[0].layer == "L1"
+        assert records[0].harness == "codex"
+
+    def test_defaults_harness_for_v1_legacy(self, tmp_path: Path) -> None:
+        """A v1 assertions.json (no ``harness`` field) defaults to
+        ``"claude-code"`` per DEC-006."""
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_assertions_v2(
+            skill_dir, rid="has_header", passed=True, harness=None
+        )
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert records[0].harness == "claude-code"
+
+    def test_malformed_harness_in_v2_sidecar_falls_back(
+        self, tmp_path: Path
+    ) -> None:
+        """A v2 assertions.json with ``harness: 1`` (non-string) loads
+        cleanly with ``harness="claude-code"`` rather than propagating
+        a non-string into ``IterationRecord`` keys."""
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        skill_dir.mkdir(parents=True)
+        payload: dict = {
+            "schema_version": 2,
+            "skill": "s",
+            "iteration": 1,
+            "harness": 1,
+            "runs": [
+                {
+                    "run": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "results": [
+                        {
+                            "id": "x",
+                            "name": "x",
+                            "passed": True,
+                            "message": "",
+                            "kind": "custom",
+                            "evidence": None,
+                            "raw_data": None,
+                        },
+                    ],
+                },
+            ],
+        }
+        (skill_dir / "assertions.json").write_text(json.dumps(payload))
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert records[0].harness == "claude-code"
+
+
+class TestRecordsFromExtractionHarness:
+    """US-005 (#152): extraction.json bumped to v4 with ``harness``.
+    Records read from v4 sidecars carry the harness; v1/v2/v3 reads
+    default to ``"claude-code"``.
+    """
+
+    def test_reads_harness_from_v4_sidecar(self, tmp_path: Path) -> None:
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_extraction_v4(
+            skill_dir, field_id="f1", passed=True, harness="codex"
+        )
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert records[0].layer == "L2"
+        assert records[0].harness == "codex"
+
+    def test_defaults_harness_for_v3_legacy(self, tmp_path: Path) -> None:
+        """A v3 extraction.json (no ``harness`` field) defaults to
+        ``"claude-code"`` per DEC-006."""
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_extraction_v4(
+            skill_dir, field_id="f1", passed=True, harness=None
+        )
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert records[0].harness == "claude-code"
+
+
+class TestRecordsFromGradingHarness:
+    """US-005 (#152): grading.json bumped to v4 with ``harness``."""
+
+    def test_reads_harness_from_v4_sidecar(self, tmp_path: Path) -> None:
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_grading_v4(
+            skill_dir, rid="quality", passed=True, harness="codex"
+        )
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert records[0].layer == "L3"
+        assert records[0].harness == "codex"
+
+    def test_defaults_harness_for_v3_legacy(self, tmp_path: Path) -> None:
+        """A v3 grading.json (no ``harness`` field) defaults to
+        ``"claude-code"`` per DEC-006."""
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_grading_v4(
+            skill_dir, rid="quality", passed=True, harness=None
+        )
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert records[0].harness == "claude-code"
+
+
+class TestApplyThresholdsFourTupleKeys:
+    """US-005 (#152): ``apply_thresholds`` consumes the new 4-tuple
+    ``(harness, provider, layer, id)`` aggregate dict key without
+    raising and propagates ``harness`` into the resulting
+    ``AuditVerdict``.
+    """
+
+    def test_handles_four_tuple_keys(self) -> None:
+        aggs = {
+            ("codex", "openai", "L3", "x"): AuditAggregate(
+                layer="L3",
+                id="x",
+                total_with_runs=20,
+                with_fails=0,
+                with_pass_rate=1.0,
+                total_baseline_runs=0,
+                baseline_fails=0,
+                baseline_pass_rate=None,
+                provider="openai",
+                harness="codex",
+            ),
+        }
+        verdicts = apply_thresholds(
+            aggs, min_fail_rate=0.0, min_discrimination=0.05
+        )
+        assert len(verdicts) == 1
+        assert verdicts[0].provider == "openai"
+        assert verdicts[0].verdict == Verdict.FLAG_ALWAYS_PASS
+
+    def test_mixed_harness_end_to_end(self, tmp_path: Path) -> None:
+        """End-to-end: two iteration dirs, one with harness=claude-code
+        and one with harness=codex, sharing the same (provider, layer,
+        id) but producing two distinct aggregates."""
+        clauditor_dir = tmp_path / ".clauditor"
+        _write_grading_v4(
+            clauditor_dir / "iteration-1" / "s",
+            rid="x",
+            passed=True,
+            harness="claude-code",
+        )
+        _write_grading_v4(
+            clauditor_dir / "iteration-2" / "s",
+            rid="x",
+            passed=True,
+            harness="codex",
+        )
+        records, _ = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        agg = aggregate(records)
+        assert ("claude-code", "anthropic", "L3", "x") in agg
+        assert ("codex", "anthropic", "L3", "x") in agg
+        assert len(agg) == 2

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -558,6 +558,7 @@ class TestRenderers:
             timestamp="20260101T000000Z",
         )
         # US-004 (#147): bumped to schema_version 2 + ``providers_seen``.
+        # US-006 (#152): bumped to schema_version 3 + ``harnesses_seen``.
         assert set(payload.keys()) == {
             "schema_version",
             "skill",
@@ -565,12 +566,14 @@ class TestRenderers:
             "iterations",
             "thresholds",
             "providers_seen",
+            "harnesses_seen",
             "assertions",
         }
-        assert payload["schema_version"] == 2
+        assert payload["schema_version"] == 3
         assert isinstance(payload["assertions"], list)
         first = payload["assertions"][0]
         for key in (
+            "harness",
             "provider",
             "layer",
             "id",
@@ -729,10 +732,13 @@ class TestCmdAuditExitCode:
 
 
 class TestSchemaVersion:
-    def test_audit_render_json_has_schema_version_2(self) -> None:
+    def test_audit_render_json_has_schema_version_3(self) -> None:
         """US-004 (#147): audit JSON output bumped from v1 to v2 to
         signal the new ``provider`` per-assertion field + top-level
-        ``providers_seen`` array (DEC-005, DEC-010)."""
+        ``providers_seen`` array (DEC-005, DEC-010 of #147).
+        US-006 (#152): bumped to v3 to signal the new ``harness``
+        per-assertion field + top-level ``harnesses_seen`` array
+        (DEC-010 of #152)."""
         payload = render_json(
             [],
             skill="s",
@@ -740,7 +746,7 @@ class TestSchemaVersion:
             thresholds={"last": 20},
             timestamp="t",
         )
-        assert payload["schema_version"] == 2
+        assert payload["schema_version"] == 3
 
 
 class TestIsAcceptedVersion:
@@ -1853,7 +1859,7 @@ class TestRenderProviderColumn:
 
     def test_render_json_v2_schema_version_first_key(self) -> None:
         """Acceptance criterion 1: ``schema_version`` is the first key
-        and equals 2 (DEC-005)."""
+        and equals 3 (DEC-005 of #147 + DEC-010 of #152 bump)."""
         payload = render_json(
             self._single_provider_verdicts(),
             skill="s",
@@ -1863,7 +1869,7 @@ class TestRenderProviderColumn:
         )
         first_key = next(iter(payload.keys()))
         assert first_key == "schema_version"
-        assert payload["schema_version"] == 2
+        assert payload["schema_version"] == 3
 
     def test_render_json_v2_includes_provider_per_assertion(self) -> None:
         """Acceptance criterion 2: every ``assertions[]`` entry carries
@@ -1994,12 +2000,23 @@ class TestRenderProviderColumn:
 
     def test_render_stdout_table_has_provider_column(self) -> None:
         """Acceptance criterion 6: ``PROVIDER`` column header + one row
-        per ``(provider, layer, id)``."""
+        per ``(provider, layer, id)``.
+
+        US-006 (#152): ``HARNESS`` is now the leftmost column;
+        ``PROVIDER`` follows. L1 rows render the PROVIDER cell as the
+        em-dash placeholder per DEC-008, so only L2/L3 rows surface
+        the actual provider string.
+        """
         table = render_stdout_table(self._mixed_verdicts())
-        # Header has PROVIDER as the leftmost column.
+        # Header has HARNESS as the leftmost column, PROVIDER second.
         first_line = table.splitlines()[0]
-        assert first_line.startswith("PROVIDER")
-        assert "PROVIDER" in table
+        assert first_line.startswith("HARNESS")
+        assert "PROVIDER" in first_line
+        assert first_line.index("HARNESS") < first_line.index("PROVIDER")
+        # Anthropic appears in L3 row (provider cell) and openai in
+        # the openai L3 row. The L1 anthropic row renders ``—`` in the
+        # provider cell, so the substring ``anthropic`` only surfaces
+        # on the anthropic L3 row.
         assert "anthropic" in table
         assert "openai" in table
 
@@ -2009,13 +2026,13 @@ class TestRenderProviderColumn:
         body_lines = [
             line
             for line in table.splitlines()
-            if line and not line.startswith(("PROVIDER", "-"))
+            if line and not line.startswith(("HARNESS", "-"))
         ]
         # The anthropic L1 row should come before the anthropic L3 row,
-        # which should come before the openai L3 row.
+        # which should come before the openai L3 row. L1 row's provider
+        # cell is the em-dash placeholder so identify it by id.
         ant_l1_idx = next(
-            i for i, ln in enumerate(body_lines)
-            if "ant_only" in ln and "anthropic" in ln
+            i for i, ln in enumerate(body_lines) if "ant_only" in ln
         )
         openai_idx = next(
             i for i, ln in enumerate(body_lines) if "openai" in ln
@@ -2024,7 +2041,9 @@ class TestRenderProviderColumn:
 
     def test_render_markdown_has_provider_column(self) -> None:
         """Acceptance criterion 7: per-layer markdown table has
-        ``| provider |`` as the first column."""
+        ``| provider |`` after ``| harness |`` (US-006 of #152
+        widened the leftmost column to harness).
+        """
         md = render_markdown(
             self._mixed_verdicts(),
             skill="s",
@@ -2032,17 +2051,21 @@ class TestRenderProviderColumn:
             thresholds={"last": 10},
             timestamp="t",
         )
-        assert "| provider |" in md
-        # Header column ordering: provider must come before id.
+        assert "| harness | provider |" in md
+        # Header column ordering: harness < provider < id.
         header_line = next(
             line for line in md.splitlines()
-            if line.startswith("| provider |")
+            if line.startswith("| harness |")
         )
+        assert header_line.index("harness") < header_line.index("provider")
         assert header_line.index("provider") < header_line.index("id")
 
     def test_render_markdown_renders_provider_value_in_row(self) -> None:
         """Mixed-provider markdown surfaces both ``anthropic`` and
-        ``openai`` in row cells under L3 detail."""
+        ``openai`` in row cells under L3 detail. L1 rows render
+        provider as ``—`` per DEC-008 so the L1 detail section is
+        intentionally not asserted on for provider strings.
+        """
         md = render_markdown(
             self._mixed_verdicts(),
             skill="s",
@@ -2050,14 +2073,19 @@ class TestRenderProviderColumn:
             thresholds={"last": 10},
             timestamp="t",
         )
-        # Both providers appear inside backtick-quoted cells under
-        # the L3 detail table.
-        assert "`anthropic`" in md
-        assert "`openai`" in md
+        # L3 detail surfaces both providers in backtick-quoted cells.
+        l3_section = md.split("## L3 detail", 1)[1]
+        assert "`anthropic`" in l3_section
+        assert "`openai`" in l3_section
 
     def test_render_stdout_table_truncates_long_provider(self) -> None:
         """Provider column is ~11 chars wide; longer strings are
-        truncated to keep the column-aligned layout."""
+        truncated to keep the column-aligned layout.
+
+        US-006 (#152): the leftmost column is now HARNESS (also
+        ~11 chars wide); PROVIDER is the second column. Truncation
+        applies to both columns.
+        """
         long_provider_agg = AuditAggregate(
             layer="L3",
             id="x",
@@ -2076,10 +2104,12 @@ class TestRenderProviderColumn:
         )
         table = render_stdout_table(verdicts)
         body = table.splitlines()[2]
-        # Only 11 a's appear in the leftmost column slice.
-        assert body.startswith("a" * 11)
-        # And there is whitespace after — the column is bounded.
-        assert body[11] == " "
+        # Leftmost is HARNESS column (claude-code, 11 chars), then space,
+        # then PROVIDER column truncated to 11 a's, then space.
+        assert body.startswith("claude-code ")
+        # Provider cell starts at position 12 with 11 a's.
+        assert body[12:23] == "a" * 11
+        assert body[23] == " "
 
 
 # --------------------------------------------------------------------------- #
@@ -2535,3 +2565,319 @@ class TestApplyThresholdsFourTupleKeys:
         assert ("claude-code", "anthropic", "L3", "x") in agg
         assert ("codex", "anthropic", "L3", "x") in agg
         assert len(agg) == 2
+
+
+class TestRenderStdoutTableHarness:
+    """US-006 (#152): ``render_stdout_table`` adds a leftmost ``HARNESS``
+    column. L1 rows render PROVIDER cell as ``"—"`` (em-dash, U+2014)
+    placeholder per DEC-008; L2/L3 keep the real provider value.
+    The HARNESS cell is real for every layer (L1 included) since the
+    skill subprocess is harnessed by definition.
+    Traces to: DEC-008, DEC-009.
+    """
+
+    def _mixed_verdicts(self) -> list[AuditVerdict]:
+        """One L1 row (claude-code/anthropic) + one L3 row (codex/openai)."""
+        l1 = AuditAggregate(
+            layer="L1",
+            id="has_header",
+            total_with_runs=10,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="anthropic",
+            harness="claude-code",
+        )
+        l3 = AuditAggregate(
+            layer="L3",
+            id="quality",
+            total_with_runs=10,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="openai",
+            harness="codex",
+        )
+        return apply_thresholds(
+            {
+                ("claude-code", "anthropic", "L1", "has_header"): l1,
+                ("codex", "openai", "L3", "quality"): l3,
+            },
+            min_fail_rate=0.0,
+            min_discrimination=0.05,
+        )
+
+    def test_includes_harness_column_leftmost(self) -> None:
+        """Header order: HARNESS is the first column, then PROVIDER."""
+        table = render_stdout_table(self._mixed_verdicts())
+        header = table.splitlines()[0]
+        assert header.startswith("HARNESS")
+        assert "HARNESS" in header
+        assert "PROVIDER" in header
+        assert header.index("HARNESS") < header.index("PROVIDER")
+
+    def test_l1_row_shows_em_dash_for_provider(self) -> None:
+        """L1 row's PROVIDER cell is ``"—"`` (U+2014), not ``"anthropic"``.
+        L2/L3 rows keep the real provider value.
+        """
+        table = render_stdout_table(self._mixed_verdicts())
+        body_lines = [
+            line
+            for line in table.splitlines()
+            if line and not line.startswith(("HARNESS", "-"))
+        ]
+        l1_line = next(line for line in body_lines if "has_header" in line)
+        # L1 row: PROVIDER cell shows em-dash, not 'anthropic'.
+        assert "—" in l1_line  # em-dash present
+        assert "anthropic" not in l1_line  # placeholder NOT shown
+        l3_line = next(line for line in body_lines if "quality" in line)
+        # L3 row keeps the real provider value.
+        assert "openai" in l3_line
+
+    def test_l1_row_shows_real_harness(self) -> None:
+        """L1 row's HARNESS cell is the actual value, NOT em-dash."""
+        table = render_stdout_table(self._mixed_verdicts())
+        body_lines = [
+            line
+            for line in table.splitlines()
+            if line and not line.startswith(("HARNESS", "-"))
+        ]
+        l1_line = next(line for line in body_lines if "has_header" in line)
+        # HARNESS cell shows real value, not em-dash.
+        assert l1_line.startswith("claude-code")
+        l3_line = next(line for line in body_lines if "quality" in line)
+        assert l3_line.startswith("codex")
+
+
+class TestRenderMarkdownHarness:
+    """US-006 (#152): ``render_markdown`` per-layer detail tables get a
+    ``| harness |`` column added before the existing ``| provider |``
+    column. L1 detail table renders provider as ``"—"`` em-dash.
+    Traces to: DEC-008, DEC-009.
+    """
+
+    def _mixed_verdicts(self) -> list[AuditVerdict]:
+        l1 = AuditAggregate(
+            layer="L1",
+            id="has_header",
+            total_with_runs=5,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="anthropic",
+            harness="claude-code",
+        )
+        l3 = AuditAggregate(
+            layer="L3",
+            id="quality",
+            total_with_runs=5,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="openai",
+            harness="codex",
+        )
+        return apply_thresholds(
+            {
+                ("claude-code", "anthropic", "L1", "has_header"): l1,
+                ("codex", "openai", "L3", "quality"): l3,
+            },
+            min_fail_rate=0.0,
+            min_discrimination=0.05,
+        )
+
+    def test_per_layer_table_includes_harness_column(self) -> None:
+        """Per-layer markdown detail tables show ``| harness | provider |``
+        with harness BEFORE provider in the header row.
+        """
+        md = render_markdown(
+            self._mixed_verdicts(),
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        # Header has harness before provider.
+        assert "| harness |" in md
+        header_line = next(
+            line for line in md.splitlines()
+            if line.startswith("| harness |")
+        )
+        assert header_line.index("harness") < header_line.index("provider")
+
+    def test_l1_row_renders_em_dash_for_provider_in_markdown(self) -> None:
+        """L1 markdown row renders provider cell as ``—`` (em-dash);
+        L2/L3 keep the real provider value.
+        """
+        md = render_markdown(
+            self._mixed_verdicts(),
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        # Find the L1 detail section.
+        l1_section = md.split("## L1 detail", 1)[1].split("## L", 1)[0]
+        # L1 row's provider cell is em-dash, not 'anthropic'.
+        assert "—" in l1_section
+        # The provider 'anthropic' string should NOT appear inside an
+        # L1 row backtick cell. (The header line itself doesn't contain
+        # 'anthropic', so checking the row body is sufficient.)
+        l1_data_lines = [
+            line
+            for line in l1_section.splitlines()
+            if line.startswith("| `claude-code`")
+        ]
+        assert len(l1_data_lines) == 1
+        assert "anthropic" not in l1_data_lines[0]
+
+
+class TestRenderJsonHarnessV3:
+    """US-006 (#152): ``render_json`` bumps to ``schema_version: 3``,
+    adds top-level ``harnesses_seen[]`` (sorted, deduped), and each
+    ``assertions[]`` entry gains a ``"harness": str`` field. L1 entries
+    keep ``"provider": "anthropic"`` placeholder in JSON output (the
+    em-dash is stdout/markdown-only per DEC-008).
+    Traces to: DEC-008, DEC-010.
+    """
+
+    def _mixed_verdicts(self) -> list[AuditVerdict]:
+        l1 = AuditAggregate(
+            layer="L1",
+            id="has_header",
+            total_with_runs=5,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="anthropic",
+            harness="claude-code",
+        )
+        l3 = AuditAggregate(
+            layer="L3",
+            id="quality",
+            total_with_runs=5,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="openai",
+            harness="codex",
+        )
+        return apply_thresholds(
+            {
+                ("claude-code", "anthropic", "L1", "has_header"): l1,
+                ("codex", "openai", "L3", "quality"): l3,
+            },
+            min_fail_rate=0.0,
+            min_discrimination=0.05,
+        )
+
+    def test_schema_version_3(self) -> None:
+        """First key is ``schema_version: 3``."""
+        payload = render_json(
+            self._mixed_verdicts(),
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        first_key = next(iter(payload.keys()))
+        assert first_key == "schema_version"
+        assert payload["schema_version"] == 3
+
+    def test_includes_harnesses_seen_array(self) -> None:
+        """Top-level ``harnesses_seen`` is a sorted, deduped list."""
+        payload = render_json(
+            self._mixed_verdicts(),
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        assert "harnesses_seen" in payload
+        assert payload["harnesses_seen"] == ["claude-code", "codex"]
+
+    def test_harnesses_seen_sorted_not_insertion_order(self) -> None:
+        """Stronger sort guard: feed harnesses whose alphabetical order
+        differs from insertion order so a regression that returned
+        ``list(set(...))`` would be caught.
+        """
+        agg_factory = lambda harness: AuditAggregate(  # noqa: E731
+            layer="L3",
+            id="x",
+            total_with_runs=5,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+            provider="anthropic",
+            harness=harness,
+        )
+        verdicts = apply_thresholds(
+            {
+                ("zebra", "anthropic", "L3", "x"): agg_factory("zebra"),
+                ("codex", "anthropic", "L3", "x"): agg_factory("codex"),
+                ("alpha", "anthropic", "L3", "x"): agg_factory("alpha"),
+                ("claude-code", "anthropic", "L3", "x"):
+                    agg_factory("claude-code"),
+            },
+            min_fail_rate=0.0,
+            min_discrimination=0.05,
+        )
+        payload = render_json(
+            verdicts,
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        assert payload["harnesses_seen"] == [
+            "alpha",
+            "claude-code",
+            "codex",
+            "zebra",
+        ]
+
+    def test_per_entry_harness_field(self) -> None:
+        """Each ``assertions[]`` entry has a ``"harness"`` field."""
+        payload = render_json(
+            self._mixed_verdicts(),
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        assert len(payload["assertions"]) == 2
+        for entry in payload["assertions"]:
+            assert "harness" in entry
+            assert entry["harness"] in {"claude-code", "codex"}
+
+    def test_l1_entry_keeps_anthropic_placeholder_in_json(self) -> None:
+        """JSON output keeps ``"provider": "anthropic"`` for L1 (the
+        em-dash is stdout/markdown only per DEC-008).
+        """
+        payload = render_json(
+            self._mixed_verdicts(),
+            skill="s",
+            iterations_analyzed=5,
+            thresholds={"last": 5},
+            timestamp="t",
+        )
+        l1_entry = next(
+            entry for entry in payload["assertions"]
+            if entry["layer"] == "L1"
+        )
+        assert l1_entry["provider"] == "anthropic"
+        assert l1_entry["harness"] == "claude-code"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -757,11 +757,14 @@ class TestIsAcceptedVersion:
         assert _is_accepted_version("extraction.json", 1) is True
         assert _is_accepted_version("extraction.json", 2) is True
         assert _is_accepted_version("extraction.json", 3) is True
+        assert _is_accepted_version("extraction.json", 4) is True
 
-    def test_is_accepted_version_extraction_json_rejects_4(self) -> None:
+    def test_is_accepted_version_extraction_json_rejects_5(self) -> None:
+        # #152 US-003 bumped extraction.json from v3 → v4. The next
+        # un-accepted version is now 5.
         from clauditor.audit import _is_accepted_version
 
-        assert _is_accepted_version("extraction.json", 4) is False
+        assert _is_accepted_version("extraction.json", 5) is False
 
     def test_is_accepted_version_assertions_json_accepts_only_1(self) -> None:
         from clauditor.audit import _is_accepted_version
@@ -1030,12 +1033,13 @@ class TestAuditLegacyCompat:
         self, tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """An extraction.json with ``schema_version=4`` (out of accepted
-        range 1..3) must be skipped with a stderr warning."""
+        """An extraction.json with ``schema_version=5`` (out of accepted
+        range 1..4 — #152 US-003 bumped the max to 4) must be skipped
+        with a stderr warning."""
         clauditor_dir = tmp_path / ".clauditor"
         skill_dir = clauditor_dir / "iteration-1" / "s"
         self._write_extraction_sidecar(
-            skill_dir, version=4, transport_source="api"
+            skill_dir, version=5, transport_source="api"
         )
         records, skipped = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
@@ -1043,7 +1047,7 @@ class TestAuditLegacyCompat:
         assert records == []
         assert skipped == 1
         err = capsys.readouterr().err
-        assert "schema_version=4" in err
+        assert "schema_version=5" in err
 
     def test_baseline_sidecar_v4_skipped_with_baseline_prefix_stripped(
         self, tmp_path: Path,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -739,17 +739,18 @@ class TestIsAcceptedVersion:
     branch and the unknown-filename ``KeyError`` contract.
     """
 
-    def test_is_accepted_version_grading_json_accepts_1_2_3(self) -> None:
+    def test_is_accepted_version_grading_json_accepts_1_2_3_4(self) -> None:
         from clauditor.audit import _is_accepted_version
 
         assert _is_accepted_version("grading.json", 1) is True
         assert _is_accepted_version("grading.json", 2) is True
         assert _is_accepted_version("grading.json", 3) is True
+        assert _is_accepted_version("grading.json", 4) is True
 
-    def test_is_accepted_version_grading_json_rejects_4(self) -> None:
+    def test_is_accepted_version_grading_json_rejects_5(self) -> None:
         from clauditor.audit import _is_accepted_version
 
-        assert _is_accepted_version("grading.json", 4) is False
+        assert _is_accepted_version("grading.json", 5) is False
 
     def test_is_accepted_version_extraction_json_accepts_1_2_3(self) -> None:
         from clauditor.audit import _is_accepted_version
@@ -798,7 +799,8 @@ class TestIsAcceptedVersion:
         assert _is_accepted_version("baseline_grading.json", 3) is True
         assert _is_accepted_version("baseline_extraction.json", 3) is True
         assert _is_accepted_version("baseline_assertions.json", 1) is True
-        assert _is_accepted_version("baseline_grading.json", 4) is False
+        assert _is_accepted_version("baseline_grading.json", 4) is True
+        assert _is_accepted_version("baseline_grading.json", 5) is False
         assert _is_accepted_version("baseline_assertions.json", 2) is False
 
     def test_is_accepted_version_unknown_filename_raises_key_error(
@@ -1010,13 +1012,13 @@ class TestAuditLegacyCompat:
         self, tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """A grading.json with ``schema_version=4`` (out of accepted
-        range 1..3 per US-002 / DEC-008 of #147) must be skipped with a
+        """A grading.json with ``schema_version=5`` (out of accepted
+        range 1..4 post-#152 / DEC-008 of #147) must be skipped with a
         stderr warning."""
         clauditor_dir = tmp_path / ".clauditor"
         skill_dir = clauditor_dir / "iteration-1" / "s"
         self._write_grading_sidecar(
-            skill_dir, version=4, transport_source="api"
+            skill_dir, version=5, transport_source="api"
         )
         records, skipped = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
@@ -1024,7 +1026,7 @@ class TestAuditLegacyCompat:
         assert records == []
         assert skipped == 1
         err = capsys.readouterr().err
-        assert "schema_version=4" in err
+        assert "schema_version=5" in err
 
     def test_extraction_unknown_schema_version_still_skipped(
         self, tmp_path: Path,
@@ -1045,14 +1047,14 @@ class TestAuditLegacyCompat:
         err = capsys.readouterr().err
         assert "schema_version=4" in err
 
-    def test_baseline_sidecar_v4_skipped_with_baseline_prefix_stripped(
+    def test_baseline_sidecar_v5_skipped_with_baseline_prefix_stripped(
         self, tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """A ``baseline_grading.json`` with v4 must be skipped with the
-        same warning as canonical ``grading.json``. Exercises the
-        ``base.startswith("baseline_")`` branch in
-        ``_check_schema_version`` so the rejection-path's
+        """A ``baseline_grading.json`` with v5 must be skipped with the
+        same warning as canonical ``grading.json`` (post-#152 grading
+        max is 4). Exercises the ``base.startswith("baseline_")``
+        branch in ``_check_schema_version`` so the rejection-path's
         ``MAX_SCHEMA_VERSION[base]`` lookup uses the family's max
         rather than crashing on an unknown ``baseline_*`` key."""
         import json
@@ -1060,7 +1062,7 @@ class TestAuditLegacyCompat:
         skill_dir = clauditor_dir / "iteration-1" / "s"
         skill_dir.mkdir(parents=True)
         payload = {
-            "schema_version": 4,
+            "schema_version": 5,
             "skill_name": "s",
             "model": "claude-sonnet-4-6",
             "transport_source": "api",
@@ -1074,7 +1076,7 @@ class TestAuditLegacyCompat:
         )
         assert records == []
         err = capsys.readouterr().err
-        assert "schema_version=4" in err
+        assert "schema_version=5" in err
 
 
 class TestCmdAuditInvalidSkillName:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -763,11 +763,14 @@ class TestIsAcceptedVersion:
 
         assert _is_accepted_version("extraction.json", 4) is False
 
-    def test_is_accepted_version_assertions_json_accepts_only_1(self) -> None:
+    def test_is_accepted_version_assertions_json_accepts_1_and_2(self) -> None:
+        """#152 US-002: assertions.json bumped 1 → 2 with top-level
+        ``harness`` field. v3+ still rejected.
+        """
         from clauditor.audit import _is_accepted_version
 
         assert _is_accepted_version("assertions.json", 1) is True
-        assert _is_accepted_version("assertions.json", 2) is False
+        assert _is_accepted_version("assertions.json", 2) is True
         assert _is_accepted_version("assertions.json", 3) is False
 
     def test_is_accepted_version_rejects_zero_and_negative(self) -> None:
@@ -798,8 +801,10 @@ class TestIsAcceptedVersion:
         assert _is_accepted_version("baseline_grading.json", 3) is True
         assert _is_accepted_version("baseline_extraction.json", 3) is True
         assert _is_accepted_version("baseline_assertions.json", 1) is True
+        # #152 US-002: assertions.json now accepts v2 (harness field).
+        assert _is_accepted_version("baseline_assertions.json", 2) is True
         assert _is_accepted_version("baseline_grading.json", 4) is False
-        assert _is_accepted_version("baseline_assertions.json", 2) is False
+        assert _is_accepted_version("baseline_assertions.json", 3) is False
 
     def test_is_accepted_version_unknown_filename_raises_key_error(
         self,
@@ -1159,14 +1164,18 @@ class TestAuditL3StableId:
     def test_loader_skips_unknown_schema_version(
         self, tmp_path: Path
     ) -> None:
-        """FIX-11: loaders must skip sidecars with unknown schema_version."""
+        """FIX-11: loaders must skip sidecars with unknown schema_version.
+
+        #152 US-002: assertions.json now accepts v2 (top-level
+        ``harness`` field), so the unknown-version probe uses v3.
+        """
         clauditor_dir = tmp_path / ".clauditor"
         skill_dir = clauditor_dir / "iteration-1" / "s"
         skill_dir.mkdir(parents=True)
         (skill_dir / "assertions.json").write_text(
             json.dumps(
                 {
-                    "schema_version": 2,
+                    "schema_version": 3,
                     "runs": [
                         {
                             "results": [

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -13,7 +13,12 @@ import json
 from unittest.mock import AsyncMock, patch
 
 from clauditor.assertions import AssertionResult, AssertionSet
-from clauditor.baseline import _SCHEMA_VERSION, BaselineReports, compute_baseline
+from clauditor.baseline import (
+    _ASSERTIONS_SCHEMA_VERSION,
+    _SCHEMA_VERSION,
+    BaselineReports,
+    compute_baseline,
+)
 from clauditor.grader import ExtractionReport
 from clauditor.quality_grader import GradingReport, GradingResult
 from clauditor.runner import SkillResult
@@ -146,7 +151,10 @@ class TestBaselineReportsToJsonMap:
         files = reports.to_json_map()
         assertions = json.loads(files["baseline_assertions.json"])
         assert list(assertions.keys())[0] == "schema_version"
-        assert assertions["schema_version"] == _SCHEMA_VERSION
+        assert assertions["schema_version"] == _ASSERTIONS_SCHEMA_VERSION
+        # #152 US-002: harness is the second top-level key.
+        assert list(assertions.keys())[1] == "harness"
+        assert assertions["harness"] == "claude-code"
 
     def test_meta_contains_run_fields(self) -> None:
         sr = _make_skill_result(

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -303,6 +303,7 @@ class TestComputeBaseline:
             "claude-sonnet-4-20250514",
             thresholds=eval_spec.grade_thresholds,
             provider="anthropic",
+            harness=sr.harness,
         )
 
     def test_skill_name_and_iteration_propagated(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6175,7 +6175,9 @@ class TestCmdValidateWorkspace:
         assert not (skill_dir / "timing.json").exists()
 
         payload = json.loads(assertions_path.read_text())
-        assert payload["schema_version"] == 1
+        # #152 US-002 / B1: assertions.json bumped to v2 with top-level harness.
+        assert payload["schema_version"] == 2
+        assert payload["harness"] == "claude-code"
         assert payload["skill"] == "test-skill"
         assert payload["iteration"] == 1
         assert len(payload["runs"]) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3642,6 +3642,31 @@ class TestCmdExtract:
         assert "results" in data
         assert len(data["results"]) == 2
 
+    def test_extract_output_uses_spec_harness_for_history(self, tmp_path):
+        """--output mode reads eval_spec.harness for the history record."""
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("some skill output with results")
+
+        eval_spec = _make_eval_spec(sections=_make_sections(), harness="codex")
+        spec = _make_spec(eval_spec=eval_spec)
+        results = self._make_extraction_results(passed=True)
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.grader.extract_and_grade",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+            patch("clauditor.cli.extract.history") as mock_history,
+        ):
+            rc = main(["extract", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+        mock_history.append_record.assert_called_once()
+        call_kwargs = mock_history.append_record.call_args.kwargs
+        assert call_kwargs["harness"] == "codex"
+
     def test_extract_failed(self, tmp_path):
         """Returns 1 when extraction grading fails."""
         output_file = tmp_path / "output.txt"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4840,6 +4840,7 @@ class TestCmdTrend:
                 metrics={"count": i + 1},
                 command="grade",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
             )
 
@@ -4946,6 +4947,7 @@ class TestCmdTrend:
             {},
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
             iteration=1,
             workspace_path="ws/1",
@@ -4979,6 +4981,7 @@ class TestCmdTrendCommandFilter:
                 metrics={},
                 command="grade",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
             )
         for i in range(2):
@@ -4989,6 +4992,7 @@ class TestCmdTrendCommandFilter:
                 metrics={"skill": {"input_tokens": 100 + i}},
                 command="extract",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
             )
 
@@ -5063,6 +5067,7 @@ class TestCmdTrendCommandFilter:
             metrics={},
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
         )
         rc = main(
@@ -5093,6 +5098,7 @@ class TestCmdTrendDottedPath:
                 metrics={"grader": {"input_tokens": tok}},
                 command="grade",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
             )
         rc = main(["trend", "test-skill", "--metric", "grader.input_tokens"])
@@ -5127,6 +5133,7 @@ class TestCmdTrendDottedPath:
             metrics={"grader": {"input_tokens": 500}},
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
         )
         history.append_record(
@@ -5136,6 +5143,7 @@ class TestCmdTrendDottedPath:
             metrics={"grader": {"input_tokens": "n/a"}},
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
         )
         rc = main(["trend", "test-skill", "--metric", "grader.input_tokens"])
@@ -5170,6 +5178,7 @@ class TestCmdTrendListMetrics:
             },
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
         )
         history.append_record(
@@ -5182,6 +5191,7 @@ class TestCmdTrendListMetrics:
             },
             command="extract",
             provider="anthropic",
+            harness="claude-code",
             path=path,
         )
 
@@ -5244,6 +5254,7 @@ class TestCmdTrendListMetrics:
             metrics={},
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
         )
         rc = main(["trend", "test-skill", "--list-metrics"])
@@ -5391,6 +5402,7 @@ class TestCmdTrendProviderFilter:
                 metrics={},
                 command="grade",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
             )
         for i in range(2):
@@ -5401,6 +5413,7 @@ class TestCmdTrendProviderFilter:
                 metrics={},
                 command="grade",
                 provider="openai",
+                harness="claude-code",
                 path=path,
             )
 
@@ -5415,6 +5428,7 @@ class TestCmdTrendProviderFilter:
                 metrics={},
                 command="grade",
                 provider=provider,
+                harness="claude-code",
                 path=path,
             )
 
@@ -5537,6 +5551,7 @@ class TestCmdTrendProviderFilter:
                 metrics={},
                 command="grade",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
             )
         for i in range(3):
@@ -5547,6 +5562,7 @@ class TestCmdTrendProviderFilter:
                 metrics={},
                 command="grade",
                 provider="openai",
+                harness="claude-code",
                 path=path,
             )
 
@@ -5638,8 +5654,8 @@ class TestCmdGradeHistory:
         assert record["skill"] == "test-skill"
         assert record["pass_rate"] == 1.0
         assert record["mean_score"] == 0.9
-        # #147 DEC-012: schema bumped to 2 with mandatory ``provider``.
-        assert record["schema_version"] == 2
+        # #152 DEC-005: schema bumped to 3 with mandatory ``harness``.
+        assert record["schema_version"] == 3
         assert record["command"] == "grade"
         # Default eval-spec uses anthropic; provider is threaded from
         # the four-layer ``_resolve_grading_provider`` resolution.
@@ -5682,7 +5698,7 @@ class TestCmdGradeHistory:
         assert rc == 0
         history_path = tmp_path / ".clauditor" / "history.jsonl"
         record = json.loads(history_path.read_text().splitlines()[0])
-        assert record["schema_version"] == 2
+        assert record["schema_version"] == 3
         assert record["provider"] == "openai"
 
     def test_grade_history_records_metrics(self, tmp_path, monkeypatch):
@@ -5940,8 +5956,8 @@ class TestCmdExtractHistory:
         assert len(lines) == 1
         record = json.loads(lines[0])
         assert record["skill"] == "test-skill"
-        # #147 DEC-012: history schema bumped to 2 with mandatory provider.
-        assert record["schema_version"] == 2
+        # #152 DEC-005: history schema bumped to 3 with mandatory harness.
+        assert record["schema_version"] == 3
         assert record["command"] == "extract"
         assert record["provider"] == "anthropic"
         assert record["pass_rate"] is None
@@ -6004,7 +6020,7 @@ class TestCmdExtractHistory:
         assert rc == 0
         history_path = tmp_path / ".clauditor" / "history.jsonl"
         record = json.loads(history_path.read_text().splitlines()[0])
-        assert record["schema_version"] == 2
+        assert record["schema_version"] == 3
         assert record["provider"] == "openai"
 
     def test_extract_live_run_records_skill_and_grader_tokens(
@@ -6076,8 +6092,8 @@ class TestCmdValidateHistory:
         assert len(lines) == 1
         record = json.loads(lines[0])
         assert record["skill"] == "test-skill"
-        # #147 DEC-012: history schema bumped to 2 with mandatory provider.
-        assert record["schema_version"] == 2
+        # #152 DEC-005: history schema bumped to 3 with mandatory harness.
+        assert record["schema_version"] == 3
         assert record["command"] == "validate"
         # Validate runs Layer 1 only; provider is the placeholder
         # ``"anthropic"`` per #147 DEC-002 / DEC-012.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -851,8 +851,13 @@ class TestCmdGradeSaveDiff:
         assert assertions_path.is_file()
 
         payload = json.loads(assertions_path.read_text())
-        # FIX-7 (#25): sidecar envelopes pin schema_version=1.
-        assert payload["schema_version"] == 1
+        # FIX-7 (#25): sidecar envelopes pin schema_version.
+        # #152 US-002: assertions.json bumped 1 → 2 with top-level
+        # ``harness`` field. ``--output`` mode has no SkillResult, so
+        # the writer falls back to ``"claude-code"`` (the default
+        # harness_name).
+        assert payload["schema_version"] == 2
+        assert payload["harness"] == "claude-code"
         assert payload["skill"] == "test-skill"
         assert payload["iteration"] == 1
         assert len(payload["runs"]) == 1

--- a/tests/test_cli_grade.py
+++ b/tests/test_cli_grade.py
@@ -17,7 +17,9 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from clauditor.cli.grade import _write_assertions_sidecar
+from unittest.mock import AsyncMock, patch
+
+from clauditor.cli.grade import _grade_all_runs, _write_assertions_sidecar
 from clauditor.spec import SkillSpec
 from clauditor.workspace import IterationWorkspace
 from tests.conftest import build_eval_spec
@@ -152,3 +154,30 @@ class TestWriteAssertionsSidecar:
         assert "skill" in keys
         assert "iteration" in keys
         assert "runs" in keys
+
+
+class TestGradeAllRunsHarness:
+    """#152: _grade_all_runs defaults harness to 'claude-code' when
+    skill_results is None (the --output path where no SkillResult exists).
+    """
+
+    def test_defaults_harness_when_skill_results_is_none(self) -> None:
+        """skill_results=None → grade_quality gets harness='claude-code'."""
+        spec = MagicMock(spec=SkillSpec)
+        spec.eval_spec = build_eval_spec()
+        canned = MagicMock()
+
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=canned),
+        ) as mock_grade:
+            reports = _grade_all_runs(
+                run_outputs=[("hello world", [])],
+                spec=spec,
+                model="claude-sonnet-4-6",
+                skill_results=None,
+            )
+
+        assert len(reports) == 1
+        call = mock_grade.await_args
+        assert call.kwargs.get("harness") == "claude-code"

--- a/tests/test_cli_grade.py
+++ b/tests/test_cli_grade.py
@@ -15,9 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
-
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from clauditor.cli.grade import _grade_all_runs, _write_assertions_sidecar
 from clauditor.spec import SkillSpec

--- a/tests/test_cli_grade.py
+++ b/tests/test_cli_grade.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``clauditor.cli.grade._write_assertions_sidecar``.
+
+#152 US-002: assertions.json bumped from schema_version 1 → 2 with a new
+top-level ``harness`` field. Tests pin:
+
+- ``schema_version: 2`` is the first key.
+- ``harness`` is the second top-level key (canonical order:
+  schema_version, harness, skill, iteration, runs).
+- The caller's ``harness`` value is stamped through verbatim
+  (``"claude-code"``, ``"codex"``, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from clauditor.cli.grade import _write_assertions_sidecar
+from clauditor.spec import SkillSpec
+from clauditor.workspace import IterationWorkspace
+from tests.conftest import build_eval_spec
+
+
+def _make_workspace(tmp_path: Path) -> IterationWorkspace:
+    """Build a real :class:`IterationWorkspace` rooted at ``tmp_path``.
+
+    The workspace is *not* finalized; ``tmp_path`` is the staging dir
+    where ``_write_assertions_sidecar`` writes its output.
+    """
+    final_path = tmp_path / "final"
+    tmp_skill_path = tmp_path / "tmp"
+    tmp_skill_path.mkdir()
+    return IterationWorkspace(
+        iteration=1,
+        final_path=final_path,
+        tmp_path=tmp_skill_path,
+    )
+
+
+def _make_spec() -> MagicMock:
+    """Build a MagicMock SkillSpec carrying a minimal EvalSpec."""
+    spec = MagicMock(spec=SkillSpec)
+    spec.skill_name = "demo"
+    spec.eval_spec = build_eval_spec(
+        assertions=[{"type": "contains", "needle": "hello"}],
+    )
+    return spec
+
+
+def _make_args(*, output: bool = False) -> argparse.Namespace:
+    """Minimal argparse.Namespace for ``_write_assertions_sidecar``."""
+    return argparse.Namespace(output=output)
+
+
+class TestWriteAssertionsSidecar:
+    """#152 US-002: schema_version=2 + top-level ``harness`` field."""
+
+    def test_emits_schema_version_2(self, tmp_path: Path) -> None:
+        """Payload starts with ``{"schema_version": 2, ...}``."""
+        workspace = _make_workspace(tmp_path)
+        spec = _make_spec()
+        args = _make_args(output=True)  # output=True skips transcript path
+        run_outputs = [("hello world", [])]
+
+        _write_assertions_sidecar(
+            args=args,
+            spec=spec,
+            workspace=workspace,
+            clauditor_dir=tmp_path / ".clauditor",
+            run_outputs=run_outputs,
+            verbose=False,
+            no_transcript=True,
+            harness="claude-code",
+        )
+
+        sidecar = workspace.tmp_path / "assertions.json"
+        assert sidecar.is_file(), "assertions.json was not written"
+        payload = json.loads(sidecar.read_text())
+        assert payload["schema_version"] == 2
+
+    def test_includes_harness_field(self, tmp_path: Path) -> None:
+        """Top-level ``harness`` from caller value is present."""
+        workspace = _make_workspace(tmp_path)
+        spec = _make_spec()
+        args = _make_args(output=True)
+        run_outputs = [("hello world", [])]
+
+        _write_assertions_sidecar(
+            args=args,
+            spec=spec,
+            workspace=workspace,
+            clauditor_dir=tmp_path / ".clauditor",
+            run_outputs=run_outputs,
+            verbose=False,
+            no_transcript=True,
+            harness="claude-code",
+        )
+
+        sidecar = workspace.tmp_path / "assertions.json"
+        payload = json.loads(sidecar.read_text())
+        assert "harness" in payload
+        assert payload["harness"] == "claude-code"
+
+    def test_harness_passed_through_unchanged(self, tmp_path: Path) -> None:
+        """Caller passes ``"codex"``; payload stamps ``"codex"``."""
+        workspace = _make_workspace(tmp_path)
+        spec = _make_spec()
+        args = _make_args(output=True)
+        run_outputs = [("hello world", [])]
+
+        _write_assertions_sidecar(
+            args=args,
+            spec=spec,
+            workspace=workspace,
+            clauditor_dir=tmp_path / ".clauditor",
+            run_outputs=run_outputs,
+            verbose=False,
+            no_transcript=True,
+            harness="codex",
+        )
+
+        sidecar = workspace.tmp_path / "assertions.json"
+        payload = json.loads(sidecar.read_text())
+        assert payload["harness"] == "codex"
+
+    def test_top_level_key_order(self, tmp_path: Path) -> None:
+        """Canonical key order: schema_version, harness, skill, iteration, runs."""
+        workspace = _make_workspace(tmp_path)
+        spec = _make_spec()
+        args = _make_args(output=True)
+        run_outputs = [("hello world", [])]
+
+        _write_assertions_sidecar(
+            args=args,
+            spec=spec,
+            workspace=workspace,
+            clauditor_dir=tmp_path / ".clauditor",
+            run_outputs=run_outputs,
+            verbose=False,
+            no_transcript=True,
+            harness="claude-code",
+        )
+
+        sidecar = workspace.tmp_path / "assertions.json"
+        payload = json.loads(sidecar.read_text())
+        keys = list(payload.keys())
+        assert keys[0] == "schema_version"
+        assert keys[1] == "harness"
+        # Remaining keys (order-insensitive but must exist).
+        assert "skill" in keys
+        assert "iteration" in keys
+        assert "runs" in keys

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -347,6 +347,10 @@ class TestValidateVerboseInvocation:
         fake_skill_result.duration_seconds = 0.1
         fake_skill_result.input_tokens = 0
         fake_skill_result.output_tokens = 0
+        # #152 US-001: SkillResult.harness is JSON-serialized into the
+        # assertions.json sidecar; MagicMock's auto-attr would not be
+        # serializable.
+        fake_skill_result.harness = "claude-code"
 
         args = MagicMock()
         args.skill = str(skill_path)
@@ -447,6 +451,10 @@ class TestValidateVerboseInvocation:
         fake_skill_result.duration_seconds = 0.0
         fake_skill_result.input_tokens = 0
         fake_skill_result.output_tokens = 0
+        # #152 US-001: SkillResult.harness is JSON-serialized into the
+        # assertions.json sidecar; pin so MagicMock auto-attr does not
+        # propagate.
+        fake_skill_result.harness = "claude-code"
 
         args = MagicMock()
         args.skill = "demo.md"

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1167,6 +1167,86 @@ class TestExtractionReport:
         with pytest.raises(ValueError, match="no stable id"):
             build_extraction_report(extracted, spec)
 
+    def test_to_json_emits_v4_with_harness(self):
+        """#152 US-003: ``to_json`` emits ``schema_version: 4`` first
+        key and includes a top-level ``harness`` field."""
+        report = ExtractionReport(
+            skill_name="s",
+            model="m",
+            results=[],
+            declared_field_ids=["v1"],
+            harness="codex",
+        )
+        raw = report.to_json()
+        data = json.loads(raw)
+        assert next(iter(data)) == "schema_version"
+        assert data["schema_version"] == 4
+        assert data["harness"] == "codex"
+
+    def test_from_json_v4_round_trip(self):
+        """#152 US-003: v4 ``to_json`` then ``from_json`` preserves
+        the ``harness`` field verbatim."""
+        original = ExtractionReport(
+            skill_name="s",
+            model="m",
+            results=[],
+            declared_field_ids=["v1"],
+            harness="codex",
+        )
+        restored = ExtractionReport.from_json(original.to_json())
+        assert restored.harness == "codex"
+
+    def test_from_json_v3_defaults_harness_to_claude_code(self):
+        """#152 US-003: v3 sidecars (no ``harness``) load with
+        ``harness="claude-code"`` defaulted so pre-#152 history
+        loads cleanly."""
+        v3_payload = json.dumps({
+            "schema_version": 3,
+            "skill_name": "legacy-v3",
+            "model": "haiku",
+            "transport_source": "cli",
+            "provider_source": "anthropic",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "parse_errors": [],
+            "fields": {},
+        })
+        restored = ExtractionReport.from_json(v3_payload)
+        assert restored.harness == "claude-code"
+        assert restored.provider_source == "anthropic"
+
+    def test_from_json_v1_v2_legacy_still_load(self):
+        """#152 US-003: v1 and v2 sidecars (pre-provider, pre-harness)
+        still load with all legacy fields defaulted."""
+        v1_payload = json.dumps({
+            "schema_version": 1,
+            "skill_name": "legacy-v1",
+            "model": "haiku",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "parse_errors": [],
+            "fields": {},
+        })
+        v1_report = ExtractionReport.from_json(v1_payload)
+        assert v1_report.harness == "claude-code"
+        assert v1_report.provider_source == "anthropic"
+        assert v1_report.transport_source == "api"
+
+        v2_payload = json.dumps({
+            "schema_version": 2,
+            "skill_name": "legacy-v2",
+            "model": "haiku",
+            "transport_source": "cli",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "parse_errors": [],
+            "fields": {},
+        })
+        v2_report = ExtractionReport.from_json(v2_payload)
+        assert v2_report.harness == "claude-code"
+        assert v2_report.provider_source == "anthropic"
+        assert v2_report.transport_source == "cli"
+
 
 class TestExtractionPromptHardening:
     def test_build_extraction_prompt_fences_untrusted_content(self) -> None:
@@ -1642,10 +1722,10 @@ class TestExtractionReportTransport:
         report = self._report()
         assert report.transport_source == "api"
 
-    def test_to_json_schema_version_bumped_to_3(self):
+    def test_to_json_schema_version_bumped_to_4(self):
         report = self._report(transport_source="cli")
         data = json.loads(report.to_json())
-        assert data["schema_version"] == 3
+        assert data["schema_version"] == 4
 
     def test_schema_version_is_first_key(self):
         report = self._report(transport_source="cli")
@@ -1803,9 +1883,11 @@ class TestExtractionReportProviderSource:
         )
         assert report.provider_source == "anthropic"
 
-    def test_extraction_report_to_json_v3_emits_provider_source(self):
-        """v3 to_json emits ``schema_version: 3`` first key,
-        ``provider_source`` field present."""
+    def test_extraction_report_to_json_v4_emits_provider_source(self):
+        """v4 to_json emits ``schema_version: 4`` first key,
+        ``provider_source`` field present (#152 US-003 bumped v3→v4
+        to add the ``harness`` field; ``provider_source`` continues
+        to ride along)."""
         report = ExtractionReport(
             skill_name="s",
             model="m",
@@ -1816,7 +1898,7 @@ class TestExtractionReportProviderSource:
         raw = report.to_json()
         data = json.loads(raw)
         assert next(iter(data)) == "schema_version"
-        assert data["schema_version"] == 3
+        assert data["schema_version"] == 4
         assert data["provider_source"] == "openai"
 
     def test_extraction_report_from_json_v3_round_trips(self):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -115,15 +115,15 @@ class TestAppendAndRead:
         path = tmp_path / "history.jsonl"
         append_record(
             "skill-a", 0.8, 0.75, {"foo": 1},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
         append_record(
             "skill-b", 0.5, None, {},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
         append_record(
             "skill-a", 0.9, 0.85, {"foo": 2},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
 
         all_records = read_records(path=path)
@@ -144,7 +144,7 @@ class TestAppendAndRead:
         path = tmp_path / "nested" / "dir" / "history.jsonl"
         append_record(
             "s", 1.0, 1.0, {},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
         assert path.exists()
         assert len(read_records(path=path)) == 1
@@ -158,13 +158,13 @@ class TestAppendAndRead:
         path = tmp_path / "history.jsonl"
         append_record(
             "s", 0.5, 0.5, {},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
         with path.open("a", encoding="utf-8") as f:
             f.write("{not valid json\n")
         append_record(
             "s", 0.7, 0.7, {},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
 
         records = read_records(path=path)
@@ -181,7 +181,7 @@ class TestAppendAndRead:
         path = tmp_path / "history.jsonl"
         append_record(
             "s", 1.0, 1.0, {"k": 1},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
         records = read_records(path=path)
         assert records[0]["schema_version"] == SCHEMA_VERSION
@@ -194,18 +194,18 @@ class TestAppendAndRead:
         with pytest.raises(ValueError, match="command must be one of"):
             append_record(
                 "s", 1.0, 1.0, {},
-                command="bogus", provider="anthropic", path=path  # type: ignore[arg-type]
+                command="bogus", provider="anthropic", harness="claude-code", path=path  # type: ignore[arg-type]
             )
         with pytest.raises(ValueError):
             append_record(
                 "s", 1.0, 1.0, {},
-                command="GRADE", provider="anthropic", path=path  # type: ignore[arg-type]
+                command="GRADE", provider="anthropic", harness="claude-code", path=path  # type: ignore[arg-type]
             )
         # Valid values still work.
         for cmd in ("grade", "extract", "validate"):
             append_record(
                 "s", None, None, {},
-                command=cmd, provider="anthropic", path=path
+                command=cmd, provider="anthropic", harness="claude-code", path=path
             )
         assert len(read_records(path=path)) == 3
 
@@ -222,6 +222,7 @@ class TestAppendRecordShape:
             {"k": 1},
             command="grade",
             provider="anthropic",
+            harness="claude-code",
             path=path,
             iteration=3,
             workspace_path=".clauditor/iteration-3/foo",
@@ -237,7 +238,7 @@ class TestAppendRecordShape:
         path = tmp_path / "history.jsonl"
         append_record(
             "s", 1.0, 1.0, {},
-            command="grade", provider="anthropic", path=path
+            command="grade", provider="anthropic", harness="claude-code", path=path
         )
         rec = read_records(path=path)[0]
         assert rec["iteration"] is None
@@ -245,18 +246,19 @@ class TestAppendRecordShape:
 
 
 class TestProviderField:
-    """v2 schema: ``provider`` required on append, defaulted on v1 reads (#147)."""
+    """v3 schema: ``provider`` required on append, defaulted on v1 reads (#147)."""
 
-    def test_append_record_v2_writes_provider_field(self, tmp_path):
+    def test_append_record_writes_provider_field(self, tmp_path):
         path = tmp_path / "history.jsonl"
         append_record(
             "skill-a", 0.8, 0.7, {},
-            command="grade", provider="openai", path=path,
+            command="grade", provider="openai", harness="claude-code",
+            path=path,
         )
         records = read_records(path=path)
         assert len(records) == 1
         rec = records[0]
-        assert rec["schema_version"] == 2
+        assert rec["schema_version"] == SCHEMA_VERSION
         assert rec["provider"] == "openai"
 
     def test_append_record_requires_provider_kwarg(self, tmp_path):
@@ -265,7 +267,7 @@ class TestProviderField:
             # missing required keyword-only ``provider``
             append_record(
                 "skill-a", 0.8, 0.7, {},
-                command="grade", path=path,  # type: ignore[call-arg]
+                command="grade", harness="claude-code", path=path,  # type: ignore[call-arg]
             )
 
     def test_append_record_rejects_blank_provider(self, tmp_path):
@@ -277,7 +279,8 @@ class TestProviderField:
         with pytest.raises(ValueError, match="provider"):
             append_record(
                 "skill-a", 0.8, 0.7, {},
-                command="grade", provider="", path=path,
+                command="grade", provider="", harness="claude-code",
+                path=path,
             )
 
     def test_append_record_rejects_whitespace_provider(self, tmp_path):
@@ -285,7 +288,8 @@ class TestProviderField:
         with pytest.raises(ValueError, match="provider"):
             append_record(
                 "skill-a", 0.8, 0.7, {},
-                command="grade", provider="   ", path=path,
+                command="grade", provider="   ", harness="claude-code",
+                path=path,
             )
 
     def test_append_record_rejects_auto(self, tmp_path):
@@ -297,7 +301,8 @@ class TestProviderField:
         with pytest.raises(ValueError, match="auto"):
             append_record(
                 "skill-a", 0.8, 0.7, {},
-                command="grade", provider="auto", path=path,
+                command="grade", provider="auto", harness="claude-code",
+                path=path,
             )
 
     def test_append_record_rejects_non_string_provider(self, tmp_path):
@@ -306,6 +311,7 @@ class TestProviderField:
             append_record(
                 "skill-a", 0.8, 0.7, {},
                 command="grade", provider=1,  # type: ignore[arg-type]
+                harness="claude-code",
                 path=path,
             )
 
@@ -334,23 +340,24 @@ class TestProviderField:
         # Defaulted on read so downstream consumers can rely on the field.
         assert records[0]["provider"] == "anthropic"
 
-    def test_read_records_v2_preserves_provider(self, tmp_path):
+    def test_read_records_preserves_provider(self, tmp_path):
         path = tmp_path / "history.jsonl"
         append_record(
             "skill-a", 0.9, 0.8, {},
-            command="grade", provider="openai", path=path,
+            command="grade", provider="openai", harness="claude-code",
+            path=path,
         )
 
         records = read_records(path=path)
         assert len(records) == 1
-        assert records[0]["schema_version"] == 2
+        assert records[0]["schema_version"] == SCHEMA_VERSION
         assert records[0]["provider"] == "openai"
 
-    def test_read_records_mixed_v1_v2_lines(self, tmp_path):
+    def test_read_records_mixed_v1_current_lines(self, tmp_path):
         import json as _json
 
         path = tmp_path / "history.jsonl"
-        # Hand-write a v1 line, then append a v2 line via the writer.
+        # Hand-write a v1 line, then append a v3 line via the writer.
         v1_record = {
             "schema_version": 1,
             "command": "grade",
@@ -365,7 +372,8 @@ class TestProviderField:
         path.write_text(_json.dumps(v1_record) + "\n")
         append_record(
             "skill-a", 0.9, 0.8, {},
-            command="grade", provider="openai", path=path,
+            command="grade", provider="openai", harness="claude-code",
+            path=path,
         )
 
         records = read_records(path=path)
@@ -373,13 +381,185 @@ class TestProviderField:
         # v1: defaulted provider
         assert records[0]["schema_version"] == 1
         assert records[0]["provider"] == "anthropic"
-        # v2: preserved provider
-        assert records[1]["schema_version"] == 2
+        # current version: preserved provider
+        assert records[1]["schema_version"] == SCHEMA_VERSION
         assert records[1]["provider"] == "openai"
 
 
+class TestHarnessField:
+    """v3 schema: ``harness`` required on append, defaulted on v1/v2 reads.
+
+    Mirrors the post-#147 ``provider`` shape; #152 DEC-005.
+    """
+
+    def test_v3_writes_harness_field(self, tmp_path):
+        """A v3 record contains the resolved harness name verbatim."""
+        path = tmp_path / "history.jsonl"
+        append_record(
+            "skill-a", 0.8, 0.7, {},
+            command="grade", provider="anthropic", harness="codex",
+            path=path,
+        )
+        records = read_records(path=path)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["schema_version"] == 3
+        assert rec["harness"] == "codex"
+
+    def test_harness_keyword_required(self, tmp_path):
+        """Calling ``append_record`` without ``harness=`` raises TypeError."""
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(TypeError):
+            # missing required keyword-only ``harness``
+            append_record(
+                "skill-a", 0.8, 0.7, {},
+                command="grade", provider="anthropic",  # type: ignore[call-arg]
+                path=path,
+            )
+
+    def test_harness_blank_rejected(self, tmp_path):
+        """Defense-in-depth: ``harness=""`` is unresolvable.
+
+        Mirror of provider validation — the CLI seam plumbs a resolved
+        harness name; rejecting blanks here prevents future callers from
+        corrupting trend/audit grouping with an unresolvable empty bucket.
+        """
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(ValueError, match="harness"):
+            append_record(
+                "skill-a", 0.8, 0.7, {},
+                command="grade", provider="anthropic", harness="",
+                path=path,
+            )
+
+    def test_harness_whitespace_rejected(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(ValueError, match="harness"):
+            append_record(
+                "skill-a", 0.8, 0.7, {},
+                command="grade", provider="anthropic", harness="   ",
+                path=path,
+            )
+
+    def test_harness_auto_rejected(self, tmp_path):
+        """``"auto"`` is the unresolved sentinel — the CLI's
+        ``_resolve_harness`` is responsible for collapsing it to a
+        concrete harness. Reject it here so a future caller that
+        bypasses the resolver cannot persist the sentinel.
+        """
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(ValueError, match="auto"):
+            append_record(
+                "skill-a", 0.8, 0.7, {},
+                command="grade", provider="anthropic", harness="auto",
+                path=path,
+            )
+
+    def test_harness_non_string_rejected(self, tmp_path):
+        path = tmp_path / "history.jsonl"
+        with pytest.raises(ValueError, match="harness"):
+            append_record(
+                "skill-a", 0.8, 0.7, {},
+                command="grade", provider="anthropic",
+                harness=1,  # type: ignore[arg-type]
+                path=path,
+            )
+
+
+class TestReadRecordsLegacyHarnessDefault:
+    """Legacy v1/v2 records default missing ``harness`` to ``"claude-code"`` on read."""
+
+    def test_v1_legacy_defaults_harness_to_claude_code(self, tmp_path):
+        import json as _json
+
+        path = tmp_path / "history.jsonl"
+        v1_record = {
+            "schema_version": 1,
+            "command": "grade",
+            "ts": "2026-01-01T00:00:00+00:00",
+            "skill": "skill-a",
+            "pass_rate": 0.5,
+            "mean_score": 0.6,
+            "metrics": {},
+            "iteration": 1,
+            "workspace_path": "ws/1",
+        }
+        path.write_text(_json.dumps(v1_record) + "\n")
+
+        records = read_records(path=path)
+        assert len(records) == 1
+        assert records[0]["schema_version"] == 1
+        # Defaulted on read so downstream consumers can rely on the field.
+        assert records[0]["harness"] == "claude-code"
+
+    def test_v2_legacy_defaults_harness_to_claude_code(self, tmp_path):
+        """v2 record without ``harness`` key defaults to ``"claude-code"`` on read."""
+        import json as _json
+
+        path = tmp_path / "history.jsonl"
+        v2_record = {
+            "schema_version": 2,
+            "command": "grade",
+            "ts": "2026-01-01T00:00:00+00:00",
+            "skill": "skill-a",
+            "pass_rate": 0.5,
+            "mean_score": 0.6,
+            "metrics": {},
+            "iteration": 2,
+            "workspace_path": "ws/2",
+            "provider": "openai",
+        }
+        path.write_text(_json.dumps(v2_record) + "\n")
+
+        records = read_records(path=path)
+        assert len(records) == 1
+        assert records[0]["schema_version"] == 2
+        assert records[0]["provider"] == "openai"
+        assert records[0]["harness"] == "claude-code"
+
+    def test_v3_round_trip(self, tmp_path):
+        """Write a v3 record, read it back; harness is preserved verbatim."""
+        path = tmp_path / "history.jsonl"
+        append_record(
+            "skill-a", 0.9, 0.8, {},
+            command="grade", provider="anthropic", harness="codex",
+            path=path,
+        )
+        records = read_records(path=path)
+        assert len(records) == 1
+        assert records[0]["schema_version"] == 3
+        assert records[0]["harness"] == "codex"
+
+    def test_v3_explicit_harness_not_overwritten(self, tmp_path):
+        """Explicit ``harness`` on v3 records is preserved (no legacy default)."""
+        import json as _json
+
+        path = tmp_path / "history.jsonl"
+        v3_record = {
+            "schema_version": 3,
+            "command": "grade",
+            "ts": "2026-01-01T00:00:00+00:00",
+            "skill": "skill-a",
+            "pass_rate": 0.9,
+            "mean_score": 0.8,
+            "metrics": {},
+            "iteration": 3,
+            "workspace_path": "ws/3",
+            "provider": "openai",
+            "harness": "codex",
+        }
+        path.write_text(_json.dumps(v3_record) + "\n")
+
+        records = read_records(path=path)
+        assert len(records) == 1
+        assert records[0]["harness"] == "codex"
+
+
 class TestSchemaVersionEnforcement:
-    """read_records accepts {1, 2} (DEC-012); rejects all other versions."""
+    """read_records accepts {1, 2, 3}; rejects all other versions.
+
+    Per #147 DEC-012 (added v2) and #152 DEC-005 (added v3).
+    """
 
     def test_wrong_version_skipped_with_warning(self, tmp_path, capsys):
         import json as _json
@@ -400,7 +580,7 @@ class TestSchemaVersionEnforcement:
         assert len(records) == 0
         err = capsys.readouterr().err
         assert "schema_version=99" in err
-        assert "expected one of [1, 2]" in err
+        assert "expected one of [1, 2, 3]" in err
 
     def test_missing_version_skipped_with_warning(self, tmp_path, capsys):
         import json as _json
@@ -419,13 +599,14 @@ class TestSchemaVersionEnforcement:
         assert len(records) == 0
         err = capsys.readouterr().err
         assert "schema_version=None" in err
-        assert "expected one of [1, 2]" in err
+        assert "expected one of [1, 2, 3]" in err
 
     def test_valid_record_passes(self, tmp_path, capsys):
         path = tmp_path / "history.jsonl"
         append_record(
             "skill-a", 0.9, 0.85, {},
-            command="grade", provider="anthropic", path=path,
+            command="grade", provider="anthropic", harness="claude-code",
+            path=path,
             iteration=2, workspace_path="ws/2",
         )
 
@@ -453,6 +634,7 @@ class TestSchemaVersionEnforcement:
             "iteration": None,
             "workspace_path": None,
             "provider": "anthropic",
+            "harness": "claude-code",
         }
         lines = [
             _json.dumps(bad),
@@ -481,6 +663,7 @@ def _concurrent_writer(args):
         {"i": idx},
         command="grade",
         provider="anthropic",
+        harness="claude-code",
         path=Path(path_str),
         iteration=idx,
         workspace_path=f"ws/{idx}",
@@ -552,6 +735,7 @@ class TestFileLockFallback:
                 metrics={},
                 command="grade",
                 provider="anthropic",
+                harness="claude-code",
                 path=path,
                 iteration=1,
                 workspace_path=".clauditor/iteration-1/foo",

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -822,7 +822,7 @@ class TestClauditorGraderFactory:
         mock_eval_spec = MagicMock()
         mock_eval_spec.grading_provider = None
         mock_eval_spec.grading_model = "claude-sonnet-4-6"
-        mock_eval_spec.harness = "codex"  # Should NOT be threaded; no run.
+        mock_eval_spec.harness = "codex"  # Concrete harness on spec.
 
         mock_spec = MagicMock()
         mock_spec.eval_spec = mock_eval_spec
@@ -841,7 +841,9 @@ class TestClauditorGraderFactory:
         # spec.run was NOT called — output was provided directly.
         mock_spec.run.assert_not_called()
         call = mock_grade.await_args
-        assert call.kwargs.get("harness") == "claude-code"
+        # When output= is provided and eval_spec.harness is a concrete
+        # value (not "auto"), the fixture uses the spec's harness.
+        assert call.kwargs.get("harness") == "codex"
 
 
 class TestClauditorTriggersFactory:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -723,6 +723,126 @@ class TestClauditorGraderFactory:
         call = mock_grade.await_args
         assert call.args[0] == "captured skill output"
 
+    def test_uses_harness_from_eval_spec(self, tmp_path, monkeypatch):
+        """#152 US-008: when ``eval_spec.harness`` is set, the fixture
+        threads it through ``spec.run`` (which honors the spec field
+        per #151 US-007), and ``result.harness`` (set by the runner
+        per #152 US-001) propagates into ``grade_quality(harness=...)``.
+
+        We mock ``grade_quality`` to inspect the kwarg shape — the
+        production code path is: ``spec.run()`` returns a SkillResult
+        whose ``harness`` field reflects the spec preference, and the
+        fixture passes that value as ``harness=`` to ``grade_quality``.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = self._request_with_model()
+
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.grading_provider = None
+        mock_eval_spec.grading_model = "claude-sonnet-4-6"
+        # Author preference: codex harness.
+        mock_eval_spec.harness = "codex"
+
+        # Simulate the runner's projection of the resolved harness onto
+        # SkillResult.harness (#152 US-001). spec.run() — already wrapped
+        # by clauditor_spec to honor eval_spec.harness — returns this.
+        mock_run_result = MagicMock()
+        mock_run_result.output = "captured codex output"
+        mock_run_result.harness = "codex"
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = mock_eval_spec
+        mock_spec.run.return_value = mock_run_result
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=canned),
+        ) as mock_grade:
+            factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+            factory(tmp_path / "skill.md")
+
+        # grade_quality received the SkillResult's harness verbatim.
+        call = mock_grade.await_args
+        assert call.kwargs.get("harness") == "codex"
+
+    def test_defaults_harness_to_claude_code_when_eval_spec_unset(
+        self, tmp_path, monkeypatch
+    ):
+        """#152 US-008: when ``eval_spec.harness`` is unset (default
+        ``"auto"``) and the runner produces a default-harness
+        SkillResult, the fixture passes ``"claude-code"`` to
+        ``grade_quality``. Verifies the default-flow stays at
+        ``"claude-code"`` post-#152.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = self._request_with_model()
+
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.grading_provider = None
+        mock_eval_spec.grading_model = "claude-sonnet-4-6"
+        # Default: "auto" — clauditor_spec leaves harness_name_override
+        # as None, and the runner's default ClaudeCodeHarness produces
+        # SkillResult.harness == "claude-code".
+        mock_eval_spec.harness = "auto"
+
+        mock_run_result = MagicMock()
+        mock_run_result.output = "captured default output"
+        mock_run_result.harness = "claude-code"
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = mock_eval_spec
+        mock_spec.run.return_value = mock_run_result
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=canned),
+        ) as mock_grade:
+            factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+            factory(tmp_path / "skill.md")
+
+        call = mock_grade.await_args
+        assert call.kwargs.get("harness") == "claude-code"
+
+    def test_harness_defaults_to_claude_code_when_output_provided(
+        self, tmp_path, monkeypatch
+    ):
+        """When the caller passes ``output=`` directly, no skill
+        subprocess runs, so the fixture falls back to ``"claude-code"``
+        as the harness label — there's no SkillResult to read it from.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = self._request_with_model()
+
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.grading_provider = None
+        mock_eval_spec.grading_model = "claude-sonnet-4-6"
+        mock_eval_spec.harness = "codex"  # Should NOT be threaded; no run.
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = mock_eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=canned),
+        ) as mock_grade:
+            factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+            factory(tmp_path / "skill.md", output="pre-captured output")
+
+        # spec.run was NOT called — output was provided directly.
+        mock_spec.run.assert_not_called()
+        call = mock_grade.await_args
+        assert call.kwargs.get("harness") == "claude-code"
+
 
 class TestClauditorTriggersFactory:
     """Direct coverage of clauditor_triggers error branch."""
@@ -742,6 +862,55 @@ class TestClauditorTriggersFactory:
         factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
         with pytest.raises(ValueError, match="No eval spec found"):
             factory(tmp_path / "skill.md")
+
+    def test_uses_harness_from_eval_spec(self, tmp_path, monkeypatch):
+        """#152 US-008: when ``eval_spec.harness`` is set, the triggers
+        fixture still works correctly. ``TriggerReport`` has no
+        ``harness`` field (the trigger-precision judge classifies
+        queries against a description and does NOT run the skill
+        subprocess), so this is a regression-guard verifying the
+        fixture stays compatible when the spec author has set a
+        non-default harness preference.
+
+        Mirrors the structural shape of
+        ``TestClauditorGraderFactory::test_uses_harness_from_eval_spec``
+        but documents the absence of harness threading at the trigger
+        layer.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {"--clauditor-model": "claude-sonnet-4-6"}.get(opt)
+        )
+
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.grading_provider = None
+        mock_eval_spec.grading_model = "claude-sonnet-4-6"
+        mock_eval_spec.harness = "codex"  # Author preference
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = mock_eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.triggers.test_triggers",
+            new=AsyncMock(return_value=canned),
+        ) as mock_triggers:
+            factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
+            result = factory(tmp_path / "skill.md")
+
+        # Triggers ran without raising despite the codex harness preference.
+        # No ``harness=`` kwarg is passed (TriggerReport has no harness
+        # axis per #152's scope; harness is recorded on captures, not
+        # trigger-precision results).
+        assert result is canned
+        call = mock_triggers.await_args
+        assert "harness" not in call.kwargs
+        # spec.run is NOT called — triggers does not run the skill.
+        mock_spec.run.assert_not_called()
 
 
 class TestClauditorBlindCompareFactory:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -845,6 +845,35 @@ class TestClauditorGraderFactory:
         # value (not "auto"), the fixture uses the spec's harness.
         assert call.kwargs.get("harness") == "codex"
 
+    def test_output_provided_auto_harness_defaults_to_claude_code(
+        self, tmp_path
+    ):
+        """output= with harness='auto' falls back to 'claude-code'."""
+        request = self._request_with_model()
+
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.grading_provider = None
+        mock_eval_spec.grading_model = "claude-sonnet-4-6"
+        mock_eval_spec.harness = "auto"  # Default — should fall back.
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = mock_eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=canned),
+        ) as mock_grade:
+            factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+            factory(tmp_path / "skill.md", output="pre-captured output")
+
+        mock_spec.run.assert_not_called()
+        call = mock_grade.await_args
+        assert call.kwargs.get("harness") == "claude-code"
+
 
 class TestClauditorTriggersFactory:
     """Direct coverage of clauditor_triggers error branch."""

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -354,10 +354,10 @@ class TestGradingReportTransport:
         report = self._report()
         assert report.transport_source == "api"
 
-    def test_to_json_schema_version_bumped_to_3(self):
+    def test_to_json_schema_version_bumped_to_4(self):
         report = self._report(transport_source="cli")
         data = json.loads(report.to_json())
-        assert data["schema_version"] == 3
+        assert data["schema_version"] == 4
 
     def test_schema_version_is_first_key(self):
         """Per ``.claude/rules/json-schema-version.md``, schema_version
@@ -399,9 +399,9 @@ class TestGradingReportTransport:
         original = self._report(transport_source="cli")
         restored = GradingReport.from_json(original.to_json())
         assert restored.transport_source == "cli"
-        # v3 round-trip still emits v3 (post-#147).
+        # v4 round-trip still emits v4 (post-#152).
         data = json.loads(restored.to_json())
-        assert data["schema_version"] == 3
+        assert data["schema_version"] == 4
 
 
 class TestBlindReportSchema:
@@ -474,13 +474,13 @@ class TestGradingReportProviderSource:
         assert report.provider_source == "anthropic"
 
     def test_grading_report_to_json_v3_emits_provider_source(self):
-        """v3 to_json emits ``schema_version: 3`` first key,
+        """to_json emits ``schema_version: 4`` first key (post-#152),
         ``provider_source`` field present."""
         report = self._report(provider_source="openai")
         raw = report.to_json()
         data = json.loads(raw)
         assert next(iter(data)) == "schema_version"
-        assert data["schema_version"] == 3
+        assert data["schema_version"] == 4
         assert data["provider_source"] == "openai"
 
     def test_grading_report_from_json_v3_round_trips(self):
@@ -525,6 +525,95 @@ class TestGradingReportProviderSource:
         report = self._report()  # default provider_source="anthropic"
         data = json.loads(report.to_json())
         assert data["provider_source"] == "anthropic"
+
+
+class TestGradingReportHarness:
+    """#152 US-004: GradingReport persists a ``harness`` field on disk
+    at ``schema_version: 4``. The field defaults to ``"claude-code"``
+    and reads through from :class:`SkillResult.harness`. Legacy
+    v1/v2/v3 sidecars (no ``harness``) load with
+    ``harness="claude-code"`` defaulted."""
+
+    def _report(self, **overrides) -> GradingReport:
+        defaults = dict(
+            skill_name="harness-test",
+            results=_make_results([True]),
+            model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
+        )
+        defaults.update(overrides)
+        return GradingReport(**defaults)
+
+    def test_harness_defaults_to_claude_code(self):
+        report = self._report()
+        assert report.harness == "claude-code"
+
+    def test_to_json_emits_v4_with_harness(self):
+        """v4 to_json emits ``schema_version: 4`` first key,
+        ``harness`` field present after ``provider_source``."""
+        report = self._report(harness="codex")
+        raw = report.to_json()
+        data = json.loads(raw)
+        assert next(iter(data)) == "schema_version"
+        assert data["schema_version"] == 4
+        assert data["harness"] == "codex"
+
+    def test_from_json_v4_round_trip(self):
+        """v4 from_json round-trips ``harness`` faithfully."""
+        original = self._report(harness="codex")
+        restored = GradingReport.from_json(original.to_json())
+        assert restored.harness == "codex"
+
+    def test_from_json_v3_defaults_harness_to_claude_code(self):
+        """v3 sidecars (no ``harness``) default to ``"claude-code"``
+        so pre-#152 history loads cleanly."""
+        v3_payload = json.dumps({
+            "schema_version": 3,
+            "skill_name": "legacy-v3",
+            "model": "claude-sonnet-4-6",
+            "transport_source": "cli",
+            "provider_source": "openai",
+            "results": [],
+        })
+        restored = GradingReport.from_json(v3_payload)
+        assert restored.harness == "claude-code"
+        assert restored.provider_source == "openai"
+        assert restored.transport_source == "cli"
+
+    def test_from_json_v1_v2_legacy_still_load(self):
+        """v1 and v2 sidecars still load, with ``harness`` defaulted
+        to ``"claude-code"`` alongside the existing v1/v2 defaults."""
+        v1_payload = json.dumps({
+            "schema_version": 1,
+            "skill_name": "legacy-v1",
+            "model": "claude-sonnet-4-6",
+            "results": [],
+        })
+        restored_v1 = GradingReport.from_json(v1_payload)
+        assert restored_v1.harness == "claude-code"
+        assert restored_v1.provider_source == "anthropic"
+        assert restored_v1.transport_source == "api"
+
+        v2_payload = json.dumps({
+            "schema_version": 2,
+            "skill_name": "legacy-v2",
+            "model": "claude-sonnet-4-6",
+            "transport_source": "cli",
+            "results": [],
+        })
+        restored_v2 = GradingReport.from_json(v2_payload)
+        assert restored_v2.harness == "claude-code"
+        assert restored_v2.provider_source == "anthropic"
+        assert restored_v2.transport_source == "cli"
+
+    def test_harness_claude_code_emitted_explicitly_on_disk(self):
+        """v4 always emits ``harness`` on disk, even for the default
+        ``"claude-code"`` value, so the field is explicit and
+        round-trip is byte-stable."""
+        report = self._report()  # default harness="claude-code"
+        data = json.loads(report.to_json())
+        assert data["harness"] == "claude-code"
 
 
 class TestBlindReportProviderSource:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -158,6 +158,52 @@ class TestSkillResultSucceeded:
 
 
 # ---------------------------------------------------------------------------
+# SkillResult.harness field (#152 US-001 / clauditor-gfo)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillResult:
+    """``SkillResult.harness`` is the foundation for #152 sidecar emitters.
+
+    DEC-002 of ``plans/super/152-sidecar-harness-field.md``: the field
+    is populated from the active harness's ``name`` ClassVar at every
+    ``SkillResult(...)`` construction site inside ``SkillRunner._invoke``.
+    """
+
+    def test_harness_field_present_with_default(self):
+        """Direct dataclass construction yields ``harness == "claude-code"``."""
+        result = SkillResult(
+            output="hi", exit_code=0, skill_name="t", args=""
+        )
+        assert result.harness == "claude-code"
+
+
+class TestSkillRunner:
+    """``SkillRunner._invoke`` stamps ``SkillResult.harness`` from
+    ``self.harness.name`` per ``harness-protocol-shape.md``.
+    """
+
+    def test_invoke_populates_harness_from_active_harness(self):
+        """A custom ``MockHarness`` (name="mock") plumbs through verbatim."""
+        from clauditor._harnesses._mock import MockHarness
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir="/tmp", harness=mock)
+        result = runner.run("foo")
+        assert result.harness == "mock"
+
+    def test_invoke_populates_harness_claude_code_default(self):
+        """Default ``ClaudeCodeHarness`` stamps ``"claude-code"`` on the result."""
+        runner = SkillRunner(project_dir="/tmp", claude_bin="claude")
+        with patch(
+            "clauditor._harnesses._claude_code.subprocess.Popen",
+            return_value=make_fake_skill_stream("ok"),
+        ):
+            result = runner.run("my-skill")
+        assert result.harness == "claude-code"
+
+
+# ---------------------------------------------------------------------------
 # Harness protocol + InvokeResult.harness_metadata (US-001 / clauditor-3sm.1)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Super plan for #152 — Multi-harness: add `harness` field to L1/L2/L3 sidecars; bump schemas.

**Phase:** detailing (awaiting approval)
**Stories:** 9 implementation + Quality Gate + Patterns & Memory
**Decisions:** 14 decisions captured (DEC-001 through DEC-014)

## Context

Mirror of #147 on the harness axis. Sidecars must record which harness produced the output so audit/trend doesn't average across non-comparable runs. Closes the gap left after #151 made the harness identity materializable but didn't yet record it on artifacts.

Dependencies #147 and #151 are both CLOSED. Blocks #153.

## Schema bumps (target state)

| Artifact | `dev` today | After #152 |
|---|---|---|
| `assertions.json` | v1 | **v2** (adds top-level `harness`) |
| `extraction.json` | v3 | **v4** (adds `harness` sibling to `provider_source`) |
| `grading.json` | v3 | **v4** (adds `harness` sibling to `provider_source`) |
| `history.jsonl` | v2 | **v3** (adds `harness`; mandatory `harness=` keyword on `append_record`) |
| audit `render_json` output | v2 | **v3** (adds top-level `harnesses_seen[]`; per-entry `harness`) |
| `BlindReport` JSON | v1 | (stays v1 — no harness axis at blind-judge time) |

`MAX_SCHEMA_VERSION` map post-#152: `{"assertions.json": 2, "extraction.json": 4, "grading.json": 4}`.

## Plan document

See `plans/super/152-sidecar-harness-field.md` for the full plan.

## Story summary

- **US-001** — `SkillResult.harness: str` field; populate from `runner.harness.name`
- **US-002** — `assertions.json` v1 → v2 (inline writer in `_write_assertions_sidecar`)
- **US-003** — `ExtractionReport` v3 → v4 + legacy default-on-read
- **US-004** — `GradingReport` v3 → v4 + legacy default-on-read
- **US-005** — `IterationRecord` / `AuditAggregate` `harness` field; aggregate grouping key 3-tuple → 4-tuple
- **US-006** — Audit renderers: HARNESS leftmost column; `render_json` v2 → v3 with `harnesses_seen[]`; L1 provider cell renders as "—"
- **US-007** — `history.jsonl` v2 → v3; mandatory `harness=` kwarg on `append_record`
- **US-008** — Pytest fixtures auto-populate `harness` from `EvalSpec.harness` resolution
- **US-009** — Docs: `.claude/rules/json-schema-version.md` "#152" section + `docs/cli-reference.md:473` HARNESS-column sentence
- **Quality Gate** — code-reviewer ×4 + CodeRabbit + validation
- **Patterns & Memory** — rule anchor updates

## Architecture review

Master rating: **PASS** (no blockers). Three concerns resolved as DEC-A1/A2/A3 in refinement:
- DEC-A1 — `HARNESS` leftmost column order (matches grouping-key tuple order)
- DEC-A2 — `render_json` bumps to v3 (mirrors #147's audit JSON v1 → v2)
- DEC-A3 — Strict doc footprint (rule + cli-reference only)

## Next steps

- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audit reports now group results by harness alongside provider to support multi-harness evaluation workflows
  * Audit output includes a new HARNESS column showing which harness generated each result
  * Persistent harness tracking in sidecar files enables improved result provenance and cross-harness analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->