### PR TITLE
#154: per-iteration context.json sidecar (plan)

### DIFF
--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -149,6 +149,83 @@ Writers and readers (post-#147):
 - `src/clauditor/history.py::append_record` (keyword-only `provider=`) /
   `read_records` (defaults missing `provider` to `"anthropic"`).
 
+### New sidecar family — `context.json` (#154)
+
+`#154` introduced `context.json` — a new per-iteration sidecar family
+written once per `iteration-N/<skill>/` alongside `assertions.json`,
+`extraction.json`, and `grading.json`. It carries the comparability
+metadata that lets `clauditor audit` / `clauditor trend` group runs
+honestly across the harness, provider, model, and sandbox axes
+(rather than bumping every existing per-call sidecar with
+correlated fields). The file ships at `schema_version: 1` and is
+**designed to stay at v1** — see the always-v1 contract below.
+
+The dataclass `src/clauditor/context.py::IterationContext` is the
+single source of truth for the v1 shape:
+
+| Field                  | Type           | Nullability                                    |
+| ---------------------- | -------------- | ---------------------------------------------- |
+| `schema_version`       | `int = 1`      | always non-null (first key per the invariant)  |
+| `harness`              | `str`          | always non-null — `{"claude-code", "codex"}`   |
+| `provider`             | `str \| None`  | null when no LLM grading happened — `{"anthropic", "openai"}` when set |
+| `model_runner`         | `str`          | always non-null — model the harness used to run the skill |
+| `model_grader`         | `str \| None`  | null iff `provider` is null                    |
+| `system_prompt_source` | `str`          | always non-null — `{"explicit", "agents_md", "skill_md"}` |
+| `sandbox_mode`         | `str \| None`  | null when `harness != "codex"` — `{"read-only", "workspace-write", "danger-full-access"}` when set |
+| `reasoning_tokens`     | `int \| None`  | always null in this PR — populated by #170     |
+| `cost_usd`             | `float \| None`| always null in this PR — populated by #169     |
+
+Registered in the audit loader's per-filename version map as
+`MAX_SCHEMA_VERSION["context.json"] = 1` in
+`src/clauditor/audit.py::MAX_SCHEMA_VERSION`, sharing the same
+`_is_accepted_version` / `_check_schema_version` plumbing every
+other sidecar family uses (DEC-008's "version-and-up" check).
+
+**Always-v1 contract — forward-compat-by-design.** Unlike
+`grading.json` / `extraction.json` (which bumped at #86 and #147
+to add new non-null fields), `context.json` is engineered so the
+two anticipated follow-ups can populate fields **without bumping
+the schema version**. The trick: `reasoning_tokens` and `cost_usd`
+ship as nullable from day one, even though no production writer
+populates them yet. A null field is an absent value, not a
+structural change — so when #169 wires up the pricing module to
+fill `cost_usd: float` and #170 wires up per-provider reasoning
+capture to fill `reasoning_tokens: int`, the on-disk shape stays
+v1 and every existing reader keeps working unchanged. Bumps cost
+audit / trend / badge integration churn (default-on-read defaults,
+loader branches, regression tests for legacy iterations); avoiding
+them by pre-declaring the fields as nullable is the cheaper shape
+when the future fields are known up-front. This is the key teaching
+this subsection codifies: **a new sidecar family that anticipates
+follow-up additions should pre-declare them as nullable in v1
+rather than ship a minimal v1 and bump on every addition.**
+
+Writers (both write the same `IterationContext.to_json()` payload
+into `skill_dir / "context.json"` during workspace staging per
+`.claude/rules/sidecar-during-staging.md`):
+
+- `src/clauditor/cli/grade.py::_write_workspace_sidecars` — the
+  `grade` command's per-iteration write site.
+- `src/clauditor/cli/validate.py::cmd_validate` — the `validate`
+  command's per-iteration write site.
+
+Readers:
+
+- `src/clauditor/audit.py::_read_context` — audit-side reader,
+  invoked from `load_iterations` parallel to the per-record
+  loaders. Iterations whose `context.json` is absent (pre-#154
+  history) map to `None` so renderers can emit a nullable column.
+- `src/clauditor/badge.py::load_iteration_context` — badge-side
+  reader that surfaces the parsed `IterationContext` into
+  `ClauditorExtension.context` (the optional carrier field on the
+  badge sidecar's clauditor-extension payload, omitted entirely
+  when `None` per the layer-omission shape — see
+  `.claude/rules/dual-version-external-schema-embed.md`).
+
+Follow-up tickets that will populate the nullable placeholders
+WITHOUT bumping the schema: #169 (`cost_usd` pricing module) and
+#170 (`reasoning_tokens` per-provider capture).
+
 ## When this rule applies
 
 Any new persisted JSON file whose shape may evolve. Internal-only debug

--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -168,7 +168,7 @@ single source of truth for the v1 shape:
 | `schema_version`       | `int = 1`      | always non-null (first key per the invariant)  |
 | `harness`              | `str`          | always non-null — `{"claude-code", "codex"}`   |
 | `provider`             | `str \| None`  | null when no LLM grading happened — `{"anthropic", "openai"}` when set |
-| `model_runner`         | `str`          | always non-null — model the harness used to run the skill |
+| `model_runner`         | `str \| None`  | null when the harness cannot expose the actually-used model (e.g. the `claude` CLI's stream-json `result` carries no model field, so `ClaudeCodeHarness` records `None` when neither the constructor nor the per-call override pinned a value); fabricating a default would be a lie |
 | `model_grader`         | `str \| None`  | null iff `provider` is null                    |
 | `system_prompt_source` | `str`          | always non-null — `{"explicit", "agents_md", "skill_md"}` |
 | `sandbox_mode`         | `str \| None`  | null when `harness != "codex"` — `{"read-only", "workspace-write", "danger-full-access"}` when set |
@@ -225,6 +225,20 @@ Readers:
 Follow-up tickets that will populate the nullable placeholders
 WITHOUT bumping the schema: #169 (`cost_usd` pricing module) and
 #170 (`reasoning_tokens` per-provider capture).
+
+**Audit-output JSON bump (`render_json` v3 → v4).** Independent of
+the per-sidecar `MAX_SCHEMA_VERSION["context.json"]: 1`
+registration above, the audit-output JSON envelope itself bumped
+from `schema_version: 3` to `schema_version: 4` in #154 US-005
+(DEC-005) when the new top-level `iteration_contexts` array
+landed. The bump follows the same shape as the #147 v1→v2 bump
+and the #152 v2→v3 bump: a new top-level field is a SHAPE change
+that demands a `schema_version` increment so downstream JSON
+consumers have a stable signal to branch on. v3 readers should
+expect the `iteration_contexts` field to be absent; v4 readers
+can treat `iteration_contexts == []` as "no contexts available"
+(the legacy-iterations case). File anchor:
+`src/clauditor/audit.py::render_json`.
 ### Schema version bumps for #152 (`harness` field)
 
 `#152` added `harness` — the harness-axis sibling to `provider_source` —

--- a/.claude/rules/path-validation.md
+++ b/.claude/rules/path-validation.md
@@ -43,7 +43,59 @@ if not candidate.is_file():
   FIFOs, character devices, etc. Combined with the strict resolve, also
   rejects broken symlinks.
 
+## Multi-anchor variant: searching multiple containment roots
+
+When a resolver consults more than one anchor (e.g. "look in
+`<skill-dir>` first, then fall back to `<project-root>`"), apply
+the recipe to **each** anchor independently — never relax it for
+the fallback tier. Anchors are typed by which containment root the
+candidate must satisfy; a candidate found via the second tier
+must still `is_relative_to` the second-tier anchor (NOT the first).
+A hostile symlink in the first-tier directory pointing outside its
+anchor is a security signal, not an excuse to silently fall through
+to the second tier — let the `ValueError` propagate.
+
+The shape collapses to one helper that loops over `(anchor, candidate)`
+pairs:
+
+```python
+def resolve_first_match(
+    candidates: list[tuple[Path, Path]],
+) -> Path | None:
+    """For each (anchor, candidate) pair, validate via the recipe;
+    return the first resolved path. Raises on escape from any
+    visited anchor; returns ``None`` if no candidate file exists."""
+    for anchor, candidate in candidates:
+        if not candidate.is_file():
+            continue
+        try:
+            resolved = candidate.resolve(strict=True)
+            anchor_resolved = anchor.resolve(strict=True)
+        except FileNotFoundError:  # pragma: no cover — defensive
+            continue
+        if not resolved.is_relative_to(anchor_resolved):
+            raise ValueError(
+                f"{candidate} resolves to {resolved!r} which "
+                f"escapes anchor {anchor_resolved!r}"
+            )
+        return resolved
+    return None
+```
+
+The order of `candidates` is the precedence order — first valid
+file wins. The fail-loud-on-escape posture means a poisoned
+first-tier anchor blocks the resolver entirely; this is the
+correct security behavior because falling through would silently
+accept the second tier as if the first didn't exist.
+
 ## Canonical implementation
 
 `src/clauditor/schemas.py` — `EvalSpec.from_file()`, the `input_files`
 validation block. Reuse this recipe verbatim for any new path-bearing field.
+
+`src/clauditor/paths.py::resolve_agents_md` — multi-anchor variant
+introduced by #154 DEC-009. Searches `<skill-dir>/AGENTS.md` first,
+then `<project-root>/AGENTS.md`, with the recipe applied to each
+anchor independently. Symlink-escape from either tier raises
+`ValueError`; absent both tiers returns `None` for the caller to
+fall through to its own default.

--- a/plans/super/154-context-sidecar.md
+++ b/plans/super/154-context-sidecar.md
@@ -228,13 +228,15 @@ User answered scoping Q1–Q6 in order: B (with follow-up ticket), A (with follo
 
 ### Decisions resolved post-Architecture-Review (user: "All Confirm")
 
-#### DEC-007: `model_runner: str` (always-non-null); harness contract guarantees `harness_metadata["model"]`
+#### DEC-007: `model_runner: str | None` (nullable); harness contract guarantees the **key** `harness_metadata["model"]` is present (value MAY be `None`)
 
-**Decision:** `IterationContext.model_runner` is typed `str` (never `None`). The contract is: every harness MUST populate `harness_metadata["model"]` on every successful invoke. CodexHarness already satisfies this (`_codex.py:747`); ClaudeCodeHarness gains it in this PR per DEC-004. The sidecar writer reads `skill_result.harness_metadata["model"]` directly — a `KeyError` here is loud and surfaces a contract violation immediately rather than persisting `null` and hiding the bug.
+**Decision:** `IterationContext.model_runner` is typed `str | None`. The contract is: every harness MUST populate the **key** `harness_metadata["model"]` on every successful invoke (presence required so the sidecar writer can use an unguarded subscript and fail loudly on a contract violation), but the **value** MAY be `None` when the harness legitimately cannot expose the model that was actually used. CodexHarness always populates a concrete string (`_codex.py:747`); ClaudeCodeHarness gains the key in this PR per DEC-004 but may stamp the value as `None` when neither the constructor nor the per-call override pinned a model — the `claude` CLI's stream-json `result` message carries no model field, so the actually-used model cannot be recovered after the fact. Recording a fabricated default (e.g. `"claude-sonnet-4-6"`) would be a lie that defeats the comparability purpose of `model_runner`. `None` is the honest "no model recorded" signal.
 
-**Rationale:** The architectural review noted that "always-non-null" is only safe if the harness contract is mechanically enforced. By making the read an unguarded subscript (not `.get("model", None)`), any future harness that forgets to populate the key fails its first integration test loudly. Defaulting to `None` would silently mask the bug — opposite of `pre-llm-contract-hard-validate.md`'s spirit.
+**Post-QG narrative update:** The original DEC-007 wording ("always-non-null `str`") proved too strict in QG: forcing `ClaudeCodeHarness` to fabricate a default for the unpinned-model case was rejected as worse than nullable. The contract was tightened to "key always present" and the type was relaxed to `str | None`. The `IterationContext.from_dict` validator and the audit/badge readers all accept `None` end-to-end; the rendered `audit --verbose` column emits `"-"` for the null case.
 
-**Validation criteria embedded:** ClaudeCodeHarness invoke unit test asserts `result.harness_metadata["model"]` matches the resolved model (default + override paths); CodexHarness retains its existing assertion; CLI integration test asserts `context.json["model_runner"]` round-trips.
+**Rationale:** The architectural review's "always-non-null is only safe if the harness contract is mechanically enforced" insight still holds — the contract enforcement just landed on key-presence (unguarded subscript) rather than value-non-nullability. A future harness that forgets to populate the key still fails its first integration test loudly. Allowing `None` for the value preserves the loud-failure-on-key-omission shape while admitting the honest "harness cannot recover this" case.
+
+**Validation criteria embedded:** ClaudeCodeHarness invoke unit test asserts `result.harness_metadata["model"]` is present (key always set, value may be `None`); CodexHarness retains its existing concrete-string assertion; CLI integration test asserts `context.json["model_runner"]` round-trips both `str` and `None` values.
 
 #### DEC-008: `system_prompt_source` flows via `harness_metadata["system_prompt_source"]`
 
@@ -287,7 +289,7 @@ The "project root" anchor is whatever clauditor's existing project-root resolver
 Story ordering follows the natural data-flow direction: foundation (dataclass + validators) → harness-side data sources → resolver → sidecar writer → readers (audit + badge) → rule refresh → quality gate → patterns. Each story is sized for one Ralph context window.
 
 Project validation command (embedded in every story's acceptance criteria):
-```
+```bash
 uv run ruff check src/ tests/ && uv run pytest --cov=clauditor --cov-report=term-missing
 ```
 The 80% coverage gate is enforced.
@@ -571,7 +573,7 @@ The 80% coverage gate is enforced.
 
 ### Dependency graph
 
-```
+```text
 US-001 ────┬─→ US-003 ──┐
            ├─→ US-004 ──┼─→ US-005 ──┐
 US-002 ────┴─→ US-003   │             ├─→ US-008 ──→ US-009

--- a/plans/super/154-context-sidecar.md
+++ b/plans/super/154-context-sidecar.md
@@ -1,0 +1,588 @@
+# 154: Comparability — per-iteration `context.json` sidecar
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/154
+- **Branch:** `feature/154-context-sidecar`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/154-context-sidecar`
+- **PR:** TBD
+- **Phase:** detailing
+- **Epic:** TBD
+- **Sessions:** 1 (2026-05-08)
+- **Total decisions:** 11 (DEC-001 through DEC-011)
+- **Depends on:** #149 (CLOSED — `CodexHarness`), #152 (CLOSED — `harness` field on L1/L2/L3 sidecars)
+- **Sibling / parent:** #143 (multi-provider / multi-harness umbrella, OPEN)
+- **Independent of:** #153
+- **Blocks (follow-ups created from scoping):** #169 (cost_usd pricing module), #170 (reasoning_tokens capture)
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Add a new per-iteration sidecar `iteration-N/<skill>/context.json` that captures comparability metadata — the data needed to interpret a score but not part of the score itself: which harness ran the skill, which model the harness used, which provider's SDK served the grader call, which model the grader used, where the system prompt came from, what sandbox mode (Codex), how many reasoning tokens, and a best-effort cost estimate. Surface the captured context in `clauditor audit --verbose` and badge generation.
+
+**Why:** Multi-provider + multi-harness work (#143 umbrella, with #149 / #146 / #147 / #151 / #152 already shipped) means two iterations of the "same" eval can now differ along multiple dimensions: harness binary, runner model, grader provider, grader model, system-prompt source, sandbox posture. Today `audit` reads L1/L2/L3 sidecars and groups by `(provider, harness, layer, id)` (post-#147 + #152) but cannot expose WHY two iterations differ — readers see two grouped lines but not "iteration 17 ran under Codex sandbox=danger-full-access while iteration 18 ran under Codex sandbox=workspace-write." `context.json` is the single per-iteration place those gotchas live so they surface instead of being normalized away.
+
+**Out of scope (per ticket):**
+- Authoritative cost-per-provider price tables — best-effort lookup with a fallback to `null` is fine.
+- Cross-iteration aggregation of context (separate concern; trend/audit grouping by context dimensions is a future ticket).
+- Bumping any existing sidecar's `schema_version` — `context.json` is a NEW sidecar family, not an extension of an existing one.
+
+### Codebase findings (from Codebase Scout)
+
+#### Sidecar-write call sites (where `context.json` slots in)
+
+- **Canonical write loop:** `src/clauditor/cli/grade.py::_write_workspace_sidecars` (lines 750–845). Writes `grading.json`, `assertions.json`, `extraction.json`, baseline + benchmark sidecars in turn, all into `workspace.tmp_path` BEFORE `workspace.finalize()`. Insertion point for `context.json`: just after `grading.json` is written, before the finalize, inside the same `try/except → workspace.abort()` envelope.
+- **Second write site:** `src/clauditor/cli/validate.py::cmd_validate` (lines 200–258). Calls `allocate_iteration` + `workspace.tmp_path`; writes `assertions.json` only (no L2/L3). For validate-only iterations the new sidecar's `provider`, `model_grader`, `cost_usd`, `reasoning_tokens` are all `null`.
+- **No other CLI commands allocate iterations.** `extract`, `capture`, `run` do NOT call `allocate_iteration` and therefore do NOT produce iteration dirs — they are out of scope for `context.json` writes.
+
+#### Field-source inventory (every schema field, mapped to what's available today)
+
+| context.json field | Source / where it lives today | Net effort |
+|---|---|---|
+| `harness: str` | `harness.name` (`ClassVar[str]`) on the protocol; resolved value already passed into `_write_workspace_sidecars` as `harness_name: str \| None` (cli/grade.py:764). For validate, resolved via `_resolve_harness(args, spec.eval_spec)` at the CLI seam too. | **Trivial** — read string already in scope. |
+| `provider: str \| None` | Resolved at `cli/grade.py:386` via `_resolve_grading_provider(args, spec.eval_spec)`. Threaded into `_write_workspace_sidecars` as `provider=` (line 839). For `validate`: no LLM grader → `null`. | **Trivial** — null when no grader call ran. |
+| `model_runner: str` | Codex puts it in `InvokeResult.harness_metadata["model"]` (`_codex.py:747`). Claude Code does NOT today — `argv += ["--model", effective_model]` (`_claude_code.py:538`) but stream-json `result` carries no model field. The harness instance has `self.model` (set at `__init__`), which is the value actually used. | **Small new plumbing** — DEC needed: option (a) post-call read `harness.model` from the runner; option (b) thread through `harness_metadata["model"]` for parity with Codex. (b) is more uniform. |
+| `model_grader: str \| None` | `GradingReport.model` (`quality_grader.py:90`) — already persisted. For ExtractionReport too (`grader.py`). For `validate`-only: `null`. | **Trivial** — read from primary report. |
+| `system_prompt_source: "skill_md" \| "agents_md" \| "explicit"` | Resolution lives in `src/clauditor/spec.py:204–228` (post-#150). `effective_system_prompt = self.eval_spec.system_prompt if (eval_spec.system_prompt is not None) else None`; if still None → auto-derived from SKILL.md body (`parse_frontmatter`). `EvalSpec.system_prompt` exists at `schemas.py:253`. **No `agents_md` path exists today** — Codex consumes a flat prompt (`_codex.py:560–562`) but does not auto-derive from `AGENTS.md`. | **DEC needed** — should `agents_md` ship in this PR or be reserved for a future ticket? Today only `"skill_md"` and `"explicit"` are reachable. Threading the source through `SkillSpec.run` → `SkillResult.harness_metadata["system_prompt_source"]` is small. |
+| `sandbox_mode: str \| None` | `_codex.py:240–242` — currently `_SANDBOX_MODE = "workspace-write"` hardcoded. Already populated into `harness_metadata["sandbox_mode"]` at `_codex.py:743`. Claude Code: `null` (no sandbox concept). | **Trivial** — read from `harness_metadata["sandbox_mode"]`, default `null`. |
+| `reasoning_tokens: int \| None` | NOT tracked today. Neither `InvokeResult` nor `ModelResult` carries a separate reasoning-token field. OpenAI o-series / GPT-5 reasoning models bill them separately; Anthropic thinking models too. | **DEC needed** — option (a) ship as `null`-only placeholder until a future ticket adds reasoning-token plumbing; option (b) add minimal capture inside `_providers/_openai.py` + `_providers/_anthropic.py` for the reasoning-model cases that exist today. |
+| `cost_usd: float \| None` | NO pricing helper exists. `grep -rn "cost_usd\|price_per_token\|pricing" src/` returns zero hits. | **DEC needed** — option (a) ship `null`-only and defer pricing module to a follow-up; option (b) ship a small `_providers/_pricing.py` with hardcoded prices for known models, `null` for unknowns. |
+
+#### Audit-reader integration
+
+- `src/clauditor/audit.py::load_iterations` (lines 356–430) reads `assertions.json`, `extraction.json`, `grading.json` via `_read_json` and dispatches to `_records_from_*` helpers.
+- `MAX_SCHEMA_VERSION` (lines 52–56) needs `"context": 1` added (per `json-schema-version.md`).
+- `--verbose` rendering: `render_stdout_table`, `render_markdown`, `render_json`. Insertion point for the per-iteration context block is render-time, not aggregation-time — context.json is **not** aggregated (it varies per iteration; aggregation is the job of #143's future tickets).
+
+#### Badge generation integration
+
+- `src/clauditor/badge.py` + `src/clauditor/cli/badge.py`. Per `dual-version-external-schema-embed.md`, the shields.io-side `<skill>.json` cannot carry unknown keys; context goes in the sibling `<skill>.clauditor.json` extension under a new `context: {...}` block. Whether the extension's `schema_version` bumps from 1 to 2 is a DEC.
+
+### Conventions / rules consulted (from Convention Checker)
+
+**Apply — drive implementation:**
+
+1. **`json-schema-version.md`** — Writer emits `schema_version: 1` as first key; loader registers `"context": 1` in `MAX_SCHEMA_VERSION`; `_check_schema_version` enforces. New sidecar family (NOT a bump of an existing one), so the rule's "Schema version bumps for #147" section does not need extension — but a small "New sidecar family — context.json (#154)" addition under canonical implementations is appropriate per `rule-refresh-vs-delete.md`.
+2. **`sidecar-during-staging.md`** — Write inside `workspace.tmp_path` BEFORE `workspace.finalize()`; sit inside the `try/except → workspace.abort()` envelope. No `--no-context` flag (always-on), so the "Skip-write flags must clean pre-staged subtrees" subsection does not apply.
+3. **`pure-compute-vs-io-split.md`** — `IterationContext` is a pure dataclass with `to_json() -> str`; the CLI caller does the `write_text`. Mirrors anchor #1 (`Benchmark.to_json` + `compute_benchmark`). Adds an eighth anchor.
+4. **`constant-with-type-info.md`** — `bool is not int` guard for `reasoning_tokens` and `cost_usd` if any post-load validator is built. The dataclass holds the type via the `int | None` / `float | None` annotation; no per-key `KeySpec` table needed at this scale.
+5. **`harness-protocol-shape.md`** — Read `harness.name` (the `ClassVar[str]`); no new protocol member needed. **However** — capturing `model_runner` for ClaudeCodeHarness uniformly with Codex's `harness_metadata["model"]` is consistent with the "harness_metadata as forward-compat surface" subsection (DEC-007 of #148). New protocol member for `system_prompt_source` capture may also be in scope.
+6. **`stream-json-schema.md`** — Token counts come from `SkillResult` (already defensively parsed). No new stream-json reading at the sidecar layer.
+7. **`pre-llm-contract-hard-validate.md`** — Hard-validate `harness ∈ {"claude-code", "codex"}`, `provider ∈ {"anthropic", "openai", None}`, `system_prompt_source ∈ {"skill_md", "agents_md", "explicit"}` at write time so a future regression cannot silently stamp garbage into history.
+8. **`multi-provider-dispatch.md`** — Read `provider` from the same CLI-seam resolution that gates `check_provider_auth`. The sidecar is a downstream observer, not a new dispatch surface.
+9. **`centralized-sdk-call.md`** — `ModelResult.provider` already carries the provider string. No new plumbing through `call_model`. The sidecar reads what's already returned.
+10. **`data-vs-asserter-split.md`** — `IterationContext` stays methodless except `to_json` / `from_dict`. If tests grow `assert_*` helpers, they live in `asserters.py` per the rule.
+11. **`rule-refresh-vs-delete.md`** — `json-schema-version.md` may benefit from a small addition documenting `context.json` as a new sidecar family. Refresh-in-place, do not create a parallel rule.
+
+**N/A — explicitly ruled out:**
+
+`back-compat-shim-discipline.md`, `spec-cli-precedence.md`, `non-mutating-scrub.md`, `dual-version-external-schema-embed.md` (context.json is clauditor-only — but the rule DOES apply to the badge integration step, see below), `llm-cli-exit-code-taxonomy.md`, `monotonic-time-indirection.md`, `bundled-skill-docs-sync.md`, `readme-promotion-recipe.md`, `positional-id-zip-validation.md`, `pytester-inprocess-coverage-hazard.md`, `mock-side-effect-for-distinct-calls.md`, `in-memory-dict-loader-path.md`, `precall-env-validation.md`, `per-type-drift-hints.md`, `permissive-parser-strict-validator.md`, `subprocess-cwd.md`, `path-validation.md`, `eval-spec-stable-ids.md`, `internal-skill-live-test-tmp-symlink.md`, `skill-identity-from-frontmatter.md`, `test-infra-shutil-which-coupling.md`, `llm-judge-prompt-injection.md`, `project-root-home-exclusion.md`. Note: `dual-version-external-schema-embed.md` DOES apply to the badge-integration story (where the context surfaces in the `.clauditor.json` extension, NOT the shields.io payload).
+
+### Scoping questions for the user
+
+These are the choices that drive the per-story breakdown — answers shape decisions DEC-001…DEC-006 below.
+
+#### Q1: `cost_usd` — ship pricing module now, or null-only placeholder?
+
+The ticket explicitly says "best-effort lookup with a fallback to null is fine." Two interpretations:
+
+- **A.** Ship a minimal `src/clauditor/_providers/_pricing.py` with hardcoded `(provider, model) → (input_$/Mtok, output_$/Mtok)` for known model families today (claude-sonnet-4-6, claude-opus-4-7, gpt-5.4, gpt-5.4-mini, etc.). Unknown model → `null`. Estimated cost computed at sidecar-write time from the grader's `input_tokens`/`output_tokens` and the harness's runner tokens too. **Pro:** delivers the ticket's headline value. **Con:** prices drift; we sign up for periodic updates.
+- **B.** Ship `cost_usd: float | None = None` as a placeholder field. Add a TODO + follow-up issue. **Pro:** zero maintenance burden today; pricing tables live elsewhere later (or are imported from a third-party library). **Con:** the ticket lists `cost_usd` as a first-class capture; shipping it null-only means the audit/badge surface only ever shows `null` until a follow-up lands.
+- **C.** Ship pricing for a single provider (e.g. Anthropic only — we have the most authoritative numbers there) and `null` for OpenAI. **Pro:** delivers value where we're most confident. **Con:** asymmetric experience.
+
+#### Q2: `reasoning_tokens` — placeholder or capture-now?
+
+- **A.** Placeholder `null` for this PR. Add reasoning-token plumbing in a future ticket once we touch `_providers/_openai.py` for o-series / GPT-5 thinking-model cases. **Pro:** smaller blast radius. **Con:** users running GPT-5 grading get `reasoning_tokens=null` even when the API returns them.
+- **B.** Capture inside both providers (`_providers/_anthropic.py` for thinking models, `_providers/_openai.py` for o-series / GPT-5) in this PR. Add `reasoning_tokens: int | None` to `ModelResult`. **Pro:** accurate from day one. **Con:** widens scope; needs SDK-version checks.
+
+#### Q3: `system_prompt_source` — ship two literals now, or all three?
+
+Today only `"skill_md"` (auto-derived) and `"explicit"` (`EvalSpec.system_prompt`) are reachable. `"agents_md"` requires new resolver work in `spec.py` to detect a sibling `AGENTS.md` and route to it (Codex convention).
+
+- **A.** Ship the literal-set as `{"skill_md", "explicit"}` and treat `"agents_md"` as a future-reserved value. The schema validator rejects it for now; future ticket adds the resolver branch + lifts the rejection.
+- **B.** Ship the full literal-set `{"skill_md", "agents_md", "explicit"}` AND wire up the AGENTS.md resolver in `spec.py` in this same PR. Adds a story.
+- **C.** Skip `system_prompt_source` from this PR entirely — defer to whichever ticket actually adds AGENTS.md support. Ticket shape would change.
+
+#### Q4: `model_runner` capture for ClaudeCodeHarness — uniform with Codex?
+
+Codex stamps `harness_metadata["model"]` already (`_codex.py:747`). ClaudeCodeHarness does not.
+
+- **A.** Add `harness_metadata["model"]` to `ClaudeCodeHarness.invoke` for parity. Tiny patch in `_claude_code.py`. The sidecar then reads `skill_result.harness_metadata.get("model")` uniformly. **Pro:** uniform; future-proof.
+- **B.** Read `self.harness.model` directly from the runner instance after invoke. **Con:** couples sidecar writer to harness internals; ignores the protocol's `harness_metadata` forward-compat surface.
+
+#### Q5: Audit `--verbose` rendering shape
+
+The ticket says "Audit verbose mode shows a context block per iteration." Two render shapes:
+
+- **A.** Per-iteration block in `render_markdown` and `render_stdout_table` — one collapsible/dedicated section per iteration listing the seven captured fields. `render_json` adds a top-level `iterations[*].context` key.
+- **B.** Tabular columns in `render_stdout_table` (one extra row group) + an annotation footer in markdown listing only the dimensions where iterations differ from each other ("only show what's interesting"). More work, less noise.
+- **C.** JSON-only for now (just expose `context` in `render_json`); markdown/stdout get a single-line summary. Defer rich rendering to a follow-up.
+
+#### Q6: Badge extension integration
+
+Per `dual-version-external-schema-embed.md`, context surfaces in the sibling `<skill>.clauditor.json` (NOT the shields.io payload). Two design choices:
+
+- **A.** Add `extension.context: {...}` (the same seven fields) AND bump `ClauditorExtension.schema_version` 1 → 2. Loader defaults missing `context` to `null` for v1.
+- **B.** Add `extension.context: {...}` as a strictly-additive optional field; do NOT bump schema_version (loaders today already tolerate unknown keys for forward-compat). Simpler, but breaks the discipline of bumping when shape changes.
+- **C.** Skip badge integration for this PR; ship audit `--verbose` only. Badge integration becomes a follow-up.
+
+---
+
+## Architecture Review
+
+### Session 1 — 2026-05-08
+
+Six parallel subagents (security, performance, data model, testing, API/integration, observability). Ratings + load-bearing findings:
+
+| Area | Rating | Headline finding |
+|---|---|---|
+| Security | **blocker + concern** | (Blocker) AGENTS.md resolver MUST apply `.claude/rules/path-validation.md` recipe before any file read — otherwise a hostile/typoed `EvalSpec` can escape the spec dir. (Concern) `sandbox_mode` strings need a closed-set validator (`{"read-only", "workspace-write", "danger-full-access"}`) — `harness_metadata: dict[str, Any]` carries them today with no constraint. |
+| Performance | pass | All adds are sub-millisecond. AGENTS.md stat per `SkillSpec.run` is microseconds, dwarfed by subprocess launch. Audit-side context read folds into the existing per-iteration loop (1–5 ms × N iterations is invisible against grading wall time). |
+| Data Model | pass + concerns | (Pass) Schema-version first-key invariant preserved; null-only `reasoning_tokens` / `cost_usd` are forward-compat without future schema bump. (Concerns) `MAX_SCHEMA_VERSION` map needs `"context.json": 1` registered; `provider ↔ model_grader` nullability invariant needs to be explicit (both null iff no grading happened); `model_runner` always-non-null claim needs the harness contract (`harness_metadata["model"]`) wired in the same PR. |
+| Testing | pass + 1 concern | All test surfaces have strong existing patterns (`TestGradingReportSerialization`, `TestCodexHarnessInvoke`, `_make_iteration_fixture`). One concern: AGENTS.md resolver tests are blocked on DEC-009 (same-dir vs walk-up). No `pytester.runpytest_inprocess` hazard. |
+| API / Integration | pass + 1 blocker echo | Module placement → new `src/clauditor/context.py` (parallel to `benchmark.py` / `baseline.py`). AGENTS.md resolver inline in `SkillSpec.run` (single-caller exception per `pure-compute-vs-io-split.md`). Badge schema bump 1→2 requires `from_dict` default-on-read for missing `context`. |
+| Observability | pass + 1 concern | (Pass) AGENTS.md resolver decision belongs in `context.json`, NOT stderr — not an implicit-coupling announcement family member. Sidecar absence follows existing `_read_json` silent-skip convention; malformed/wrong-schema fires the existing stderr warning via `_check_schema_version`. (Concern) Audit `--verbose` shows per-iteration blocks per DEC-005, but a top-line "iterations span 2 harnesses, 1 provider" rollup is underspecified — recommend deferring to #143 aggregation tickets. |
+
+**Blockers (must resolve before refinement closes):**
+
+1. **AGENTS.md resolver path-validation** — DEC-009 must pin (a) the search shape AND (b) explicitly reference `.claude/rules/path-validation.md`'s recipe (`is_absolute()` reject, `resolve(strict=True)`, `is_relative_to(spec_dir)`, `is_file()`).
+
+**Concerns to resolve in refinement (DEC-007..DEC-011):**
+
+- **DEC-007 — `model_runner` always-non-null vs nullable.** Architecture review recommendation: declare `model_runner: str` (always-non-null) and enforce the harness contract that `harness_metadata["model"]` is populated by both ClaudeCodeHarness (new in this PR per DEC-004) and CodexHarness (already populates per `_codex.py:747`). If the contract holds, sidecar writer reads `skill_result.harness_metadata["model"]` with a `KeyError` if missing (loud failure surfaces a contract violation immediately).
+- **DEC-008 — `system_prompt_source` in transit.** Architecture review recommendation: `harness_metadata["system_prompt_source"]` (the forward-compat surface). Pure read at the sidecar writer; no new typed `SkillResult` field needed in this PR.
+- **DEC-009 — AGENTS.md search path.** Architecture review recommendation: `<skill-dir>/AGENTS.md` first, fall back to `<project-root>/AGENTS.md`. Both reads gated by the path-validation recipe (resolved path must be `is_relative_to` the spec dir OR the project root). Codex's project-root convention preserved; per-skill override available.
+- **DEC-010 — `json-schema-version.md` rule refresh.** Architecture review: ADD a short paragraph under "Canonical implementation" documenting `context.json` as a new sidecar family with `MAX_SCHEMA_VERSION["context.json"] = 1`. Refresh-in-place per `rule-refresh-vs-delete.md`; no new rule file.
+- **DEC-011 — Audit loader integration.** Architecture review recommendation: `context.json` is read parallel to records, attached to render-time output only; does NOT participate in `IterationRecord` / `aggregate` machinery. Per-iteration display data, not score data.
+
+**Out-of-scope clarifications surfaced by review:**
+
+- Audit `--verbose` rollup summary ("N iterations span K harnesses") deferred to #143 aggregation tickets — this PR ships the per-iteration block only.
+- `harness_metadata` namespacing (e.g. `"system": {"prompt_source": ...}`) deferred until a future harness adds enough keys to crowd the dict.
+
+---
+
+## Refinement Log
+
+### Session 1 — 2026-05-08
+
+User answered scoping Q1–Q6 in order: B (with follow-up ticket), A (with follow-up ticket), B, A, A, A.
+
+#### DEC-001: `cost_usd` ships as `null`-only placeholder; pricing logic in #169
+
+**Decision:** `IterationContext.cost_usd: float | None` is declared in this PR with default `None`. No pricing module is built; the field is always serialized as `null`. Follow-up ticket #169 ("Pricing: cost_usd estimation module for context.json") owns the `_providers/_pricing.py` module + price tables + wiring into `_write_workspace_sidecars`.
+
+**Rationale:** The ticket explicitly permits "best-effort with fallback to null." Shipping the schema slot today fixes the on-disk shape forever; the pricing logic can land asynchronously without a schema bump (the field is already there). Avoids signing this PR up for periodic price-table maintenance and keeps the diff focused on the sidecar plumbing.
+
+**Validation criteria embedded:** the `to_json()` round-trip test must show `cost_usd: null` in the serialized output; the `from_dict` loader must accept either `null` or a `float`; the bool-guard from `constant-with-type-info.md` applies if a future writer accidentally passes `True`/`False`.
+
+#### DEC-002: `reasoning_tokens` ships as `null`-only placeholder; capture logic in #170
+
+**Decision:** `IterationContext.reasoning_tokens: int | None` is declared in this PR with default `None`. No `ModelResult.reasoning_tokens` field is added; no per-provider backend changes for reasoning capture. Follow-up ticket #170 ("Reasoning tokens: capture separately-billed reasoning tokens in ModelResult") owns the `ModelResult` field, the per-provider capture, and the wiring at sidecar-write time.
+
+**Rationale:** Same logic as DEC-001 — fixing the on-disk shape now lets the capture work land asynchronously without a schema bump. Avoids growing the PR with `_providers/_anthropic.py` + `_providers/_openai.py` SDK-version checks for thinking / o-series / GPT-5 reasoning models.
+
+**Validation criteria embedded:** `to_json()` must serialize `reasoning_tokens: null`; `from_dict` must accept `null` or an `int`; the bool-guard from `constant-with-type-info.md` (a `True` passed through must be rejected as `int` because `bool ⊂ int` in Python).
+
+#### DEC-003: `system_prompt_source` ships full literal-set `{"skill_md", "agents_md", "explicit"}` AND wires up the AGENTS.md resolver in `spec.py` in this PR
+
+**Decision:** The `system_prompt_source` field accepts all three literals from day one. `src/clauditor/spec.py::SkillSpec.run`'s prompt-resolution block (lines 204–228) gains an AGENTS.md detection step BETWEEN the explicit-spec branch and the SKILL.md auto-derive: if `EvalSpec.system_prompt` is None AND a sibling `AGENTS.md` exists in the skill's directory (or, for the modern layout, in the parent dir of `SKILL.md`), read its body as the system prompt and stamp `system_prompt_source = "agents_md"`. Otherwise fall through to SKILL.md auto-derive (`"skill_md"`). When `EvalSpec.system_prompt` is set, stamp `"explicit"`. The resolved label is threaded into `SkillResult` (or its `harness_metadata`) so the sidecar writer can read it without re-running the resolver.
+
+**Rationale:** The user picked option B explicitly to avoid the "future-reserved enum value with rejection" anti-pattern that costs a follow-up to lift. Adds one resolver branch plus tests; the AGENTS.md convention is the Codex / OpenAI ecosystem norm so users running `--harness codex` will benefit immediately. The cost is one extra story (US-002) in this PR.
+
+**Open sub-questions parked for the architecture review:**
+- AGENTS.md location: same dir as SKILL.md only, or also walk up one level? (Codex's convention is project-root.) Architecture review will recommend.
+- Where does the resolved `system_prompt_source` live in transit — a new field on `SkillResult` or a key in `harness_metadata`?
+
+**Validation criteria embedded:** Hard-validate against the literal-set per `pre-llm-contract-hard-validate.md`; reject any other value at `to_json` / `from_dict` boundaries with a descriptive `ValueError`.
+
+#### DEC-004: `model_runner` capture for ClaudeCodeHarness via `harness_metadata["model"]` (uniform with Codex)
+
+**Decision:** Add `harness_metadata["model"] = effective_model` to `ClaudeCodeHarness.invoke` (mirroring `_codex.py:747`). `IterationContext.model_runner` is read from `skill_result.harness_metadata.get("model")` regardless of harness — one read path, no harness-name branching at the sidecar layer.
+
+**Rationale:** Per `harness-protocol-shape.md`'s "harness_metadata as forward-compat surface" subsection (DEC-007 of #148), `harness_metadata` is exactly the right place for per-harness observability that doesn't fit the protocol's stable members. Reading `harness.model` directly couples the sidecar to harness internals and cannot survive a future harness whose model is per-call. Uniformity also pays off when a third harness lands (raw-API, Vertex, etc.) — same key works.
+
+**Validation criteria embedded:** Both harnesses populate the key for runs that have a model; the sidecar reader uses `.get("model")` so a missing key produces `model_runner = ""` (or we declare `model_runner: str | None` — TBD in detailing). The protocol's `harness_metadata` contract (a `dict[str, Any]` per `_harnesses/__init__.py`) is unchanged.
+
+#### DEC-005: `audit --verbose` per-iteration block in all three render formats
+
+**Decision:** When `--verbose` is passed to `clauditor audit`, every iteration's `context.json` (when present) is loaded and rendered. Three formats:
+- `render_stdout_table`: a per-iteration "Context" sub-section under each iteration's row group, listing the seven captured fields as `key: value` lines.
+- `render_markdown`: a "### Context" subsection per iteration with a small `key | value` table.
+- `render_json`: a top-level `iterations[*].context: {...}` key on each iteration record. Always present (verbose or not — JSON consumers shouldn't need a flag to opt in to a stable field).
+
+**Rationale:** The user picked A for breadth — show all seven fields per iteration. Option B ("only show what differs") is appealing UX but requires a cross-iteration diff in the renderer, doubles the tests, and the user explicitly chose against it. Option C (JSON-only) defers user-facing value too long. The per-iteration block is bounded (seven small fields) so even a 50-iteration audit stays readable.
+
+**Validation criteria embedded:** `render_json` always includes `context` (even pre-#154 iterations get `context: null`); `render_markdown` and `render_stdout_table` only render the block under `--verbose`. Audit loader uses `_records_from_context` (or equivalent helper) and gates on schema_version per `json-schema-version.md`.
+
+#### DEC-006: Badge integration adds `extension.context` AND bumps `ClauditorExtension.schema_version` 1 → 2
+
+**Decision:** `src/clauditor/badge.py::ClauditorExtension` gains a `context: IterationContext | None` field. The extension's `schema_version` bumps from 1 to 2; the loader defaults missing `context` to `None` for v1 reads. The shields.io payload (`<skill>.json`) is unchanged — context goes only in the sibling `<skill>.clauditor.json` per `dual-version-external-schema-embed.md` (shields.io rejects unknown top-level keys). Badge writer reads the latest iteration's `context.json` (when present) at badge-generation time.
+
+**Rationale:** The user picked A for schema-discipline reasons — "additive optional field without bump" (option B) is the exact slow-leak that `json-schema-version.md` was written to prevent. Option C (skip badge entirely) defers value and creates a second PR for the same conceptual change. The schema bump is cheap (one number + one default-on-read) and pays compounding interest in audit-trail clarity.
+
+**Validation criteria embedded:** Pre-#154 `<skill>.clauditor.json` files (v1) load cleanly with `context = None`; new files emit `schema_version: 2` and the full context object. Round-trip test on both v1 and v2. Per `dual-version-external-schema-embed.md`, NO change to `<skill>.json` (shields.io payload).
+
+### Decisions resolved post-Architecture-Review (user: "All Confirm")
+
+#### DEC-007: `model_runner: str` (always-non-null); harness contract guarantees `harness_metadata["model"]`
+
+**Decision:** `IterationContext.model_runner` is typed `str` (never `None`). The contract is: every harness MUST populate `harness_metadata["model"]` on every successful invoke. CodexHarness already satisfies this (`_codex.py:747`); ClaudeCodeHarness gains it in this PR per DEC-004. The sidecar writer reads `skill_result.harness_metadata["model"]` directly — a `KeyError` here is loud and surfaces a contract violation immediately rather than persisting `null` and hiding the bug.
+
+**Rationale:** The architectural review noted that "always-non-null" is only safe if the harness contract is mechanically enforced. By making the read an unguarded subscript (not `.get("model", None)`), any future harness that forgets to populate the key fails its first integration test loudly. Defaulting to `None` would silently mask the bug — opposite of `pre-llm-contract-hard-validate.md`'s spirit.
+
+**Validation criteria embedded:** ClaudeCodeHarness invoke unit test asserts `result.harness_metadata["model"]` matches the resolved model (default + override paths); CodexHarness retains its existing assertion; CLI integration test asserts `context.json["model_runner"]` round-trips.
+
+#### DEC-008: `system_prompt_source` flows via `harness_metadata["system_prompt_source"]`
+
+**Decision:** The label string (`"explicit" | "agents_md" | "skill_md"`) lives in `SkillResult.harness_metadata["system_prompt_source"]`. Stamped by `SkillSpec.run` in the same block where the resolved system prompt is computed. The sidecar writer reads it via `skill_result.harness_metadata["system_prompt_source"]` (unguarded subscript per DEC-007's contract-enforcement shape).
+
+**Rationale:** `harness_metadata` is the explicit forward-compat surface (`harness-protocol-shape.md`'s "harness_metadata as forward-compat surface" subsection, DEC-007 of #148). Adding a new typed field on `SkillResult` would be a breaking change to the dataclass that ripples into every test fixture; reusing the existing forward-compat dict is the right cost. Future PRs can promote the key to a typed field if it stabilizes across multiple consumers.
+
+**Validation criteria embedded:** Three `tests/test_spec.py::TestSkillSpecRun` cases pin the three sources (explicit / agents_md / skill_md). Sidecar round-trip test asserts the field flows through correctly. Hard-validate the literal-set at `IterationContext.from_dict` per `pre-llm-contract-hard-validate.md`.
+
+#### DEC-009: AGENTS.md search — `<skill-dir>/AGENTS.md` first, then `<project-root>/AGENTS.md`; both gated by `path-validation.md` recipe
+
+**Decision:** `SkillSpec.run`'s prompt-resolution block (after the `EvalSpec.system_prompt` explicit branch, before the SKILL.md auto-derive) walks two locations:
+
+1. `<skill-dir>/AGENTS.md` (the modern layout's per-skill override).
+2. If absent, `<project-root>/AGENTS.md` (the Codex / OpenAI ecosystem norm — project-root convention).
+
+Both reads gated by the security recipe from `.claude/rules/path-validation.md`:
+- Resolve via `Path.resolve(strict=True)` (the `is_file()` check is implicit since we only attempt the read when the file exists).
+- Verify the resolved path is `is_relative_to` the skill dir (for case 1) or the project root (for case 2).
+- Reject any path that escapes its anchor with a descriptive `ValueError` naming the offending input.
+
+The "project root" anchor is whatever clauditor's existing project-root resolver returns (re-uses the home-exclusion-aware walker — see `.claude/rules/project-root-home-exclusion.md`). When neither location yields a valid file, fall through to the SKILL.md auto-derive (`system_prompt_source = "skill_md"`). When a file IS found and validates, stamp `system_prompt_source = "agents_md"` and use its body as the system prompt.
+
+**Rationale:** Matches Codex's ecosystem expectation while preserving per-skill override capability. Two-tier search costs ~10 LOC and one stat call (negligible). The path-validation recipe resolves the architecture-review BLOCKER — a hostile/typoed `EvalSpec` cannot escape spec containment, and the project-root anchor inherits the same home-exclusion guard that already protects `.clauditor/`.
+
+**Validation criteria embedded:** Tests cover (a) skill-dir AGENTS.md wins over project-root AGENTS.md, (b) project-root AGENTS.md found when skill-dir absent, (c) absent both falls through to skill_md, (d) symlink escaping skill dir raises ValueError, (e) absolute path inside AGENTS.md content is fine (the recipe applies to the AGENTS.md path itself, not its content).
+
+#### DEC-010: Refresh `.claude/rules/json-schema-version.md` in-place; no new rule file
+
+**Decision:** Add a short subsection under "Canonical implementation" in `.claude/rules/json-schema-version.md` documenting `context.json` as a new sidecar family. Update the file's "Schema version bumps for #147 / #86" subsections by appending a new "New sidecar family — context.json (#154)" subsection that names: the file, the v1 schema (the dataclass field set), the `MAX_SCHEMA_VERSION["context.json"] = 1` registration, the always-v1 status (no future bumps needed for `reasoning_tokens` / `cost_usd` since they ship as nullable from day one).
+
+**Rationale:** Per `.claude/rules/rule-refresh-vs-delete.md`, the rule's pattern is unchanged ("every persisted JSON declares schema_version") — only the canonical-implementation list grows. Refresh-in-place; the existing rule's framing fully covers the new sidecar.
+
+**Validation criteria embedded:** A test in `tests/test_audit.py` asserts `MAX_SCHEMA_VERSION["context.json"] == 1` and rejects v999. The rule update lands in the same PR so the documented contract matches the shipped code.
+
+#### DEC-011: Audit loader reads `context.json` parallel to records; renders only — no aggregation participation
+
+**Decision:** `context.json` is loaded by a new pure helper `_read_context(skill_dir: Path) -> IterationContext | None` (no `_records_from_context` dispatcher, no `IterationRecord.context` field). The loader maps `iteration_dir → IterationContext | None` parallel to the existing `_records_from_*` reads in `audit.py::load_iterations`. The result attaches to the rendered output only — `render_json` always emits `iterations[*].context: {...} | null`, `render_markdown` and `render_stdout_table` emit the per-iteration block under `--verbose` only.
+
+`aggregate()` and `IterationRecord` are unchanged. Context does not participate in pass-rate grouping or threshold evaluation.
+
+**Rationale:** Context is comparability metadata, not score data. Adding `context: IterationContext | None` to `IterationRecord` would force every aggregate call site to branch on presence; the parallel-read shape keeps aggregation logic clean and matches `badge.py`'s precedent (it reads each sidecar independently, composes at render time).
+
+**Validation criteria embedded:** `aggregate()` tests are unchanged (no new field). New tests in `tests/test_audit.py` cover (a) `_read_context` returns `IterationContext` for a valid sidecar, (b) returns `None` for a missing file (silent skip per the `_read_json` convention), (c) emits stderr warning + returns `None` for a wrong-schema-version file (per `_check_schema_version`), (d) `render_json` always includes `context` (legacy iterations get `null`), (e) `render_markdown` / `render_stdout_table` emit the block only under `--verbose`.
+
+---
+
+## Detailed Breakdown
+
+Story ordering follows the natural data-flow direction: foundation (dataclass + validators) → harness-side data sources → resolver → sidecar writer → readers (audit + badge) → rule refresh → quality gate → patterns. Each story is sized for one Ralph context window.
+
+Project validation command (embedded in every story's acceptance criteria):
+```
+uv run ruff check src/ tests/ && uv run pytest --cov=clauditor --cov-report=term-missing
+```
+The 80% coverage gate is enforced.
+
+---
+
+### US-001 — `IterationContext` dataclass + `to_json` / `from_dict` + closed-set validators
+
+**Description:** Introduce a new pure-data module `src/clauditor/context.py` with an `IterationContext` dataclass, a `to_json() -> str` method (schema_version first key), a `from_dict(data: dict) -> IterationContext` loader with hard-validation of discriminator literals, and a closed-set sandbox-mode validator. Methodless dataclass per `data-vs-asserter-split.md`.
+
+**Traces to:** DEC-001, DEC-002, DEC-007, DEC-008, plus the security CONCERN around `sandbox_mode` validation (closed-set `{"read-only", "workspace-write", "danger-full-access"}`).
+
+**Acceptance criteria:**
+- New file `src/clauditor/context.py` exports `IterationContext` dataclass with fields: `schema_version: int = 1`, `harness: str`, `provider: str | None`, `model_runner: str`, `model_grader: str | None`, `system_prompt_source: str`, `sandbox_mode: str | None`, `reasoning_tokens: int | None = None`, `cost_usd: float | None = None`.
+- `to_json()` emits `schema_version` as the first key per `.claude/rules/json-schema-version.md`; round-trips losslessly.
+- `from_dict(data)` hard-rejects: `harness` not in `{"claude-code", "codex"}`; `provider` not in `{"anthropic", "openai", None}`; `system_prompt_source` not in `{"explicit", "agents_md", "skill_md"}`; `sandbox_mode` not in `{"read-only", "workspace-write", "danger-full-access", None}` per the security review.
+- Bool-guard on `reasoning_tokens` (must be `int`, not `bool`) per `.claude/rules/constant-with-type-info.md`.
+- `__init__.py` exports `IterationContext` per the project export convention.
+- Validation command passes; new tests reach >80% line coverage on `context.py`.
+
+**Done when:** `tests/test_context.py` exists with the test classes below; `from src.clauditor import IterationContext` works; `ruff` clean.
+
+**Files:**
+- NEW `src/clauditor/context.py` (~80–120 LOC).
+- MODIFY `src/clauditor/__init__.py` (add export).
+- NEW `tests/test_context.py` (~150 LOC).
+
+**Depends on:** none.
+
+**TDD:**
+- `TestIterationContextSerialization::test_to_json_first_key_is_schema_version`
+- `TestIterationContextSerialization::test_to_json_emits_all_fields`
+- `TestIterationContextSerialization::test_round_trip_full_payload`
+- `TestIterationContextSerialization::test_round_trip_with_nulls` (validate-only iteration shape: `provider=None`, `model_grader=None`, `cost_usd=None`, `reasoning_tokens=None`)
+- `TestIterationContextValidation::test_from_dict_rejects_unknown_harness` (with descriptive error message)
+- `TestIterationContextValidation::test_from_dict_rejects_unknown_provider`
+- `TestIterationContextValidation::test_from_dict_rejects_unknown_system_prompt_source`
+- `TestIterationContextValidation::test_from_dict_rejects_unknown_sandbox_mode`
+- `TestIterationContextValidation::test_from_dict_rejects_bool_for_reasoning_tokens` (per `constant-with-type-info.md` bool-guard)
+- `TestIterationContextValidation::test_from_dict_accepts_known_literals` (parametrized over the valid literal sets)
+
+---
+
+### US-002 — Harness contract: `harness_metadata["model"]` (ClaudeCodeHarness) + sandbox_mode closed-set (CodexHarness)
+
+**Description:** Add `harness_metadata["model"] = effective_model` to `ClaudeCodeHarness.invoke` (parity with CodexHarness). Promote the existing Codex `sandbox_mode` to a module-level `_SANDBOX_MODES: frozenset[str]` constant; validate inside `CodexHarness` before stamping `harness_metadata["sandbox_mode"]`. Establishes the harness contract that DEC-007 depends on.
+
+**Traces to:** DEC-004, DEC-007, plus the security CONCERN on sandbox_mode.
+
+**Acceptance criteria:**
+- `ClaudeCodeHarness.invoke` populates `result.harness_metadata["model"]` with `effective_model` (the value used for the `--model` argv flag, or `self.model` when none was passed).
+- `CodexHarness` defines `_SANDBOX_MODES = frozenset({"read-only", "workspace-write", "danger-full-access"})` at module level; raises `ValueError` if a future code path attempts to stamp an unknown mode (defense-in-depth — today's value is hardcoded, so no runtime change).
+- Both harnesses' existing tests continue to pass.
+- New tests cover the model-stamp paths (default, override).
+- Validation command passes.
+
+**Done when:** `result.harness_metadata["model"]` is asserted in tests for both harnesses; `_SANDBOX_MODES` exists and is referenced.
+
+**Files:**
+- MODIFY `src/clauditor/_harnesses/_claude_code.py` (~5 LOC).
+- MODIFY `src/clauditor/_harnesses/_codex.py` (~3 LOC for the constant + validation).
+- MODIFY `tests/test_runner.py` or `tests/test_harnesses.py` (~50 LOC).
+
+**Depends on:** none.
+
+**TDD:**
+- `TestClaudeCodeHarnessHarnessMetadata::test_invoke_populates_model_default` — `ClaudeCodeHarness(model="claude-sonnet-4-6").invoke(...)` → `result.harness_metadata["model"] == "claude-sonnet-4-6"`.
+- `TestClaudeCodeHarnessHarnessMetadata::test_invoke_populates_model_override` — `invoke(..., model="claude-opus-4-7")` overrides; `harness_metadata["model"] == "claude-opus-4-7"`.
+- `TestCodexHarnessSandboxModes::test_sandbox_modes_constant_matches_known_values`
+- `TestCodexHarnessSandboxModes::test_invalid_sandbox_mode_raises` (defense-in-depth — call the validator directly)
+
+---
+
+### US-003 — AGENTS.md resolver in `SkillSpec.run` + `system_prompt_source` stamping
+
+**Description:** Extend `SkillSpec.run`'s prompt-resolution block (lines 204–228) with a two-tier AGENTS.md search (`<skill-dir>/AGENTS.md` first, then `<project-root>/AGENTS.md`). Both reads gated by the `path-validation.md` recipe. Stamp the resolved source label into `harness_metadata["system_prompt_source"]` on the returned `SkillResult`.
+
+**Traces to:** DEC-003, DEC-008, DEC-009. Resolves the security blocker.
+
+**Acceptance criteria:**
+- New pure helper (likely `src/clauditor/paths.py::resolve_agents_md(skill_path: Path, project_root: Path) -> Path | None`) returns the validated path or `None`. The helper applies `Path.resolve(strict=True)` and `is_relative_to(anchor)` per `.claude/rules/path-validation.md`; raises `ValueError` on escape attempts.
+- `SkillSpec.run`'s prompt-resolution block consults the helper between the explicit-spec and SKILL.md auto-derive branches.
+- Three source labels round-trip correctly: `"explicit"` (when `EvalSpec.system_prompt` is set), `"agents_md"` (when AGENTS.md found and validated at either tier), `"skill_md"` (auto-derive fallback).
+- `SkillResult.harness_metadata["system_prompt_source"]` is populated on every successful run.
+- Validation command passes; >80% coverage on the new resolver helper.
+
+**Done when:** All four AGENTS.md test cases (DEC-009 acceptance set) pass; `harness_metadata["system_prompt_source"]` is asserted in `tests/test_spec.py`.
+
+**Files:**
+- MODIFY `src/clauditor/spec.py` (~25 LOC in `SkillSpec.run`).
+- MODIFY `src/clauditor/paths.py` (new pure helper, ~30 LOC).
+- MODIFY `tests/test_spec.py` (~120 LOC of new test class).
+- MODIFY `tests/test_paths.py` (~80 LOC for the resolver-helper tests).
+
+**Depends on:** US-002 (the harness_metadata pattern).
+
+**TDD:**
+- `TestResolveAgentsMd::test_skill_dir_wins_when_both_exist`
+- `TestResolveAgentsMd::test_falls_back_to_project_root`
+- `TestResolveAgentsMd::test_returns_none_when_neither_exists`
+- `TestResolveAgentsMd::test_rejects_symlink_escape_from_skill_dir`
+- `TestResolveAgentsMd::test_rejects_absolute_path_outside_anchor`
+- `TestSkillSpecRunSystemPromptSource::test_explicit_eval_spec_wins_over_agents_md`
+- `TestSkillSpecRunSystemPromptSource::test_agents_md_wins_over_skill_md_body`
+- `TestSkillSpecRunSystemPromptSource::test_falls_through_to_skill_md_when_agents_md_absent`
+- `TestSkillSpecRunSystemPromptSource::test_harness_metadata_carries_source_label`
+
+---
+
+### US-004 — Sidecar writer integration in `cli/grade.py` and `cli/validate.py`
+
+**Description:** Wire `IterationContext` construction and `context.json` write into both iteration-allocating CLI commands. Read fields from `harness_metadata` (model, system_prompt_source, sandbox_mode), the resolved provider (cli-seam value), the primary report's `model` (for `model_grader`), and harness identity from `harness.name`. Write inside the staging block per `.claude/rules/sidecar-during-staging.md`.
+
+**Traces to:** DEC-001, DEC-002, DEC-005 (write side), DEC-007, DEC-008.
+
+**Acceptance criteria:**
+- `cli/grade.py::_write_workspace_sidecars` builds an `IterationContext` from in-scope variables and writes `workspace.tmp_path / "context.json"` BEFORE `workspace.finalize()`. For non-grading runs (no L2/L3 reached), `provider`, `model_grader`, and `cost_usd` are stamped `None`.
+- `cli/validate.py::cmd_validate` performs the equivalent write inside its staging block (line ~258 region). Always: `provider=None`, `model_grader=None`, `cost_usd=None`, `reasoning_tokens=None`. Stamps `harness`, `model_runner`, `system_prompt_source`, and `sandbox_mode` (when applicable).
+- `cost_usd` and `reasoning_tokens` ship as `None` always (placeholders for #169 / #170).
+- The write sits inside the existing `try/except → workspace.abort()` envelope per the staging contract.
+- CLI integration tests verify `context.json` lands on disk with the correct fields after `cmd_grade` and `cmd_validate`.
+- Validation command passes; coverage holds.
+
+**Done when:** `iteration-N/<skill>/context.json` exists after both `cmd_grade` and `cmd_validate` runs in tests; field round-trip matches resolved values.
+
+**Files:**
+- MODIFY `src/clauditor/cli/grade.py` (~25 LOC).
+- MODIFY `src/clauditor/cli/validate.py` (~20 LOC).
+- MODIFY `tests/test_cli.py` (~150 LOC of new test cases).
+- MODIFY `tests/test_cli_validate.py` if it exists, otherwise extend `tests/test_cli.py`.
+
+**Depends on:** US-001, US-002, US-003.
+
+**TDD:**
+- `TestCmdGradeWritesContextJson::test_anthropic_default_path` (full populated fields)
+- `TestCmdGradeWritesContextJson::test_openai_provider_path` (with `--grading-provider openai`)
+- `TestCmdGradeWritesContextJson::test_no_l2_l3_branch` (provider/model_grader stay set when grade ran; only validate-only path nulls them)
+- `TestCmdValidateWritesContextJson::test_default_path` (provider/model_grader/cost_usd/reasoning_tokens all `null`)
+- `TestCmdValidateWritesContextJson::test_codex_harness_carries_sandbox_mode` (under `--harness codex`)
+- `TestCmdGradeContextJsonFirstKeyOrder` (assert serialized first key is `schema_version`)
+
+---
+
+### US-005 — Audit `--verbose` reads context + renders per-iteration block; `MAX_SCHEMA_VERSION` registration
+
+**Description:** Register `"context.json": 1` in `audit.py::MAX_SCHEMA_VERSION`. Add a pure helper `_read_context(skill_dir: Path) -> IterationContext | None` that reads + schema-validates the sidecar. Wire it into `load_iterations` parallel to existing `_records_from_*` reads (NOT into `IterationRecord` per DEC-011). Update three render functions: `render_json` always emits `iterations[*].context` (null for legacy); `render_markdown` and `render_stdout_table` emit a per-iteration block under `--verbose`. Add `--verbose` flag to the audit CLI subparser.
+
+**Traces to:** DEC-005, DEC-010 (rule pointer), DEC-011.
+
+**Acceptance criteria:**
+- `MAX_SCHEMA_VERSION["context.json"] == 1`; `_is_accepted_version("context.json", 1)` → `True`; `_is_accepted_version("context.json", 999)` → `False`.
+- `_read_context` returns `IterationContext` for a valid sidecar, `None` for missing (silent skip per existing `_read_json` convention), `None` plus stderr warning for wrong-schema-version (via `_check_schema_version`).
+- `render_json` ALWAYS includes a `context` key on each iteration record (legacy: `null`). No `--verbose` gate on JSON output.
+- `render_markdown` / `render_stdout_table` emit the per-iteration context block ONLY under `--verbose` (default behavior unchanged for non-verbose audit users).
+- `clauditor audit --verbose` accepts the new flag without argparse errors.
+- `IterationRecord` and `aggregate()` are UNCHANGED (verified by existing tests passing without modification).
+- Validation command passes.
+
+**Done when:** Verbose audit output shows the per-iteration context block in markdown/stdout/json; non-verbose output unchanged in markdown/stdout but JSON now includes `context: null` for legacy iterations.
+
+**Files:**
+- MODIFY `src/clauditor/audit.py` (~80 LOC: helper + render-path additions + map registration).
+- MODIFY `src/clauditor/cli/audit.py` (~5 LOC: argparse `--verbose` flag).
+- MODIFY `tests/test_audit.py` (~200 LOC).
+
+**Depends on:** US-001, US-004.
+
+**TDD:**
+- `TestMaxSchemaVersion::test_context_json_registered_at_v1`
+- `TestMaxSchemaVersion::test_context_json_v999_rejected`
+- `TestReadContext::test_returns_iteration_context_for_valid_sidecar`
+- `TestReadContext::test_returns_none_on_missing_file_silent`
+- `TestReadContext::test_returns_none_with_stderr_warning_on_schema_mismatch` (use `capsys`)
+- `TestRenderJsonContext::test_always_includes_context_key`
+- `TestRenderJsonContext::test_legacy_iteration_emits_null`
+- `TestRenderMarkdownVerbose::test_per_iteration_block_under_verbose`
+- `TestRenderMarkdownVerbose::test_no_block_without_verbose`
+- `TestRenderStdoutTableVerbose` (mirrors markdown shape)
+- `TestAggregateUnchanged::test_iteration_record_has_no_context_field` (regression guard for DEC-011)
+
+---
+
+### US-006 — Badge `ClauditorExtension` v1 → v2 bump with optional `context` field
+
+**Description:** Add `context: IterationContext | None = None` field to `ClauditorExtension`. Bump `_CLAUDITOR_EXTENSION_SCHEMA_VERSION` from 1 to 2. `from_dict` (or equivalent loader) defaults missing `context` to `None` for v1 reads. `_extension_to_dict` omits the `context` block when `None` (mirrors existing l1/l3/variance optional-block pattern). Badge writer reads the latest iteration's `context.json` (when present) and stamps it onto the extension. Shields.io `<skill>.json` payload UNCHANGED per `.claude/rules/dual-version-external-schema-embed.md`.
+
+**Traces to:** DEC-006.
+
+**Acceptance criteria:**
+- `ClauditorExtension.schema_version` defaults to 2; the constant is updated.
+- v1 `<skill>.clauditor.json` files load cleanly with `context = None` (default-on-read precedent).
+- v2 files round-trip with full `context` populated.
+- `<skill>.json` (shields.io payload) is unchanged byte-for-byte before and after this story (regression assertion).
+- Badge writer reads `iteration-N/<skill>/context.json` for the latest iteration N and threads through; absent file → `extension.context = None`.
+- Validation command passes.
+
+**Done when:** A `clauditor badge` run after a graded iteration writes the extension with `schema_version: 2` and the populated `context` block; pre-existing v1 fixtures still load.
+
+**Files:**
+- MODIFY `src/clauditor/badge.py` (~30 LOC).
+- MODIFY `src/clauditor/cli/badge.py` (~10 LOC for the latest-iteration read).
+- MODIFY `tests/test_badge.py` (~120 LOC).
+- MODIFY `tests/test_cli_badge.py` (~50 LOC).
+
+**Depends on:** US-001, US-004.
+
+**TDD:**
+- `TestClauditorExtensionSchemaBump::test_schema_version_is_2`
+- `TestClauditorExtensionV1Compat::test_v1_payload_loads_with_context_none`
+- `TestClauditorExtensionV2RoundTrip::test_serializes_and_deserializes`
+- `TestClauditorExtensionContextOmission::test_extension_dict_omits_context_when_none`
+- `TestShieldsPayloadUnchanged::test_shields_json_byte_identical_before_after`
+- `TestCmdBadgeReadsLatestContext::test_extension_carries_context_when_present`
+- `TestCmdBadgeReadsLatestContext::test_extension_context_null_when_absent`
+
+---
+
+### US-007 — Refresh `.claude/rules/json-schema-version.md` with `context.json` paragraph
+
+**Description:** Add a "New sidecar family — context.json (#154)" subsection under "Canonical implementation" in `.claude/rules/json-schema-version.md`. Document the file, its v1 schema (the dataclass field set with nullability table), the `MAX_SCHEMA_VERSION["context.json"] = 1` registration, and the always-v1 status (no future bumps needed for `reasoning_tokens` / `cost_usd` since they ship nullable from day one). Refresh-in-place per `.claude/rules/rule-refresh-vs-delete.md`.
+
+**Traces to:** DEC-010.
+
+**Acceptance criteria:**
+- `.claude/rules/json-schema-version.md` gains a new subsection (~20 lines) under the canonical-implementation list.
+- The subsection names: filename, dataclass module, dataclass field list with nullability, `MAX_SCHEMA_VERSION` registration line, the always-v1 contract, the link to follow-up tickets #169 (`cost_usd`) and #170 (`reasoning_tokens`).
+- The rule's existing prose, structure, and other sections are byte-unchanged (refresh-in-place).
+- Validation command passes (no code change in this story; doc only).
+
+**Done when:** A `git diff` on the rule file shows ONLY the additive subsection.
+
+**Files:**
+- MODIFY `.claude/rules/json-schema-version.md` (~20 LOC additive).
+
+**Depends on:** US-001, US-005.
+
+**TDD:** N/A — pure documentation update.
+
+---
+
+### US-008 — Quality Gate (code review × 4 + CodeRabbit)
+
+**Description:** Run code reviewer four times across the full changeset, fixing every real bug found per pass. Run CodeRabbit if available. Project validation must pass after all fixes.
+
+**Traces to:** All implementation decisions; this is the safety net before merge.
+
+**Acceptance criteria:**
+- Four passes of the code-reviewer agent (`subagent_type=code-reviewer`) on the full diff vs `dev`. Each pass fixes every real bug; false positives are documented inline.
+- One CodeRabbit pass via PR comment if the integration is available.
+- All `.claude/rules/` constraints from Discovery are explicitly verified (the validation criteria embedded in DEC-001..DEC-011, especially the security path-validation invariants).
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes the 80% gate.
+- Each context-related test class from US-001..US-006 is present and green.
+
+**Done when:** All four review passes complete with no real bugs remaining; CI green; merge-ready.
+
+**Files:** Whatever the review passes touch.
+
+**Depends on:** US-001, US-002, US-003, US-004, US-005, US-006, US-007.
+
+---
+
+### US-009 — Patterns & Memory
+
+**Description:** Update `.claude/rules/`, `docs/`, or memory entries with new patterns or learnings from #154. The most likely candidates: the harness-contract pattern from DEC-007 ("unguarded subscript surfaces missing-key bugs loudly") may deserve a sentence on `.claude/rules/harness-protocol-shape.md`. The two-tier path-validation pattern from DEC-009 (resolver consults two anchors with the same recipe) may warrant a paragraph on `.claude/rules/path-validation.md`. Inspect what was learned during implementation and add only if non-obvious.
+
+**Traces to:** Cross-cutting patterns surfaced during implementation.
+
+**Acceptance criteria:**
+- Inspect the implementation diffs for any pattern that recurred or was non-obvious; add to the corresponding rule file (refresh-in-place per `.claude/rules/rule-refresh-vs-delete.md`).
+- If no non-obvious pattern emerged, this story closes with a note ("no rule updates needed") rather than fabricating one.
+- Memory updates per the `auto memory` shape if any user feedback or session-context lessons emerged.
+
+**Done when:** Either the rule files are updated (with a justification line) OR a one-line "no patterns to add" note is recorded in this plan.
+
+**Files:** Possibly `.claude/rules/harness-protocol-shape.md`, `.claude/rules/path-validation.md`, or memory.
+
+**Depends on:** US-008.
+
+---
+
+### Dependency graph
+
+```
+US-001 ────┬─→ US-003 ──┐
+           ├─→ US-004 ──┼─→ US-005 ──┐
+US-002 ────┴─→ US-003   │             ├─→ US-008 ──→ US-009
+                        ├─→ US-006 ──┤
+                        └─→ US-007 ──┘
+```
+
+US-001 and US-002 are independent; everything downstream depends on at least one of them.
+
+---
+
+## Beads Manifest
+
+_(Pending — populated on devolve.)_

--- a/plans/super/154-context-sidecar.md
+++ b/plans/super/154-context-sidecar.md
@@ -5,9 +5,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/154
 - **Branch:** `feature/154-context-sidecar`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/154-context-sidecar`
-- **PR:** TBD
-- **Phase:** detailing
-- **Epic:** TBD
+- **PR:** https://github.com/wjduenow/clauditor/pull/171
+- **Phase:** devolved
+- **Epic:** clauditor-hqv
 - **Sessions:** 1 (2026-05-08)
 - **Total decisions:** 11 (DEC-001 through DEC-011)
 - **Depends on:** #149 (CLOSED — `CodexHarness`), #152 (CLOSED — `harness` field on L1/L2/L3 sidecars)
@@ -585,4 +585,21 @@ US-001 and US-002 are independent; everything downstream depends on at least one
 
 ## Beads Manifest
 
-_(Pending — populated on devolve.)_
+- **Epic:** `clauditor-hqv` — #154: per-iteration context.json sidecar
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/154-context-sidecar`
+- **Branch:** `feature/154-context-sidecar`
+- **Plan PR:** https://github.com/wjduenow/clauditor/pull/171
+
+| ID | Story | Priority | Depends on |
+|---|---|---|---|
+| `clauditor-hqv.1` | US-001 — IterationContext dataclass + to_json/from_dict + closed-set validators | P2 | — |
+| `clauditor-hqv.2` | US-002 — harness_metadata['model'] in ClaudeCodeHarness + sandbox_mode closed-set in CodexHarness | P2 | — |
+| `clauditor-hqv.3` | US-003 — AGENTS.md resolver in SkillSpec.run + system_prompt_source stamping | P2 | hqv.2 |
+| `clauditor-hqv.4` | US-004 — sidecar writer in cli/grade.py + cli/validate.py | P2 | hqv.1, hqv.2, hqv.3 |
+| `clauditor-hqv.5` | US-005 — audit --verbose reads context + per-iteration block render + MAX_SCHEMA_VERSION registration | P2 | hqv.1, hqv.4 |
+| `clauditor-hqv.6` | US-006 — badge ClauditorExtension v1→v2 bump with optional context field | P2 | hqv.1, hqv.4 |
+| `clauditor-hqv.7` | US-007 — refresh json-schema-version.md with context.json paragraph | P3 | hqv.1, hqv.5 |
+| `clauditor-hqv.8` | Quality Gate — code review x4 + CodeRabbit | P2 | hqv.1..hqv.7 |
+| `clauditor-hqv.9` | Patterns & Memory — update conventions and docs | P4 | hqv.8 |
+
+**Initial ready set:** `clauditor-hqv.1` (US-001) + `clauditor-hqv.2` (US-002) — both unblocked, can run in parallel.

--- a/plans/super/154-context-sidecar.md
+++ b/plans/super/154-context-sidecar.md
@@ -117,7 +117,7 @@ Codex stamps `harness_metadata["model"]` already (`_codex.py:747`). ClaudeCodeHa
 
 The ticket says "Audit verbose mode shows a context block per iteration." Two render shapes:
 
-- **A.** Per-iteration block in `render_markdown` and `render_stdout_table` — one collapsible/dedicated section per iteration listing the seven captured fields. `render_json` adds a top-level `iterations[*].context` key.
+- **A.** Per-iteration block in `render_markdown` and `render_stdout_table` — one collapsible/dedicated section per iteration listing the eight captured fields. `render_json` adds a top-level `iterations[*].context` key.
 - **B.** Tabular columns in `render_stdout_table` (one extra row group) + an annotation footer in markdown listing only the dimensions where iterations differ from each other ("only show what's interesting"). More work, less noise.
 - **C.** JSON-only for now (just expose `context` in `render_json`); markdown/stdout get a single-line summary. Defer rich rendering to a follow-up.
 
@@ -125,7 +125,7 @@ The ticket says "Audit verbose mode shows a context block per iteration." Two re
 
 Per `dual-version-external-schema-embed.md`, context surfaces in the sibling `<skill>.clauditor.json` (NOT the shields.io payload). Two design choices:
 
-- **A.** Add `extension.context: {...}` (the same seven fields) AND bump `ClauditorExtension.schema_version` 1 → 2. Loader defaults missing `context` to `null` for v1.
+- **A.** Add `extension.context: {...}` (the same eight fields) AND bump `ClauditorExtension.schema_version` 1 → 2. Loader defaults missing `context` to `null` for v1.
 - **B.** Add `extension.context: {...}` as a strictly-additive optional field; do NOT bump schema_version (loaders today already tolerate unknown keys for forward-compat). Simpler, but breaks the discipline of bumping when shape changes.
 - **C.** Skip badge integration for this PR; ship audit `--verbose` only. Badge integration becomes a follow-up.
 
@@ -210,11 +210,11 @@ User answered scoping Q1–Q6 in order: B (with follow-up ticket), A (with follo
 #### DEC-005: `audit --verbose` per-iteration block in all three render formats
 
 **Decision:** When `--verbose` is passed to `clauditor audit`, every iteration's `context.json` (when present) is loaded and rendered. Three formats:
-- `render_stdout_table`: a per-iteration "Context" sub-section under each iteration's row group, listing the seven captured fields as `key: value` lines.
+- `render_stdout_table`: a per-iteration "Context" sub-section under each iteration's row group, listing the eight captured fields as `key: value` lines.
 - `render_markdown`: a "### Context" subsection per iteration with a small `key | value` table.
 - `render_json`: a top-level `iterations[*].context: {...}` key on each iteration record. Always present (verbose or not — JSON consumers shouldn't need a flag to opt in to a stable field).
 
-**Rationale:** The user picked A for breadth — show all seven fields per iteration. Option B ("only show what differs") is appealing UX but requires a cross-iteration diff in the renderer, doubles the tests, and the user explicitly chose against it. Option C (JSON-only) defers user-facing value too long. The per-iteration block is bounded (seven small fields) so even a 50-iteration audit stays readable.
+**Rationale:** The user picked A for breadth — show all eight fields per iteration. Option B ("only show what differs") is appealing UX but requires a cross-iteration diff in the renderer, doubles the tests, and the user explicitly chose against it. Option C (JSON-only) defers user-facing value too long. The per-iteration block is bounded (eight small fields) so even a 50-iteration audit stays readable.
 
 **Validation criteria embedded:** `render_json` always includes `context` (even pre-#154 iterations get `context: null`); `render_markdown` and `render_stdout_table` only render the block under `--verbose`. Audit loader uses `_records_from_context` (or equivalent helper) and gates on schema_version per `json-schema-version.md`.
 

--- a/src/clauditor/__init__.py
+++ b/src/clauditor/__init__.py
@@ -2,6 +2,7 @@
 
 from clauditor.asserters import SkillAsserter, assert_from
 from clauditor.assertions import AssertionResult, AssertionSet
+from clauditor.context import IterationContext
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.schemas import (
     EvalSpec,
@@ -20,6 +21,7 @@ __all__ = [
     "FieldRequirement",
     "GradingReport",
     "GradingResult",
+    "IterationContext",
     "SectionRequirement",
     "TierRequirement",
     "SkillAsserter",

--- a/src/clauditor/_harnesses/_claude_code.py
+++ b/src/clauditor/_harnesses/_claude_code.py
@@ -546,10 +546,17 @@ class ClaudeCodeHarness:
                     env=env,
                 )
             except FileNotFoundError:
+                # DEC-004 of #154: stamp ``harness_metadata["model"]``
+                # uniformly across all return paths (parity with
+                # ``CodexHarness``). The sidecar reader at #154 US-004
+                # uses ``skill_result.harness_metadata.get("model")``
+                # so a missing-binary failure still surfaces the
+                # intended model on the iteration-context sidecar.
                 result = InvokeResult(
                     output="",
                     exit_code=-1,
                     error=f"Claude CLI not found: {claude_bin}",
+                    harness_metadata={"model": effective_model},
                 )
                 return result
 
@@ -736,6 +743,7 @@ class ClaudeCodeHarness:
                     stream_events=stream_events,
                     warnings=list(warnings),
                     api_key_source=api_key_source,
+                    harness_metadata={"model": effective_model},
                 )
                 # Early return is load-bearing: a post-timeout
                 # stream-json is_error:true must not clobber the
@@ -848,6 +856,15 @@ class ClaudeCodeHarness:
                 final_error = stderr_text if returncode != 0 and stderr_text else None
                 final_category = None
 
+            # DEC-004 of #154: stamp ``harness_metadata["model"]`` so a
+            # downstream sidecar writer can read the effective model
+            # uniformly (``skill_result.harness_metadata.get("model")``)
+            # regardless of which harness produced the result. Mirrors
+            # ``CodexHarness.invoke``'s metadata population at
+            # :file:`_codex.py` (DEC-008 of #149). May be ``None`` when
+            # neither the constructor nor the per-call override pinned
+            # a value — that is the honest "no model recorded" signal
+            # for the sidecar reader.
             result = InvokeResult(
                 output=final_text,
                 exit_code=returncode,
@@ -859,6 +876,7 @@ class ClaudeCodeHarness:
                 stream_events=stream_events,
                 warnings=list(warnings),
                 api_key_source=api_key_source,
+                harness_metadata={"model": effective_model},
             )
             return result
         finally:

--- a/src/clauditor/_harnesses/_codex.py
+++ b/src/clauditor/_harnesses/_codex.py
@@ -237,9 +237,48 @@ _REDACTED_LINE_SENTINEL = "<line redacted: matched auth-leak pattern>"
 _NO_DETAIL_SENTINEL = "API error (no detail)"
 
 
-# DEC-001: hardcoded sandbox mode for v1. Configurability deferred to
-# #151 (the ``EvalSpec.harness`` flag ticket).
+# DEC-001 of #149: hardcoded sandbox mode for v1. Configurability
+# deferred to #151 (the ``EvalSpec.harness`` flag ticket).
+#
+# US-002 of #154 promotes the single string to a closed-set frozenset
+# of the three Codex-supported sandbox values (the surface documented
+# by ``codex exec --help``). The active value is referenced via
+# :data:`_SANDBOX_MODE`; defense-in-depth validator
+# :func:`_validate_sandbox_mode` enforces membership before any code
+# path stamps ``harness_metadata["sandbox_mode"]`` so a future
+# regression that pins an unknown value (typo, a new mode added to
+# Codex without a corresponding clauditor update, a hostile dynamic
+# value flowing in from config) fails loudly at the seam rather than
+# silently writing a non-conformant sidecar.
+_SANDBOX_MODES: frozenset[str] = frozenset(
+    {"read-only", "workspace-write", "danger-full-access"}
+)
 _SANDBOX_MODE = "workspace-write"
+
+
+def _validate_sandbox_mode(mode: str) -> str:
+    """Defense-in-depth: assert ``mode`` is a known Codex sandbox value.
+
+    Per the security CONCERN raised in the architecture review of #154,
+    the sandbox mode is an authorization-relevant value that downstream
+    sidecar consumers (audit, badge, trend) treat as authoritative.
+    Any code path stamping ``harness_metadata["sandbox_mode"]`` MUST
+    route the value through this validator first, even when the value
+    is sourced from a module-level constant — the validator catches a
+    future regression where the constant gains a typo or a dynamic
+    value bypasses the constant.
+
+    Returns the validated ``mode`` so callers can write
+    ``harness_metadata["sandbox_mode"] = _validate_sandbox_mode(value)``
+    inline. Raises :class:`ValueError` on any value not in
+    :data:`_SANDBOX_MODES`.
+    """
+    if mode not in _SANDBOX_MODES:
+        raise ValueError(
+            f"sandbox_mode={mode!r} not in known set "
+            f"{sorted(_SANDBOX_MODES)!r}"
+        )
+    return mode
 
 
 # Default Codex model used when neither the constructor nor the
@@ -740,7 +779,14 @@ class CodexHarness:
                         error=f"Codex CLI not found: {self.codex_bin}",
                         error_category=None,
                         harness_metadata={
-                            "sandbox_mode": _SANDBOX_MODE,
+                            # US-002 of #154: route through the
+                            # closed-set validator so a future
+                            # regression that pins an unknown
+                            # value fails here, not in a silently-
+                            # malformed sidecar.
+                            "sandbox_mode": _validate_sandbox_mode(
+                                _SANDBOX_MODE
+                            ),
                             "auth_source": auth_source,
                             "last_message_path": "",
                             "turn_count": 0,
@@ -1060,7 +1106,11 @@ class CodexHarness:
                 # ``last_message_path``, ``turn_count``) land
                 # unconditionally.
                 metadata: dict[str, Any] = {
-                    "sandbox_mode": _SANDBOX_MODE,
+                    # US-002 of #154: route through the closed-set
+                    # validator (defense-in-depth) before stamping
+                    # — see :func:`_validate_sandbox_mode` for the
+                    # security rationale.
+                    "sandbox_mode": _validate_sandbox_mode(_SANDBOX_MODE),
                     "auth_source": auth_source,
                     "last_message_path": last_message_path,
                     "turn_count": turn_count,

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -735,7 +735,7 @@ def _providers_seen(verdicts: list[AuditVerdict]) -> list[str]:
 
 
 def _context_field_lines(ctx: IterationContext) -> list[tuple[str, str]]:
-    """Return ``[(label, value_str)]`` for the seven captured context fields.
+    """Return ``[(label, value_str)]`` for the eight captured context fields.
 
     Pure helper consumed by the verbose stdout/markdown renderers per
     #154 DEC-005. Field order matches the dataclass declaration so the
@@ -770,7 +770,7 @@ def render_stdout_table(
 
     #154 US-005 / DEC-005: when ``verbose=True`` and
     ``iteration_contexts`` is provided, append a per-iteration
-    ``Context for iteration N`` block listing the seven captured
+    ``Context for iteration N`` block listing the eight captured
     fields. Pre-#154 iterations whose ``context.json`` is absent are
     skipped (no block emitted) so the verbose output stays readable.
     """

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 
+from clauditor.context import IterationContext
 from clauditor.paths import resolve_clauditor_dir
 
 # US-002 / #147 / DEC-008: per-sidecar maximum accepted schema version.
@@ -53,6 +54,11 @@ MAX_SCHEMA_VERSION: dict[str, int] = {
     "assertions.json": 1,
     "extraction.json": 3,
     "grading.json": 3,
+    # #154 US-005 / DEC-010: context.json is a new sidecar family;
+    # always-v1 (the v1 dataclass already ships nullable fields for the
+    # observability surface, so future ``reasoning_tokens`` /
+    # ``cost_usd`` work needs no schema bump).
+    "context.json": 1,
 }
 
 
@@ -239,6 +245,47 @@ def _read_json(path: Path) -> dict | None:
         return None
 
 
+def _read_context(skill_dir: Path) -> IterationContext | None:
+    """Read ``context.json`` from ``skill_dir`` and return the parsed
+    :class:`IterationContext`, or ``None`` for any failure mode.
+
+    #154 US-005 / DEC-011: context is read parallel to records and
+    attached to render output only — does NOT participate in
+    :class:`IterationRecord` or :func:`aggregate`. Failure modes:
+
+    - Missing file → ``None`` silently (per the existing ``_read_json``
+      convention; defensive read posture per
+      ``.claude/rules/stream-json-schema.md``).
+    - Malformed JSON → ``None`` silently.
+    - Wrong/missing ``schema_version`` → ``None`` PLUS a stderr warning
+      via :func:`_check_schema_version` (the canonical seam owning
+      sidecar-version stderr emission).
+    - Hard-validator ``ValueError`` from
+      :meth:`IterationContext.from_dict` (e.g. unknown ``harness``
+      literal) → ``None`` PLUS a stderr warning. Do not propagate;
+      audit must keep moving across iterations.
+    """
+    path = skill_dir / "context.json"
+    data = _read_json(path)
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not _check_schema_version(
+        data, iteration_dir=str(skill_dir), filename="context.json"
+    ):
+        return None
+    try:
+        return IterationContext.from_dict(data)
+    except (ValueError, KeyError, TypeError) as exc:
+        print(
+            f"clauditor.audit: skipping {skill_dir}/context.json — "
+            f"malformed payload: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
 def _records_from_assertions(
     data: dict,
     *,
@@ -357,12 +404,16 @@ def load_iterations(
     skill: str,
     last: int,
     clauditor_dir: Path | None = None,
-) -> tuple[list[IterationRecord], int]:
+) -> tuple[list[IterationRecord], int, dict[int, IterationContext | None]]:
     """Load per-iteration assertion records for ``skill``.
 
     Walks ``.clauditor/iteration-*/<skill>/`` newest-first, loads the
     L1/L2/L3 sidecars (primary and baseline variants), and flattens
-    them into :class:`IterationRecord` entries.
+    them into :class:`IterationRecord` entries. Reads ``context.json``
+    in parallel and returns a ``dict[iteration_num, IterationContext |
+    None]`` for renderers to consume — context is comparability
+    metadata only, NOT score data, so it does NOT participate in
+    :func:`aggregate` per #154 DEC-011.
 
     Args:
         skill: Skill name (subdirectory under each iteration dir).
@@ -372,9 +423,17 @@ def load_iterations(
             Defaults to :func:`resolve_clauditor_dir`.
 
     Returns:
-        Tuple of ``(records, skipped_count)`` where ``skipped_count``
-        is the number of iteration dirs that had no primary and no
-        baseline sidecar for this skill (per DEC-002).
+        Tuple of ``(records, skipped_count, contexts)``:
+
+        - ``records`` — flat list of :class:`IterationRecord`.
+        - ``skipped_count`` — iteration dirs that had no primary and no
+          baseline sidecar for this skill (per DEC-002).
+        - ``contexts`` — ``{iteration_num: IterationContext | None}``
+          for every iteration dir that was visited (selected before the
+          skill-dir-missing skip). Iterations whose ``context.json``
+          is absent / malformed / wrong-schema map to ``None`` so
+          renderers can emit ``context: null`` for legacy iterations
+          (per #154 DEC-005).
     """
     if clauditor_dir is None:
         clauditor_dir = resolve_clauditor_dir()
@@ -384,6 +443,7 @@ def load_iterations(
 
     records: list[IterationRecord] = []
     skipped = 0
+    contexts: dict[int, IterationContext | None] = {}
 
     for iteration_num, iteration_dir in selected:
         skill_dir = iteration_dir / skill
@@ -429,12 +489,19 @@ def load_iterations(
                     )
                 )
 
+        # #154 DEC-011: read context.json parallel to records; do NOT
+        # attach to ``IterationRecord`` (would force every aggregate
+        # call site to branch on presence). Legacy iterations with no
+        # ``context.json`` map to ``None`` so renderers can emit a
+        # uniform shape.
+        contexts[iteration_num] = _read_context(skill_dir)
+
         # Count as skipped if no records were produced for this iteration —
         # sidecars may exist but be empty / schema-mismatched / unparseable.
         if len(records) == records_before:
             skipped += 1
 
-    return records, skipped
+    return records, skipped, contexts
 
 
 # --------------------------------------------------------------------------- #
@@ -667,12 +734,45 @@ def _providers_seen(verdicts: list[AuditVerdict]) -> list[str]:
     return sorted({v.provider for v in verdicts})
 
 
-def render_stdout_table(verdicts: list[AuditVerdict]) -> str:
+def _context_field_lines(ctx: IterationContext) -> list[tuple[str, str]]:
+    """Return ``[(label, value_str)]`` for the seven captured context fields.
+
+    Pure helper consumed by the verbose stdout/markdown renderers per
+    #154 DEC-005. Field order matches the dataclass declaration so the
+    on-screen layout stays predictable across renderers.
+    """
+    def _fmt(v: object) -> str:
+        return "-" if v is None else str(v)
+
+    return [
+        ("harness", _fmt(ctx.harness)),
+        ("provider", _fmt(ctx.provider)),
+        ("model_runner", _fmt(ctx.model_runner)),
+        ("model_grader", _fmt(ctx.model_grader)),
+        ("system_prompt_source", _fmt(ctx.system_prompt_source)),
+        ("sandbox_mode", _fmt(ctx.sandbox_mode)),
+        ("reasoning_tokens", _fmt(ctx.reasoning_tokens)),
+        ("cost_usd", _fmt(ctx.cost_usd)),
+    ]
+
+
+def render_stdout_table(
+    verdicts: list[AuditVerdict],
+    *,
+    iteration_contexts: dict[int, IterationContext | None] | None = None,
+    verbose: bool = False,
+) -> str:
     """Compact table: provider, layer, id, with%, verdict.
 
     DEC-004 (#147): leftmost ``PROVIDER`` column (~11 chars wide) so a
     mixed-provider audit shows which provider's SDK produced each
     grouped result. Sort order: ``(provider, layer, id)``.
+
+    #154 US-005 / DEC-005: when ``verbose=True`` and
+    ``iteration_contexts`` is provided, append a per-iteration
+    ``Context for iteration N`` block listing the seven captured
+    fields. Pre-#154 iterations whose ``context.json`` is absent are
+    skipped (no block emitted) so the verbose output stays readable.
     """
     header = (
         f"{'PROVIDER':<11} {'LAYER':<6} {'ID':<40} "
@@ -686,6 +786,19 @@ def render_stdout_table(verdicts: list[AuditVerdict]) -> str:
             f"{v.provider[:11]:<11} {v.layer:<6} {v.id[:40]:<40} "
             f"{with_pct:>8} {v.verdict.value:<24}"
         )
+
+    if verbose and iteration_contexts:
+        # Sort iterations descending (newest-first) to match the
+        # iteration-dir scan order in :func:`load_iterations`.
+        for iteration_num in sorted(iteration_contexts.keys(), reverse=True):
+            ctx = iteration_contexts[iteration_num]
+            if ctx is None:
+                continue
+            lines.append("")
+            lines.append(f"Context for iteration {iteration_num}:")
+            for label, value in _context_field_lines(ctx):
+                lines.append(f"  {label}: {value}")
+
     return "\n".join(lines)
 
 
@@ -696,8 +809,18 @@ def render_markdown(
     iterations_analyzed: int,
     thresholds: dict[str, float | int],
     timestamp: str,
+    iteration_contexts: dict[int, IterationContext | None] | None = None,
+    verbose: bool = False,
 ) -> str:
-    """Render the audit report as markdown."""
+    """Render the audit report as markdown.
+
+    #154 US-005 / DEC-005: when ``verbose=True`` and
+    ``iteration_contexts`` is provided, append a ``## Per-iteration
+    context`` section with one ``### Iteration N`` subsection per
+    iteration that has a populated ``context.json``. Pre-#154
+    iterations whose context is ``None`` are skipped so the verbose
+    output stays readable.
+    """
     flagged = [v for v in verdicts if v.is_flagged]
     kept = [v for v in verdicts if not v.is_flagged]
 
@@ -770,6 +893,33 @@ def render_markdown(
             )
         lines.append("")
 
+    if verbose and iteration_contexts:
+        # #154 DEC-005: emit per-iteration context block under
+        # ``--verbose``. Iterations with no ``context.json`` (legacy
+        # pre-#154 runs) are skipped so the section stays readable.
+        populated = sorted(
+            (
+                (n, c)
+                for n, c in iteration_contexts.items()
+                if c is not None
+            ),
+            key=lambda pair: pair[0],
+            reverse=True,
+        )
+        if populated:
+            lines.append("## Per-iteration context")
+            lines.append("")
+            for iteration_num, ctx in populated:
+                lines.append(f"### Iteration {iteration_num}")
+                lines.append("")
+                lines.append("| field | value |")
+                lines.append("|-------|-------|")
+                for label, value in _context_field_lines(ctx):
+                    lines.append(
+                        f"| `{_md_escape(label)}` | `{_md_escape(value)}` |"
+                    )
+                lines.append("")
+
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -780,6 +930,7 @@ def render_json(
     iterations_analyzed: int,
     thresholds: dict[str, float | int],
     timestamp: str,
+    iteration_contexts: dict[int, IterationContext | None] | None = None,
 ) -> dict:
     """Return a JSON-serializable audit payload.
 
@@ -789,6 +940,15 @@ def render_json(
     alphabetically) so JSON consumers can detect mixed-provider history
     without iterating ``assertions[]``. Sort order across ``assertions``
     matches the stdout/markdown renderers: ``(provider, layer, id)``.
+
+    #154 US-005 / DEC-005: always emits a top-level
+    ``iteration_contexts`` array — one record per iteration that was
+    visited by :func:`load_iterations`, sorted by iteration number
+    descending (newest first). Each record carries ``iteration: <int>``
+    and ``context: {...} | null`` (legacy iterations with no
+    ``context.json`` get ``null``). Unconditional emission per DEC-005
+    — JSON consumers should not need a ``--verbose`` flag to opt into
+    a stable field.
     """
     sorted_verdicts = _sorted_verdicts(verdicts)
     assertions_list: list[dict] = []
@@ -810,6 +970,31 @@ def render_json(
                 "reasons": list(v.reasons),
             }
         )
+
+    # #154 DEC-005: always emit ``iteration_contexts`` (list of
+    # ``{iteration, context}`` records). Legacy iterations and missing
+    # data emit ``context: null``.
+    contexts_list: list[dict] = []
+    if iteration_contexts:
+        for iteration_num in sorted(iteration_contexts.keys(), reverse=True):
+            ctx = iteration_contexts[iteration_num]
+            if ctx is None:
+                payload: dict | None = None
+            else:
+                payload = {
+                    "harness": ctx.harness,
+                    "provider": ctx.provider,
+                    "model_runner": ctx.model_runner,
+                    "model_grader": ctx.model_grader,
+                    "system_prompt_source": ctx.system_prompt_source,
+                    "sandbox_mode": ctx.sandbox_mode,
+                    "reasoning_tokens": ctx.reasoning_tokens,
+                    "cost_usd": ctx.cost_usd,
+                }
+            contexts_list.append(
+                {"iteration": iteration_num, "context": payload}
+            )
+
     return {
         "schema_version": 2,
         "skill": skill,
@@ -818,4 +1003,5 @@ def render_json(
         "thresholds": dict(thresholds),
         "providers_seen": _providers_seen(verdicts),
         "assertions": assertions_list,
+        "iteration_contexts": contexts_list,
     }

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -1088,6 +1088,17 @@ def render_json(
     Sort order across ``assertions`` matches the stdout/markdown
     renderers: ``(harness, provider, layer, id)``.
 
+    #154 US-005 / DEC-005: ``schema_version`` bumped from 3 to 4 to
+    signal the new top-level ``iteration_contexts`` array — a shape
+    change that adds a new sibling key to the audit-output payload.
+    JSON consumers that branch on ``schema_version`` need a stable
+    signal to detect the shape change (per
+    ``.claude/rules/json-schema-version.md``: "when a future bump
+    ships, writers emit ``schema_version: <next>``"). v3 readers
+    should expect the field to be absent; v4 readers can treat
+    ``iteration_contexts == []`` as "no contexts available" (the
+    legacy-iterations case).
+
     DEC-008 (#152): L1 entries keep ``"provider": "anthropic"``
     placeholder in the JSON output (the em-dash is stdout/markdown
     only) — keeps mixed-layer JSON aggregation semantically honest for
@@ -1149,7 +1160,7 @@ def render_json(
             )
 
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "skill": skill,
         "timestamp": timestamp,
         "iterations": iterations_analyzed,

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -73,7 +73,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from clauditor.audit import _read_json, _scan_iteration_dirs
+from clauditor.audit import _check_schema_version, _read_json, _scan_iteration_dirs
 from clauditor.context import IterationContext
 
 __all__ = [
@@ -261,13 +261,18 @@ class Badge:
 
         Written to a sibling file ``<skill>.clauditor.json`` alongside
         the shields.io badge JSON. Carries the per-layer breakdown,
-        thresholds, iteration number, and ``generated_at`` timestamp
-        for trend-audit / forensic consumers.
+        thresholds, iteration number, ``generated_at`` timestamp, and
+        (when available) the optional ``context`` block for
+        trend-audit / forensic consumers.
 
-        First key is ``schema_version: 1`` per
-        ``.claude/rules/json-schema-version.md``. Shape unchanged
-        from the pre-split ``clauditor`` sub-dict so existing
-        docstrings / tests of the nested shape still apply.
+        First key is ``schema_version: 2`` (the value of
+        :data:`_CLAUDITOR_EXTENSION_SCHEMA_VERSION`) per
+        ``.claude/rules/json-schema-version.md``. Bumped 1 → 2 in
+        #154 US-006 (DEC-006) when the optional ``context`` field
+        landed; v1 readers default ``context`` to ``None``. The
+        ``context`` block is omitted entirely when
+        ``ext.context is None`` per the layer-omission shape — see
+        :func:`_extension_to_dict`.
         """
         return _extension_to_dict(self.clauditor)
 
@@ -817,16 +822,34 @@ def load_iteration_context(iteration_skill_dir: Path) -> IterationContext | None
 
     Returns the parsed :class:`IterationContext` when the file
     exists and validates; returns ``None`` for missing file, JSON
-    parse error, or :class:`IterationContext.from_dict` rejection
-    (closed-set discriminator outside its valid range, bool-for-int,
-    etc.). Defensive read shape mirrors :func:`audit._read_json` —
+    parse error, out-of-range ``schema_version``, or
+    :class:`IterationContext.from_dict` rejection (closed-set
+    discriminator outside its valid range, bool-for-int, etc.).
+    Defensive read shape mirrors :func:`audit._read_context` —
     a malformed sidecar must not abort the whole badge command.
+
+    The ``schema_version`` check is delegated to
+    :func:`audit._check_schema_version` so the badge reader and
+    the audit reader behave consistently across the whole sidecar
+    family (per ``.claude/rules/json-schema-version.md`` the same
+    ``MAX_SCHEMA_VERSION["context.json"]`` registry gates both
+    readers — without this check, badge generation could silently
+    embed an unsupported future ``context.json`` version that
+    ``clauditor audit`` would reject).
 
     Pure from the caller's perspective: best-effort read, never
     raises on the common error paths, never mutates the input path.
     """
     raw = _read_json(iteration_skill_dir / "context.json")
     if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    if not _check_schema_version(
+        raw,
+        iteration_dir=str(iteration_skill_dir),
+        filename="context.json",
+    ):
         return None
     try:
         return IterationContext.from_dict(raw)

--- a/src/clauditor/badge.py
+++ b/src/clauditor/badge.py
@@ -47,20 +47,34 @@ Decisions traced (see ``plans/super/77-clauditor-badge.md``):
     * Top-level ``schemaVersion: 1`` — shields.io's contract
       (camelCase per their docs), first top-level key of the endpoint
       JSON.
-    * Nested ``clauditor.schema_version: 1`` — our extension
+    * Nested ``clauditor.schema_version: 2`` — our extension
       contract, first key of the ``clauditor`` block per
-      ``.claude/rules/json-schema-version.md``.
+      ``.claude/rules/json-schema-version.md``. Bumped 1 → 2 in
+      #154 US-006 (DEC-006) when the optional ``context`` field
+      landed.
   The two versions bump independently.
+
+- **DEC-006 (#154 US-006)** — ``ClauditorExtension`` gains an
+  optional ``context: IterationContext | None`` field. The extension
+  ``schema_version`` bumps 1 → 2; ``_extension_to_dict`` omits the
+  ``context`` block when ``None`` (mirrors the existing l1 / l3 /
+  variance optional-block pattern). The shields.io ``<skill>.json``
+  payload is UNCHANGED per
+  ``.claude/rules/dual-version-external-schema-embed.md`` — context
+  goes only into the sibling ``<skill>.clauditor.json`` extension
+  file.
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
 from clauditor.audit import _read_json, _scan_iteration_dirs
+from clauditor.context import IterationContext
 
 __all__ = [
     "Badge",
@@ -72,6 +86,7 @@ __all__ = [
     "build_markdown_image",
     "compute_badge",
     "discover_iteration",
+    "load_iteration_context",
     "load_iteration_sidecars",
 ]
 
@@ -85,8 +100,13 @@ __all__ = [
 _SHIELDS_SCHEMA_VERSION: int = 1
 
 # The ``clauditor`` extension block's own version — first key of the
-# block per ``.claude/rules/json-schema-version.md``.
-_CLAUDITOR_EXTENSION_SCHEMA_VERSION: int = 1
+# block per ``.claude/rules/json-schema-version.md``. Bumped 1 → 2 in
+# #154 US-006 (DEC-006) when the optional ``context`` field landed
+# (default-on-read for v1 readers per the
+# ``.claude/rules/json-schema-version.md`` precedent set by #86 and
+# #147 — pre-#154 ``<skill>.clauditor.json`` files load with
+# ``context = None``).
+_CLAUDITOR_EXTENSION_SCHEMA_VERSION: int = 2
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +191,13 @@ class ClauditorExtension:
     ``.claude/rules/json-schema-version.md``. ``layers`` is built on
     the fly at serialization time from the (optional) summary fields
     — omit any layer whose summary is ``None``.
+
+    ``context`` (#154 US-006, DEC-006) is the optional per-iteration
+    comparability metadata read from ``iteration-N/<skill>/context.json``
+    by the badge writer. Omitted from the serialized block when
+    ``None`` (mirrors the l1/l3/variance optional-block pattern). Pre-
+    #154 ``<skill>.clauditor.json`` files (v1) had no ``context``
+    field; loading them defaults this attribute to ``None``.
     """
 
     skill_name: str
@@ -179,6 +206,7 @@ class ClauditorExtension:
     l1: L1Summary | None = None
     l3: L3Summary | None = None
     variance: VarianceSummary | None = None
+    context: IterationContext | None = None
     schema_version: int = _CLAUDITOR_EXTENSION_SCHEMA_VERSION
 
 
@@ -250,6 +278,13 @@ def _extension_to_dict(ext: ClauditorExtension) -> dict[str, Any]:
     Layers are omitted entirely when their summary is ``None``
     (DEC-003 for variance; DEC-020 for L1-when-no-data; absent L3
     when grading sidecar is missing).
+
+    The ``context`` block (#154 US-006, DEC-006) is omitted entirely
+    when ``ext.context is None`` — mirrors the layer-omission shape.
+    When present, it embeds the same field set ``IterationContext.to_json``
+    emits to the standalone ``context.json`` sidecar (round-trip via
+    ``json.loads(ctx.to_json())`` so the writer and reader agree on
+    field order and serialization shape without duplication here).
     """
     block: dict[str, Any] = {
         "schema_version": ext.schema_version,
@@ -279,6 +314,12 @@ def _extension_to_dict(ext: ClauditorExtension) -> dict[str, Any]:
             "passed": ext.variance.passed,
         }
     block["layers"] = layers
+    if ext.context is not None:
+        # Round-trip via ``IterationContext.to_json`` so the embedded
+        # shape stays in lockstep with the standalone ``context.json``
+        # sidecar without duplicating the field list. The cost is
+        # one tiny serialize+parse on a flat dict.
+        block["context"] = json.loads(ext.context.to_json())
     return block
 
 
@@ -554,6 +595,7 @@ def compute_badge(
     generated_at: str,
     label: str = "clauditor",
     style_overrides: dict[str, str | int] | None = None,
+    context: IterationContext | None = None,
 ) -> Badge:
     """Aggregate per-iteration sidecars into a :class:`Badge`.
 
@@ -584,6 +626,16 @@ def compute_badge(
     ``style_overrides`` is a dict of shields.io ``--style`` passthrough
     keys (DEC-015); alphabetically serialized between the top-level
     ``color`` and ``clauditor`` keys.
+
+    ``context`` (#154 US-006, DEC-006) is the optional per-iteration
+    comparability metadata loaded from
+    ``iteration-N/<skill>/context.json`` by the CLI layer (see
+    :func:`load_iteration_context`). When ``None``, the extension
+    omits the ``context`` block entirely. When non-``None``, the
+    extension stamps it through verbatim. The shields.io payload is
+    NOT touched — context lives only in the sibling
+    ``<skill>.clauditor.json`` file per
+    ``.claude/rules/dual-version-external-schema-embed.md``.
     """
     l1 = _summarize_l1(assertions)
     l3, l3_parse_failed = _summarize_l3(grading)
@@ -603,6 +655,7 @@ def compute_badge(
             l1=l1,
             l3=l3,
             variance=var,
+            context=context,
         ),
         style_overrides=dict(style_overrides) if style_overrides else {},
     )
@@ -757,6 +810,28 @@ def load_iteration_sidecars(iteration_skill_dir: Path) -> IterationSidecars:
         variance=variance,
         assertions_missing=assertions_missing,
     )
+
+
+def load_iteration_context(iteration_skill_dir: Path) -> IterationContext | None:
+    """Read ``context.json`` from an iteration skill dir.
+
+    Returns the parsed :class:`IterationContext` when the file
+    exists and validates; returns ``None`` for missing file, JSON
+    parse error, or :class:`IterationContext.from_dict` rejection
+    (closed-set discriminator outside its valid range, bool-for-int,
+    etc.). Defensive read shape mirrors :func:`audit._read_json` —
+    a malformed sidecar must not abort the whole badge command.
+
+    Pure from the caller's perspective: best-effort read, never
+    raises on the common error paths, never mutates the input path.
+    """
+    raw = _read_json(iteration_skill_dir / "context.json")
+    if raw is None:
+        return None
+    try:
+        return IterationContext.from_dict(raw)
+    except (ValueError, KeyError, TypeError):
+        return None
 
 
 def build_markdown_image(

--- a/src/clauditor/cli/audit.py
+++ b/src/clauditor/cli/audit.py
@@ -59,6 +59,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="(US-006) directory to write audit reports",
     )
+    p_audit.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "(#154 US-005) include per-iteration context.json fields "
+            "in stdout/markdown output (JSON output always includes them)"
+        ),
+    )
 
 
 def cmd_audit(args: argparse.Namespace) -> int:
@@ -89,9 +97,11 @@ def cmd_audit(args: argparse.Namespace) -> int:
         return 2
 
     clauditor_dir = resolve_clauditor_dir()
-    records, skipped = load_iterations(
+    records, skipped, iteration_contexts = load_iterations(
         args.skill, last=args.last, clauditor_dir=clauditor_dir
     )
+
+    verbose = bool(getattr(args, "verbose", False))
 
     if skipped:
         print(
@@ -134,6 +144,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
                 iterations_analyzed=iterations_analyzed,
                 thresholds=thresholds,
                 timestamp=timestamp,
+                iteration_contexts=iteration_contexts,
             )
             print(json.dumps(payload, indent=2))
         else:
@@ -160,6 +171,8 @@ def cmd_audit(args: argparse.Namespace) -> int:
                             iterations_analyzed=iterations_analyzed,
                             thresholds=thresholds,
                             timestamp=timestamp,
+                            iteration_contexts=iteration_contexts,
+                            verbose=verbose,
                         ),
                         encoding="utf-8",
                     )
@@ -172,7 +185,13 @@ def cmd_audit(args: argparse.Namespace) -> int:
                         file=sys.stderr,
                     )
                     return 2
-                print(render_stdout_table(verdicts))
+                print(
+                    render_stdout_table(
+                        verdicts,
+                        iteration_contexts=iteration_contexts,
+                        verbose=verbose,
+                    )
+                )
                 print(f"\nReport written to {report_path}")
     except Exception as exc:  # pragma: no cover - defensive
         print(f"clauditor audit: error rendering report: {exc}", file=sys.stderr)

--- a/src/clauditor/cli/badge.py
+++ b/src/clauditor/cli/badge.py
@@ -39,6 +39,7 @@ from clauditor.badge import (
     build_markdown_image,
     compute_badge,
     discover_iteration,
+    load_iteration_context,
     load_iteration_sidecars,
 )
 from clauditor.cli import _positive_int
@@ -698,6 +699,12 @@ def cmd_badge(args: argparse.Namespace) -> int:
             skill_name=skill_name,
         )
 
+    # #154 US-006 (DEC-006): read the per-iteration context.json
+    # (when present) and stamp it onto the extension. Absent /
+    # malformed file → context = None silently — the badge still
+    # writes successfully.
+    context = load_iteration_context(iter_skill_dir)
+
     badge = compute_badge(
         assertions=sidecars.assertions,
         grading=sidecars.grading,
@@ -707,6 +714,7 @@ def cmd_badge(args: argparse.Namespace) -> int:
         generated_at=_now_iso_z(),
         label=args.label,
         style_overrides=style_overrides,
+        context=context,
     )
 
     # DEC-021 sibling to DEC-001: if the badge came out lightgrey with

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -21,6 +21,7 @@ from clauditor._providers import (
 )
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.benchmark import Benchmark, compute_benchmark
+from clauditor.context import IterationContext
 from clauditor.paths import resolve_clauditor_dir
 from clauditor.runner import (
     SkillResult,
@@ -786,6 +787,21 @@ def _write_workspace_sidecars(
         primary_report.to_json(), encoding="utf-8"
     )
 
+    # #154 US-004 / DEC-007 / DEC-008: write the per-iteration
+    # comparability sidecar inside the staging block. Skip in
+    # captured-text mode (``--output`` without variance/baseline)
+    # where ``harness_name`` is ``None`` and there is no real
+    # ``SkillResult`` to read ``harness_metadata`` from.
+    primary_skill_result = skill_results[0] if skill_results else None
+    if harness_name is not None and primary_skill_result is not None:
+        _write_context_sidecar(
+            skill_dir=skill_dir,
+            harness_name=harness_name,
+            provider=provider,
+            primary_skill_result=primary_skill_result,
+            model_grader=primary_report.model,
+        )
+
     _write_assertions_sidecar(
         args=args,
         spec=spec,
@@ -843,6 +859,48 @@ def _write_workspace_sidecars(
         )
 
     return None
+
+
+def _write_context_sidecar(
+    *,
+    skill_dir: Path,
+    harness_name: str,
+    provider: str,
+    primary_skill_result: SkillResult,
+    model_grader: str | None,
+) -> None:
+    """Write per-iteration comparability metadata as ``context.json``.
+
+    #154 US-004. Reads the runner-side fields from the primary
+    :class:`SkillResult`'s ``harness_metadata`` per the harness contract
+    (DEC-007, DEC-008): ``model`` and ``system_prompt_source`` are
+    UNGUARDED subscripts — a missing key surfaces a contract violation
+    immediately. ``sandbox_mode`` IS optional (only Codex populates it)
+    so it uses ``.get(...)``.
+
+    ``cost_usd`` and ``reasoning_tokens`` ship as ``None`` per DEC-001 /
+    DEC-002 (placeholders for #169 / #170).
+
+    Runs inside the workspace staging block per
+    ``.claude/rules/sidecar-during-staging.md``; the caller's
+    ``try/except → workspace.abort()`` envelope ensures a failed write
+    never publishes a partial iteration.
+    """
+    context = IterationContext(
+        harness=harness_name,
+        provider=provider,
+        model_runner=primary_skill_result.harness_metadata["model"],
+        model_grader=model_grader,
+        system_prompt_source=primary_skill_result.harness_metadata[
+            "system_prompt_source"
+        ],
+        sandbox_mode=primary_skill_result.harness_metadata.get("sandbox_mode"),
+        cost_usd=None,
+        reasoning_tokens=None,
+    )
+    (skill_dir / "context.json").write_text(
+        context.to_json(), encoding="utf-8"
+    )
 
 
 def _write_run_dirs_or_scrub(

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -13,6 +13,7 @@ from clauditor._providers import (
     check_codex_auth,
 )
 from clauditor.assertions import run_assertions
+from clauditor.context import IterationContext
 from clauditor.paths import resolve_clauditor_dir
 from clauditor.runner import SkillResult
 from clauditor.workspace import (
@@ -295,6 +296,30 @@ def cmd_validate(args: argparse.Namespace) -> int:
             (skill_dir / "assertions.json").write_text(
                 json.dumps(assertions_payload, indent=2) + "\n",
                 encoding="utf-8",
+            )
+
+            # #154 US-004 / DEC-007 / DEC-008: write the per-iteration
+            # comparability sidecar inside the staging block. Validate
+            # has no Layer 3 grading, so ``provider`` and ``model_grader``
+            # stay ``None``; ``cost_usd`` and ``reasoning_tokens`` are
+            # ``None`` per DEC-001 / DEC-002 (placeholders for #169 /
+            # #170). ``model``/``system_prompt_source`` are unguarded
+            # subscripts per the harness contract; ``sandbox_mode`` IS
+            # optional (Codex-only).
+            context = IterationContext(
+                harness=harness_name,
+                provider=None,
+                model_runner=skill_result.harness_metadata["model"],
+                model_grader=None,
+                system_prompt_source=skill_result.harness_metadata[
+                    "system_prompt_source"
+                ],
+                sandbox_mode=skill_result.harness_metadata.get("sandbox_mode"),
+                cost_usd=None,
+                reasoning_tokens=None,
+            )
+            (skill_dir / "context.json").write_text(
+                context.to_json(), encoding="utf-8"
             )
 
             workspace.finalize()

--- a/src/clauditor/context.py
+++ b/src/clauditor/context.py
@@ -21,9 +21,16 @@ Decisions traced:
 - **DEC-002** — ``reasoning_tokens`` ships as an ``int | None``
   placeholder with default ``None``; per-provider reasoning capture
   lives in #170.
-- **DEC-007** — ``model_runner: str`` is non-nullable; the harness
-  contract (every harness populates ``harness_metadata["model"]``)
-  is enforced upstream at the sidecar writer.
+- **DEC-007** — ``model_runner: str | None`` is nullable. The harness
+  contract is "every harness populates ``harness_metadata["model"]``"
+  (loud ``KeyError`` if the key is missing — surfaces a contract
+  violation at the sidecar writer). But ``ClaudeCodeHarness``
+  legitimately stamps the value as ``None`` when neither the
+  constructor nor the per-call override pinned a model: the
+  ``claude`` CLI's stream-json ``result`` message carries no model
+  field, so we cannot recover the actually-used model after the
+  fact. ``None`` is the honest signal in that case; recording a
+  fabricated default would be worse.
 - **DEC-008** — ``system_prompt_source`` is a closed-set literal
   validated here; the writer reads it verbatim from
   ``harness_metadata["system_prompt_source"]``.
@@ -61,7 +68,7 @@ class IterationContext:
 
     harness: str
     provider: str | None
-    model_runner: str
+    model_runner: str | None
     model_grader: str | None
     system_prompt_source: str
     sandbox_mode: str | None
@@ -149,11 +156,27 @@ class IterationContext:
                 )
             cost_usd = float(cost_usd)
 
+        model_runner = data.get("model_runner")
+        if model_runner is not None and not isinstance(model_runner, str):
+            raise ValueError(
+                f"IterationContext.from_dict: 'model_runner' must be "
+                f"str or None, got {type(model_runner).__name__} "
+                f"{model_runner!r}"
+            )
+
+        model_grader = data.get("model_grader")
+        if model_grader is not None and not isinstance(model_grader, str):
+            raise ValueError(
+                f"IterationContext.from_dict: 'model_grader' must be "
+                f"str or None, got {type(model_grader).__name__} "
+                f"{model_grader!r}"
+            )
+
         return cls(
             harness=harness,
             provider=provider,
-            model_runner=data["model_runner"],
-            model_grader=data.get("model_grader"),
+            model_runner=model_runner,
+            model_grader=model_grader,
             system_prompt_source=system_prompt_source,
             sandbox_mode=sandbox_mode,
             reasoning_tokens=reasoning_tokens,

--- a/src/clauditor/context.py
+++ b/src/clauditor/context.py
@@ -102,7 +102,33 @@ class IterationContext:
         ``.claude/rules/constant-with-type-info.md`` — ``bool`` is a
         subclass of ``int`` in Python and would otherwise pass
         ``isinstance(val, int)`` checks).
+
+        Hard-rejects any ``schema_version`` value other than the
+        current ``_CONTEXT_SCHEMA_VERSION`` (today: ``1``). Defends
+        the always-v1 contract documented in
+        ``.claude/rules/json-schema-version.md`` — ``context.json``
+        is engineered so the two anticipated follow-ups (#169
+        ``cost_usd``, #170 ``reasoning_tokens``) populate already-
+        nullable fields WITHOUT bumping the schema. A future bump
+        will need to lift this gate explicitly; that is the point —
+        it forces a deliberate decision rather than a silent
+        forward-compat drift. ``bool`` is rejected explicitly per
+        ``.claude/rules/constant-with-type-info.md`` (``True``
+        compares as ``1`` and would otherwise pass an integer
+        equality check).
         """
+        schema_version = data.get("schema_version", _CONTEXT_SCHEMA_VERSION)
+        if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+            raise ValueError(
+                f"IterationContext.from_dict: 'schema_version' must be int, "
+                f"got {type(schema_version).__name__} {schema_version!r}"
+            )
+        if schema_version != _CONTEXT_SCHEMA_VERSION:
+            raise ValueError(
+                f"IterationContext.from_dict: unsupported 'schema_version' "
+                f"{schema_version!r}; expected {_CONTEXT_SCHEMA_VERSION}"
+            )
+
         harness = data["harness"]
         if harness not in _VALID_HARNESSES:
             raise ValueError(
@@ -181,5 +207,5 @@ class IterationContext:
             sandbox_mode=sandbox_mode,
             reasoning_tokens=reasoning_tokens,
             cost_usd=cost_usd,
-            schema_version=data.get("schema_version", _CONTEXT_SCHEMA_VERSION),
+            schema_version=schema_version,
         )

--- a/src/clauditor/context.py
+++ b/src/clauditor/context.py
@@ -1,0 +1,162 @@
+"""Per-iteration comparability metadata sidecar (``context.json``).
+
+Pure-data module: declares the :class:`IterationContext` dataclass,
+its :meth:`IterationContext.to_json` serializer (with
+``schema_version`` as the first top-level key per
+``.claude/rules/json-schema-version.md``), and a
+:meth:`IterationContext.from_dict` loader that hard-rejects
+unknown discriminator literals per
+``.claude/rules/pre-llm-contract-hard-validate.md``.
+
+Methodless dataclass per ``.claude/rules/data-vs-asserter-split.md``:
+only ``to_json`` and the ``from_dict`` classmethod live on the class
+— no ``assert_*`` helpers, no rendering helpers. Any future test-
+side helpers go in a sibling module wrapped around an instance.
+
+Decisions traced:
+
+- **DEC-001** — ``cost_usd`` ships as a ``float | None`` placeholder
+  with default ``None``; the pricing module that populates it lives
+  in #169.
+- **DEC-002** — ``reasoning_tokens`` ships as an ``int | None``
+  placeholder with default ``None``; per-provider reasoning capture
+  lives in #170.
+- **DEC-007** — ``model_runner: str`` is non-nullable; the harness
+  contract (every harness populates ``harness_metadata["model"]``)
+  is enforced upstream at the sidecar writer.
+- **DEC-008** — ``system_prompt_source`` is a closed-set literal
+  validated here; the writer reads it verbatim from
+  ``harness_metadata["system_prompt_source"]``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+__all__ = ["IterationContext"]
+
+_CONTEXT_SCHEMA_VERSION = 1
+
+_VALID_HARNESSES: frozenset[str] = frozenset({"claude-code", "codex"})
+_VALID_PROVIDERS: frozenset[str] = frozenset({"anthropic", "openai"})
+_VALID_SYSTEM_PROMPT_SOURCES: frozenset[str] = frozenset(
+    {"explicit", "agents_md", "skill_md"}
+)
+_VALID_SANDBOX_MODES: frozenset[str] = frozenset(
+    {"read-only", "workspace-write", "danger-full-access"}
+)
+
+
+@dataclass
+class IterationContext:
+    """Comparability metadata for a single iteration's run + grading.
+
+    Persisted as ``iteration-N/<skill>/context.json`` alongside the
+    other per-iteration sidecars (``assertions.json``,
+    ``extraction.json``, ``grading.json``). The ``schema_version``
+    field is emitted as the first top-level key on serialization
+    per ``.claude/rules/json-schema-version.md``.
+    """
+
+    harness: str
+    provider: str | None
+    model_runner: str
+    model_grader: str | None
+    system_prompt_source: str
+    sandbox_mode: str | None
+    reasoning_tokens: int | None = None
+    cost_usd: float | None = None
+    schema_version: int = _CONTEXT_SCHEMA_VERSION
+
+    def to_json(self) -> str:
+        """Serialize to JSON with ``schema_version`` as the first key."""
+        data = {
+            "schema_version": self.schema_version,
+            "harness": self.harness,
+            "provider": self.provider,
+            "model_runner": self.model_runner,
+            "model_grader": self.model_grader,
+            "system_prompt_source": self.system_prompt_source,
+            "sandbox_mode": self.sandbox_mode,
+            "reasoning_tokens": self.reasoning_tokens,
+            "cost_usd": self.cost_usd,
+        }
+        return json.dumps(data, indent=2) + "\n"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> IterationContext:
+        """Construct from a parsed dict, hard-rejecting invalid literals.
+
+        Raises :class:`ValueError` with a message naming both the
+        offending value and the valid set for any discriminator
+        outside its closed-set, and for ``bool`` values supplied for
+        ``reasoning_tokens`` / ``cost_usd`` (per
+        ``.claude/rules/constant-with-type-info.md`` — ``bool`` is a
+        subclass of ``int`` in Python and would otherwise pass
+        ``isinstance(val, int)`` checks).
+        """
+        harness = data["harness"]
+        if harness not in _VALID_HARNESSES:
+            raise ValueError(
+                f"IterationContext.from_dict: 'harness' must be one of "
+                f"{sorted(_VALID_HARNESSES)!r}, got {harness!r}"
+            )
+
+        provider = data.get("provider")
+        if provider is not None and provider not in _VALID_PROVIDERS:
+            raise ValueError(
+                f"IterationContext.from_dict: 'provider' must be one of "
+                f"{sorted(_VALID_PROVIDERS)!r} or None, got {provider!r}"
+            )
+
+        system_prompt_source = data["system_prompt_source"]
+        if system_prompt_source not in _VALID_SYSTEM_PROMPT_SOURCES:
+            raise ValueError(
+                f"IterationContext.from_dict: 'system_prompt_source' must be "
+                f"one of {sorted(_VALID_SYSTEM_PROMPT_SOURCES)!r}, "
+                f"got {system_prompt_source!r}"
+            )
+
+        sandbox_mode = data.get("sandbox_mode")
+        if sandbox_mode is not None and sandbox_mode not in _VALID_SANDBOX_MODES:
+            raise ValueError(
+                f"IterationContext.from_dict: 'sandbox_mode' must be one of "
+                f"{sorted(_VALID_SANDBOX_MODES)!r} or None, got {sandbox_mode!r}"
+            )
+
+        reasoning_tokens = data.get("reasoning_tokens")
+        if reasoning_tokens is not None:
+            # bool is an int subclass; reject explicitly per
+            # .claude/rules/constant-with-type-info.md.
+            if isinstance(reasoning_tokens, bool) or not isinstance(
+                reasoning_tokens, int
+            ):
+                raise ValueError(
+                    f"IterationContext.from_dict: 'reasoning_tokens' must be "
+                    f"int or None, got {type(reasoning_tokens).__name__} "
+                    f"{reasoning_tokens!r}"
+                )
+
+        cost_usd = data.get("cost_usd")
+        if cost_usd is not None:
+            # bool is an int subclass; int is float-coercible. Reject bool;
+            # accept float OR int (treated as float).
+            if isinstance(cost_usd, bool) or not isinstance(cost_usd, (int, float)):
+                raise ValueError(
+                    f"IterationContext.from_dict: 'cost_usd' must be float, "
+                    f"int, or None, got {type(cost_usd).__name__} {cost_usd!r}"
+                )
+            cost_usd = float(cost_usd)
+
+        return cls(
+            harness=harness,
+            provider=provider,
+            model_runner=data["model_runner"],
+            model_grader=data.get("model_grader"),
+            system_prompt_source=system_prompt_source,
+            sandbox_mode=sandbox_mode,
+            reasoning_tokens=reasoning_tokens,
+            cost_usd=cost_usd,
+            schema_version=data.get("schema_version", _CONTEXT_SCHEMA_VERSION),
+        )

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -140,6 +140,66 @@ def derive_skill_name(skill_path: Path, skill_md_text: str) -> str:
     return fm_name
 
 
+def resolve_agents_md(skill_path: Path, project_root: Path) -> Path | None:
+    """Locate an ``AGENTS.md`` file for the skill — pure, gated by
+    :doc:`path-validation</.claude/rules/path-validation>` recipe.
+
+    Two-tier search per DEC-009 of ``plans/super/154-context-sidecar.md``:
+
+    1. ``<skill_path.parent>/AGENTS.md`` — the modern-layout per-skill
+       override. Anchor: the skill directory.
+    2. ``<project_root>/AGENTS.md`` — the Codex / OpenAI ecosystem
+       project-root convention. Anchor: ``project_root``.
+
+    For each candidate, the search short-circuits when ``Path.is_file``
+    returns ``True`` and applies the canonical path-validation recipe
+    (see ``.claude/rules/path-validation.md`` and the canonical writer
+    ``EvalSpec.from_dict`` ``input_files`` block):
+
+    - ``Path.resolve(strict=True)`` to normalize ``..`` and follow
+      symlinks to their real target.
+    - The resolved path must be ``is_relative_to`` the corresponding
+      anchor; otherwise raise :class:`ValueError` naming the offending
+      path AND the anchor it escaped.
+    - ``is_file()`` is implicit because the candidate-presence check
+      already used :meth:`Path.is_file`. The strict resolve also
+      rejects broken symlinks.
+
+    Returns the validated :class:`Path` of the first usable AGENTS.md,
+    or :class:`None` if neither location yields a valid file. Raises
+    :class:`ValueError` when a candidate exists but its resolved target
+    escapes the anchor — the security posture is "fail loud, not
+    silently include the wrong file."
+
+    Pure: the only I/O is the ``stat()`` implicit in ``is_file`` and
+    ``resolve``; no stderr writes; no subprocess; no global state.
+    """
+    candidates: list[tuple[Path, Path]] = [
+        (skill_path.parent / "AGENTS.md", skill_path.parent),
+        (project_root / "AGENTS.md", project_root),
+    ]
+    for candidate, anchor in candidates:
+        if not candidate.is_file():
+            continue
+        try:
+            anchor_resolved = anchor.resolve(strict=True)
+        except FileNotFoundError:  # pragma: no cover — defensive
+            # Anchor itself does not exist — skip this tier silently;
+            # the search may still succeed at a later tier. In practice
+            # both anchors are real dirs by the time the caller reaches
+            # this helper (since ``candidate.is_file()`` returned True
+            # above, the parent must exist).
+            continue
+        resolved = candidate.resolve(strict=True)
+        if not resolved.is_relative_to(anchor_resolved):
+            raise ValueError(
+                f"AGENTS.md at {candidate!s} resolves to {resolved!s} "
+                f"which escapes anchor {anchor_resolved!s}"
+            )
+        return resolved
+    return None
+
+
 def derive_project_dir(skill_path: Path) -> Path:
     """Return the project dir the runner should launch ``claude`` in.
 

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -146,10 +146,20 @@ def resolve_agents_md(skill_path: Path, project_root: Path) -> Path | None:
 
     Two-tier search per DEC-009 of ``plans/super/154-context-sidecar.md``:
 
-    1. ``<skill_path.parent>/AGENTS.md`` — the modern-layout per-skill
-       override. Anchor: the skill directory.
+    1. **Modern layout only** (``skill_path.name == "SKILL.md"``):
+       ``<skill_path.parent>/AGENTS.md`` — the per-skill override.
+       Anchor: the skill directory. Skipped for legacy ``<name>.md``
+       layouts because ``skill_path.parent`` for a legacy skill points
+       at the shared commands directory (e.g.
+       ``.claude/commands/``), NOT a per-skill directory — letting one
+       ``AGENTS.md`` there silently override the project-root fallback
+       for every legacy skill in the directory would surprise authors
+       and make the resolver's behavior context-dependent on the
+       layout. Legacy layouts skip this tier and fall through to the
+       project-root tier.
     2. ``<project_root>/AGENTS.md`` — the Codex / OpenAI ecosystem
-       project-root convention. Anchor: ``project_root``.
+       project-root convention. Anchor: ``project_root``. Always
+       consulted.
 
     For each candidate, the search short-circuits when ``Path.is_file``
     returns ``True`` and applies the canonical path-validation recipe
@@ -174,10 +184,15 @@ def resolve_agents_md(skill_path: Path, project_root: Path) -> Path | None:
     Pure: the only I/O is the ``stat()`` implicit in ``is_file`` and
     ``resolve``; no stderr writes; no subprocess; no global state.
     """
-    candidates: list[tuple[Path, Path]] = [
-        (skill_path.parent / "AGENTS.md", skill_path.parent),
-        (project_root / "AGENTS.md", project_root),
-    ]
+    candidates: list[tuple[Path, Path]] = []
+    # Tier 1 fires only for modern-layout skills (``<dir>/SKILL.md``)
+    # because ``skill_path.parent`` is a per-skill directory in that
+    # layout. For legacy ``<name>.md`` skills the parent is the shared
+    # commands directory, so a tier-1 hit there would be a surprising
+    # cross-skill override — skip it entirely.
+    if skill_path.name == "SKILL.md":
+        candidates.append((skill_path.parent / "AGENTS.md", skill_path.parent))
+    candidates.append((project_root / "AGENTS.md", project_root))
     for candidate, anchor in candidates:
         if not candidate.is_file():
             continue

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from clauditor._frontmatter import parse_frontmatter
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.conformance import check_conformance, format_issue_line
-from clauditor.paths import derive_project_dir, derive_skill_name
+from clauditor.paths import derive_project_dir, derive_skill_name, resolve_agents_md
 from clauditor.runner import SkillResult, SkillRunner, env_with_sync_tasks
 from clauditor.schemas import EvalSpec
 from clauditor.workspace import stage_inputs
@@ -202,30 +202,72 @@ class SkillSpec:
             effective_env = env_with_sync_tasks(effective_env)
 
         # US-004 of issue #150: resolve the effective system_prompt.
-        # Explicit ``EvalSpec.system_prompt`` wins; otherwise auto-derive
-        # from the skill file body (post-frontmatter). Wrap I/O failures
-        # (missing file, malformed frontmatter, permission errors) as a
-        # friendly RuntimeError that names the skill and path; the
+        # US-003 of #154 (DEC-003 / DEC-008 / DEC-009): three-tier
+        # resolution with provenance stamping into
+        # ``SkillResult.harness_metadata["system_prompt_source"]``.
+        #
+        # Order:
+        #   (a) Explicit ``EvalSpec.system_prompt`` set →
+        #       source = "explicit".
+        #   (b) AGENTS.md found via :func:`clauditor.paths.resolve_agents_md`
+        #       (skill-dir first, then project-root) → source = "agents_md".
+        #   (c) Auto-derive from SKILL.md body (post-frontmatter) →
+        #       source = "skill_md".
+        #
+        # Wrap I/O failures (missing file, malformed frontmatter,
+        # permission errors) on the SKILL.md auto-derive path as a
+        # friendly ``RuntimeError`` that names the skill and path; the
         # original exception chains through ``__cause__`` for debug.
         # The empty-string body case threads through verbatim — we do
         # NOT fall back to None, so misconfigured skills surface clearly
         # rather than silently masking the missing prompt.
-        effective_system_prompt = (
-            self.eval_spec.system_prompt
-            if (self.eval_spec is not None and self.eval_spec.system_prompt is not None)
-            else None
-        )
-        if effective_system_prompt is None:
-            try:
-                skill_text = self.skill_path.read_text(encoding="utf-8")
-                _meta, body = parse_frontmatter(skill_text)
-                effective_system_prompt = body
-            except (FileNotFoundError, OSError, ValueError) as exc:
-                raise RuntimeError(
-                    f"clauditor.spec: failed to auto-derive system_prompt "
-                    f"for skill {self.skill_name!r} from {self.skill_path}: "
-                    f"{exc}"
-                ) from exc
+        effective_system_prompt: str | None = None
+        system_prompt_source: str
+        if self.eval_spec is not None and self.eval_spec.system_prompt is not None:
+            effective_system_prompt = self.eval_spec.system_prompt
+            system_prompt_source = "explicit"
+        else:
+            # AGENTS.md tier — pure resolver applies the
+            # ``.claude/rules/path-validation.md`` recipe (resolve
+            # strict + ``is_relative_to`` anchor) before the read. A
+            # ValueError from the resolver is intentionally
+            # un-wrapped: a hostile/typoed symlink escape is a
+            # security-relevant signal, not a friendly auto-derive
+            # failure, and should propagate to the CLI seam.
+            agents_md_path = resolve_agents_md(
+                self.skill_path, self.runner.project_dir
+            )
+            if agents_md_path is not None:
+                # Theoretical race: ``resolve_agents_md`` validated via
+                # ``Path.resolve(strict=True)`` so the file existed when
+                # the resolver ran. A concurrent delete or perms change
+                # between resolve and read surfaces as a friendly
+                # RuntimeError naming the skill + path; ``__cause__``
+                # chains the original. The ``except`` arm is defensive
+                # and not exercised by tests.
+                try:
+                    effective_system_prompt = agents_md_path.read_text(
+                        encoding="utf-8"
+                    )
+                    system_prompt_source = "agents_md"
+                except (FileNotFoundError, OSError) as exc:  # pragma: no cover
+                    raise RuntimeError(
+                        f"clauditor.spec: failed to read AGENTS.md "
+                        f"for skill {self.skill_name!r} from "
+                        f"{agents_md_path}: {exc}"
+                    ) from exc
+            else:
+                try:
+                    skill_text = self.skill_path.read_text(encoding="utf-8")
+                    _meta, body = parse_frontmatter(skill_text)
+                    effective_system_prompt = body
+                    system_prompt_source = "skill_md"
+                except (FileNotFoundError, OSError, ValueError) as exc:
+                    raise RuntimeError(
+                        f"clauditor.spec: failed to auto-derive system_prompt "
+                        f"for skill {self.skill_name!r} from {self.skill_path}: "
+                        f"{exc}"
+                    ) from exc
 
         # US-006 / DEC-004 of #151: when the caller (typically the CLI
         # seam) has resolved a concrete harness name, materialize a fresh
@@ -270,6 +312,16 @@ class SkillSpec:
             env=effective_env,
             system_prompt=effective_system_prompt,
         )
+
+        # US-003 of #154 (DEC-008): stamp the resolved provenance label
+        # into ``SkillResult.harness_metadata`` so the context-sidecar
+        # writer can read it without re-running the resolver.
+        # ``harness_metadata`` is the additive forward-compat surface
+        # introduced by DEC-007 of #148; merging here is correct
+        # because each call returns its own ``SkillResult`` (the
+        # underlying ``InvokeResult`` is constructed fresh per harness
+        # invocation, never shared across runs).
+        result.harness_metadata["system_prompt_source"] = system_prompt_source
 
         # Read output from files if eval spec specifies file-based output
         # Only read files on successful runs to avoid stale output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -968,12 +968,25 @@ def make_skill_result(
     output_tokens: int = 0,
     error: str | None = None,
     stream_events: list[dict] | None = None,
+    harness_metadata: dict | None = None,
 ) -> SkillResult:
     """Build a real SkillResult with sensible defaults.
 
     Prefer this over MagicMock for tests that only need a value object;
     keeping it a real dataclass means attribute typos fail loudly.
+
+    ``harness_metadata`` defaults to a dict pre-populated with the
+    ``model`` and ``system_prompt_source`` keys per the harness contract
+    (#154 DEC-007 / DEC-008): every real harness invocation populates
+    these keys, so the test factory mirrors that contract by default.
+    Tests exercising the missing-key contract-violation path can pass
+    ``harness_metadata={}`` explicitly.
     """
+    if harness_metadata is None:
+        harness_metadata = {
+            "model": "claude-sonnet-4-6",
+            "system_prompt_source": "skill_md",
+        }
     return SkillResult(
         output=output,
         exit_code=exit_code,
@@ -984,6 +997,7 @@ def make_skill_result(
         output_tokens=output_tokens,
         error=error,
         stream_events=stream_events if stream_events is not None else [],
+        harness_metadata=harness_metadata,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -906,10 +906,16 @@ def tmp_skill_file(tmp_path):
 
 
 @pytest.fixture
-def mock_runner():
+def mock_runner(tmp_path):
     """Factory fixture returning a MagicMock SkillRunner.
 
     The mock's .run() returns a configurable SkillResult.
+
+    The mock's ``project_dir`` defaults to a fresh ``tmp_path`` so that
+    helpers walking the project root (e.g. ``resolve_agents_md`` from
+    US-003 of #154) do not accidentally pick up files in the real
+    repo-root cwd. Tests that need a specific project_dir can override
+    via ``project_dir=`` kwarg.
 
     Usage:
         def test_something(mock_runner):
@@ -925,9 +931,10 @@ def mock_runner():
         args: str = "",
         duration_seconds: float = 1.0,
         error: str | None = None,
+        project_dir: Path | None = None,
     ) -> MagicMock:
         mock = MagicMock(spec=SkillRunner)
-        mock.project_dir = Path.cwd()
+        mock.project_dir = project_dir if project_dir is not None else tmp_path
         result = SkillResult(
             output=output,
             exit_code=exit_code,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -560,7 +560,8 @@ class TestRenderers:
         )
         # US-004 (#147): bumped to schema_version 2 + ``providers_seen``.
         # US-006 (#152): bumped to schema_version 3 + ``harnesses_seen``.
-        # #154 US-005 / DEC-005: always emits ``iteration_contexts`` array.
+        # #154 US-005 / DEC-005: bumped to schema_version 4 with new
+        # ``iteration_contexts`` array (always emitted).
         assert set(payload.keys()) == {
             "schema_version",
             "skill",
@@ -572,7 +573,7 @@ class TestRenderers:
             "assertions",
             "iteration_contexts",
         }
-        assert payload["schema_version"] == 3
+        assert payload["schema_version"] == 4
         assert isinstance(payload["assertions"], list)
         first = payload["assertions"][0]
         for key in (
@@ -735,13 +736,15 @@ class TestCmdAuditExitCode:
 
 
 class TestSchemaVersion:
-    def test_audit_render_json_has_schema_version_3(self) -> None:
+    def test_audit_render_json_has_schema_version_4(self) -> None:
         """US-004 (#147): audit JSON output bumped from v1 to v2 to
         signal the new ``provider`` per-assertion field + top-level
         ``providers_seen`` array (DEC-005, DEC-010 of #147).
         US-006 (#152): bumped to v3 to signal the new ``harness``
         per-assertion field + top-level ``harnesses_seen`` array
-        (DEC-010 of #152)."""
+        (DEC-010 of #152).
+        #154 US-005 / DEC-005: bumped to v4 to signal the new
+        top-level ``iteration_contexts`` array."""
         payload = render_json(
             [],
             skill="s",
@@ -749,7 +752,7 @@ class TestSchemaVersion:
             thresholds={"last": 20},
             timestamp="t",
         )
-        assert payload["schema_version"] == 3
+        assert payload["schema_version"] == 4
 
 
 class TestIsAcceptedVersion:
@@ -1862,7 +1865,8 @@ class TestRenderProviderColumn:
 
     def test_render_json_v2_schema_version_first_key(self) -> None:
         """Acceptance criterion 1: ``schema_version`` is the first key
-        and equals 3 (DEC-005 of #147 + DEC-010 of #152 bump)."""
+        and equals 4 (DEC-005 of #147 + DEC-010 of #152 + #154 US-005
+        DEC-005 bump for ``iteration_contexts``)."""
         payload = render_json(
             self._single_provider_verdicts(),
             skill="s",
@@ -1872,7 +1876,7 @@ class TestRenderProviderColumn:
         )
         first_key = next(iter(payload.keys()))
         assert first_key == "schema_version"
-        assert payload["schema_version"] == 3
+        assert payload["schema_version"] == 4
 
     def test_render_json_v2_includes_provider_per_assertion(self) -> None:
         """Acceptance criterion 2: every ``assertions[]`` entry carries
@@ -2812,12 +2816,15 @@ class TestRenderMarkdownHarness:
 
 
 class TestRenderJsonHarnessV3:
-    """US-006 (#152): ``render_json`` bumps to ``schema_version: 3``,
-    adds top-level ``harnesses_seen[]`` (sorted, deduped), and each
+    """US-006 (#152): ``render_json`` bumps ``schema_version`` to add
+    top-level ``harnesses_seen[]`` (sorted, deduped), and each
     ``assertions[]`` entry gains a ``"harness": str`` field. L1 entries
     keep ``"provider": "anthropic"`` placeholder in JSON output (the
-    em-dash is stdout/markdown-only per DEC-008).
-    Traces to: DEC-008, DEC-010.
+    em-dash is stdout/markdown-only per DEC-008). #154 US-005 / DEC-005
+    further bumped the audit-output ``schema_version`` from 3 to 4
+    when the new top-level ``iteration_contexts`` array landed; the
+    harness invariants tested in this class are unchanged.
+    Traces to: DEC-008, DEC-010 (#152) + DEC-005 (#154 US-005).
     """
 
     def _mixed_verdicts(self) -> list[AuditVerdict]:
@@ -2854,8 +2861,8 @@ class TestRenderJsonHarnessV3:
             min_discrimination=0.05,
         )
 
-    def test_schema_version_3(self) -> None:
-        """First key is ``schema_version: 3``."""
+    def test_schema_version_4(self) -> None:
+        """First key is ``schema_version: 4`` (post-#154 bump)."""
         payload = render_json(
             self._mixed_verdicts(),
             skill="s",
@@ -2865,7 +2872,7 @@ class TestRenderJsonHarnessV3:
         )
         first_key = next(iter(payload.keys()))
         assert first_key == "schema_version"
-        assert payload["schema_version"] == 3
+        assert payload["schema_version"] == 4
 
     def test_includes_harnesses_seen_array(self) -> None:
         """Top-level ``harnesses_seen`` is a sorted, deduped list."""

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -20,6 +20,7 @@ from clauditor.audit import (
     render_stdout_table,
 )
 from clauditor.cli import main as cli_main
+from clauditor.context import IterationContext
 
 # --------------------------------------------------------------------------- #
 # Fixture helper                                                               #
@@ -165,7 +166,7 @@ class TestLoadIterations:
                 for i in range(1, 6)
             },
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "skillX", last=3, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -182,7 +183,7 @@ class TestLoadIterations:
                 3: {"l1": [{"id": "a", "passed": False}]},
             },
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=10, clauditor_dir=clauditor_dir
         )
         assert skipped == 1
@@ -200,7 +201,7 @@ class TestLoadIterations:
                 },
             },
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=10, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -209,7 +210,7 @@ class TestLoadIterations:
         assert records[0].id == "a"
 
     def test_returns_empty_when_no_data(self, tmp_path: Path) -> None:
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=10, clauditor_dir=tmp_path / ".clauditor"
         )
         assert records == []
@@ -228,7 +229,7 @@ class TestLoadIterations:
                 },
             },
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=10, clauditor_dir=clauditor_dir
         )
         with_skill = [r for r in records if r.with_skill]
@@ -248,7 +249,7 @@ class TestLoadIterations:
                 },
             },
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=10, clauditor_dir=clauditor_dir
         )
         layers = {r.layer for r in records}
@@ -283,7 +284,7 @@ class TestLoadIterations:
         (skill_dir / "extraction.json").write_text(
             json.dumps(extraction, indent=2) + "\n"
         )
-        records, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
+        records, _, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
         l2 = [r for r in records if r.layer == "L2"]
         assert len(l2) == 1
         assert l2[0].passed is True
@@ -546,6 +547,7 @@ class TestRenderers:
             timestamp="20260101T000000Z",
         )
         # US-004 (#147): bumped to schema_version 2 + ``providers_seen``.
+        # #154 US-005 / DEC-005: always emits ``iteration_contexts`` array.
         assert set(payload.keys()) == {
             "schema_version",
             "skill",
@@ -554,6 +556,7 @@ class TestRenderers:
             "thresholds",
             "providers_seen",
             "assertions",
+            "iteration_contexts",
         }
         assert payload["schema_version"] == 2
         assert isinstance(payload["assertions"], list)
@@ -892,7 +895,7 @@ class TestAuditLegacyCompat:
         self._write_grading_sidecar(
             skill_dir, version=1, transport_source=None
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -911,7 +914,7 @@ class TestAuditLegacyCompat:
         self._write_extraction_sidecar(
             skill_dir, version=1, transport_source=None
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -930,7 +933,7 @@ class TestAuditLegacyCompat:
         self._write_grading_sidecar(
             skill_dir, version=2, transport_source="cli"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -948,7 +951,7 @@ class TestAuditLegacyCompat:
         self._write_extraction_sidecar(
             skill_dir, version=2, transport_source="cli"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -965,7 +968,7 @@ class TestAuditLegacyCompat:
         self._write_grading_sidecar(
             skill_dir, version=2, transport_source="api"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -982,7 +985,7 @@ class TestAuditLegacyCompat:
         self._write_grading_sidecar(
             skill_dir, version=3, transport_source="api"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -999,7 +1002,7 @@ class TestAuditLegacyCompat:
         self._write_extraction_sidecar(
             skill_dir, version=3, transport_source="api"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -1018,7 +1021,7 @@ class TestAuditLegacyCompat:
         self._write_grading_sidecar(
             skill_dir, version=4, transport_source="api"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert records == []
@@ -1037,7 +1040,7 @@ class TestAuditLegacyCompat:
         self._write_extraction_sidecar(
             skill_dir, version=4, transport_source="api"
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert records == []
@@ -1069,7 +1072,7 @@ class TestAuditLegacyCompat:
         (skill_dir / "baseline_grading.json").write_text(
             json.dumps(payload)
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert records == []
@@ -1147,7 +1150,7 @@ class TestAuditL3StableId:
         data["results"][0]["criterion"] = "Totally different wording"
         gj.write_text(json.dumps(data))
 
-        records, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
+        records, _, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
         l3 = [r for r in records if r.layer == "L3"]
         assert len(l3) == 2
         assert {r.id for r in l3} == {"quality"}
@@ -1185,7 +1188,7 @@ class TestAuditL3StableId:
                 }
             )
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert records == []
@@ -1204,7 +1207,7 @@ class TestAuditL3StableId:
         skill_dir = clauditor_dir / "iteration-1" / "s"
         skill_dir.mkdir(parents=True)
         (skill_dir / "assertions.json").write_text("{not valid json")
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert records == []
@@ -1231,7 +1234,7 @@ class TestAuditL3StableId:
                 }
             )
         )
-        records, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
+        records, _, _ = load_iterations("s", last=5, clauditor_dir=clauditor_dir)
         assert [r for r in records if r.layer == "L3"] == []
 
 
@@ -1433,7 +1436,7 @@ class TestProviderDimension:
             passed=True,
             provider_source="openai",
         )
-        records, skipped = load_iterations(
+        records, skipped, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert skipped == 0
@@ -1456,7 +1459,7 @@ class TestProviderDimension:
             passed=True,
             provider_source=None,
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert len(records) == 1
@@ -1473,7 +1476,7 @@ class TestProviderDimension:
             passed=True,
             provider_source="openai",
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert len(records) == 1
@@ -1493,7 +1496,7 @@ class TestProviderDimension:
                 1: {"l1": [{"id": "has_header", "passed": True}]},
             },
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         l1 = [r for r in records if r.layer == "L1"]
@@ -1621,7 +1624,7 @@ class TestProviderDimension:
             passed=True,
             provider_source="openai",
         )
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         agg = aggregate(records)
@@ -1656,7 +1659,7 @@ class TestProviderDimension:
             ],
         }
         (skill_dir / "grading.json").write_text(json.dumps(payload))
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert len(records) == 1
@@ -1734,7 +1737,7 @@ class TestProviderOrDefault:
             ],
         }
         (skill_dir / "grading.json").write_text(json.dumps(payload))
-        records, _ = load_iterations(
+        records, _, _ = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
         )
         assert len(records) == 1
@@ -2046,3 +2049,525 @@ class TestRenderProviderColumn:
         assert body.startswith("a" * 11)
         # And there is whitespace after — the column is bounded.
         assert body[11] == " "
+
+
+# --------------------------------------------------------------------------- #
+# #154 US-005 — context.json sidecar reading + verbose render                  #
+# --------------------------------------------------------------------------- #
+
+
+def _write_context_sidecar(
+    skill_dir: Path,
+    *,
+    schema_version: int = 1,
+    harness: str = "claude-code",
+    provider: str | None = "anthropic",
+    model_runner: str = "claude-sonnet-4-6",
+    model_grader: str | None = "claude-sonnet-4-6",
+    system_prompt_source: str = "explicit",
+    sandbox_mode: str | None = "workspace-write",
+    reasoning_tokens: int | None = None,
+    cost_usd: float | None = None,
+) -> None:
+    """Write a synthetic ``context.json`` sidecar under ``skill_dir``.
+
+    Helper for #154 US-005 tests; mirrors the ``_write_grading_v3`` /
+    ``_write_extraction_v3`` shape above.
+    """
+    payload: dict = {
+        "schema_version": schema_version,
+        "harness": harness,
+        "provider": provider,
+        "model_runner": model_runner,
+        "model_grader": model_grader,
+        "system_prompt_source": system_prompt_source,
+        "sandbox_mode": sandbox_mode,
+        "reasoning_tokens": reasoning_tokens,
+        "cost_usd": cost_usd,
+    }
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "context.json").write_text(
+        json.dumps(payload, indent=2) + "\n"
+    )
+
+
+class TestMaxSchemaVersion:
+    """#154 US-005 / DEC-010: ``context.json`` registered at v1 in the
+    canonical ``MAX_SCHEMA_VERSION`` map."""
+
+    def test_context_json_registered_at_v1(self) -> None:
+        from clauditor.audit import MAX_SCHEMA_VERSION, _is_accepted_version
+
+        assert MAX_SCHEMA_VERSION["context.json"] == 1
+        assert _is_accepted_version("context.json", 1) is True
+
+    def test_context_json_v999_rejected(self) -> None:
+        from clauditor.audit import _is_accepted_version
+
+        assert _is_accepted_version("context.json", 999) is False
+        assert _is_accepted_version("context.json", 2) is False
+
+
+class TestReadContext:
+    """#154 US-005 / DEC-011: pure helper that reads + schema-validates
+    ``context.json``. Returns ``IterationContext`` on success, ``None``
+    on every failure mode (missing file silently; schema/validation
+    errors with stderr warning)."""
+
+    def test_returns_iteration_context_for_valid_sidecar(
+        self, tmp_path: Path
+    ) -> None:
+        from clauditor.audit import _read_context
+
+        skill_dir = tmp_path / "skill"
+        _write_context_sidecar(
+            skill_dir,
+            harness="codex",
+            provider="openai",
+            model_runner="gpt-5.4",
+            model_grader=None,
+            system_prompt_source="agents_md",
+            sandbox_mode="read-only",
+            reasoning_tokens=42,
+            cost_usd=0.0123,
+        )
+        ctx = _read_context(skill_dir)
+        assert ctx is not None
+        assert ctx.harness == "codex"
+        assert ctx.provider == "openai"
+        assert ctx.model_runner == "gpt-5.4"
+        assert ctx.model_grader is None
+        assert ctx.system_prompt_source == "agents_md"
+        assert ctx.sandbox_mode == "read-only"
+        assert ctx.reasoning_tokens == 42
+        assert ctx.cost_usd == pytest.approx(0.0123)
+
+    def test_returns_none_on_missing_file_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        from clauditor.audit import _read_context
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        # No context.json written.
+        assert _read_context(skill_dir) is None
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
+
+    def test_returns_none_with_stderr_warning_on_schema_mismatch(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        from clauditor.audit import _read_context
+
+        skill_dir = tmp_path / "skill"
+        _write_context_sidecar(skill_dir, schema_version=999)
+        result = _read_context(skill_dir)
+        assert result is None
+        captured = capsys.readouterr()
+        assert "context.json" in captured.err
+        assert "999" in captured.err
+
+    def test_returns_none_on_malformed_json(self, tmp_path: Path) -> None:
+        from clauditor.audit import _read_context
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "context.json").write_text("{ this is not json")
+        assert _read_context(skill_dir) is None
+
+    def test_returns_none_on_hard_validator_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """``IterationContext.from_dict`` raises ``ValueError`` for an
+        unknown ``harness`` literal (per US-001 hard-validators).
+        ``_read_context`` translates that to ``None`` plus a stderr
+        warning rather than propagating."""
+        from clauditor.audit import _read_context
+
+        skill_dir = tmp_path / "skill"
+        _write_context_sidecar(skill_dir, harness="not-a-real-harness")
+        assert _read_context(skill_dir) is None
+        captured = capsys.readouterr()
+        assert "context.json" in captured.err
+        assert "malformed payload" in captured.err
+
+    def test_returns_none_when_top_level_is_not_dict(
+        self, tmp_path: Path
+    ) -> None:
+        """A JSON file containing a list/scalar at the top level is
+        rejected without raising — defensive read posture per
+        ``stream-json-schema.md``."""
+        from clauditor.audit import _read_context
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "context.json").write_text("[1, 2, 3]")
+        assert _read_context(skill_dir) is None
+
+
+class TestRenderJsonContext:
+    """#154 US-005 / DEC-005: ``render_json`` always emits
+    ``iteration_contexts`` (no ``--verbose`` gate on JSON output)."""
+
+    def _verdicts(self) -> list[AuditVerdict]:
+        agg = AuditAggregate(
+            layer="L1",
+            id="a",
+            total_with_runs=2,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+        )
+        return [AuditVerdict(layer="L1", id="a", verdict=Verdict.KEEP, aggregate=agg)]
+
+    def test_always_includes_iteration_contexts_key(self) -> None:
+        payload = render_json(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=0,
+            thresholds={"last": 20},
+            timestamp="t",
+        )
+        assert "iteration_contexts" in payload
+        assert payload["iteration_contexts"] == []
+
+    def test_legacy_iteration_emits_null_context(self) -> None:
+        contexts: dict[int, IterationContext | None] = {3: None}
+        payload = render_json(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=1,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts=contexts,
+        )
+        assert payload["iteration_contexts"] == [
+            {"iteration": 3, "context": None}
+        ]
+
+    def test_populated_context_serializes_full_field_set(
+        self, tmp_path: Path
+    ) -> None:
+        skill_dir = tmp_path / "skill"
+        _write_context_sidecar(
+            skill_dir,
+            harness="codex",
+            provider="openai",
+            model_runner="gpt-5.4",
+            model_grader="gpt-5.4",
+            system_prompt_source="explicit",
+            sandbox_mode="workspace-write",
+            reasoning_tokens=100,
+            cost_usd=0.5,
+        )
+        from clauditor.audit import _read_context
+
+        ctx = _read_context(skill_dir)
+        payload = render_json(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=1,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts={5: ctx},
+        )
+        assert payload["iteration_contexts"] == [
+            {
+                "iteration": 5,
+                "context": {
+                    "harness": "codex",
+                    "provider": "openai",
+                    "model_runner": "gpt-5.4",
+                    "model_grader": "gpt-5.4",
+                    "system_prompt_source": "explicit",
+                    "sandbox_mode": "workspace-write",
+                    "reasoning_tokens": 100,
+                    "cost_usd": 0.5,
+                },
+            }
+        ]
+
+    def test_iteration_contexts_sorted_descending(
+        self, tmp_path: Path
+    ) -> None:
+        contexts: dict[int, IterationContext | None] = {1: None, 5: None, 3: None}
+        payload = render_json(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=3,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts=contexts,
+        )
+        nums = [entry["iteration"] for entry in payload["iteration_contexts"]]
+        assert nums == [5, 3, 1]
+
+
+class TestRenderMarkdownVerbose:
+    """#154 US-005 / DEC-005: ``render_markdown`` emits a
+    per-iteration ``## Per-iteration context`` section ONLY under
+    ``verbose=True``."""
+
+    def _verdicts(self) -> list[AuditVerdict]:
+        agg = AuditAggregate(
+            layer="L1",
+            id="a",
+            total_with_runs=1,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+        )
+        return [AuditVerdict(layer="L1", id="a", verdict=Verdict.KEEP, aggregate=agg)]
+
+    def _make_ctx(self) -> IterationContext:
+        return IterationContext(
+            harness="codex",
+            provider="openai",
+            model_runner="gpt-5.4",
+            model_grader="gpt-5.4",
+            system_prompt_source="agents_md",
+            sandbox_mode="read-only",
+            reasoning_tokens=42,
+            cost_usd=0.01,
+        )
+
+    def test_per_iteration_block_under_verbose(self) -> None:
+        markdown = render_markdown(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=1,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts={7: self._make_ctx()},
+            verbose=True,
+        )
+        assert "## Per-iteration context" in markdown
+        assert "### Iteration 7" in markdown
+        assert "harness" in markdown
+        assert "codex" in markdown
+        assert "gpt-5.4" in markdown
+        assert "agents_md" in markdown
+
+    def test_no_block_without_verbose(self) -> None:
+        markdown = render_markdown(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=1,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts={7: self._make_ctx()},
+            verbose=False,
+        )
+        assert "Per-iteration context" not in markdown
+        assert "Iteration 7" not in markdown
+
+    def test_no_block_when_contexts_dict_is_none(self) -> None:
+        markdown = render_markdown(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=1,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts=None,
+            verbose=True,
+        )
+        assert "Per-iteration context" not in markdown
+
+    def test_legacy_only_iterations_skipped_under_verbose(self) -> None:
+        """Iterations with ``context = None`` (pre-#154) do NOT
+        produce an ``### Iteration N`` block — verbose markdown stays
+        readable."""
+        markdown = render_markdown(
+            self._verdicts(),
+            skill="s",
+            iterations_analyzed=1,
+            thresholds={"last": 20},
+            timestamp="t",
+            iteration_contexts={3: None},
+            verbose=True,
+        )
+        assert "Per-iteration context" not in markdown
+        assert "Iteration 3" not in markdown
+
+
+class TestRenderStdoutTableVerbose:
+    """#154 US-005 / DEC-005: ``render_stdout_table`` emits a per-
+    iteration ``Context for iteration N:`` block ONLY under
+    ``verbose=True``."""
+
+    def _verdicts(self) -> list[AuditVerdict]:
+        agg = AuditAggregate(
+            layer="L1",
+            id="a",
+            total_with_runs=1,
+            with_fails=0,
+            with_pass_rate=1.0,
+            total_baseline_runs=0,
+            baseline_fails=0,
+            baseline_pass_rate=None,
+        )
+        return [AuditVerdict(layer="L1", id="a", verdict=Verdict.KEEP, aggregate=agg)]
+
+    def _make_ctx(self) -> IterationContext:
+        return IterationContext(
+            harness="claude-code",
+            provider="anthropic",
+            model_runner="claude-sonnet-4-6",
+            model_grader="claude-sonnet-4-6",
+            system_prompt_source="explicit",
+            sandbox_mode="workspace-write",
+        )
+
+    def test_per_iteration_block_under_verbose(self) -> None:
+        out = render_stdout_table(
+            self._verdicts(),
+            iteration_contexts={3: self._make_ctx()},
+            verbose=True,
+        )
+        assert "Context for iteration 3:" in out
+        assert "harness: claude-code" in out
+        assert "provider: anthropic" in out
+        assert "system_prompt_source: explicit" in out
+
+    def test_no_block_without_verbose(self) -> None:
+        out = render_stdout_table(
+            self._verdicts(),
+            iteration_contexts={3: self._make_ctx()},
+            verbose=False,
+        )
+        assert "Context for iteration" not in out
+
+    def test_legacy_only_iterations_skipped_under_verbose(self) -> None:
+        out = render_stdout_table(
+            self._verdicts(),
+            iteration_contexts={3: None, 1: None},
+            verbose=True,
+        )
+        assert "Context for iteration" not in out
+
+
+class TestAggregateUnchanged:
+    """#154 DEC-011 regression guard: ``IterationRecord`` does NOT carry
+    a ``context`` field. Context lives parallel to records, attached at
+    render time only."""
+
+    def test_iteration_record_has_no_context_field(self) -> None:
+        import dataclasses
+
+        names = {f.name for f in dataclasses.fields(IterationRecord)}
+        assert "context" not in names
+        # Sanity check that we still own the existing fields so the
+        # test does not become vacuous if the dataclass is renamed.
+        assert {"iteration", "layer", "id", "passed"}.issubset(names)
+
+
+class TestLoadIterationsContextDict:
+    """#154 US-005 / DEC-011: ``load_iterations`` returns a
+    ``dict[int, IterationContext | None]`` parallel to the records."""
+
+    def test_returns_context_for_iteration_with_sidecar(
+        self, tmp_path: Path
+    ) -> None:
+        clauditor_dir = _make_iteration_fixture(
+            tmp_path,
+            "s",
+            {1: {"l1": [{"id": "a", "passed": True}]}},
+        )
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        _write_context_sidecar(
+            skill_dir,
+            harness="codex",
+            provider="openai",
+            model_runner="gpt-5.4",
+            model_grader=None,
+            system_prompt_source="agents_md",
+            sandbox_mode="read-only",
+        )
+        records, _, contexts = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert len(records) == 1
+        assert 1 in contexts
+        ctx = contexts[1]
+        assert ctx is not None
+        assert ctx.harness == "codex"
+
+    def test_returns_none_for_iteration_without_sidecar(
+        self, tmp_path: Path
+    ) -> None:
+        """Pre-#154 iterations (no ``context.json`` on disk) map to
+        ``None`` in the contexts dict so renderers can emit a uniform
+        shape."""
+        clauditor_dir = _make_iteration_fixture(
+            tmp_path,
+            "s",
+            {1: {"l1": [{"id": "a", "passed": True}]}},
+        )
+        _, _, contexts = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert contexts == {1: None}
+
+
+class TestCmdAuditVerboseFlag:
+    """#154 US-005 argparse smoke test: ``--verbose`` is a valid flag
+    on ``clauditor audit``."""
+
+    def test_verbose_flag_accepted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        clauditor_dir = _make_iteration_fixture(
+            project,
+            "my_skill",
+            {1: {"l1": [{"id": "a", "passed": True}]}},
+        )
+        skill_dir = clauditor_dir / "iteration-1" / "my_skill"
+        _write_context_sidecar(skill_dir)
+        monkeypatch.chdir(project)
+        rc = cli_main(["audit", "my_skill", "--verbose"])
+        # --verbose is accepted; ``always_pass`` flagging still drives
+        # the exit code.
+        assert rc in (0, 1)
+        out = capsys.readouterr().out
+        assert "Context for iteration 1:" in out
+
+    def test_verbose_emits_per_iteration_block_in_json(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """JSON output emits ``iteration_contexts`` regardless of the
+        ``--verbose`` flag (per DEC-005 — JSON consumers should not
+        need a flag for a stable field)."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        clauditor_dir = _make_iteration_fixture(
+            project,
+            "my_skill",
+            {1: {"l1": [{"id": "a", "passed": True}]}},
+        )
+        skill_dir = clauditor_dir / "iteration-1" / "my_skill"
+        _write_context_sidecar(skill_dir)
+        monkeypatch.chdir(project)
+        rc = cli_main(["audit", "my_skill", "--json"])
+        assert rc in (0, 1)
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert "iteration_contexts" in payload
+        assert any(
+            entry["iteration"] == 1 and entry["context"] is not None
+            for entry in payload["iteration_contexts"]
+        )

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1534,3 +1534,58 @@ class TestLoadIterationContext:
         }
         (skill_dir / "context.json").write_text(json.dumps(bad))
         assert load_iteration_context(skill_dir) is None
+
+    def test_returns_none_for_unsupported_schema_version(self, tmp_path, capsys):
+        """Out-of-range ``schema_version`` (e.g. ``999``) → ``None`` PLUS
+        a stderr warning via :func:`audit._check_schema_version`.
+
+        Mirrors the audit-side reader: badge generation must NOT silently
+        embed a future, unsupported ``context.json`` revision when
+        :func:`clauditor.audit._read_context` would deliberately skip it.
+        Without this gate the two readers would diverge on which
+        sidecars are accepted.
+        """
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        bad = {
+            "schema_version": 999,
+            "harness": "claude-code",
+            "provider": "anthropic",
+            "model_runner": "x",
+            "model_grader": None,
+            "system_prompt_source": "agents_md",
+            "sandbox_mode": None,
+        }
+        (skill_dir / "context.json").write_text(json.dumps(bad))
+        assert load_iteration_context(skill_dir) is None
+        captured = capsys.readouterr()
+        # Stderr names the file + the expected accepted range so an
+        # operator can immediately diagnose the version mismatch.
+        assert "context.json" in captured.err
+        assert "999" in captured.err
+
+    def test_returns_none_when_schema_version_missing(self, tmp_path, capsys):
+        """A ``context.json`` payload without ``schema_version`` →
+        ``None`` (the version guard treats missing as out-of-range)."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        bad = {
+            "harness": "claude-code",
+            "provider": "anthropic",
+            "model_runner": "x",
+            "model_grader": None,
+            "system_prompt_source": "agents_md",
+            "sandbox_mode": None,
+        }
+        (skill_dir / "context.json").write_text(json.dumps(bad))
+        assert load_iteration_context(skill_dir) is None
+        captured = capsys.readouterr()
+        assert "context.json" in captured.err
+
+    def test_returns_none_when_top_level_not_dict(self, tmp_path):
+        """A ``context.json`` whose top level is not a dict (e.g. a
+        scalar JSON value) → ``None`` silently."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "context.json").write_text("42")
+        assert load_iteration_context(skill_dir) is None

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -29,8 +29,10 @@ from clauditor.badge import (
     build_markdown_image,
     compute_badge,
     discover_iteration,
+    load_iteration_context,
     load_iteration_sidecars,
 )
+from clauditor.context import IterationContext
 from clauditor.quality_grader import GradingReport, GradingResult
 from clauditor.schemas import GradeThresholds
 
@@ -536,7 +538,11 @@ class TestBadgeSerialization:
         assert "schema_version" not in result
 
     def test_clauditor_extension_schema_version_is_first_key(self):
-        """DEC-027 + json-schema-version.md: extension file's first key."""
+        """DEC-027 + json-schema-version.md: extension file's first key.
+
+        Bumped to 2 in #154 US-006 (DEC-006) when the optional
+        ``context`` field landed.
+        """
         badge = compute_badge(
             _make_assertions_dict(passed=8, total=8),
             None,
@@ -548,7 +554,7 @@ class TestBadgeSerialization:
         ext = badge.to_clauditor_extension_json()
         inner_keys = list(ext.keys())
         assert inner_keys[0] == "schema_version"
-        assert ext["schema_version"] == 1
+        assert ext["schema_version"] == 2
 
     def test_clauditor_extension_key_order(self):
         """Extension file layout: schema_version, skill_name,
@@ -746,10 +752,12 @@ class TestDataclassShapes:
             generated_at=_GEN_AT,
             iteration=1,
         )
-        assert ext.schema_version == 1
+        # Bumped 1 → 2 in #154 US-006 (DEC-006).
+        assert ext.schema_version == 2
         assert ext.l1 is None
         assert ext.l3 is None
         assert ext.variance is None
+        assert ext.context is None
 
     def test_badge_defaults(self):
         ext = ClauditorExtension(skill_name="demo", generated_at=_GEN_AT, iteration=1)
@@ -1241,3 +1249,288 @@ class TestDiscoverIterationSkipsIterationZero:
         assert result is not None
         n, _path = result
         assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# US-006 — ClauditorExtension v1 → v2 bump with optional ``context`` field.
+#
+# Traces to DEC-006 of ``plans/super/154-context-sidecar.md``.
+# ---------------------------------------------------------------------------
+
+
+def _make_context() -> IterationContext:
+    """Build a fully-populated :class:`IterationContext` for tests."""
+    return IterationContext(
+        harness="claude-code",
+        provider="anthropic",
+        model_runner="claude-sonnet-4-6",
+        model_grader="claude-sonnet-4-6",
+        system_prompt_source="agents_md",
+        sandbox_mode="workspace-write",
+        reasoning_tokens=None,
+        cost_usd=None,
+    )
+
+
+class TestClauditorExtensionSchemaBump:
+    """DEC-006: ``_CLAUDITOR_EXTENSION_SCHEMA_VERSION`` bumps 1 → 2."""
+
+    def test_schema_version_is_2(self):
+        """Top-level constant + dataclass default both equal 2."""
+        from clauditor.badge import _CLAUDITOR_EXTENSION_SCHEMA_VERSION
+
+        assert _CLAUDITOR_EXTENSION_SCHEMA_VERSION == 2
+        ext = ClauditorExtension(
+            skill_name="demo", generated_at=_GEN_AT, iteration=1
+        )
+        assert ext.schema_version == 2
+
+    def test_serialized_schema_version_is_2(self):
+        """The on-disk extension JSON carries ``schema_version: 2``."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        ext = badge.to_clauditor_extension_json()
+        assert ext["schema_version"] == 2
+
+
+class TestClauditorExtensionContextOmission:
+    """DEC-006: ``_extension_to_dict`` omits ``context`` when ``None``.
+
+    Mirrors the existing l1 / l3 / variance optional-block pattern.
+    """
+
+    def test_extension_dict_omits_context_when_none(self):
+        """``context=None`` → no ``context`` key in the serialized dict."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+            context=None,
+        )
+        ext = badge.to_clauditor_extension_json()
+        assert "context" not in ext
+
+    def test_extension_dict_emits_context_when_present(self):
+        """``context=<populated>`` → ``context`` key present, full shape."""
+        ctx = _make_context()
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+            context=ctx,
+        )
+        ext = badge.to_clauditor_extension_json()
+        assert "context" in ext
+        assert ext["context"]["harness"] == "claude-code"
+        assert ext["context"]["provider"] == "anthropic"
+        assert ext["context"]["model_runner"] == "claude-sonnet-4-6"
+        assert ext["context"]["system_prompt_source"] == "agents_md"
+        assert ext["context"]["sandbox_mode"] == "workspace-write"
+        # Schema version of the embedded context preserves the
+        # ``IterationContext`` sidecar's own version (currently 1).
+        assert ext["context"]["schema_version"] == 1
+
+    def test_default_compute_badge_call_omits_context(self):
+        """``compute_badge`` without ``context=`` defaults to None → omitted."""
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        # No ``context=`` kwarg passed; extension carries no context.
+        assert badge.clauditor.context is None
+        ext = badge.to_clauditor_extension_json()
+        assert "context" not in ext
+
+
+class TestClauditorExtensionV2RoundTrip:
+    """DEC-006: v2 extension serializes losslessly with the ``context`` block.
+
+    There is no ``ClauditorExtension.from_dict`` / ``from_json`` loader
+    today (badges are write-only — the audit / forensic readers parse
+    the inner ``context`` block via :meth:`IterationContext.from_dict`
+    on the standalone sidecar). This class verifies the writer side
+    of the round-trip — that the serialized shape matches what a
+    future loader would consume.
+    """
+
+    def test_serializes_with_context(self):
+        """Full v2 extension JSON contains the populated context block."""
+        ctx = _make_context()
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            _make_grading_dict(pass_fractions=(True, True, True)),
+            None,
+            skill_name="demo",
+            iteration=7,
+            generated_at=_GEN_AT,
+            context=ctx,
+        )
+        ext = json.loads(json.dumps(badge.to_clauditor_extension_json()))
+        assert ext["schema_version"] == 2
+        assert ext["context"]["harness"] == "claude-code"
+        # The embedded context dict is parseable as an IterationContext
+        # (round-trip-via-from_dict shape parity).
+        loaded = IterationContext.from_dict(ext["context"])
+        assert loaded.harness == ctx.harness
+        assert loaded.provider == ctx.provider
+        assert loaded.model_runner == ctx.model_runner
+        assert loaded.model_grader == ctx.model_grader
+        assert loaded.system_prompt_source == ctx.system_prompt_source
+        assert loaded.sandbox_mode == ctx.sandbox_mode
+
+    def test_extension_key_order_preserves_context_after_layers(self):
+        """v2 key order: schema_version, skill_name, generated_at,
+        iteration, layers, context."""
+        ctx = _make_context()
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+            context=ctx,
+        )
+        ext = badge.to_clauditor_extension_json()
+        keys = list(ext.keys())
+        assert keys == [
+            "schema_version",
+            "skill_name",
+            "generated_at",
+            "iteration",
+            "layers",
+            "context",
+        ]
+
+
+class TestShieldsPayloadUnchanged:
+    """DEC-006 + ``.claude/rules/dual-version-external-schema-embed.md``.
+
+    The shields.io ``<skill>.json`` payload MUST stay byte-for-byte
+    identical regardless of whether the extension carries a ``context``
+    block. Shields.io strictly validates its endpoint schema and
+    rejects unknown top-level keys — context belongs in the sibling
+    extension file, not in the shields.io payload.
+    """
+
+    def test_shields_json_byte_identical_for_same_input(self):
+        """Two badges with identical L1/L3/variance inputs but different
+        ``context`` values produce byte-identical shields.io JSON."""
+        ctx = _make_context()
+        common_kwargs = dict(
+            assertions=_make_assertions_dict(passed=8, total=8),
+            grading=_make_grading_dict(pass_fractions=(True, True, True)),
+            variance=None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+        )
+        badge_no_context = compute_badge(**common_kwargs, context=None)
+        badge_with_context = compute_badge(**common_kwargs, context=ctx)
+
+        shields_no_ctx = json.dumps(badge_no_context.to_endpoint_json())
+        shields_with_ctx = json.dumps(badge_with_context.to_endpoint_json())
+        assert shields_no_ctx == shields_with_ctx
+        # Defense in depth: no ``context`` key in either payload.
+        assert "context" not in badge_no_context.to_endpoint_json()
+        assert "context" not in badge_with_context.to_endpoint_json()
+
+    def test_shields_payload_has_no_clauditor_or_context_key(self):
+        """Shields.io payload remains the minimal four-field shape."""
+        ctx = _make_context()
+        badge = compute_badge(
+            _make_assertions_dict(passed=8, total=8),
+            None,
+            None,
+            skill_name="demo",
+            iteration=1,
+            generated_at=_GEN_AT,
+            context=ctx,
+        )
+        shields = badge.to_endpoint_json()
+        assert set(shields.keys()) == {"schemaVersion", "label", "message", "color"}
+
+
+class TestLoadIterationContext:
+    """:func:`clauditor.badge.load_iteration_context` — defensive read."""
+
+    def test_returns_context_when_file_present(self, tmp_path):
+        """A valid ``context.json`` parses into an IterationContext."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        ctx = _make_context()
+        (skill_dir / "context.json").write_text(ctx.to_json())
+        loaded = load_iteration_context(skill_dir)
+        assert loaded is not None
+        assert loaded.harness == "claude-code"
+        assert loaded.system_prompt_source == "agents_md"
+
+    def test_returns_none_when_file_absent(self, tmp_path):
+        """Missing ``context.json`` → ``None`` silently."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        assert load_iteration_context(skill_dir) is None
+
+    def test_returns_none_when_dir_absent(self, tmp_path):
+        """Missing skill dir → ``None`` silently."""
+        skill_dir = tmp_path / "missing"
+        assert load_iteration_context(skill_dir) is None
+
+    def test_returns_none_for_malformed_json(self, tmp_path):
+        """Invalid JSON in ``context.json`` → ``None`` silently."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        (skill_dir / "context.json").write_text("{not valid json")
+        assert load_iteration_context(skill_dir) is None
+
+    def test_returns_none_when_validation_fails(self, tmp_path):
+        """``IterationContext.from_dict`` rejection → ``None`` silently.
+
+        A ``context.json`` with a closed-set discriminator outside its
+        valid range (e.g. ``harness="bogus"``) must not abort the
+        whole badge command — the badge writer still writes a usable
+        sidecar, just with ``context = None``.
+        """
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        bad = {
+            "schema_version": 1,
+            "harness": "bogus",  # not in {"claude-code", "codex"}
+            "provider": "anthropic",
+            "model_runner": "x",
+            "model_grader": None,
+            "system_prompt_source": "agents_md",
+            "sandbox_mode": None,
+        }
+        (skill_dir / "context.json").write_text(json.dumps(bad))
+        assert load_iteration_context(skill_dir) is None
+
+    def test_returns_none_when_required_key_missing(self, tmp_path):
+        """Missing required key (e.g. ``harness``) → ``None`` silently."""
+        skill_dir = tmp_path / "demo"
+        skill_dir.mkdir()
+        # Missing 'harness' → KeyError inside from_dict.
+        bad = {
+            "schema_version": 1,
+            "provider": "anthropic",
+            "model_runner": "x",
+            "system_prompt_source": "agents_md",
+        }
+        (skill_dir / "context.json").write_text(json.dumps(bad))
+        assert load_iteration_context(skill_dir) is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8994,3 +8994,275 @@ class TestCmdRunHarness:
         assert env_override.get("OPENAI_API_KEY") == "sk-openai"
         # Anthropic auth IS still stripped (Codex doesn't need it).
         assert "ANTHROPIC_API_KEY" not in env_override
+
+
+class TestCmdGradeWritesContextJson:
+    """#154 US-004: ``cmd_grade`` writes a per-iteration ``context.json``
+    sidecar inside the staging block (DEC-001, DEC-002, DEC-005, DEC-007,
+    DEC-008)."""
+
+    def _make_grading_report(self, model="claude-sonnet-4-6"):
+        return make_grading_report(passed=True, score=0.9, model=model)
+
+    def _spec_with_live_run(self, eval_spec=None, *, harness_metadata=None):
+        """Build a spec whose ``run()`` returns a real :class:`SkillResult`
+        carrying a populated ``harness_metadata`` (the harness contract
+        from #154 DEC-007 / DEC-008)."""
+        if eval_spec is None:
+            eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        if harness_metadata is None:
+            harness_metadata = {
+                "model": "claude-sonnet-4-6",
+                "system_prompt_source": "skill_md",
+            }
+        spec.run.return_value = make_skill_result(
+            output="primary output containing hello",
+            stream_events=[
+                {"type": "assistant", "text": "primary output containing hello"}
+            ],
+            input_tokens=10,
+            output_tokens=5,
+            duration_seconds=0.5,
+            harness_metadata=harness_metadata,
+        )
+        return spec
+
+    def test_anthropic_default_path(self, tmp_path, monkeypatch):
+        """Live grade run writes ``context.json`` populated with the
+        resolved harness, provider, and model fields."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = self._make_grading_report(model="claude-sonnet-4-6")
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        assert payload["harness"] == "claude-code"
+        assert payload["provider"] == "anthropic"
+        assert payload["model_runner"] == "claude-sonnet-4-6"
+        assert payload["model_grader"] == "claude-sonnet-4-6"
+        assert payload["system_prompt_source"] == "skill_md"
+        assert payload["sandbox_mode"] is None
+        # DEC-001 / DEC-002: placeholder None values.
+        assert payload["cost_usd"] is None
+        assert payload["reasoning_tokens"] is None
+
+    def test_openai_provider_path(self, tmp_path, monkeypatch):
+        """``--grading-provider openai --model gpt-5.4`` stamps
+        ``provider="openai"`` and ``model_grader="gpt-5.4"`` on the
+        sidecar, while the runner-side fields stay rooted in
+        ``harness_metadata`` (which describes the skill subprocess,
+        not the grader call)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        spec = self._spec_with_live_run()
+        report = self._make_grading_report(model="gpt-5.4")
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(
+                [
+                    "grade",
+                    "skill.md",
+                    "--grading-provider",
+                    "openai",
+                    "--model",
+                    "gpt-5.4",
+                ]
+            )
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        assert payload["provider"] == "openai"
+        assert payload["model_grader"] == "gpt-5.4"
+        # Runner-side fields come from harness_metadata, untouched by
+        # the grader provider axis.
+        assert payload["harness"] == "claude-code"
+        assert payload["model_runner"] == "claude-sonnet-4-6"
+        assert payload["system_prompt_source"] == "skill_md"
+
+    def test_first_key_is_schema_version(self, tmp_path, monkeypatch):
+        """Per ``.claude/rules/json-schema-version.md`` the first
+        top-level key on disk is ``schema_version``."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = self._make_grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        payload = json.loads(context_path.read_text())
+        assert next(iter(payload.keys())) == "schema_version"
+        assert payload["schema_version"] == 1
+
+    def test_captured_output_mode_skips_context_sidecar(
+        self, tmp_path, monkeypatch
+    ):
+        """``--output`` mode (no subprocess, no real harness) skips
+        the ``context.json`` write because there is no
+        ``harness_metadata`` to populate the runner-side fields from."""
+        monkeypatch.chdir(tmp_path)
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("captured text")
+
+        eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        report = self._make_grading_report()
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md", "--output", str(output_file)])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        # Captured-text mode has no real run; context sidecar is not
+        # written (the runner-side fields cannot be populated).
+        assert not context_path.exists()
+
+
+class TestCmdValidateWritesContextJson:
+    """#154 US-004: ``cmd_validate`` writes a per-iteration
+    ``context.json`` sidecar with grader fields stamped ``None``
+    (validate has no Layer 3)."""
+
+    def _live_spec(self, *, harness_metadata=None):
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        if harness_metadata is None:
+            harness_metadata = {
+                "model": "claude-sonnet-4-6",
+                "system_prompt_source": "skill_md",
+            }
+        spec.run.return_value = make_skill_result(
+            output="hello world output",
+            duration_seconds=1.5,
+            input_tokens=100,
+            output_tokens=50,
+            stream_events=[
+                {"type": "system", "session_id": "abc"},
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hi"}]},
+                },
+            ],
+            harness_metadata=harness_metadata,
+        )
+        return spec
+
+    def test_default_path(self, tmp_path, monkeypatch):
+        """``cmd_validate`` writes ``context.json`` with grader fields
+        ``None`` (no Layer 3) and runner fields populated from
+        ``harness_metadata``."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._live_spec()
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        # Validate has no Layer 3 grading; provider/model_grader/cost
+        # are all None.
+        assert payload["provider"] is None
+        assert payload["model_grader"] is None
+        assert payload["cost_usd"] is None
+        assert payload["reasoning_tokens"] is None
+        # Runner-side fields populated from harness_metadata.
+        assert payload["harness"] == "claude-code"
+        assert payload["model_runner"] == "claude-sonnet-4-6"
+        assert payload["system_prompt_source"] == "skill_md"
+        assert payload["sandbox_mode"] is None
+
+    def test_first_key_is_schema_version(self, tmp_path, monkeypatch):
+        """Per ``.claude/rules/json-schema-version.md`` the first
+        top-level key on disk is ``schema_version``."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._live_spec()
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        payload = json.loads(context_path.read_text())
+        assert next(iter(payload.keys())) == "schema_version"
+        assert payload["schema_version"] == 1
+
+    def test_codex_harness_carries_sandbox_mode(self, tmp_path, monkeypatch):
+        """Under a Codex harness, ``sandbox_mode`` lands on disk."""
+        monkeypatch.chdir(tmp_path)
+        # Pin codex auth + harness selection. The autouse fixture
+        # stubs ``shutil.which`` to None so the auto-resolver would
+        # otherwise refuse to pick codex; pin the env-var layer
+        # explicitly to override the autouse default.
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex")
+        monkeypatch.setenv("CLAUDITOR_HARNESS", "codex")
+
+        spec = self._live_spec(
+            harness_metadata={
+                "model": "gpt-5-codex",
+                "system_prompt_source": "agents_md",
+                "sandbox_mode": "workspace-write",
+            }
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        payload = json.loads(context_path.read_text())
+        assert payload["harness"] == "codex"
+        assert payload["model_runner"] == "gpt-5-codex"
+        assert payload["system_prompt_source"] == "agents_md"
+        assert payload["sandbox_mode"] == "workspace-write"

--- a/tests/test_cli_badge.py
+++ b/tests/test_cli_badge.py
@@ -247,7 +247,7 @@ class TestCmdBadgeNoIteration:
         assert "clauditor" not in shields
         # Extension sidecar: full telemetry.
         ext = json.loads(ext_target.read_text())
-        assert ext["schema_version"] == 1
+        assert ext["schema_version"] == 2
         assert ext["iteration"] is None
 
     def test_emits_dec021_warning(
@@ -350,7 +350,7 @@ class TestCmdBadgeNoIteration:
         assert json.loads(target.read_text())["color"] == "lightgrey"
         # Extension file was overwritten with fresh content.
         ext = json.loads(ext_target.read_text())
-        assert ext["schema_version"] == 1
+        assert ext["schema_version"] == 2
         assert ext["skill_name"] == "demo"
 
 
@@ -1313,3 +1313,122 @@ class TestDispatcherWiring:
             "--verbose",
         ):
             assert flag in out
+
+
+# ---------------------------------------------------------------------------
+# US-006 — context.json read at badge generation time.
+#
+# Traces to DEC-006 of ``plans/super/154-context-sidecar.md``.
+# ---------------------------------------------------------------------------
+
+
+def _write_context_sidecar(iter_skill_dir: Path) -> None:
+    """Write a fully-populated ``context.json`` under ``iter_skill_dir``.
+
+    Uses :meth:`IterationContext.to_json` so the on-disk shape matches
+    the writer's actual output (no hand-rolled JSON drift).
+    """
+    from clauditor.context import IterationContext
+
+    ctx = IterationContext(
+        harness="claude-code",
+        provider="anthropic",
+        model_runner="claude-sonnet-4-6",
+        model_grader="claude-sonnet-4-6",
+        system_prompt_source="agents_md",
+        sandbox_mode="workspace-write",
+        reasoning_tokens=None,
+        cost_usd=None,
+    )
+    (iter_skill_dir / "context.json").write_text(ctx.to_json())
+
+
+class TestCmdBadgeReadsLatestContext:
+    """DEC-006: badge writer reads the latest iteration's context.json
+    and threads it onto the extension. Absent file → context omitted.
+    Shields.io payload is unchanged in either case.
+    """
+
+    def test_extension_carries_context_when_present(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """``context.json`` exists → extension JSON contains the context block."""
+        skill_md = _write_skill(tmp_path)
+        iter_skill_dir = _setup_iteration(tmp_path, 1)
+        _write_context_sidecar(iter_skill_dir)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        ext_target = tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
+        ext = json.loads(ext_target.read_text())
+        assert ext["schema_version"] == 2
+        assert "context" in ext
+        assert ext["context"]["harness"] == "claude-code"
+        assert ext["context"]["provider"] == "anthropic"
+        assert ext["context"]["model_runner"] == "claude-sonnet-4-6"
+        assert ext["context"]["system_prompt_source"] == "agents_md"
+        assert ext["context"]["sandbox_mode"] == "workspace-write"
+
+    def test_extension_context_omitted_when_absent(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """No ``context.json`` on disk → extension omits the context block."""
+        skill_md = _write_skill(tmp_path)
+        _setup_iteration(tmp_path, 1)
+        # No _write_context_sidecar() call.
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        ext_target = tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
+        ext = json.loads(ext_target.read_text())
+        assert ext["schema_version"] == 2
+        assert "context" not in ext
+
+    def test_shields_payload_unchanged_with_context_present(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Context presence does NOT alter the shields.io ``<skill>.json``.
+
+        Per ``.claude/rules/dual-version-external-schema-embed.md``,
+        shields.io strictly validates its endpoint schema and rejects
+        unknown top-level keys with an ``invalid properties: <key>``
+        SVG response. The context block lives only in the sibling
+        extension file, never in the shields.io payload.
+        """
+        skill_md = _write_skill(tmp_path)
+        iter_skill_dir = _setup_iteration(tmp_path, 1)
+        _write_context_sidecar(iter_skill_dir)
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        assert rc == 0
+
+        target = tmp_path / ".clauditor" / "badges" / "demo.json"
+        shields = json.loads(target.read_text())
+        # Minimal four-field shape — no context, no clauditor key.
+        assert set(shields.keys()) == {"schemaVersion", "label", "message", "color"}
+        assert "context" not in shields
+        assert "clauditor" not in shields
+
+    def test_extension_context_omitted_when_context_json_malformed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Malformed ``context.json`` → context omitted; badge still writes."""
+        skill_md = _write_skill(tmp_path)
+        iter_skill_dir = _setup_iteration(tmp_path, 1)
+        (iter_skill_dir / "context.json").write_text("{not valid json")
+        monkeypatch.chdir(tmp_path)
+
+        rc = main(["badge", str(skill_md)])
+        # Must still succeed — a broken context sidecar must not abort
+        # the whole badge command.
+        assert rc == 0
+
+        ext_target = tmp_path / ".clauditor" / "badges" / "demo.clauditor.json"
+        ext = json.loads(ext_target.read_text())
+        assert ext["schema_version"] == 2
+        assert "context" not in ext

--- a/tests/test_cli_transcript_slice.py
+++ b/tests/test_cli_transcript_slice.py
@@ -191,6 +191,10 @@ class TestGradeVerboseInvocation:
             args="",
             duration_seconds=0.5,
             stream_events=[_assistant_event("assistant ctx line")],
+            harness_metadata={
+                "model": "claude-sonnet-4-6",
+                "system_prompt_source": "skill_md",
+            },
         )
 
     def _grading_report(self):
@@ -347,6 +351,15 @@ class TestValidateVerboseInvocation:
         fake_skill_result.duration_seconds = 0.1
         fake_skill_result.input_tokens = 0
         fake_skill_result.output_tokens = 0
+        # #154 US-004: ``cmd_validate`` writes ``context.json`` from
+        # ``skill_result.harness_metadata`` (DEC-007 / DEC-008 unguarded
+        # subscripts). MagicMock would return a chained MagicMock that
+        # leaks into JSON serialization; pin to the harness contract's
+        # required keys.
+        fake_skill_result.harness_metadata = {
+            "model": "claude-sonnet-4-6",
+            "system_prompt_source": "skill_md",
+        }
 
         args = MagicMock()
         args.skill = str(skill_path)
@@ -447,6 +460,11 @@ class TestValidateVerboseInvocation:
         fake_skill_result.duration_seconds = 0.0
         fake_skill_result.input_tokens = 0
         fake_skill_result.output_tokens = 0
+        # #154 US-004: see analogous pin above.
+        fake_skill_result.harness_metadata = {
+            "model": "claude-sonnet-4-6",
+            "system_prompt_source": "skill_md",
+        }
 
         args = MagicMock()
         args.skill = "demo.md"

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -61,12 +61,15 @@ from clauditor._harnesses._codex import (  # noqa: E402
     _PRESERVED_ENV_VARS_DOC,
     _RATE_LIMIT_PATTERNS,
     _RESULT_TEXT_MAX_CHARS,
+    _SANDBOX_MODE,
+    _SANDBOX_MODES,
     _STRIP_ENV_VARS,
     CodexHarness,
     _classify_codex_failure,
     _detect_codex_dropped_events,
     _detect_codex_truncated_output,
     _filter_stderr,
+    _validate_sandbox_mode,
 )
 from clauditor.runner import (  # noqa: E402
     _CODEX_DEPRECATION_WARNING_PREFIX,
@@ -156,6 +159,74 @@ class TestRunnerWarningPrefixes:
 
     def test_last_message_empty_prefix(self) -> None:
         assert _LAST_MESSAGE_EMPTY_WARNING_PREFIX == "last-message-empty:"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox-mode closed-set + defense-in-depth validator (US-002 of #154)
+# ---------------------------------------------------------------------------
+
+
+class TestCodexHarnessSandboxModes:
+    """US-002 of #154: ``_SANDBOX_MODES`` is the closed set of values
+    Codex's ``-s`` flag accepts; ``_validate_sandbox_mode`` is the
+    defense-in-depth guard every ``harness_metadata["sandbox_mode"]``
+    stamp must route through.
+
+    Today the active value is hardcoded to ``"workspace-write"``, so
+    the validator never raises in production. The tests pin both the
+    closed set and the raise-on-unknown branch so a future regression
+    (a typo in the constant, a hostile dynamic value flowing in from
+    config, a new Codex sandbox value not yet in the set) fails loudly
+    at the seam rather than producing a silently-malformed sidecar.
+    Traces to the security CONCERN in the architecture review of #154.
+    """
+
+    def test_sandbox_modes_constant_matches_known_values(self) -> None:
+        """The frozenset's contents are byte-pinned to the three Codex
+        sandbox values documented at the time of #154."""
+        assert _SANDBOX_MODES == frozenset(
+            {"read-only", "workspace-write", "danger-full-access"}
+        )
+
+    def test_active_sandbox_mode_is_a_member(self) -> None:
+        """Drift-guard: the ``_SANDBOX_MODE`` active value MUST be a
+        member of the closed set. A future bump of the active value
+        without updating the set (or a typo in either) breaks here."""
+        assert _SANDBOX_MODE in _SANDBOX_MODES
+
+    def test_validator_returns_value_unchanged_on_known_mode(self) -> None:
+        """``_validate_sandbox_mode("workspace-write")`` returns the
+        value unchanged so callers can use the inline pattern
+        ``metadata["sandbox_mode"] = _validate_sandbox_mode(...)``."""
+        assert _validate_sandbox_mode("workspace-write") == "workspace-write"
+        assert _validate_sandbox_mode("read-only") == "read-only"
+        assert _validate_sandbox_mode("danger-full-access") == (
+            "danger-full-access"
+        )
+
+    def test_invalid_sandbox_mode_raises(self) -> None:
+        """``_validate_sandbox_mode("bogus")`` raises ``ValueError``
+        with the offending value AND the known set in the message —
+        operator-actionable feedback per the security CONCERN."""
+        with pytest.raises(ValueError, match="sandbox_mode='bogus'"):
+            _validate_sandbox_mode("bogus")
+
+    def test_invalid_sandbox_mode_message_lists_known_set(self) -> None:
+        """The raise message names every known mode so an operator
+        debugging a future regression knows the legal set without
+        having to grep the source."""
+        with pytest.raises(ValueError) as exc_info:
+            _validate_sandbox_mode("not-a-mode")
+        msg = str(exc_info.value)
+        assert "read-only" in msg
+        assert "workspace-write" in msg
+        assert "danger-full-access" in msg
+
+    def test_empty_string_rejected(self) -> None:
+        """Empty string is not in the closed set; defense-in-depth
+        catches a stamp site that fed in an unset value."""
+        with pytest.raises(ValueError):
+            _validate_sandbox_mode("")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -108,6 +108,72 @@ class TestIterationContextSerialization:
         assert ctx.schema_version == 1
 
 
+class TestIterationContextSchemaVersionGate:
+    """Hard-rejection of unsupported / malformed ``schema_version``.
+
+    Defends the always-v1 contract documented in
+    ``.claude/rules/json-schema-version.md``: ``context.json`` is
+    engineered so the two anticipated follow-ups (#169 ``cost_usd``,
+    #170 ``reasoning_tokens``) populate already-nullable fields
+    WITHOUT a schema bump. Any future bump must lift this gate
+    deliberately rather than letting a stale reader silently ingest
+    a forward-incompatible payload.
+    """
+
+    def test_rejects_higher_schema_version(self) -> None:
+        payload = _full_payload()
+        payload["schema_version"] = 2
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "schema_version" in msg
+        assert "2" in msg
+        assert "expected 1" in msg
+
+    def test_rejects_zero_schema_version(self) -> None:
+        payload = _full_payload()
+        payload["schema_version"] = 0
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        assert "schema_version" in str(exc.value)
+
+    def test_rejects_negative_schema_version(self) -> None:
+        payload = _full_payload()
+        payload["schema_version"] = -1
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        assert "schema_version" in str(exc.value)
+
+    def test_rejects_string_schema_version(self) -> None:
+        payload = _full_payload()
+        payload["schema_version"] = "1"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "schema_version" in msg
+        assert "must be int" in msg
+
+    def test_rejects_bool_schema_version(self) -> None:
+        # bool is an int subclass in Python; reject explicitly per
+        # .claude/rules/constant-with-type-info.md.
+        payload = _full_payload()
+        payload["schema_version"] = True
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "schema_version" in msg
+        assert "must be int" in msg
+
+    def test_rejects_none_schema_version(self) -> None:
+        # Explicit JSON ``null`` for schema_version (distinct from
+        # missing-key, which uses the default).
+        payload = _full_payload()
+        payload["schema_version"] = None
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        assert "schema_version" in str(exc.value)
+
+
 class TestIterationContextValidation:
     def test_from_dict_rejects_unknown_harness(self) -> None:
         payload = _full_payload()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,248 @@
+"""Tests for :mod:`clauditor.context` — IterationContext sidecar shape."""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+import clauditor.context as _context_mod
+
+# The pytest plugin imports ``clauditor`` (which transitively imports
+# clauditor.context) before coverage starts, so the dataclass decorator
+# and module-level constants execute pre-instrumentation. Reload the
+# module here so coverage sees those lines. See test_schemas.py for the
+# canonical anchor of this pattern (referenced in CLAUDE.md).
+importlib.reload(_context_mod)
+
+from clauditor.context import IterationContext  # noqa: E402
+
+
+def _full_payload() -> dict:
+    """Canonical full-fidelity payload (every field non-null)."""
+    return {
+        "schema_version": 1,
+        "harness": "claude-code",
+        "provider": "anthropic",
+        "model_runner": "claude-sonnet-4-6",
+        "model_grader": "claude-sonnet-4-6",
+        "system_prompt_source": "explicit",
+        "sandbox_mode": "workspace-write",
+        "reasoning_tokens": 1024,
+        "cost_usd": 0.0234,
+    }
+
+
+def _validate_only_payload() -> dict:
+    """Validate-only iteration shape — graders never ran."""
+    return {
+        "schema_version": 1,
+        "harness": "claude-code",
+        "provider": None,
+        "model_runner": "claude-sonnet-4-6",
+        "model_grader": None,
+        "system_prompt_source": "skill_md",
+        "sandbox_mode": None,
+        "reasoning_tokens": None,
+        "cost_usd": None,
+    }
+
+
+class TestIterationContextSerialization:
+    def test_to_json_first_key_is_schema_version(self) -> None:
+        ctx = IterationContext.from_dict(_full_payload())
+        raw = ctx.to_json()
+        # Inspect the raw text — Python's json module preserves dict
+        # insertion order on emit, but the load-bearing contract is
+        # that ``schema_version`` literally appears first in the on-
+        # disk bytes per .claude/rules/json-schema-version.md.
+        first_key_marker = raw.find('"')
+        assert raw[first_key_marker : first_key_marker + len('"schema_version"')] == (
+            '"schema_version"'
+        )
+
+    def test_to_json_emits_all_fields(self) -> None:
+        ctx = IterationContext.from_dict(_full_payload())
+        data = json.loads(ctx.to_json())
+        assert set(data.keys()) == {
+            "schema_version",
+            "harness",
+            "provider",
+            "model_runner",
+            "model_grader",
+            "system_prompt_source",
+            "sandbox_mode",
+            "reasoning_tokens",
+            "cost_usd",
+        }
+
+    def test_round_trip_full_payload(self) -> None:
+        original = IterationContext.from_dict(_full_payload())
+        restored = IterationContext.from_dict(json.loads(original.to_json()))
+        assert restored == original
+
+    def test_round_trip_with_nulls(self) -> None:
+        original = IterationContext.from_dict(_validate_only_payload())
+        restored = IterationContext.from_dict(json.loads(original.to_json()))
+        assert restored == original
+        assert restored.provider is None
+        assert restored.model_grader is None
+        assert restored.sandbox_mode is None
+        assert restored.reasoning_tokens is None
+        assert restored.cost_usd is None
+
+    def test_to_json_preserves_int_cost_as_float(self) -> None:
+        # Coverage for the int → float coercion branch on cost_usd.
+        payload = _full_payload()
+        payload["cost_usd"] = 1  # int, accepted-as-float
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.cost_usd == 1.0
+        assert isinstance(ctx.cost_usd, float)
+
+    def test_default_schema_version_when_missing(self) -> None:
+        # Coverage for the schema_version default path.
+        payload = _full_payload()
+        del payload["schema_version"]
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.schema_version == 1
+
+
+class TestIterationContextValidation:
+    def test_from_dict_rejects_unknown_harness(self) -> None:
+        payload = _full_payload()
+        payload["harness"] = "raw-api"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "'raw-api'" in msg
+        assert "claude-code" in msg
+        assert "codex" in msg
+        assert "harness" in msg
+
+    def test_from_dict_rejects_unknown_provider(self) -> None:
+        payload = _full_payload()
+        payload["provider"] = "vertex"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "'vertex'" in msg
+        assert "anthropic" in msg
+        assert "openai" in msg
+        assert "provider" in msg
+
+    def test_from_dict_rejects_unknown_system_prompt_source(self) -> None:
+        payload = _full_payload()
+        payload["system_prompt_source"] = "claude_md"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "'claude_md'" in msg
+        assert "explicit" in msg
+        assert "agents_md" in msg
+        assert "skill_md" in msg
+        assert "system_prompt_source" in msg
+
+    def test_from_dict_rejects_unknown_sandbox_mode(self) -> None:
+        payload = _full_payload()
+        payload["sandbox_mode"] = "full-write"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "'full-write'" in msg
+        assert "read-only" in msg
+        assert "workspace-write" in msg
+        assert "danger-full-access" in msg
+        assert "sandbox_mode" in msg
+
+    def test_from_dict_rejects_bool_for_reasoning_tokens(self) -> None:
+        payload = _full_payload()
+        payload["reasoning_tokens"] = True
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "reasoning_tokens" in msg
+        assert "bool" in msg
+
+    def test_from_dict_rejects_non_int_reasoning_tokens(self) -> None:
+        payload = _full_payload()
+        payload["reasoning_tokens"] = "1024"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "reasoning_tokens" in msg
+        assert "str" in msg
+
+    def test_from_dict_rejects_bool_for_cost_usd(self) -> None:
+        payload = _full_payload()
+        payload["cost_usd"] = True
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "cost_usd" in msg
+        assert "bool" in msg
+
+    def test_from_dict_rejects_non_numeric_cost_usd(self) -> None:
+        payload = _full_payload()
+        payload["cost_usd"] = "0.05"
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "cost_usd" in msg
+        assert "str" in msg
+
+    @pytest.mark.parametrize("harness", ["claude-code", "codex"])
+    def test_from_dict_accepts_known_harness(self, harness: str) -> None:
+        payload = _full_payload()
+        payload["harness"] = harness
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.harness == harness
+
+    @pytest.mark.parametrize("provider", ["anthropic", "openai", None])
+    def test_from_dict_accepts_known_provider(self, provider: str | None) -> None:
+        payload = _full_payload()
+        payload["provider"] = provider
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.provider == provider
+
+    @pytest.mark.parametrize(
+        "source", ["explicit", "agents_md", "skill_md"]
+    )
+    def test_from_dict_accepts_known_system_prompt_source(self, source: str) -> None:
+        payload = _full_payload()
+        payload["system_prompt_source"] = source
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.system_prompt_source == source
+
+    @pytest.mark.parametrize(
+        "mode", ["read-only", "workspace-write", "danger-full-access", None]
+    )
+    def test_from_dict_accepts_known_sandbox_mode(self, mode: str | None) -> None:
+        payload = _full_payload()
+        payload["sandbox_mode"] = mode
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.sandbox_mode == mode
+
+    def test_from_dict_accepts_known_literals(self) -> None:
+        # Combined sweep — explicit acceptance of every literal-set
+        # member at once on the same payload, mirroring the per-axis
+        # parametrized cases above.
+        for harness in ("claude-code", "codex"):
+            for provider in ("anthropic", "openai", None):
+                for source in ("explicit", "agents_md", "skill_md"):
+                    for mode in (
+                        "read-only",
+                        "workspace-write",
+                        "danger-full-access",
+                        None,
+                    ):
+                        payload = _full_payload()
+                        payload["harness"] = harness
+                        payload["provider"] = provider
+                        payload["system_prompt_source"] = source
+                        payload["sandbox_mode"] = mode
+                        ctx = IterationContext.from_dict(payload)
+                        assert ctx.harness == harness
+                        assert ctx.provider == provider
+                        assert ctx.system_prompt_source == source
+                        assert ctx.sandbox_mode == mode

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -223,6 +223,34 @@ class TestIterationContextValidation:
         ctx = IterationContext.from_dict(payload)
         assert ctx.sandbox_mode == mode
 
+    def test_from_dict_accepts_null_model_runner(self) -> None:
+        # ClaudeCodeHarness legitimately stamps None when no override
+        # was pinned (claude CLI's stream-json result message carries
+        # no model field; we cannot recover it after the fact). Per
+        # DEC-007 the sidecar honestly records None.
+        payload = _full_payload()
+        payload["model_runner"] = None
+        ctx = IterationContext.from_dict(payload)
+        assert ctx.model_runner is None
+
+    def test_from_dict_rejects_non_string_model_runner(self) -> None:
+        payload = _full_payload()
+        payload["model_runner"] = 42
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "'model_runner'" in msg
+        assert "str or None" in msg
+
+    def test_from_dict_rejects_non_string_model_grader(self) -> None:
+        payload = _full_payload()
+        payload["model_grader"] = ["claude-sonnet-4-6"]
+        with pytest.raises(ValueError) as exc:
+            IterationContext.from_dict(payload)
+        msg = str(exc.value)
+        assert "'model_grader'" in msg
+        assert "str or None" in msg
+
     def test_from_dict_accepts_known_literals(self) -> None:
         # Combined sweep — explicit acceptance of every literal-set
         # member at once on the same payload, mirroring the per-axis

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -360,3 +360,60 @@ class TestResolveAgentsMd:
         assert "escapes" in msg
         assert str(outside.resolve()) in msg
         assert str(project_root.resolve()) in msg
+
+    def test_legacy_layout_skips_skill_dir_tier(self, tmp_path):
+        """Legacy ``<name>.md`` skills MUST skip the per-skill AGENTS.md
+        tier and fall through directly to the project-root tier.
+
+        For a legacy skill ``<commands>/foo.md``, ``skill_path.parent``
+        is the shared commands directory (``<commands>/``), NOT a
+        per-skill directory. Treating that as a per-skill anchor would
+        let one ``AGENTS.md`` in the commands directory silently
+        override the documented project-root fallback for every legacy
+        skill there. The first tier is restricted to modern
+        ``SKILL.md`` layouts; legacy layouts skip it.
+        """
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        commands_dir = project_root / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        # Legacy skill: ``<commands>/foo.md`` (NOT ``<commands>/foo/SKILL.md``).
+        skill_path = commands_dir / "foo.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+
+        # An AGENTS.md in the shared commands directory would be the
+        # tier-1 candidate for a modern-layout skill at this anchor.
+        # For the legacy skill, this file MUST be skipped — it is not
+        # a per-skill override.
+        commands_agents = commands_dir / "AGENTS.md"
+        commands_agents.write_text("# commands-dir agents (must NOT win)")
+
+        # Project-root AGENTS.md is the only legitimate tier for this
+        # legacy skill; the resolver must return it.
+        project_agents = project_root / "AGENTS.md"
+        project_agents.write_text("# project agents (the legitimate winner)")
+
+        result = resolve_agents_md(skill_path, project_root)
+        assert result == project_agents.resolve()
+        # Defensive: confirm the commands-dir file was NOT silently
+        # consulted. Equality above is sufficient, but spell out the
+        # invariant for the next reader.
+        assert result != commands_agents.resolve()
+
+    def test_legacy_layout_returns_none_when_only_skill_dir_agents(self, tmp_path):
+        """Legacy skill with an ``AGENTS.md`` only in the skill's
+        ``parent`` (commands) directory and NO project-root file →
+        ``None``. Tier 1 is gated to modern layouts, so the
+        commands-dir file is invisible to the resolver."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        commands_dir = project_root / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        skill_path = commands_dir / "foo.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+
+        commands_agents = commands_dir / "AGENTS.md"
+        commands_agents.write_text("# commands-dir agents")
+
+        result = resolve_agents_md(skill_path, project_root)
+        assert result is None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -4,6 +4,8 @@ import importlib
 import re
 from pathlib import Path
 
+import pytest
+
 import clauditor.paths as _paths_mod
 
 importlib.reload(_paths_mod)
@@ -12,6 +14,7 @@ from clauditor.paths import (  # noqa: E402
     SKILL_NAME_RE,
     derive_project_dir,
     derive_skill_name,
+    resolve_agents_md,
     resolve_clauditor_dir,
 )
 
@@ -241,3 +244,119 @@ class TestDeriveProjectDir:
         skill_path.write_text("---\nname: foo\n---\n")
         # parent.parent.parent.parent = tmp_path / "a" / "b"
         assert derive_project_dir(skill_path) == tmp_path / "a" / "b"
+
+
+class TestResolveAgentsMd:
+    """Unit tests for the pure ``resolve_agents_md`` helper.
+
+    Two-tier search per DEC-009 of ``plans/super/154-context-sidecar.md``:
+    skill dir wins over project root; both validated by the canonical
+    path-validation recipe (``Path.resolve(strict=True)`` then
+    ``is_relative_to(anchor)``).
+    """
+
+    def test_skill_dir_wins_when_both_exist(self, tmp_path):
+        """Skill-dir ``AGENTS.md`` short-circuits the search; project-
+        root file is not consulted when the skill-dir tier has a hit."""
+        project_root = tmp_path
+        skill_dir = project_root / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+        skill_agents = skill_dir / "AGENTS.md"
+        skill_agents.write_text("# skill agents")
+        project_agents = project_root / "AGENTS.md"
+        project_agents.write_text("# project agents")
+
+        result = resolve_agents_md(skill_path, project_root)
+        assert result == skill_agents.resolve()
+
+    def test_falls_back_to_project_root(self, tmp_path):
+        """When only the project-root tier has an AGENTS.md, the
+        helper returns its validated path."""
+        project_root = tmp_path
+        skill_dir = project_root / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+        project_agents = project_root / "AGENTS.md"
+        project_agents.write_text("# project agents")
+
+        result = resolve_agents_md(skill_path, project_root)
+        assert result == project_agents.resolve()
+
+    def test_returns_none_when_neither_exists(self, tmp_path):
+        """Neither tier yields a file → return ``None``."""
+        project_root = tmp_path
+        skill_dir = project_root / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+
+        result = resolve_agents_md(skill_path, project_root)
+        assert result is None
+
+    def test_rejects_symlink_escape_from_skill_dir(self, tmp_path):
+        """A symlink at ``<skill_dir>/AGENTS.md`` whose resolved target
+        sits outside the skill dir raises :class:`ValueError` naming
+        both the offending input and the anchor it escaped.
+
+        Defense-in-depth: even though the symlink lives under the skill
+        dir, ``Path.resolve(strict=True)`` follows it to the real
+        target, and the ``is_relative_to`` check flags the escape.
+        """
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        skill_dir = project_root / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+
+        # Real file living outside both anchors.
+        outside = tmp_path / "outside.md"
+        outside.write_text("# outside")
+
+        # Symlink under skill_dir pointing at the outside file.
+        skill_agents = skill_dir / "AGENTS.md"
+        skill_agents.symlink_to(outside)
+
+        with pytest.raises(ValueError) as exc_info:
+            resolve_agents_md(skill_path, project_root)
+
+        msg = str(exc_info.value)
+        assert "AGENTS.md" in msg
+        assert "escapes" in msg
+        # The resolved-target path AND the anchor are both in the message
+        # so the operator can immediately see what went wrong.
+        assert str(outside.resolve()) in msg
+        assert str(skill_dir.resolve()) in msg
+
+    def test_rejects_path_outside_anchor(self, tmp_path):
+        """Defense-in-depth check: a symlink at the project-root tier
+        that escapes the project root anchor also raises ``ValueError``.
+
+        Exercises the second-tier branch of the resolver (the skill-dir
+        tier has no AGENTS.md, the project-root tier has a hostile
+        symlink).
+        """
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        skill_dir = project_root / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text("---\nname: foo\n---\n")
+
+        outside = tmp_path / "elsewhere.md"
+        outside.write_text("# elsewhere")
+
+        project_agents = project_root / "AGENTS.md"
+        project_agents.symlink_to(outside)
+
+        with pytest.raises(ValueError) as exc_info:
+            resolve_agents_md(skill_path, project_root)
+
+        msg = str(exc_info.value)
+        assert "AGENTS.md" in msg
+        assert "escapes" in msg
+        assert str(outside.resolve()) in msg
+        assert str(project_root.resolve()) in msg

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -364,6 +364,98 @@ class TestInvokeResultHarnessMetadata:
         assert "k" not in r2.harness_metadata
 
 
+class TestClaudeCodeHarnessHarnessMetadata:
+    """US-002 of #154: ``ClaudeCodeHarness.invoke`` populates
+    ``result.harness_metadata["model"]`` so the iteration-context
+    sidecar reader (US-004) can read the effective model uniformly
+    across harnesses via ``skill_result.harness_metadata.get("model")``
+    — mirrors :class:`CodexHarness`'s metadata population per DEC-008
+    of #149.
+
+    Per DEC-004 of :file:`plans/super/154-context-sidecar.md` the read
+    path is harness-agnostic, so the write-side parity is the load-
+    bearing invariant.
+    """
+
+    def test_invoke_populates_model_default(self):
+        """``ClaudeCodeHarness(model="claude-sonnet-4-6").invoke(...)``
+        — the constructor-pinned model lands on
+        ``harness_metadata["model"]``."""
+        harness = ClaudeCodeHarness(model="claude-sonnet-4-6")
+        with patch(
+            "clauditor._harnesses._claude_code.subprocess.Popen",
+            return_value=make_fake_skill_stream("hello"),
+        ):
+            result = harness.invoke(
+                "/test",
+                cwd=None,
+                env=None,
+                timeout=180,
+            )
+        assert result.harness_metadata["model"] == "claude-sonnet-4-6"
+
+    def test_invoke_populates_model_override(self):
+        """``invoke(..., model="claude-opus-4-7")`` overrides the
+        constructor default; the per-call value lands on
+        ``harness_metadata["model"]``. Mirrors :class:`CodexHarness`'s
+        same-shaped override (per DEC-006 of #148)."""
+        harness = ClaudeCodeHarness(model="claude-sonnet-4-6")
+        with patch(
+            "clauditor._harnesses._claude_code.subprocess.Popen",
+            return_value=make_fake_skill_stream("hello"),
+        ):
+            result = harness.invoke(
+                "/test",
+                cwd=None,
+                env=None,
+                timeout=180,
+                model="claude-opus-4-7",
+            )
+        assert result.harness_metadata["model"] == "claude-opus-4-7"
+
+    def test_invoke_populates_model_none_when_unset(self):
+        """When neither the constructor nor the per-call kwarg pin a
+        model, the effective value is ``None`` and that is what lands
+        on the metadata dict — the honest "no model recorded" signal
+        for the sidecar reader (which uses ``.get("model")`` and
+        treats ``None`` identically to a missing key)."""
+        harness = ClaudeCodeHarness()
+        with patch(
+            "clauditor._harnesses._claude_code.subprocess.Popen",
+            return_value=make_fake_skill_stream("hello"),
+        ):
+            result = harness.invoke(
+                "/test",
+                cwd=None,
+                env=None,
+                timeout=180,
+            )
+        assert "model" in result.harness_metadata
+        assert result.harness_metadata["model"] is None
+
+    def test_invoke_populates_model_on_missing_binary(self):
+        """The FileNotFoundError early-return path also stamps the
+        metadata dict — uniform contract across success and pre-spawn
+        failure paths so the sidecar writer never has to branch on
+        outcome to read ``model``."""
+        harness = ClaudeCodeHarness(
+            claude_bin="nonexistent-binary",
+            model="claude-sonnet-4-6",
+        )
+        with patch(
+            "clauditor._harnesses._claude_code.subprocess.Popen",
+            side_effect=FileNotFoundError,
+        ):
+            result = harness.invoke(
+                "/test",
+                cwd=None,
+                env=None,
+                timeout=180,
+            )
+        assert result.exit_code == -1
+        assert result.harness_metadata["model"] == "claude-sonnet-4-6"
+
+
 # ---------------------------------------------------------------------------
 # SkillAsserter — Layer 1 test-helper wrapper (US-006)
 # ---------------------------------------------------------------------------

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1217,6 +1217,106 @@ class TestSystemPromptResolution:
         assert isinstance(exc_info.value.__cause__, ValueError)
 
 
+class TestSkillSpecRunSystemPromptSource:
+    """US-003 of #154 (DEC-003 / DEC-008 / DEC-009): ``SkillSpec.run``
+    resolves the system prompt across three tiers and stamps the
+    resolved label into ``SkillResult.harness_metadata
+    ["system_prompt_source"]``.
+
+    Order:
+      1. Explicit ``EvalSpec.system_prompt`` set → ``"explicit"``.
+      2. AGENTS.md found via :func:`resolve_agents_md` (skill-dir then
+         project-root) → ``"agents_md"``.
+      3. Auto-derive from SKILL.md body (post-frontmatter) →
+         ``"skill_md"``.
+
+    Uses :class:`MockHarness` to drive a real :class:`SkillRunner` so
+    we observe both the system-prompt thread-through AND the
+    harness_metadata stamp on the returned result.
+    """
+
+    @staticmethod
+    def _build_runner_with_mock_harness(project_dir):
+        from clauditor._harnesses._mock import MockHarness
+        from clauditor.runner import SkillRunner
+
+        mock = MockHarness()
+        runner = SkillRunner(project_dir=project_dir, harness=mock)
+        return runner, mock
+
+    def test_explicit_eval_spec_wins_over_agents_md(self, tmp_skill_file):
+        """Both ``EvalSpec.system_prompt`` AND an AGENTS.md present →
+        explicit content wins, source stamped ``"explicit"``."""
+        content = "---\nname: prompt-skill\n---\nBODY"
+        eval_data = {
+            "skill_name": "prompt-skill",
+            "test_args": "",
+            "assertions": [],
+            "system_prompt": "EXPLICIT",
+        }
+        skill_path, _ = tmp_skill_file(
+            "prompt-skill", content=content, eval_data=eval_data
+        )
+        # AGENTS.md sits next to the legacy-layout skill file.
+        (skill_path.parent / "AGENTS.md").write_text("# agents")
+        runner, mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        result = spec.run()
+
+        assert mock.build_prompt_calls[-1]["system_prompt"] == "EXPLICIT"
+        assert result.harness_metadata["system_prompt_source"] == "explicit"
+
+    def test_agents_md_wins_over_skill_md_body(self, tmp_skill_file):
+        """No explicit, AGENTS.md present (skill-dir tier) → AGENTS.md
+        content used as system prompt, source stamped ``"agents_md"``."""
+        body = "# Skill\n\nBody content.\n"
+        content = "---\nname: prompt-skill\n---\n" + body
+        skill_path = tmp_skill_file("prompt-skill", content=content)
+        agents_text = "# AGENTS\n\nProject-level agent instructions.\n"
+        (skill_path.parent / "AGENTS.md").write_text(agents_text)
+        runner, mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        result = spec.run()
+
+        assert mock.build_prompt_calls[-1]["system_prompt"] == agents_text
+        assert result.harness_metadata["system_prompt_source"] == "agents_md"
+
+    def test_falls_through_to_skill_md_when_agents_md_absent(
+        self, tmp_skill_file
+    ):
+        """No explicit, no AGENTS.md → auto-derive from SKILL.md body,
+        source stamped ``"skill_md"``."""
+        body = "# Skill\n\nThis is the body.\n"
+        content = "---\nname: prompt-skill\n---\n" + body
+        skill_path = tmp_skill_file("prompt-skill", content=content)
+        runner, mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        result = spec.run()
+
+        assert mock.build_prompt_calls[-1]["system_prompt"] == body
+        assert result.harness_metadata["system_prompt_source"] == "skill_md"
+
+    def test_harness_metadata_carries_source_label(self, tmp_skill_file):
+        """Every successful run stamps a non-empty source label into
+        ``harness_metadata["system_prompt_source"]``."""
+        content = "---\nname: prompt-skill\n---\nBODY"
+        skill_path = tmp_skill_file("prompt-skill", content=content)
+        runner, _mock = self._build_runner_with_mock_harness(skill_path.parent)
+        spec = SkillSpec.from_file(skill_path, runner=runner)
+
+        result = spec.run()
+
+        assert "system_prompt_source" in result.harness_metadata
+        assert result.harness_metadata["system_prompt_source"] in {
+            "explicit",
+            "agents_md",
+            "skill_md",
+        }
+
+
 class TestSkillSpecRunHarnessOverride:
     """US-006 / DEC-004 of #151: ``SkillSpec.run`` accepts a
     keyword-only ``harness_name_override: str | None``. When non-


### PR DESCRIPTION
## Summary

Super plan for #154 — per-iteration `context.json` sidecar capturing comparability metadata (harness, provider, runner/grader models, system_prompt_source, sandbox_mode, reasoning_tokens, cost_usd).

**Phase:** detailing (awaiting approval)
**Stories:** 7 implementation stories (US-001..US-007) + Quality Gate (US-008) + Patterns & Memory (US-009)
**Decisions:** 11 captured (DEC-001..DEC-011)

## Plan document

See `plans/super/154-context-sidecar.md` for the full plan including:
- Discovery (ticket summary, codebase findings, applicable conventions from 35 `.claude/rules/*.md` files)
- Architecture Review (6 parallel review areas: security, performance, data model, testing, API/integration, observability)
- Refinement Log (DEC-001..DEC-011 with rationale)
- Detailed Breakdown (9 stories with TDD test classes, file anchors, dependency graph)

## Scope decisions worth flagging

- `cost_usd` and `reasoning_tokens` ship as `null`-only placeholders in this PR. Follow-up tickets created:
  - #169 — Pricing: cost_usd estimation module
  - #170 — Reasoning tokens: separately-billed capture in ModelResult
- `system_prompt_source` ships the full literal-set including `agents_md`, with the AGENTS.md resolver landing in `SkillSpec.run` in this same PR (per DEC-003 / DEC-009).
- AGENTS.md search is two-tier: `<skill-dir>/AGENTS.md` first, then `<project-root>/AGENTS.md`, both gated by `.claude/rules/path-validation.md` (resolves the security blocker surfaced in architecture review).
- Badge `ClauditorExtension` bumps `schema_version` 1 → 2 with optional `context` field; shields.io payload unchanged.
- Audit `--verbose` shows per-iteration block in markdown / stdout / json; rollup-summary deferred to #143 aggregation tickets.

## Next steps

- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-iteration `context.json` sidecar now captures and records comparability metadata (model, provider, system prompt source, sandbox mode)
  * Added `--verbose` flag to audit command to display per-iteration context details in reports
  * Badge extensions now optionally embed comparability context metadata

* **Improvements**
  * Enhanced system prompt resolution with three-tier fallback strategy
  * Better harness metadata propagation across evaluation pipeline
  * Improved multi-anchor path resolution for agent configuration files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/171)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->