### PR TITLE
#155: pytest fixtures parametrize harness/provider (plan)

### DIFF
--- a/.claude/rules/spec-cli-precedence.md
+++ b/.claude/rules/spec-cli-precedence.md
@@ -706,7 +706,7 @@ the seam's available context:
 
 **Shape A — `clauditor_runner` (harness axis, no spec layer).**
 The runner-factory fixture does not load an `EvalSpec`, so only
-the operator-intent and default layers apply. Three layers:
+the operator-intent and default layers apply. Four layers:
 
 1. Factory `harness=` kwarg — operator intent at the call site.
 2. `--clauditor-harness` pytest option — operator intent at
@@ -839,7 +839,7 @@ canonical implementation defers the call inside
 
 Canonical implementation paths:
 
-- Factory fixture (Shape A — operator-only, three layers):
+- Factory fixture (Shape A — operator-only, four layers):
   `src/clauditor/pytest_plugin.py::clauditor_runner` — closes over
   `request.config.getoption("--clauditor-harness")`, env via
   `os.environ.get("CLAUDITOR_HARNESS")`, and the factory `harness=`

--- a/.claude/rules/spec-cli-precedence.md
+++ b/.claude/rules/spec-cli-precedence.md
@@ -688,6 +688,222 @@ deferred per-call imports inside `construct_harness` that keep
 test patches on `clauditor._harnesses._claude_code.ClaudeCodeHarness`
 / `clauditor._harnesses._codex.CodexHarness` working).
 
+### Pytest fixture mirror — operator-intent precedence in fixture-land (#155)
+
+The CLI seams (`grade`, `extract`, `triggers`, `compare --blind`,
+`propose-eval`, `suggest`, `validate`, `capture`, `run`) and the
+pytest fixture seams now mirror each other on every multi-axis
+precedence resolver above (`harness`, `grading_provider`,
+`grading_model`). The fixture seam is a **factory-fixture mirror**:
+each fixture exposes a `_factory(...)` callable whose kwargs are
+the operator-intent layer at the call site, and the factory closes
+over the pytest CLI options + env vars + spec fields to compose the
+same operator > author > default direction the CLI honors.
+
+The mirror is intentionally asymmetric across the four fixtures —
+**three distinct precedence shapes** ship in #155, each tuned to
+the seam's available context:
+
+**Shape A — `clauditor_runner` (harness axis, no spec layer).**
+The runner-factory fixture does not load an `EvalSpec`, so only
+the operator-intent and default layers apply. Three layers:
+
+1. Factory `harness=` kwarg — operator intent at the call site.
+2. `--clauditor-harness` pytest option — operator intent at
+   session start.
+3. `CLAUDITOR_HARNESS` env var — operator intent in the shell.
+4. Default `"auto"` — `resolve_harness(..., spec_value=None)`
+   delegates to PATH lookup (`claude` first, then `codex`).
+
+The author layer (`EvalSpec.harness`) is structurally absent, NOT
+silently skipped. A test that wants spec-author intent honored must
+use `clauditor_spec` (Shape B) instead. This trim is intentional
+per DEC-006 (cross-axis isolation): `clauditor_runner` is the
+operator-only seam; mixing in spec-author intent at the runner
+factory would re-introduce the "harness ≠ provider" axis confusion
+DEC-010 of #151 explicitly rejected. When the resolved harness is
+`"codex"`, an eager `check_codex_auth("runner")` fires per DEC-005
+so a missing-key surfaces as a `CodexAuthMissingError` (sibling of
+`Exception`) at fixture setup rather than a deep subprocess error
+later.
+
+**Shape B — `clauditor_spec` (harness axis, spec layer only).**
+The spec-loading fixture honors `EvalSpec.harness` (when set to a
+concrete value, not `"auto"`) and threads it as
+`harness_name_override` to `SkillSpec.run`. Operator-intent layers
+do NOT apply at this fixture — there is no `harness=` factory
+kwarg, no pytest CLI option consulted, no env var consulted. The
+operator-intent layers live on `clauditor_runner`'s factory; the
+spec-author layer lives here. Two seams, one axis, no overlap.
+When the spec author declared `harness="codex"`, the fixture also
+fires an eager `check_codex_auth("spec")` per DEC-005 — mirroring
+the runner-side guard so any test using either fixture sees the
+same crisp `CodexAuthMissingError`.
+
+**Shape C — `clauditor_grader` / `clauditor_blind_compare` /
+`clauditor_triggers` (provider + model axes, full mirror).** The
+three grading fixtures expose a five-layer precedence on each axis,
+mirroring the CLI seam's `_resolve_grading_provider` /
+`resolve_grading_model` chain:
+
+1. Factory `provider=` / `model=` kwarg — operator intent at the
+   call site (highest precedence per DEC-007).
+2. `--clauditor-grading-provider` / `--clauditor-model` pytest
+   option — operator intent at session start.
+3. `CLAUDITOR_GRADING_PROVIDER` env var (provider only — no
+   `CLAUDITOR_MODEL` env var ships in #155 per DEC-010).
+4. `EvalSpec.grading_provider` / `EvalSpec.grading_model` — author
+   intent.
+5. Default — `"auto"` (provider, with auto-inference from model)
+   or per-provider model default (`"claude-sonnet-4-6"` /
+   `_providers._openai.DEFAULT_MODEL_L3`).
+
+Both axes flow through the same pure resolver chain
+(`resolve_grading_provider` + `resolve_grading_model`) the CLI
+uses, so a fixture caller and an operator running `clauditor
+grade` get the same provider+model resolution from the same
+`EvalSpec`. The auth dispatch fires per-provider via
+`_dispatch_fixture_auth_guard`, which mirrors the CLI's
+`check_provider_auth` ladder with distinct exception classes
+(`AnthropicAuthMissingError` / `OpenAIAuthMissingError`) so
+fixture callers route on a structural `except` ladder per
+`.claude/rules/multi-provider-dispatch.md`. The Anthropic branch
+retains the `CLAUDITOR_FIXTURE_ALLOW_CLI` opt-in toggle (relaxed
+`check_any_auth_available` vs strict `check_api_key_only`) per #86
+DEC-009; the OpenAI branch is always strict (no CLI-fallback /
+subscription analogue per #145 DEC-002).
+
+**Shape A vs Shape B — why the asymmetry is load-bearing.**
+`clauditor_runner` is operator-only because it has no spec to
+read; `clauditor_spec` is author-only because it is the spec-load
+seam itself, and mixing operator-intent layers at the spec-load
+boundary would let a `--clauditor-harness` flag silently override
+a skill author's explicit `EvalSpec.harness` even for tests that
+deliberately probe author intent. The five grading fixtures (Shape
+C) compose both layers because they wrap a spec-load AND a grader
+call, so they have BOTH author intent (in the loaded spec) AND
+operator intent (factory kwargs + pytest options + env). Per DEC-007
+of #155, the operator-intent factory kwarg always wins at the call
+site, mirroring the CLI's CLI-flag-wins-over-spec direction.
+
+**Eager `check_codex_auth` at TWO seams, not one (DEC-005).**
+Both `clauditor_runner` (when its resolved harness is `"codex"`)
+AND `clauditor_spec` (when `eval_spec.harness == "codex"`) fire
+the codex auth guard eagerly, before returning to the test body.
+The double-guard mirrors the CLI's `cli/grade.py::cmd_grade` shape
+(`_resolve_harness` resolves the harness; `check_codex_auth`
+dispatches the guard) and ensures any test using either fixture
+sees the same `CodexAuthMissingError` shape at setup time. The
+two seams are independent: `clauditor_runner` does not load a
+spec, so its guard fires on the resolved-from-PATH-or-env-or-CLI
+harness; `clauditor_spec` does load a spec, so its guard fires on
+the spec-author preference. A test using both fixtures sees both
+guards fire (when applicable); a test using only one sees only
+that seam's guard.
+
+**Hard break, not back-compat shim.** Per DEC-002 / DEC-009 of
+#155, the pre-#155 value-fixture form
+(`def test(clauditor_runner): clauditor_runner.run("foo")`) is a
+hard break — `clauditor_runner` is now a factory and callers must
+invoke `clauditor_runner()` to get the runner. There is no
+back-compat shim because the value-fixture shape conflicts
+structurally with the per-call `harness=` kwarg the factory needs;
+keeping a shim would defeat the whole point of the conversion.
+Migration is mechanical (search for `clauditor_runner.run(` →
+`clauditor_runner().run(`) and the CHANGELOG documents the
+recipe. Companion discipline:
+`.claude/rules/back-compat-shim-discipline.md` codifies the
+class-identity invariants (Pattern 2) shims must preserve when
+they ARE shipped — this case ships none, but the discipline
+informed the decision to break loudly rather than degrade
+silently.
+
+**B1 / non-mutating per-call env scrub.** A subtle pitfall
+discovered in #155 QG pass 4: `clauditor_spec`'s factory tempts
+the implementer to pre-compute `env_without_api_key()` outside
+the per-call `_run_with_overrides` closure (since the
+`--clauditor-no-api-key` option is session-scoped). Doing so
+defaults the scrub to claude-code semantics (strips
+`OPENAI_API_KEY`), which silently breaks codex callers when the
+resolved harness is codex — the eager `check_codex_auth` accepts
+the key from `os.environ`, but the subprocess inherits a stripped
+env and fails with no auth. The fix is to defer the
+`env_without_api_key(harness_name=...)` call until inside the
+per-call wrapper, after the effective harness is resolved. This
+is the inverse failure mode of
+`.claude/rules/test-infra-shutil-which-coupling.md`, where
+pre-computed `shutil.which` patches couple unrelated resolvers; here
+the pre-computed scrub couples unrelated harness backends. The
+canonical implementation defers the call inside
+`_run_with_overrides` per DEC-006 / US-007.
+
+Canonical implementation paths:
+
+- Factory fixture (Shape A — operator-only, three layers):
+  `src/clauditor/pytest_plugin.py::clauditor_runner` — closes over
+  `request.config.getoption("--clauditor-harness")`, env via
+  `os.environ.get("CLAUDITOR_HARNESS")`, and the factory `harness=`
+  kwarg. Calls `clauditor._providers.resolve_harness(cli, env, None)`
+  (note `spec_value=None` — no spec at this seam) then
+  `check_codex_auth("runner")` when name == `"codex"`. Materializes
+  a fresh `SkillRunner` via `construct_harness(name)` for non-default
+  harnesses; preserves the `--clauditor-claude-bin` plumbing for the
+  default `"claude-code"` path.
+- Spec fixture (Shape B — author-only, one layer):
+  `src/clauditor/pytest_plugin.py::clauditor_spec` — reads
+  `spec.eval_spec.harness` (when set to a concrete value) and threads
+  it as `harness_name_override=` to `SkillSpec.run`. Eager
+  `check_codex_auth("spec")` fires when the spec author declared
+  `harness="codex"`. Same-harness skip layer (defense-in-depth)
+  avoids reconstructing a runner with the same harness class but
+  losing the fixture's `--clauditor-claude-bin` configuration.
+- Grading fixtures (Shape C — full five-layer mirror):
+  `src/clauditor/pytest_plugin.py::clauditor_grader`,
+  `clauditor_blind_compare`, `clauditor_triggers`. Each closes over
+  `--clauditor-grading-provider` / `--clauditor-model` pytest
+  options, accepts `provider=` / `model=` factory kwargs (operator
+  intent, kwarg > pytest option), loads the spec, dispatches
+  `_dispatch_fixture_auth_guard` and `_resolve_fixture_provider`,
+  then invokes the grader orchestrator with the resolved values.
+- Pure helpers (no I/O, mirror the CLI seam):
+  `src/clauditor/pytest_plugin.py::_resolve_fixture_provider` —
+  pure resolver mirroring the CLI's
+  `_resolve_grading_provider`. Threads `provider_override` (factory
+  kwarg or pytest option, kwarg wins at call site) as
+  `cli_override` to `clauditor._providers.resolve_grading_provider`,
+  honoring the same env > spec > auto chain. Does NOT swallow
+  `ValueError` (CodeRabbit finding on PR #164) — fail-fast on
+  misconfigured spec / CLI override at test setup.
+- Auth dispatcher (mirror of `check_provider_auth`):
+  `src/clauditor/pytest_plugin.py::_dispatch_fixture_auth_guard` —
+  routes by resolved provider (anthropic strict/relaxed via
+  `CLAUDITOR_FIXTURE_ALLOW_CLI`; openai always strict). Distinct
+  exception classes per `.claude/rules/multi-provider-dispatch.md`.
+
+Test-infra coupling: the autouse `shutil.which` pin in
+`tests/conftest.py:754` (originally from #86 to force `transport=
+"auto"` to API) needs a parallel `monkeypatch.setenv("CLAUDITOR_HARNESS",
+"claude-code")` line so the new harness resolver short-circuits at
+the env layer rather than landing on the `which → None` path and
+hard-failing every test in the suite. Pattern documented in
+`.claude/rules/test-infra-shutil-which-coupling.md` (the autouse
+clobbering hazard); #155 DEC-011 inherits the recipe.
+
+Traces to DEC-001 through DEC-012 of
+`plans/super/155-pytest-fixtures-parametrize.md`. Companion rules:
+`.claude/rules/multi-provider-dispatch.md` (the structural-routing
+invariant the distinct fixture-side exception classes preserve),
+`.claude/rules/precall-env-validation.md` (the eager auth-guard
+pattern at the fixture seam, mirroring the CLI's
+`check_provider_auth` shape and `CodexAuthMissingError`-as-sibling-
+of-`Exception` discipline), `.claude/rules/back-compat-shim-discipline.md`
+(the value→factory hard break — Pattern 2 ≠ here, but the
+discipline's "don't ship a shim that silently degrades" posture
+informs the decision),
+`.claude/rules/test-infra-shutil-which-coupling.md` (the autouse-
+PATH-pin coupling the new harness resolver inherits at fixture
+collection time).
+
 ### Implicit coupling at the operator-intent layers
 
 An adjacent pattern to the precedence rule: when a CLI flag (or its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **New factory kwargs (operator-intent, top of precedence stack):**
     - `clauditor_runner(harness=...)` — pin harness for this runner.
     - `clauditor_grader(skill, eval_path, output, *, provider=..., model=...)`
-      — `provider=` is new; `model=` already existed.
+      — both new factory kwargs. (Pre-#155 the fixture only consulted
+      the `--clauditor-model` pytest option; the kwarg layer is new.)
     - `clauditor_blind_compare(skill, output_a, output_b, eval_path, *, provider=..., model=...)`
       — both new.
     - `clauditor_triggers(skill, eval_path, *, provider=..., model=...)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- **`clauditor_runner` is now a factory fixture (#155).** Pytest fixtures
+  cannot accept call-site kwargs; only factory fixtures can. To support
+  the new `harness=` operator-intent kwarg, `clauditor_runner` was
+  converted from a value fixture to a factory.
+
+  **Migration:**
+
+  ```python
+  # Before
+  def test_my_skill(clauditor_runner):
+      runner = clauditor_runner          # value fixture
+      result = runner.run("my-skill")
+
+  # After
+  def test_my_skill(clauditor_runner):
+      runner = clauditor_runner()        # factory — call it
+      result = runner.run("my-skill")
+  ```
+
+  No deprecation shim ships — pre-1.0 accepts the hard break (same
+  precedent as the `SkillResult.assert_*` → `SkillAsserter` migration in
+  v0.1.0). See [`docs/pytest-plugin.md#parametrizing-harness--provider`](docs/pytest-plugin.md#parametrizing-harness--provider).
+
 ### Added
 
+- **Pytest fixtures: `harness` × `provider` parametrization (#155).** The
+  pytest plugin gained two new CLI options and four new factory kwargs so
+  a single test can sweep across `{claude-code, codex} × {anthropic, openai}`
+  without changing skill or eval-spec files.
+  - **New pytest CLI options:**
+    - `--clauditor-harness {claude-code, codex, auto}` — overrides the
+      harness used by `clauditor_runner` and `clauditor_spec` session-wide.
+    - `--clauditor-grading-provider {anthropic, openai, auto}` — overrides
+      the grading provider used by `clauditor_grader`,
+      `clauditor_blind_compare`, and `clauditor_triggers` session-wide.
+  - **New factory kwargs (operator-intent, top of precedence stack):**
+    - `clauditor_runner(harness=...)` — pin harness for this runner.
+    - `clauditor_grader(skill, eval_path, output, *, provider=..., model=...)`
+      — `provider=` is new; `model=` already existed.
+    - `clauditor_blind_compare(skill, output_a, output_b, eval_path, *, provider=..., model=...)`
+      — both new.
+    - `clauditor_triggers(skill, eval_path, *, provider=..., model=...)`
+      — both new.
+  - **Operator-intent precedence (highest → lowest):** factory kwarg >
+    pytest CLI option > env var (`CLAUDITOR_HARNESS`,
+    `CLAUDITOR_GRADING_PROVIDER`) > spec field (`EvalSpec.harness`,
+    `EvalSpec.grading_provider`) > default `"auto"`. Mirrors the CLI seam
+    exactly per `.claude/rules/spec-cli-precedence.md`.
+  - **Eager `check_codex_auth` from `clauditor_runner` and `clauditor_spec`.**
+    When the resolved harness is `"codex"`, both factories fire
+    `check_codex_auth` before returning the runner / wrapped spec; missing
+    auth raises `CodexAuthMissingError` (a sibling of `Exception`, NOT a
+    subclass of `AnthropicAuthMissingError` / `OpenAIAuthMissingError`)
+    so callers route on a structural `except` ladder rather than
+    substring-matching error text.
+  - **Asymmetry note.** There is intentionally no
+    `CLAUDITOR_FIXTURE_ALLOW_OPENAI` env var (DEC-001 of #155). The
+    existing `CLAUDITOR_FIXTURE_ALLOW_CLI=1` opts into a *relaxed*
+    Anthropic guard (accepts subscription auth via the `claude` CLI on
+    PATH); OpenAI has no CLI-fallback / subscription analog (per #145
+    DEC-002), so there is nothing to opt into. See
+    [`docs/pytest-plugin.md`](docs/pytest-plugin.md) for the full
+    documentation including a `pytest.mark.parametrize` worked example.
 - **`EvalSpec.system_prompt: str | None = None` field (#150).** Mirrors
   `user_prompt`'s shape and validation: optional at load time, when set
   must be a non-empty, non-whitespace string (`EvalSpec.from_file`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without changing skill or eval-spec files.
   - **New pytest CLI options:**
     - `--clauditor-harness {claude-code, codex, auto}` — overrides the
-      harness used by `clauditor_runner` and `clauditor_spec` session-wide.
+      harness used by `clauditor_runner` session-wide. (Note:
+      `clauditor_spec` honors only `EvalSpec.harness` — set `harness:`
+      in `eval.json` for per-skill author preference.)
     - `--clauditor-grading-provider {anthropic, openai, auto}` — overrides
       the grading provider used by `clauditor_grader`,
       `clauditor_blind_compare`, and `clauditor_triggers` session-wide.

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -44,14 +44,14 @@ Options:
 pytest --clauditor-project-dir /path/to/project
 pytest --clauditor-timeout 300
 pytest --clauditor-claude-bin /usr/local/bin/claude
-pytest --clauditor-no-api-key                   # Strip ANTHROPIC_{API_KEY,AUTH_TOKEN}
+pytest --clauditor-no-api-key                   # Strip ANTHROPIC_{API_KEY,AUTH_TOKEN} + OPENAI_API_KEY (codex preserves OPENAI_API_KEY)
 pytest --clauditor-grade                        # Enable Layer 3 tests (costs money)
 pytest --clauditor-model claude-sonnet-4-6      # Override grading model
 pytest --clauditor-harness codex                # Override harness for this session ({claude-code,codex,auto})
 pytest --clauditor-grading-provider openai      # Override grading provider ({anthropic,openai,auto})
 ```
 
-`--clauditor-no-api-key` is the plugin-option counterpart to `--no-api-key` on the CLI: strips both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the `claude -p` subprocess environment so the child falls back to whatever auth is cached in `~/.claude/` (typically a Pro/Max subscription). Scoped to the `clauditor_spec` fixture's `env_override` wiring; the bare `clauditor_runner` fixture is unaffected (its `SkillRunner` is constructed without the env scrub). For per-test overrides, `spec.run(env_override=..., timeout_override=...)` accepts both kwargs directly — the fixture wrapper forwards caller-provided values over the fixture-level default.
+`--clauditor-no-api-key` is the plugin-option counterpart to `--no-api-key` on the CLI: strips `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, **and `OPENAI_API_KEY`** (the default `env_without_api_key()` strip set) from the skill subprocess environment so the child falls back to whatever auth is cached in `~/.claude/` (typically a Pro/Max subscription). The codex harness branch preserves `OPENAI_API_KEY` so the codex subprocess can still authenticate — `clauditor_spec` computes the scrub per-call with the resolved harness name so codex callers retain their key. Scoped to the `clauditor_spec` fixture's `env_override` wiring; the bare `clauditor_runner` fixture is unaffected (its `SkillRunner` is constructed without the env scrub). For per-test overrides, `spec.run(env_override=..., timeout_override=...)` accepts both kwargs directly — the fixture wrapper forwards caller-provided values over the fixture-level default.
 
 `--clauditor-harness` (#155) overrides the harness used by `clauditor_runner` for the entire pytest session. Operator-intent precedence on `clauditor_runner`: factory `harness=` kwarg > `--clauditor-harness` > `CLAUDITOR_HARNESS` env > default `"auto"`. Auto-resolution mirrors the CLI: `shutil.which("claude")` first, then `shutil.which("codex")`, with a one-time stderr announcement when auto picks codex. **Scope note:** the option does NOT override `clauditor_spec`'s harness selection — that fixture honors only `EvalSpec.harness` (author intent). Set `harness:` in `eval.json` for per-skill author preference; use `clauditor_runner(harness=...)` or this CLI option for operator-intent selection of the bare runner.
 

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -6,15 +6,20 @@ Reference for clauditor's pytest plugin: the fixtures it registers, the command-
 
 clauditor registers as a pytest plugin automatically. Available fixtures:
 
-- `clauditor_runner` — pre-configured `SkillRunner`
+- `clauditor_runner` — **factory** returning a configured `SkillRunner`. Signature: `clauditor_runner(harness: str | None = None) → SkillRunner`. Call with no args (`runner = clauditor_runner()`) to get the default-resolved harness, or pass `harness="codex"` / `harness="claude-code"` to pin one for the test. **Migration note (#155):** previously a value fixture (`runner = clauditor_runner`); now you must invoke it (`runner = clauditor_runner()`). Hard break, no deprecation shim — see `CHANGELOG.md` under `[Unreleased]` for the one-line migration.
 - `clauditor_asserter` — factory wrapping a `SkillResult` with `assert_*` helpers (`assert_contains`, `assert_not_contains`, `assert_matches`, `assert_has_urls`, `assert_has_entries`, `assert_min_count`, `assert_min_length`, `run_assertions`) — see `.claude/rules/data-vs-asserter-split.md`. **Migration note:** the `assert_*` methods previously lived directly on `SkillResult`; they now live on a separate `SkillAsserter` class (`src/clauditor/asserters.py`). Existing test code calling `result.assert_contains(...)` must switch to `clauditor_asserter(result).assert_contains(...)` — this is a hard break with no deprecation shim (pre-1.0 project; see `CHANGELOG.md` for details).
-- `clauditor_spec` — factory for loading `SkillSpec` from skill files
-- `clauditor_grader` — factory for Layer 3 quality grading
-- `clauditor_triggers` — factory for trigger precision testing
-- `clauditor_blind_compare` — factory wrapping `blind_compare_from_spec` for A/B comparison of two skill outputs (requires `user_prompt` on the eval spec). Signature: `clauditor_blind_compare(skill_path, output_a, output_b, eval_path=None, *, model=None) → BlindReport`.
+- `clauditor_spec` — factory for loading `SkillSpec` from skill files. Honors `eval_spec.harness` automatically; eagerly fires `check_codex_auth` at factory call time when the spec declares `harness: "codex"` so a missing `CODEX_API_KEY` / `OPENAI_API_KEY` surfaces as a crisp `CodexAuthMissingError` rather than a deep subprocess failure.
+- `clauditor_grader` — factory for Layer 3 quality grading. Signature: `clauditor_grader(skill_path, eval_path=None, output=None, *, provider=None, model=None) → GradingReport`. Both `provider=` and `model=` are operator-intent overrides at the top of the precedence stack.
+- `clauditor_triggers` — factory for trigger precision testing. Signature: `clauditor_triggers(skill_path, eval_path=None, *, provider=None, model=None)`.
+- `clauditor_blind_compare` — factory wrapping `blind_compare_from_spec` for A/B comparison of two skill outputs (requires `user_prompt` on the eval spec). Signature: `clauditor_blind_compare(skill_path, output_a, output_b, eval_path=None, *, provider=None, model=None) → BlindReport`.
 - `clauditor_capture` — factory returning a `Path` to `tests/eval/captured/<skill>.txt` for captured-output tests
 
-> **Auth required for grading fixtures.** `clauditor_grader`, `clauditor_blind_compare`, and `clauditor_triggers` enforce a strict `ANTHROPIC_API_KEY` check at fixture invocation time and raise `AnthropicAuthMissingError` (not `pytest.skip`) when the key is missing. The strict guard fires **even when the `claude` CLI is on PATH** — by default these fixtures route through the Anthropic SDK, not the CLI subprocess. To opt into CLI-transport for fixtures (e.g. on a Claude Pro/Max subscription with no API key), set `CLAUDITOR_FIXTURE_ALLOW_CLI=1` in the test environment. See [`docs/transport-architecture.md`](transport-architecture.md) for the auth-state matrix.
+> **Auth required for grading fixtures — per-provider model.** `clauditor_grader`, `clauditor_blind_compare`, and `clauditor_triggers` resolve the active grading provider per the precedence chain below and dispatch a per-provider auth guard at fixture-invocation time. Both providers raise distinct exception classes (sibling of `Exception`, not subclasses of each other) so tests can route on a structural `except` ladder per `.claude/rules/multi-provider-dispatch.md`.
+>
+> - **`provider="anthropic"`** (default) — strict `ANTHROPIC_API_KEY` check; raises `AnthropicAuthMissingError` when the key is missing. Strict by default **even when the `claude` CLI is on PATH** so a CI run under subscription-only auth surfaces a config regression rather than silently routing through the CLI transport. To opt into CLI transport (relaxed Anthropic guard accepting subscription auth via the `claude` CLI on PATH), set `CLAUDITOR_FIXTURE_ALLOW_CLI=1` in the test environment.
+> - **`provider="openai"`** — strict `OPENAI_API_KEY` check; raises `OpenAIAuthMissingError` when the key is missing. **There is intentionally no `CLAUDITOR_FIXTURE_ALLOW_OPENAI` env var** — OpenAI has no CLI-fallback / subscription analog (per #145 DEC-002), so there is no relaxed-mode to opt into. The asymmetry is deliberate (DEC-001 of #155).
+>
+> See [`docs/transport-architecture.md`](transport-architecture.md) for the auth-state matrix on the Anthropic side.
 
 ### SkillResult fields
 
@@ -39,14 +44,76 @@ Options:
 pytest --clauditor-project-dir /path/to/project
 pytest --clauditor-timeout 300
 pytest --clauditor-claude-bin /usr/local/bin/claude
-pytest --clauditor-no-api-key         # Strip ANTHROPIC_{API_KEY,AUTH_TOKEN}
-pytest --clauditor-grade              # Enable Layer 3 tests (costs money)
-pytest --clauditor-model claude-sonnet-4-6  # Override grading model
+pytest --clauditor-no-api-key                   # Strip ANTHROPIC_{API_KEY,AUTH_TOKEN}
+pytest --clauditor-grade                        # Enable Layer 3 tests (costs money)
+pytest --clauditor-model claude-sonnet-4-6      # Override grading model
+pytest --clauditor-harness codex                # Override harness for this session ({claude-code,codex,auto})
+pytest --clauditor-grading-provider openai      # Override grading provider ({anthropic,openai,auto})
 ```
 
 `--clauditor-no-api-key` is the plugin-option counterpart to `--no-api-key` on the CLI: strips both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the `claude -p` subprocess environment so the child falls back to whatever auth is cached in `~/.claude/` (typically a Pro/Max subscription). Scoped to the `clauditor_spec` fixture's `env_override` wiring; the bare `clauditor_runner` fixture is unaffected (its `SkillRunner` is constructed without the env scrub). For per-test overrides, `spec.run(env_override=..., timeout_override=...)` accepts both kwargs directly — the fixture wrapper forwards caller-provided values over the fixture-level default.
 
+`--clauditor-harness` (#155) overrides the harness used by `clauditor_runner` and `clauditor_spec` for the entire pytest session. Operator-intent precedence: factory `harness=` kwarg > `--clauditor-harness` > `CLAUDITOR_HARNESS` env > `EvalSpec.harness` > default `"auto"`. Auto-resolution mirrors the CLI: `shutil.which("claude")` first, then `shutil.which("codex")`, with a one-time stderr announcement when auto picks codex.
+
+`--clauditor-grading-provider` (#155) overrides the grading provider used by `clauditor_grader`, `clauditor_blind_compare`, and `clauditor_triggers` for the entire pytest session. Operator-intent precedence: factory `provider=` kwarg > `--clauditor-grading-provider` > `CLAUDITOR_GRADING_PROVIDER` env > `EvalSpec.grading_provider` > default `"auto"` (auto-inferred from `--clauditor-model` / `EvalSpec.grading_model` per `claude-*` → anthropic, `gpt-*` / `o[0-9]+*` → openai).
+
 Mark tests that need Layer 3 with `@pytest.mark.clauditor_grade`; they are skipped by default and only run under `--clauditor-grade`.
+
+## Parametrizing harness × provider
+
+clauditor exposes harness (skill runtime) and grading-provider (judge runtime) as independent axes, so a single test can sweep across `{claude-code, codex} × {anthropic, openai}` without changing skill or eval spec. The two axes are structurally separate per `.claude/rules/multi-provider-dispatch.md`; the factory kwargs are the highest-precedence layer of the operator-intent stack.
+
+### Operator-intent precedence (highest → lowest)
+
+For both `harness` and `provider`:
+
+1. **Factory kwarg** at the call site — e.g. `clauditor_runner(harness="codex")`, `clauditor_grader(skill, output, provider="openai")`. Wins over everything below.
+2. **Pytest CLI option** — `--clauditor-harness=codex`, `--clauditor-grading-provider=openai`. Session-wide.
+3. **Env var** — `CLAUDITOR_HARNESS=codex`, `CLAUDITOR_GRADING_PROVIDER=openai`.
+4. **Spec field** — `EvalSpec.harness`, `EvalSpec.grading_provider`. Author-intent.
+5. **Default** — `"auto"` for both axes (PATH lookup for harness, model-prefix inference for provider).
+
+Each layer falls through to the next when `None` (or `"auto"`, for the auto-resolved fields). Mirrors the CLI seam exactly per `.claude/rules/spec-cli-precedence.md`.
+
+### Worked example: `pytest.mark.parametrize` over `{harness, provider}`
+
+```python
+import pytest
+
+
+@pytest.mark.parametrize(
+    "harness,provider",
+    [
+        ("claude-code", "anthropic"),
+        ("codex", "openai"),
+    ],
+)
+@pytest.mark.clauditor_grade
+def test_my_skill_across_stacks(
+    clauditor_runner,
+    clauditor_grader,
+    harness,
+    provider,
+):
+    runner = clauditor_runner(harness=harness)
+    result = runner.run("my-skill")
+    report = clauditor_grader(
+        "skills/my-skill/SKILL.md",
+        result.output,
+        provider=provider,
+    )
+    assert report.score >= 0.8
+```
+
+The same matrix can be driven from the command line with no test changes — the pytest CLI options sit one precedence layer below the factory kwargs, so leaving the kwargs off lets the session-wide flags take over:
+
+```bash
+pytest --clauditor-harness=codex --clauditor-grading-provider=openai
+```
+
+### Cross-axis isolation (DEC-006)
+
+`clauditor_runner` accepts only `harness=`. The grading fixtures (`clauditor_grader`, `clauditor_blind_compare`, `clauditor_triggers`) accept only `provider=` and `model=`. The two axes are independent — the runner has no grading concern, and the graders do not run the skill subprocess. Conflating them would re-introduce the "harness ≠ provider" bug DEC-010 of #151 explicitly avoided.
 
 ### Related commands (not covered by fixtures)
 

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -53,7 +53,7 @@ pytest --clauditor-grading-provider openai      # Override grading provider ({an
 
 `--clauditor-no-api-key` is the plugin-option counterpart to `--no-api-key` on the CLI: strips both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the `claude -p` subprocess environment so the child falls back to whatever auth is cached in `~/.claude/` (typically a Pro/Max subscription). Scoped to the `clauditor_spec` fixture's `env_override` wiring; the bare `clauditor_runner` fixture is unaffected (its `SkillRunner` is constructed without the env scrub). For per-test overrides, `spec.run(env_override=..., timeout_override=...)` accepts both kwargs directly — the fixture wrapper forwards caller-provided values over the fixture-level default.
 
-`--clauditor-harness` (#155) overrides the harness used by `clauditor_runner` and `clauditor_spec` for the entire pytest session. Operator-intent precedence: factory `harness=` kwarg > `--clauditor-harness` > `CLAUDITOR_HARNESS` env > `EvalSpec.harness` > default `"auto"`. Auto-resolution mirrors the CLI: `shutil.which("claude")` first, then `shutil.which("codex")`, with a one-time stderr announcement when auto picks codex.
+`--clauditor-harness` (#155) overrides the harness used by `clauditor_runner` for the entire pytest session. Operator-intent precedence on `clauditor_runner`: factory `harness=` kwarg > `--clauditor-harness` > `CLAUDITOR_HARNESS` env > default `"auto"`. Auto-resolution mirrors the CLI: `shutil.which("claude")` first, then `shutil.which("codex")`, with a one-time stderr announcement when auto picks codex. **Scope note:** the option does NOT override `clauditor_spec`'s harness selection — that fixture honors only `EvalSpec.harness` (author intent). Set `harness:` in `eval.json` for per-skill author preference; use `clauditor_runner(harness=...)` or this CLI option for operator-intent selection of the bare runner.
 
 `--clauditor-grading-provider` (#155) overrides the grading provider used by `clauditor_grader`, `clauditor_blind_compare`, and `clauditor_triggers` for the entire pytest session. Operator-intent precedence: factory `provider=` kwarg > `--clauditor-grading-provider` > `CLAUDITOR_GRADING_PROVIDER` env > `EvalSpec.grading_provider` > default `"auto"` (auto-inferred from `--clauditor-model` / `EvalSpec.grading_model` per `claude-*` → anthropic, `gpt-*` / `o[0-9]+*` → openai).
 
@@ -65,13 +65,24 @@ clauditor exposes harness (skill runtime) and grading-provider (judge runtime) a
 
 ### Operator-intent precedence (highest → lowest)
 
-For both `harness` and `provider`:
+The two axes have slightly different chains because the harness axis on `clauditor_runner` has no spec layer (the runner factory does not load an `EvalSpec`).
 
-1. **Factory kwarg** at the call site — e.g. `clauditor_runner(harness="codex")`, `clauditor_grader(skill, output, provider="openai")`. Wins over everything below.
-2. **Pytest CLI option** — `--clauditor-harness=codex`, `--clauditor-grading-provider=openai`. Session-wide.
-3. **Env var** — `CLAUDITOR_HARNESS=codex`, `CLAUDITOR_GRADING_PROVIDER=openai`.
-4. **Spec field** — `EvalSpec.harness`, `EvalSpec.grading_provider`. Author-intent.
-5. **Default** — `"auto"` for both axes (PATH lookup for harness, model-prefix inference for provider).
+**Provider axis** (`clauditor_grader`, `clauditor_blind_compare`, `clauditor_triggers`):
+
+1. **Factory kwarg** — e.g. `clauditor_grader(skill, output=..., provider="openai")`.
+2. **Pytest CLI option** — `--clauditor-grading-provider=openai`.
+3. **Env var** — `CLAUDITOR_GRADING_PROVIDER=openai`.
+4. **Spec field** — `EvalSpec.grading_provider`.
+5. **Default** — `"auto"` (model-prefix inference).
+
+**Harness axis** (`clauditor_runner` factory only):
+
+1. **Factory kwarg** — `clauditor_runner(harness="codex")`.
+2. **Pytest CLI option** — `--clauditor-harness=codex`.
+3. **Env var** — `CLAUDITOR_HARNESS=codex`.
+4. **Default** — `"auto"` (PATH lookup: `claude` first, then `codex`).
+
+`clauditor_spec` honors only `EvalSpec.harness` (author intent) and applies it via `harness_name_override` when wrapping `spec.run`; the operator-intent layers (CLI flag, env, factory kwarg) do not affect `clauditor_spec`'s harness selection. To pin a session-wide harness for skills loaded via `clauditor_spec`, set the `harness:` field in each skill's `eval.json`.
 
 Each layer falls through to the next when `None` (or `"auto"`, for the auto-resolved fields). Mirrors the CLI seam exactly per `.claude/rules/spec-cli-precedence.md`.
 
@@ -99,10 +110,10 @@ def test_my_skill_across_stacks(
     result = runner.run("my-skill")
     report = clauditor_grader(
         "skills/my-skill/SKILL.md",
-        result.output,
+        output=result.output,
         provider=provider,
     )
-    assert report.score >= 0.8
+    assert report.pass_rate >= 0.8
 ```
 
 The same matrix can be driven from the command line with no test changes — the pytest CLI options sit one precedence layer below the factory kwargs, so leaving the kwargs off lets the session-wide flags take over:

--- a/plans/super/155-pytest-fixtures-parametrize.md
+++ b/plans/super/155-pytest-fixtures-parametrize.md
@@ -5,8 +5,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/155
 - **Branch:** `feature/155-pytest-fixtures-parametrize`
 - **Worktree:** `worktrees/clauditor/155-pytest-fixtures-parametrize` (relative)
-- **PR:** _(pending)_
-- **Phase:** detailing
+- **PR:** https://github.com/wjduenow/clauditor/pull/172
+- **Phase:** published
 - **Sessions:** 1 (2026-05-09)
 - **Total decisions:** 12 (DEC-001 through DEC-012)
 - **Stories:** 7 implementation + Quality Gate + Patterns & Memory = 9

--- a/plans/super/155-pytest-fixtures-parametrize.md
+++ b/plans/super/155-pytest-fixtures-parametrize.md
@@ -1,0 +1,757 @@
+# 155: Comparability — pytest fixtures parametrize harness/provider
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/155
+- **Branch:** `feature/155-pytest-fixtures-parametrize`
+- **Worktree:** `worktrees/clauditor/155-pytest-fixtures-parametrize` (relative)
+- **PR:** _(pending)_
+- **Phase:** detailing
+- **Sessions:** 1 (2026-05-09)
+- **Total decisions:** 12 (DEC-001 through DEC-012)
+- **Stories:** 7 implementation + Quality Gate + Patterns & Memory = 9
+- **Depends on:** #147 (CLOSED — provider sidecar field), #151 (CLOSED — `EvalSpec.harness` four-layer precedence), #152 (CLOSED — harness sidecar field)
+- **Blocks:** _(none)_
+- **Parent epic:** #143 (multi-provider / multi-harness)
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Extend the pytest plugin (`src/clauditor/pytest_plugin.py`)
+so test suites can parametrize across `{harness × provider}` combinations.
+
+Adds:
+1. `clauditor_runner` accepts a `harness` kwarg / pytest option,
+   instantiating the matching `Harness`.
+2. `clauditor_grader` / `clauditor_blind_compare` / `clauditor_triggers`
+   accept `provider=` and `model=` kwargs on the factory call (operator
+   intent), threaded into the underlying orchestrator calls.
+3. New pytest CLI options:
+   - `--clauditor-harness {claude-code,codex,auto}`
+   - `--clauditor-grading-provider {anthropic,openai,auto}`
+   - (`--clauditor-grading-model` already exists as `--clauditor-model`.)
+4. Per-harness/provider auth-guard env vars:
+   - `CLAUDITOR_FIXTURE_ALLOW_OPENAI=1` (mirrors existing
+     `CLAUDITOR_FIXTURE_ALLOW_CLI=1`) — semantics TBD in scoping
+     (see Q1 below).
+5. Fixture-level **hard error** when required auth missing for
+   selected provider/harness, per
+   `.claude/rules/precall-env-validation.md` — never `pytest.skip`.
+6. `docs/pytest-plugin.md` extended with parametrization examples.
+
+**Why:** Epic #143 multi-harness. #146 wired the four-layer
+`grading_provider` precedence into the CLI; #151 wired the same
+shape for `harness`. The pytest plugin was given partial automation
+(eval_spec.harness/grading_provider are honored by fixtures already)
+but lacks the **operator-intent** layers (factory kwargs and pytest
+CLI options) that the CLI commands all expose. Without those layers,
+a CI matrix like `pytest --clauditor-harness=codex
+--clauditor-grading-provider=openai` is impossible from fixture-land.
+
+**Done when (per ticket acceptance):**
+1. `clauditor_grader(spec_path, output, provider="openai")` runs
+   against OpenAI.
+2. `pytest --clauditor-harness=codex` runs all fixtures under Codex.
+3. Auth-missing surfaces a hard error (not `pytest.skip`).
+4. Tests cover the new fixture branches.
+
+**Out of scope (per ticket):**
+- Built-in `pytest.mark.parametrize` matrix helpers (users compose
+  their own).
+
+### Codebase findings
+
+#### Existing fixture surface (pytest_plugin.py — 607 lines)
+
+- `clauditor_runner` (line 117): bare `SkillRunner`, no harness selection.
+- `clauditor_spec` (line 145): wraps `SkillSpec.from_file`; honors
+  `eval_spec.harness` via `harness_name_override` (per #151 US-007).
+- `clauditor_grader` (line 397): factory; takes `(skill_path,
+  eval_path, output)`. Calls `_dispatch_fixture_auth_guard` +
+  `_resolve_fixture_provider`. Threads provider/model into
+  `grade_quality(...)`.
+- `clauditor_blind_compare` (line 471): factory; takes `(skill_path,
+  output_a, output_b, eval_path, *, model)`. **Already has `model=`
+  kwarg**, but no `provider=` kwarg.
+- `clauditor_triggers` (line 530): factory; no `provider`/`model`
+  kwargs on the call signature.
+- `clauditor_capture` (line 451): unrelated to this work.
+
+Helpers already in place:
+- `_resolve_fixture_provider(eval_spec, model_override)` — pure;
+  consults env + spec via `resolve_grading_provider`.
+- `_dispatch_fixture_auth_guard(eval_spec, fixture_name, model_override)`
+  — routes per provider, raises `AnthropicAuthMissingError` /
+  `OpenAIAuthMissingError`.
+
+#### Existing pytest CLI options (lines 53–95)
+
+- `--clauditor-project-dir`
+- `--clauditor-timeout`
+- `--clauditor-no-api-key`
+- `--clauditor-claude-bin`
+- `--clauditor-grade`
+- `--clauditor-model` (this is the `--clauditor-grading-model` from
+  the ticket, already shipped)
+
+**Missing:**
+- `--clauditor-harness {claude-code,codex,auto}`
+- `--clauditor-grading-provider {anthropic,openai,auto}`
+
+#### Existing env-var seam
+
+- `CLAUDITOR_FIXTURE_ALLOW_CLI=1` (lines 31–48): opts into
+  Anthropic CLI transport (relaxed auth). Strict `check_api_key_only`
+  is the default; relaxed `check_any_auth_available` fires when env
+  is set. **Anthropic-only by design** — OpenAI has no
+  CLI-fallback / subscription concept (#145 DEC-002).
+- `CLAUDITOR_GRADING_PROVIDER` (used in `_dispatch_fixture_auth_guard`):
+  already honored by the env-precedence layer of
+  `resolve_grading_provider`.
+- `CLAUDITOR_HARNESS`: honored by `resolve_harness` for the CLI
+  commands. **Not yet read by fixtures** — `clauditor_runner` does
+  not call `resolve_harness`.
+
+#### Available pure resolvers (no I/O at the precedence layer)
+
+- `clauditor._providers.resolve_grading_provider(cli, env, spec, model)`
+  — returns concrete `"anthropic"` / `"openai"`.
+- `clauditor._providers.resolve_grading_model(eval_spec, provider)`
+  — provider-aware default-picker.
+- `clauditor._providers.resolve_harness(cli, env, spec)` — returns
+  `(name, auto_codex_flag)` tuple; reads PATH via `shutil.which`.
+- `clauditor._harnesses.construct_harness(name)` — materializes a
+  `ClaudeCodeHarness` / `CodexHarness` instance from a literal name.
+
+These are the same helpers the CLI commands already use; the pytest
+plugin will adopt them so a single change to precedence semantics
+propagates to fixtures and CLI together.
+
+#### Auth machinery
+
+- `clauditor._providers.check_provider_auth(provider, cmd_name)` —
+  multi-provider dispatcher (raises `AnthropicAuthMissingError` or
+  `OpenAIAuthMissingError`).
+- `clauditor._providers.check_codex_auth(cmd_name)` — harness-axis
+  guard (raises `CodexAuthMissingError` when neither
+  `CODEX_API_KEY` nor `OPENAI_API_KEY` is set).
+- `clauditor._providers.check_api_key_only(cmd_name)` — strict
+  Anthropic guard (default in fixture-land).
+- `clauditor._providers.check_any_auth_available(cmd_name)` —
+  relaxed Anthropic guard (opt-in via `CLAUDITOR_FIXTURE_ALLOW_CLI=1`).
+
+The harness-axis guard is **not yet wired** in fixture-land. Today,
+when `eval_spec.harness == "codex"` (set via spec), fixtures
+auto-construct `CodexHarness` but never call `check_codex_auth` —
+the failure surfaces as the harness's SDK error rather than the
+crisp `CodexAuthMissingError` the CLI emits.
+
+### Convention Checker findings (`.claude/rules/`)
+
+Rules that constrain this plan (full list):
+
+- **`precall-env-validation.md`** — fixture guards must raise distinct
+  exception classes per provider/harness; never `pytest.skip` on
+  auth-missing. The three grading fixtures already comply for
+  Anthropic/OpenAI; add `CodexAuthMissingError` branch when fixture
+  resolves harness to `"codex"`.
+- **`spec-cli-precedence.md`** — operator > author > library default.
+  Factory kwargs (operator) win over pytest CLI options (operator),
+  win over env vars (operator), win over spec fields (author), win
+  over default. The four operator-intent layers stack:
+  factory-kwarg > pytest-CLI > env > spec > default.
+- **`multi-provider-dispatch.md`** — sibling exception classes per
+  provider (no shared parent); structural `except` ladder. The new
+  `clauditor_runner` harness-aware path adds a third sibling branch
+  (`CodexAuthMissingError`) per the post-#162 dispatcher pattern.
+- **`pure-compute-vs-io-split.md`** — fixture-land helpers stay pure
+  (no stderr, no `sys.exit`); pytest fixtures themselves own raising
+  the exception which pytest then surfaces as a setup error.
+- **`test-infra-shutil-which-coupling.md`** — `tests/conftest.py`
+  autouse fixture pins `CLAUDITOR_HARNESS=claude-code`. The new
+  fixture path that calls `resolve_harness` will short-circuit at
+  the env layer under that pin (no `shutil.which` collision). New
+  tests that *want* to exercise the auto-PATH branch must
+  `monkeypatch.delenv("CLAUDITOR_HARNESS")` and pin `shutil.which`
+  inline.
+- **`back-compat-shim-discipline.md`** — Pattern 3 (deferred-import
+  for test patches): the new fixture-internal `resolve_harness` call
+  must target the canonical seam
+  (`clauditor._providers.resolve_harness`), not a re-export.
+- **`json-schema-version.md`** — N/A (no sidecar emission in
+  fixture-land).
+- **`pytester-inprocess-coverage-hazard.md`** — N/A (no
+  `pytester.runpytest_inprocess` involved).
+
+No rule forbids the work. The fixture seam needs to mirror the CLI
+seam structurally; that mirror is exactly what
+`spec-cli-precedence.md` and `multi-provider-dispatch.md` codify.
+
+### Phase status
+
+`discovery` — awaiting answers to scoping questions before moving
+to architecture review.
+
+---
+
+## Architecture Review
+
+| Area | Rating | Summary |
+|---|---|---|
+| Security (auth-guard) | concern | Eager `check_codex_auth` in `clauditor_runner` factory is correct, but `clauditor_spec` also constructs runners (when `eval_spec.harness=="codex"`); needs the same guard for consistency. |
+| API Design (factory signature) | concern | `clauditor_runner` value→factory conversion is breaking. Two pyetster-internal call sites today (low blast radius), but doc + 1 README example need update. Open: should the factory accept ALL of `harness=`, `timeout=`, `claude_bin=` for symmetry, or only `harness=` per ticket scope? |
+| API Design (precedence stacking) | pass | Operator > author > library default (per `spec-cli-precedence.md`). Four operator-intent layers stack as: factory-kwarg > pytest-CLI-option > env-var > spec-field > default. Mirrors the CLI seam exactly (no new precedence shape). |
+| Testing Strategy | concern | `test_pytest_plugin.py:102` asserts `addoption call_count == 6` — bumps to 8 with two new options. New branches need coverage: factory `harness=` override, pytest CLI option, env var, auto-resolution under PATH-pinned conftest. |
+| Test-infra coupling | pass | `tests/conftest.py:754` already pins `CLAUDITOR_HARNESS="claude-code"` per `test-infra-shutil-which-coupling.md`. New tests that exercise the auto-PATH branch must `monkeypatch.delenv("CLAUDITOR_HARNESS")` + pin `shutil.which` inline. Symmetric `CLAUDITOR_GRADING_PROVIDER` env-pin is **not** needed (no autouse `shutil.which` collision on that axis). |
+| Documentation | concern | `docs/pytest-plugin.md` is the canonical surface (~53 lines today). Per `readme-promotion-recipe.md`, adding parametrization examples likely lands in `docs/pytest-plugin.md` (already a docs/ file with breadcrumb); `README.md` teaser may need a one-sentence extension only if the workflow shape changes. |
+| Backward compatibility | concern | `clauditor_runner` becoming a factory is a breaking change for any user calling `def test_x(clauditor_runner):` and treating it as a value. Pre-1.0 project + `CHANGELOG.md` is the canonical break-with-note seam. |
+
+### Findings detail
+
+**Eager `check_codex_auth` from two seams.** The `clauditor_runner`
+factory (per Q4 answer) calls `check_codex_auth` when resolved
+harness is `"codex"`. But `clauditor_spec` also constructs codex
+runners (via `harness_name_override` in `SkillSpec.run`). The
+guard should fire from **both seams**, otherwise a test using
+only `clauditor_spec` (no `clauditor_runner`) bypasses the guard
+when `eval_spec.harness == "codex"`. Two options:
+(a) duplicate the guard at both seams, (b) call `check_codex_auth`
+inside `SkillSpec.run` itself when materializing a fresh codex
+runner — the latter centralizes the guard but moves it out of
+fixture-land. The CLI seam guards eagerly (per #151 DEC-012) so
+duplicating in `clauditor_spec` is idiomatic.
+
+**Factory signature scope.** The ticket scope mentions `harness`
+kwarg only on `clauditor_runner`. But the existing fixture wiring
+already passes `timeout` and `claude_bin` from pytest options;
+the factory could either:
+(a) accept just `harness=` as additive kwarg over today's pytest
+options, or (b) become the full constructor surface (factory
+takes `harness=`, `timeout=`, `claude_bin=`, falling back to
+pytest options when `None`). Option (a) keeps scope minimal;
+option (b) is forward-compat for future runner kwargs.
+
+**Test brittleness.** `test_pytest_plugin.py:102` and the addoption
+counter assertions are fragile to option-set changes. Same shape
+fired on every prior option add (#86 added `--clauditor-no-api-key`,
+#151 did not need a fixture option since it's harness-axis). Bump
+the count and add per-option assertions.
+
+---
+
+## Refinement Log
+
+### Decisions
+
+**DEC-001: Drop `CLAUDITOR_FIXTURE_ALLOW_OPENAI`.**
+*Decision:* The ticket suggests mirroring `CLAUDITOR_FIXTURE_ALLOW_CLI=1`
+for OpenAI. Reject the mirror; do not introduce the env var.
+*Rationale:* `CLAUDITOR_FIXTURE_ALLOW_CLI=1` opts into a *relaxed*
+Anthropic guard (accepts subscription auth via the `claude` CLI on
+PATH). OpenAI has no CLI-fallback / subscription analog (#145
+DEC-002). There is no relaxed-mode to opt into; a no-op env var
+would be misleading. Document the asymmetry in
+`docs/pytest-plugin.md` so users understand why one provider has
+the env-var and the other does not.
+
+**DEC-002: Convert `clauditor_runner` to a factory fixture.**
+*Decision:* `clauditor_runner` becomes `def clauditor_runner(...)
+→ Callable[[harness?: str], SkillRunner]`. Today's value-shape
+(`def test(clauditor_runner): runner = clauditor_runner`) becomes
+`def test(clauditor_runner): runner = clauditor_runner()`.
+*Rationale:* Pytest fixtures cannot accept call-site kwargs; only
+factory fixtures can. Per the audit, only 2 in-repo tests use
+`clauditor_runner` as a value (both pytester-internal); user-facing
+test code is unaffected. Pre-1.0 project precedent is a hard break
+with `CHANGELOG.md` note + docs update (per the
+`data-vs-asserter-split.md` migration that broke
+`result.assert_*`).
+
+**DEC-003: `clauditor_runner` factory accepts only `harness=`
+kwarg (minimal scope).** *Decision:* Signature is
+`clauditor_runner(harness: str | None = None) → SkillRunner`.
+`timeout` and `claude_bin` continue to come from pytest options
+exclusively. *Rationale:* Ticket-aligned. Forward-compat is fine
+to widen in a follow-up; the wider signature has no current call
+sites today and would be solving a problem we don't have.
+
+**DEC-004: Auto-resolution via `resolve_harness` (PATH lookup
+mirroring the CLI).** *Decision:* When `--clauditor-harness=auto`
+(default) and no `harness=` factory kwarg, the fixture calls
+`clauditor._providers.resolve_harness(cli_override=harness_kwarg,
+env_override=os.environ.get("CLAUDITOR_HARNESS"),
+spec_value=None)` and uses the returned name.
+*Rationale:* Mirror the CLI seam exactly. `tests/conftest.py:754`
+already pins `CLAUDITOR_HARNESS=claude-code` per
+`test-infra-shutil-which-coupling.md`, so the in-repo suite
+short-circuits before PATH lookup. User test suites get the
+auto-resolution behavior.
+
+**DEC-005: Eager `check_codex_auth` from BOTH `clauditor_runner`
+factory AND `clauditor_spec` factory.** *Decision:* When the
+resolved harness is `"codex"`, both factories call
+`check_codex_auth("runner")` / `check_codex_auth("spec")` before
+returning the runner. Distinct exception class
+`CodexAuthMissingError` per `precall-env-validation.md` and
+`multi-provider-dispatch.md`. *Rationale:* CLI commands all
+guard eagerly per #151 DEC-012; fixtures must match. Two seams
+because tests can use either fixture in isolation; missing the
+guard at `clauditor_spec` would let a `clauditor_spec`-only test
+bypass it. Push-down into `SkillSpec.run` was rejected: it
+moves the guard out of fixture-land and changes CLI behavior
+(wider blast radius).
+
+**DEC-006: Cross-axis isolation — no `provider=`/`model=` on
+`clauditor_runner`.** *Decision:* Only the three grading
+fixtures (`clauditor_grader`, `clauditor_blind_compare`,
+`clauditor_triggers`) accept `provider=` and `model=` factory
+kwargs. `clauditor_runner` accepts only `harness=`.
+*Rationale:* The harness vs grading-provider distinction is
+structural per `multi-provider-dispatch.md` (harness=skill
+runtime, provider=grader runtime). They are independent axes;
+the runner has no grading concern. Conflating them would
+re-introduce the "harness ≠ provider" bug DEC-010 of #151
+explicitly avoided.
+
+**DEC-007: Factory-kwarg precedence: kwarg > pytest CLI option >
+env > spec > default.** *Decision:* The new factory kwargs
+(`harness=` on runner; `provider=`/`model=` on graders) sit at
+the top of the operator-intent stack. Each layer falls through to
+the next when `None` (or `"auto"`, for the auto-resolved fields).
+*Rationale:* Mirrors the CLI seam exactly per
+`spec-cli-precedence.md`. The four operator-intent layers stack
+above the existing `eval_spec.<field>` (author intent) and the
+library default. No new precedence shape; this rule's pytest
+fixture anchor is the goal.
+
+**DEC-008: Sibling `CodexAuthMissingError` as a third except
+branch on `clauditor_runner`.** *Decision:* The `clauditor_runner`
+factory `except` ladder has three branches:
+`AnthropicAuthMissingError` (when transport-related auth bridges
+fail), `OpenAIAuthMissingError` (defensive — provider auth is
+graders, not runners; included for ladder shape stability), and
+`CodexAuthMissingError`. Per `multi-provider-dispatch.md`, no
+shared parent class. *Rationale:* Structural routing, not
+substring matching. Each class is a sibling of `Exception`; the
+exit-code-equivalent here is "pytest setup failure with this
+specific error class" — assertable in tests via
+`pytest.raises(CodexAuthMissingError)`.
+
+**DEC-009: CHANGELOG + docs update; no back-compat shim.**
+*Decision:* Document the `clauditor_runner` value→factory break
+in `CHANGELOG.md` with a one-line migration guide. Update
+`docs/pytest-plugin.md` and any README example. *Rationale:*
+Pre-1.0 project. Established precedent: #1 (data-vs-asserter
+split broke `result.assert_*` with no shim). Two fixtures for
+one concept (`clauditor_runner` + `clauditor_runner_factory`)
+would carry deprecation surface for years; the hard break is
+cleaner.
+
+**DEC-010: `--clauditor-model` is the canonical grading-model
+option name; do NOT rename to `--clauditor-grading-model`.**
+*Decision:* The ticket's mention of `--clauditor-grading-model
+STR` is interpreted as "ensure a grading-model knob exists"
+(it does, named `--clauditor-model`). No rename, no alias.
+*Rationale:* Renaming a public CLI option pre-1.0 is still a
+breaking change with no upside; readers can see from
+`docs/pytest-plugin.md` and the option's `help=` string that it
+governs grading. The cleanup belongs to a future dedicated
+naming-pass ticket if at all.
+
+**DEC-011: Test-infra: existing `tests/conftest.py:754` pin
+covers harness axis; no new pin needed for grading-provider.**
+*Decision:* Per the audit, no `shutil.which` collision exists on
+the grading-provider axis (provider resolution reads only env +
+spec, no PATH). New tests that exercise the auto-PATH harness
+branch must `monkeypatch.delenv("CLAUDITOR_HARNESS")` AND pin
+`shutil.which` inline (per `test-infra-shutil-which-coupling.md`).
+*Rationale:* Don't add coupling we don't need. The defensive pin
+is for the autouse-shutil-which-collision class of bug; that
+class doesn't apply on the grading-provider axis.
+
+**DEC-012: Documentation lands in `docs/pytest-plugin.md`; no
+README teaser change.** *Decision:* Add parametrization examples
++ env-var docs to `docs/pytest-plugin.md`. The README's "Pytest
+Integration" teaser is unchanged (workflow shape stays the
+same; the README points at the doc). *Rationale:* Per
+`readme-promotion-recipe.md`, the workflow's *shape* did not
+change — only its *capability* widened. README teaser bumps are
+reserved for shape changes (per the rule's update criteria).
+`CHANGELOG.md` carries the migration note for the
+factory break.
+
+### Session notes
+
+Three of four scoping questions and four of four architecture-
+review questions chose the recommended option (the safe path).
+The fourth scoping question (auto-resolution mode) also chose
+recommended. Decisions feel well-anchored; no surprising
+trade-offs surfaced.
+
+---
+
+## Detailed Breakdown
+
+Architecture order: **pytest-options → factory conversion → grader
+fixtures → spec auth-guard → tests → docs → quality gate → patterns**.
+
+### US-001: Add `--clauditor-harness` and `--clauditor-grading-provider` pytest options
+
+**Description.** Register two new pytest CLI options in
+`pytest_addoption` with closed-set choice validation. No fixture
+behavior change yet — this is the option-parsing seam only.
+
+**Traces to:** DEC-008 (option naming), DEC-010 (no rename).
+
+**Acceptance Criteria:**
+- `pytest --clauditor-harness {claude-code,codex,auto}` accepts
+  the three values; rejects others with argparse error.
+- `pytest --clauditor-grading-provider {anthropic,openai,auto}`
+  same shape.
+- `pytest_addoption` registers both options under the existing
+  `clauditor` group; help strings explain the operator-intent
+  precedence.
+- `tests/test_pytest_plugin.py:102` `addoption call_count == 6`
+  assertion bumps to `== 8`.
+- `uv run ruff check src/ tests/ && uv run pytest --cov=clauditor
+  --cov-report=term-missing` passes (80% coverage gate).
+
+**Done when:** Both options parseable from `pytest --help`; existing
+test suite green with the count bump.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py` (add options to
+  `pytest_addoption`).
+- `tests/test_pytest_plugin.py` (bump count assertion + add
+  per-option presence assertions).
+
+**Depends on:** none.
+
+**TDD:** Write failing assertions for `--clauditor-harness=codex`
+and `--clauditor-grading-provider=openai` parsing (via
+`pytester` or `_argparse` introspection); add option-presence
+checks. Implement in `pytest_addoption` until green.
+
+---
+
+### US-002: Convert `clauditor_runner` to factory; harness resolution + Codex auth guard
+
+**Description.** Replace the value fixture with a factory that
+accepts an optional `harness=` kwarg. Resolve the harness via
+`resolve_harness(cli_override, env_override, spec_value=None)`,
+where `cli_override` is the factory kwarg (when set) **or** the
+`--clauditor-harness` pytest option (when set). When the
+resolved harness is `"codex"`, eagerly call
+`check_codex_auth("runner")`. Materialize via
+`construct_harness(name)`.
+
+**Traces to:** DEC-002, DEC-003, DEC-004, DEC-005 (codex guard
+at runner seam), DEC-007 (precedence stacking), DEC-008 (sibling
+exception class).
+
+**Acceptance Criteria:**
+- `def test(clauditor_runner): runner = clauditor_runner()` works
+  with default harness resolution.
+- `runner = clauditor_runner(harness="codex")` overrides to Codex
+  even when `--clauditor-harness=claude-code` is set (factory
+  kwarg wins).
+- When the resolved harness is `"codex"` and neither
+  `CODEX_API_KEY` nor `OPENAI_API_KEY` is set,
+  `clauditor_runner()` raises `CodexAuthMissingError` (NOT
+  `pytest.skip`).
+- The two existing in-repo callers
+  (`tests/test_pytest_plugin.py:65-66, 74-75`) updated to call
+  `clauditor_runner()`.
+- `runner.harness.name == "codex"` after the codex path.
+- `CodexAuthMissingError` is a sibling of `Exception` (not a
+  subclass of `AnthropicAuthMissingError`) — verified by an
+  identity test.
+- `uv run ruff check && uv run pytest` passes.
+
+**Done when:** Factory invocation produces correct runner per
+precedence layer; auth guard fires before any subprocess; all
+in-repo tests pass.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py::clauditor_runner` (rewrite).
+- `tests/test_pytest_plugin.py` (update 2 in-repo callers; add
+  factory branch tests).
+
+**Depends on:** US-001.
+
+**TDD:**
+- `test_factory_kwarg_wins_over_pytest_option` — set option to
+  `claude-code`, call `clauditor_runner(harness="codex")`,
+  assert `runner.harness.name == "codex"`.
+- `test_pytest_option_used_when_no_kwarg` — set option to
+  `codex`, call `clauditor_runner()`, assert codex.
+- `test_env_var_used_when_no_kwarg_no_option` —
+  `monkeypatch.setenv("CLAUDITOR_HARNESS", "codex")`, assert
+  codex.
+- `test_codex_auth_missing_raises` —
+  `monkeypatch.delenv("CODEX_API_KEY", raising=False)`,
+  `monkeypatch.delenv("OPENAI_API_KEY", raising=False)`, expect
+  `CodexAuthMissingError`.
+- `test_class_identity_codex_auth_missing` — `assert
+  CodexAuthMissingError is not AnthropicAuthMissingError`.
+- `test_auto_resolution_path_lookup` —
+  `monkeypatch.delenv("CLAUDITOR_HARNESS")`,
+  `monkeypatch.setattr(shutil, "which", lambda n: "/x/codex" if
+  n == "codex" else None)`, expect codex (per
+  `test-infra-shutil-which-coupling.md`).
+
+---
+
+### US-003: `clauditor_grader` accepts `provider=` and `model=` factory kwargs
+
+**Description.** Extend `clauditor_grader` factory signature with
+`provider: str | None = None` and `model: str | None = None`.
+Thread `provider` through `_dispatch_fixture_auth_guard` and
+`_resolve_fixture_provider` as the highest-precedence layer
+(operator intent kwarg > pytest CLI option > env > spec). Thread
+`model` similarly. Pass both into `grade_quality(provider=...,
+model=...)`.
+
+**Traces to:** DEC-007 (precedence), DEC-006 (axis isolation).
+
+**Acceptance Criteria:**
+- `clauditor_grader(skill, output, provider="openai")` routes
+  through OpenAI auth + SDK regardless of spec's
+  `grading_provider`.
+- `clauditor_grader(skill, output, model="gpt-5.4")` overrides
+  pytest `--clauditor-model`.
+- Without kwargs, today's resolution path (pytest CLI option →
+  env → spec) is unchanged.
+- `_dispatch_fixture_auth_guard` and `_resolve_fixture_provider`
+  accept the new operator-intent layer (likely a new
+  `provider_override` param) and pass it as
+  `cli_override` to `resolve_grading_provider`.
+- `pytest --clauditor-grading-provider=openai` (without factory
+  kwarg) routes to OpenAI auth + SDK on a default spec.
+
+**Done when:** All four operator-intent layers honored;
+`grade_quality` receives the resolved provider; existing tests
+pass; new branch tests cover each layer.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py::clauditor_grader`,
+  `_dispatch_fixture_auth_guard`, `_resolve_fixture_provider`.
+- `tests/test_pytest_plugin.py` (new branch tests).
+
+**Depends on:** US-001.
+
+**TDD:**
+- `test_grader_factory_kwarg_provider_wins` — spec has
+  `grading_provider="anthropic"`; pass
+  `provider="openai"` kwarg; assert OpenAI auth dispatched.
+- `test_grader_pytest_option_provider_used_when_no_kwarg` —
+  `pytest --clauditor-grading-provider=openai` honored.
+- `test_grader_env_used_when_no_kwarg_no_option` —
+  `CLAUDITOR_GRADING_PROVIDER=openai`.
+- `test_grader_factory_kwarg_model_wins` — assert override
+  threads to `grade_quality`.
+
+---
+
+### US-004: `clauditor_blind_compare` accepts `provider=` factory kwarg
+
+**Description.** Same shape as US-003. `clauditor_blind_compare`
+already has `model=` kwarg; add `provider=`. Thread through
+`_dispatch_fixture_auth_guard` + `_resolve_fixture_provider` and
+into `blind_compare_from_spec(provider=...)`.
+
+**Traces to:** DEC-007.
+
+**Acceptance Criteria:**
+- `clauditor_blind_compare(skill, a, b, provider="openai")`
+  dispatches OpenAI auth.
+- All four operator-intent layers honored.
+- `BlindReport.provider_source` reflects the resolved provider.
+
+**Done when:** Branch tests pass; existing blind-compare tests
+pass.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py::clauditor_blind_compare`.
+- `tests/test_pytest_plugin.py`.
+
+**Depends on:** US-003 (shares helper plumbing).
+
+**TDD:** mirror US-003's TDD list for the blind-compare seam.
+
+---
+
+### US-005: `clauditor_triggers` accepts `provider=` and `model=` factory kwargs
+
+**Description.** Same shape as US-003. `clauditor_triggers`
+factory signature gains `provider: str | None = None`,
+`model: str | None = None`. Thread through helpers and into
+`run_triggers(...)`.
+
+**Traces to:** DEC-007.
+
+**Acceptance Criteria:** mirror US-003.
+
+**Done when:** Branch tests pass.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py::clauditor_triggers`.
+- `tests/test_pytest_plugin.py`.
+
+**Depends on:** US-003 (shared helpers).
+
+**TDD:** mirror US-003's list for triggers.
+
+---
+
+### US-006: Eager `check_codex_auth` in `clauditor_spec` factory
+
+**Description.** When `clauditor_spec` is instantiated and the
+loaded spec has `eval_spec.harness == "codex"` (or the spec
+override resolves to codex), eagerly call
+`check_codex_auth("spec")` before returning the wrapped
+`SkillSpec`. Mirrors the runner-side guard in US-002 so any
+test using `clauditor_spec` alone (no `clauditor_runner`) gets
+the same crisp `CodexAuthMissingError` instead of a deep
+subprocess error.
+
+**Traces to:** DEC-005.
+
+**Acceptance Criteria:**
+- A test with `eval_spec.harness="codex"` and missing
+  `CODEX_API_KEY`/`OPENAI_API_KEY` raises
+  `CodexAuthMissingError` from the `clauditor_spec(...)` call.
+- Specs that don't resolve to codex are unaffected.
+
+**Done when:** Branch test passes.
+
+**Files:**
+- `src/clauditor/pytest_plugin.py::clauditor_spec`.
+- `tests/test_pytest_plugin.py`.
+
+**Depends on:** US-002 (introduces `CodexAuthMissingError` in
+fixture-land).
+
+**TDD:**
+- `test_spec_factory_codex_auth_missing` — load spec with
+  `harness="codex"`, no env keys, expect
+  `CodexAuthMissingError`.
+- `test_spec_factory_claude_code_no_guard` — load spec with
+  `harness="claude-code"`, missing OpenAI key, no raise.
+
+---
+
+### US-007: Update `docs/pytest-plugin.md` + `CHANGELOG.md`
+
+**Description.** Add a new section to `docs/pytest-plugin.md`
+covering parametrization across `{harness × provider}`. Include
+a worked example using `pytest.mark.parametrize` over
+`{("claude-code", "anthropic"), ("codex", "openai")}`. Document
+the `clauditor_runner` factory shape change and call out the
+intentional `CLAUDITOR_FIXTURE_ALLOW_OPENAI` non-mirror.
+`CHANGELOG.md` gets a new entry under `## Unreleased` with the
+factory-conversion migration line.
+
+**Traces to:** DEC-001 (asymmetry doc), DEC-002 (break-comms),
+DEC-009 (no shim), DEC-012 (docs landing site).
+
+**Acceptance Criteria:**
+- `docs/pytest-plugin.md` has a `## Parametrizing harness × provider`
+  H2 with at least one runnable code block.
+- The asymmetry note explains why `_ALLOW_OPENAI=1` does not
+  exist (no relaxed mode for OpenAI auth).
+- `CHANGELOG.md` documents:
+  ```
+  - `clauditor_runner` is now a factory fixture. Migration:
+    `runner = clauditor_runner` → `runner = clauditor_runner()`.
+  ```
+- README's "Pytest Integration" teaser unchanged (DEC-012).
+
+**Done when:** Docs render cleanly on GitHub; the CHANGELOG entry
+is one line and accurate.
+
+**Files:**
+- `docs/pytest-plugin.md`.
+- `CHANGELOG.md`.
+
+**Depends on:** US-002, US-003, US-004, US-005, US-006.
+
+---
+
+### US-008: Quality Gate
+
+**Description.** Run code-reviewer agent 4× across the full
+changeset, fixing every real bug each pass. Run CodeRabbit (if
+available). Run `uv run ruff check src/ tests/` and
+`uv run pytest --cov=clauditor --cov-report=term-missing` —
+80% coverage gate must pass.
+
+**Traces to:** Project validation gate.
+
+**Acceptance Criteria:**
+- 4 passes of code-reviewer agent; all real findings addressed.
+- CodeRabbit pass clean (or all findings explicitly resolved).
+- `ruff check` clean.
+- `pytest` green; coverage ≥ 80%.
+
+**Done when:** All quality signals green; PR ready to flip to
+non-draft.
+
+**Files:** any file the reviewers point at.
+
+**Depends on:** US-001 through US-007.
+
+---
+
+### US-009: Patterns & Memory
+
+**Description.** Update `.claude/rules/spec-cli-precedence.md`
+to add the pytest fixture seam as another four-layer-precedence
+canonical-implementation anchor. Specifically: factory-kwarg >
+pytest-CLI-option > env > spec > default. The CLI seams
+(`grade`, `extract`, etc.) and pytest fixture seams now mirror
+each other; the rule should call this out.
+
+If session surfaced any non-obvious pattern (e.g. the codex
+auth guard living at TWO fixture seams), add a memory entry per
+the auto-memory `feedback`/`project` schema.
+
+**Traces to:** All decisions; rule-anchor maintenance.
+
+**Acceptance Criteria:**
+- `spec-cli-precedence.md` has a new subsection (or extended
+  existing one) documenting the pytest fixture mirror.
+- Memory updated only if a non-obvious pattern surfaced (avoid
+  noise per memory hygiene).
+
+**Done when:** Rule file updated; final commit lands.
+
+**Files:**
+- `.claude/rules/spec-cli-precedence.md`.
+- (optional) `~/.claude/projects/.../memory/MEMORY.md` + entry.
+
+**Depends on:** US-008.
+
+---
+
+## Beads Manifest
+
+_(pending devolve)_
+
+---
+
+## Session Notes
+
+### 2026-05-09 — Discovery
+
+- Created worktree, plan doc, ran parallel research.
+- Key finding: ~70% of the work is already done by #146/#151's
+  fixture wiring (`_resolve_fixture_provider`,
+  `_dispatch_fixture_auth_guard`, `eval_spec.harness` honoring in
+  `clauditor_spec`). #155 is mostly the **operator-intent** layers:
+  factory kwargs + pytest CLI options + harness-axis auth guard.
+- Three open scoping questions surfaced; presenting before
+  architecture review.

--- a/plans/super/155-pytest-fixtures-parametrize.md
+++ b/plans/super/155-pytest-fixtures-parametrize.md
@@ -6,7 +6,7 @@
 - **Branch:** `feature/155-pytest-fixtures-parametrize`
 - **Worktree:** `worktrees/clauditor/155-pytest-fixtures-parametrize` (relative)
 - **PR:** https://github.com/wjduenow/clauditor/pull/172
-- **Phase:** published
+- **Phase:** approved
 - **Sessions:** 1 (2026-05-09)
 - **Total decisions:** 12 (DEC-001 through DEC-012)
 - **Stories:** 7 implementation + Quality Gate + Patterns & Memory = 9

--- a/plans/super/155-pytest-fixtures-parametrize.md
+++ b/plans/super/155-pytest-fixtures-parametrize.md
@@ -34,10 +34,12 @@ Adds:
    - `--clauditor-harness {claude-code,codex,auto}`
    - `--clauditor-grading-provider {anthropic,openai,auto}`
    - (`--clauditor-grading-model` already exists as `--clauditor-model`.)
-4. Per-harness/provider auth-guard env vars:
-   - `CLAUDITOR_FIXTURE_ALLOW_OPENAI=1` (mirrors existing
-     `CLAUDITOR_FIXTURE_ALLOW_CLI=1`) — semantics TBD in scoping
-     (see Q1 below).
+4. Per-harness/provider auth-guard env vars: ~~`CLAUDITOR_FIXTURE_ALLOW_OPENAI=1`
+   was considered (mirroring existing `CLAUDITOR_FIXTURE_ALLOW_CLI=1`)
+   but **rejected by DEC-001** — OpenAI has no CLI-fallback /
+   subscription analog (per #145 DEC-002), so there is no
+   relaxed-mode to opt into. The asymmetry with the Anthropic side is
+   deliberate.~~
 5. Fixture-level **hard error** when required auth missing for
    selected provider/harness, per
    `.claude/rules/precall-env-validation.md` — never `pytest.skip`.
@@ -193,8 +195,12 @@ seam structurally; that mirror is exactly what
 
 ### Phase status
 
-`discovery` — awaiting answers to scoping questions before moving
-to architecture review.
+`devolved` — discovery, architecture review, decisions, and
+implementation are complete. All 12 decisions and 9 user stories
+shipped. The summary above is preserved as the original Discovery
+ticket-summary; refer to the Decisions section below and the
+implemented code (`src/clauditor/pytest_plugin.py`) for the final
+state. DEC-001 explicitly rejected `CLAUDITOR_FIXTURE_ALLOW_OPENAI=1`.
 
 ---
 

--- a/plans/super/155-pytest-fixtures-parametrize.md
+++ b/plans/super/155-pytest-fixtures-parametrize.md
@@ -6,7 +6,8 @@
 - **Branch:** `feature/155-pytest-fixtures-parametrize`
 - **Worktree:** `worktrees/clauditor/155-pytest-fixtures-parametrize` (relative)
 - **PR:** https://github.com/wjduenow/clauditor/pull/172
-- **Phase:** approved
+- **Phase:** devolved
+- **Epic:** clauditor-6fy
 - **Sessions:** 1 (2026-05-09)
 - **Total decisions:** 12 (DEC-001 through DEC-012)
 - **Stories:** 7 implementation + Quality Gate + Patterns & Memory = 9
@@ -739,7 +740,24 @@ the auto-memory `feedback`/`project` schema.
 
 ## Beads Manifest
 
-_(pending devolve)_
+- **Epic:** `clauditor-6fy`
+- **Worktree:** `worktrees/clauditor/155-pytest-fixtures-parametrize`
+- **Branch:** `feature/155-pytest-fixtures-parametrize`
+- **PR:** https://github.com/wjduenow/clauditor/pull/172
+
+| Story | Bead | Depends on |
+|---|---|---|
+| US-001 — pytest options | `clauditor-6fy.1` | (ready) |
+| US-002 — runner factory + codex guard | `clauditor-6fy.2` | US-001 |
+| US-003 — grader provider/model kwargs | `clauditor-6fy.3` | US-001 |
+| US-004 — blind_compare provider kwarg | `clauditor-6fy.4` | US-003 |
+| US-005 — triggers provider/model kwargs | `clauditor-6fy.5` | US-003 |
+| US-006 — spec-side codex guard | `clauditor-6fy.6` | US-002 |
+| US-007 — docs + CHANGELOG | `clauditor-6fy.7` | US-002, US-003, US-004, US-005, US-006 |
+| US-008 — Quality Gate | `clauditor-6fy.8` | US-007 |
+| US-009 — Patterns & Memory | `clauditor-6fy.9` | US-008 |
+
+Ready set on devolve: `clauditor-6fy.1` (US-001).
 
 ---
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from clauditor._harnesses._claude_code import env_without_api_key
+from clauditor._providers import check_codex_auth
 from clauditor.asserters import SkillAsserter
 from clauditor.cli import _harness_choice, _provider_choice
 from clauditor.runner import SkillResult, SkillRunner
@@ -178,10 +179,8 @@ def clauditor_runner(request: pytest.FixtureRequest):
             runner = clauditor_runner(harness="codex")  # pin to codex
             result = runner.run("my-skill")
     """
-    import os
-
     from clauditor._harnesses import construct_harness
-    from clauditor._providers import check_codex_auth, resolve_harness
+    from clauditor._providers import resolve_harness
 
     def _factory(harness: str | None = None) -> SkillRunner:
         # Precedence: factory kwarg > pytest option > env > default.
@@ -220,10 +219,13 @@ def clauditor_runner(request: pytest.FixtureRequest):
                 timeout=timeout,
                 claude_bin=claude_bin,
             )
+        # Non-claude-code harnesses ignore ``claude_bin``; passing it
+        # would trigger ``SkillRunner.__init__``'s DeprecationWarning
+        # about claude_bin alongside an explicit harness=. Construct
+        # the harness via :func:`construct_harness` and omit the kwarg.
         return SkillRunner(
             project_dir=project_dir,
             timeout=timeout,
-            claude_bin=claude_bin,
             harness=construct_harness(name),
         )
 
@@ -268,13 +270,15 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
         timeout=request.config.getoption("--clauditor-timeout"),
         claude_bin=request.config.getoption("--clauditor-claude-bin"),
     )
-    # DEC-006 (US-007): when ``--clauditor-no-api-key`` is set, compute
-    # the env dict once per fixture call and thread it as
-    # ``env_override`` through ``SkillSpec.run``. ``None`` otherwise —
-    # the spec's ``env_override`` kwarg default preserves today's
-    # behavior.
+    # DEC-006 (US-007): when ``--clauditor-no-api-key`` is set, the
+    # subprocess env scrub is computed **per-call** inside
+    # ``_run_with_overrides`` (below) so we can pass the resolved
+    # harness name to :func:`env_without_api_key`. Pre-computing it
+    # here would default to claude-code semantics (strips
+    # ``OPENAI_API_KEY``), which would launch a codex subprocess
+    # without usable auth even though :func:`check_codex_auth`
+    # accepted the key from ``os.environ`` — see B1 of #155 QG pass 4.
     no_api_key = request.config.getoption("--clauditor-no-api-key")
-    fixture_env_override = env_without_api_key() if no_api_key else None
 
     def _factory(skill_path: str | Path, eval_path: str | Path | None = None):
         spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
@@ -293,8 +297,6 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
             spec.eval_spec is not None
             and spec.eval_spec.harness == "codex"
         ):
-            from clauditor._providers import check_codex_auth
-
             check_codex_auth("spec")
         has_input_files = (
             spec.eval_spec is not None and bool(spec.eval_spec.input_files)
@@ -331,7 +333,7 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                 spec_harness_override = spec.eval_spec.harness
         if (
             has_input_files
-            or fixture_env_override is not None
+            or no_api_key
             or spec_harness_override is not None
         ):
             original_run = spec.run
@@ -349,17 +351,6 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                 if has_input_files and effective_run_dir is None:
                     default_run_dir.mkdir(parents=True, exist_ok=True)
                     effective_run_dir = default_run_dir
-                # Caller-provided overrides win over the fixture-level
-                # default computed from ``--clauditor-no-api-key``;
-                # otherwise the fixture value is used. Keeping the
-                # pre-US-007 call shape means existing tests that don't
-                # pass either override see ``original_run(args,
-                # run_dir=effective_run_dir)`` verbatim.
-                effective_env = (
-                    env_override
-                    if env_override is not None
-                    else fixture_env_override
-                )
                 # US-007 (#151) / DEC-005: caller-provided
                 # ``harness_name_override=`` (operator intent) wins over
                 # the spec-field default (author intent), mirroring the
@@ -369,6 +360,23 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                     if harness_name_override is not None
                     else spec_harness_override
                 )
+                # Caller-provided ``env_override`` wins. Otherwise, when
+                # ``--clauditor-no-api-key`` is set, compute the scrub
+                # using the harness that will actually run the skill so
+                # ``env_without_api_key`` keeps ``OPENAI_API_KEY`` for
+                # the codex path (per its ``harness_name="codex"``
+                # branch) — fixes B1 of #155 QG pass 4.
+                if env_override is not None:
+                    effective_env = env_override
+                elif no_api_key:
+                    resolved_harness_for_env = (
+                        effective_harness or "claude-code"
+                    )
+                    effective_env = env_without_api_key(
+                        harness_name=resolved_harness_for_env
+                    )
+                else:
+                    effective_env = None
                 if (
                     effective_env is not None
                     or timeout_override is not None
@@ -423,8 +431,6 @@ def _resolve_fixture_provider(
     or CLI override surfaces as a pytest test-setup error instead of
     silently routing through the wrong provider.
     """
-    import os
-
     from clauditor._providers import resolve_grading_provider
 
     if eval_spec is None:
@@ -484,8 +490,6 @@ def _dispatch_fixture_auth_guard(
     structural ``except`` ladder rather than substring-matching on
     error text.
     """
-    import os
-
     from clauditor._providers import (
         check_any_auth_available,
         check_api_key_only,

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -140,13 +140,94 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
 
 
 @pytest.fixture
-def clauditor_runner(request: pytest.FixtureRequest) -> SkillRunner:
-    """Fixture providing a SkillRunner configured from pytest options."""
-    return SkillRunner(
-        project_dir=request.config.getoption("--clauditor-project-dir"),
-        timeout=request.config.getoption("--clauditor-timeout"),
-        claude_bin=request.config.getoption("--clauditor-claude-bin"),
-    )
+def clauditor_runner(request: pytest.FixtureRequest):
+    """Factory fixture returning a configured ``SkillRunner``.
+
+    DEC-002 / DEC-003 / DEC-004 / DEC-005 / DEC-007 of
+    ``plans/super/155-pytest-fixtures-parametrize.md``. The pre-#155
+    value-fixture form (``def test(clauditor_runner): runner.run(...)``)
+    is replaced by a factory; callers MUST invoke ``clauditor_runner()``
+    to get the runner. This is a hard break — see CHANGELOG (US-007)
+    for migration notes.
+
+    Harness resolution composes three of the four CLI precedence layers
+    (the fourth, ``EvalSpec.harness``, is meaningless at the runner
+    seam since no spec is loaded here):
+
+    1. Factory ``harness=`` kwarg (operator intent at the call site).
+    2. ``--clauditor-harness`` pytest option (operator intent at
+       session start).
+    3. ``CLAUDITOR_HARNESS`` env var.
+    4. Default ``"auto"`` — PATH lookup picks ``claude`` then
+       ``codex`` per
+       :func:`clauditor._providers.resolve_harness`.
+
+    When the resolved harness is ``"codex"`` an eager
+    :func:`clauditor._providers.check_codex_auth` fires (DEC-005);
+    missing auth raises :class:`CodexAuthMissingError` (a sibling of
+    :class:`Exception`, NOT a subclass of
+    :class:`AnthropicAuthMissingError`) which propagates as a pytest
+    setup failure rather than a silent ``pytest.skip`` so a CI
+    misconfig surfaces loudly.
+
+    Usage::
+
+        def test_my_skill(clauditor_runner, clauditor_asserter):
+            runner = clauditor_runner()           # default harness
+            # or:
+            runner = clauditor_runner(harness="codex")  # pin to codex
+            result = runner.run("my-skill")
+    """
+    import os
+
+    from clauditor._harnesses import construct_harness
+    from clauditor._providers import check_codex_auth, resolve_harness
+
+    def _factory(harness: str | None = None) -> SkillRunner:
+        # Precedence: factory kwarg > pytest option > env > default.
+        cli_override = harness
+        if cli_override is None:
+            cli_override = request.config.getoption("--clauditor-harness")
+        env_value = os.environ.get("CLAUDITOR_HARNESS")
+        if env_value is not None and env_value.strip() == "":
+            env_value = None
+
+        # No EvalSpec at the runner seam — pass spec_value=None.
+        name, _auto_resolved_to = resolve_harness(
+            cli_override, env_value, None
+        )
+
+        # DEC-005: eager codex auth guard. Surfaces as
+        # CodexAuthMissingError (sibling of Exception per DEC-008) so
+        # callers route on a structural ``except`` ladder.
+        if name == "codex":
+            check_codex_auth("runner")
+
+        project_dir = request.config.getoption("--clauditor-project-dir")
+        timeout = request.config.getoption("--clauditor-timeout")
+        claude_bin = request.config.getoption("--clauditor-claude-bin")
+
+        # When the resolved harness is ``"claude-code"`` (the default
+        # SkillRunner shape), do NOT pass an explicit ``harness=`` —
+        # SkillRunner's __init__ constructs a ClaudeCodeHarness using
+        # the configured ``--clauditor-claude-bin``. Passing a
+        # construct_harness("claude-code") instance here would lose
+        # that custom binary path (CodeRabbit-style same-harness skip
+        # mirroring the clauditor_spec wrapper logic).
+        if name == "claude-code":
+            return SkillRunner(
+                project_dir=project_dir,
+                timeout=timeout,
+                claude_bin=claude_bin,
+            )
+        return SkillRunner(
+            project_dir=project_dir,
+            timeout=timeout,
+            claude_bin=claude_bin,
+            harness=construct_harness(name),
+        )
+
+    return _factory
 
 
 @pytest.fixture

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -25,6 +25,7 @@ import pytest
 
 from clauditor._harnesses._claude_code import env_without_api_key
 from clauditor.asserters import SkillAsserter
+from clauditor.cli import _harness_choice, _provider_choice
 from clauditor.runner import SkillResult, SkillRunner
 from clauditor.spec import SkillSpec
 
@@ -85,6 +86,30 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--clauditor-model",
         default=None,
         help="Override grading model for Layer 3 tests (default: claude-sonnet-4-6)",
+    )
+    group.addoption(
+        "--clauditor-harness",
+        type=_harness_choice,
+        default=None,
+        help=(
+            "Override the harness used by clauditor fixtures "
+            "({claude-code, codex, auto}). Operator-intent precedence: "
+            "factory kwarg > pytest CLI > CLAUDITOR_HARNESS env > "
+            "EvalSpec.harness > default 'auto'. See DEC-008 of "
+            "plans/super/155-pytest-fixtures-parametrize.md."
+        ),
+    )
+    group.addoption(
+        "--clauditor-grading-provider",
+        type=_provider_choice,
+        default=None,
+        help=(
+            "Override the grading provider used by clauditor fixtures "
+            "({anthropic, openai, auto}). Operator-intent precedence: "
+            "factory kwarg > pytest CLI > CLAUDITOR_GRADING_PROVIDER "
+            "env > EvalSpec.grading_provider > default 'auto'. See "
+            "DEC-008 of plans/super/155-pytest-fixtures-parametrize.md."
+        ),
     )
 
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -291,7 +291,10 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
 
 
 def _resolve_fixture_provider(
-    eval_spec, model_override: str | None = None
+    eval_spec,
+    model_override: str | None = None,
+    *,
+    provider_override: str | None = None,
 ) -> str:
     """Pure resolver for the active provider in fixture-land.
 
@@ -308,6 +311,13 @@ def _resolve_fixture_provider(
     silently route as Anthropic and then send an OpenAI model through
     the Anthropic backend (CodeRabbit finding on PR #164).
 
+    ``provider_override`` carries the operator-intent provider value
+    (factory kwarg or ``--clauditor-grading-provider`` pytest option,
+    whichever was set, with the kwarg winning at the call site per
+    DEC-007 of ``plans/super/155-pytest-fixtures-parametrize.md``).
+    Threads to ``resolve_grading_provider`` as ``cli_override`` —
+    the highest-precedence layer.
+
     Returns the resolved provider; does NOT swallow ``ValueError``.
     Fail-fast on resolver failure (e.g. ``grading_provider="auto"``
     with an unknown model prefix) per DEC-003 so a misconfigured spec
@@ -319,6 +329,13 @@ def _resolve_fixture_provider(
     from clauditor._providers import resolve_grading_provider
 
     if eval_spec is None:
+        # When ``provider_override`` is set even without an eval_spec,
+        # honor it (operator intent always wins). Otherwise preserve
+        # the pre-#146 fallback to ``"anthropic"``.
+        if provider_override is not None:
+            return resolve_grading_provider(
+                provider_override, None, None, model_override
+            )
         return "anthropic"
 
     env_value = os.environ.get("CLAUDITOR_GRADING_PROVIDER")
@@ -329,11 +346,17 @@ def _resolve_fixture_provider(
     # (eval_spec.grading_model) for auto-inference per
     # .claude/rules/spec-cli-precedence.md.
     model = model_override or getattr(eval_spec, "grading_model", None)
-    return resolve_grading_provider(None, env_value, spec_value, model)
+    return resolve_grading_provider(
+        provider_override, env_value, spec_value, model
+    )
 
 
 def _dispatch_fixture_auth_guard(
-    eval_spec, fixture_name: str, model_override: str | None = None
+    eval_spec,
+    fixture_name: str,
+    model_override: str | None = None,
+    *,
+    provider_override: str | None = None,
 ) -> None:
     """Pre-flight auth guard for the three grading fixtures.
 
@@ -375,7 +398,19 @@ def _dispatch_fixture_auth_guard(
     # failure we do not control here), preserve pre-#146 behavior and
     # use the Anthropic strict-vs-relaxed guard. The wrapping fixture
     # raises its own ``ValueError`` for the missing-spec case.
+    #
+    # If ``provider_override`` is set explicitly (operator intent),
+    # honor it and route through the pure resolver so the override
+    # can take effect even without an eval_spec. Per DEC-007 of #155.
     if eval_spec is None:
+        if provider_override is not None:
+            provider = resolve_grading_provider(
+                provider_override, None, None, model_override
+            )
+            if provider == "openai":
+                check_openai_auth(fixture_name)
+                return
+            # Anthropic falls through to the strict-vs-relaxed split.
         if _fixture_allow_cli():
             check_any_auth_available(fixture_name)
         else:
@@ -398,8 +433,10 @@ def _dispatch_fixture_auth_guard(
     # (eval_spec.grading_model) for auto-inference per
     # .claude/rules/spec-cli-precedence.md.
     model = model_override or getattr(eval_spec, "grading_model", None)
+    # ``provider_override`` (operator intent: factory kwarg or pytest
+    # CLI option) is the highest-precedence layer per DEC-007 of #155.
     provider = resolve_grading_provider(
-        None, env_value, spec_value, model
+        provider_override, env_value, spec_value, model
     )
 
     if provider == "anthropic":
@@ -421,17 +458,33 @@ def _dispatch_fixture_auth_guard(
 
 @pytest.fixture
 def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
-    """Fixture factory for quality grading. Returns a callable that grades a skill."""
+    """Fixture factory for quality grading. Returns a callable that grades a skill.
+
+    Factory kwargs (US-003 of #155):
+
+    - ``provider``: override the grading provider for this call.
+      Sits at the top of the operator-intent precedence stack
+      (kwarg > ``--clauditor-grading-provider`` > env > spec) per
+      DEC-007 of ``plans/super/155-pytest-fixtures-parametrize.md``.
+    - ``model``: override the grading model for this call. Wins over
+      ``--clauditor-model`` pytest option.
+    """
     import asyncio
 
     from clauditor.quality_grader import grade_quality
 
-    model_override = request.config.getoption("--clauditor-model")
+    pytest_model_option = request.config.getoption("--clauditor-model")
+    pytest_provider_option = request.config.getoption(
+        "--clauditor-grading-provider"
+    )
 
     def _factory(
         skill_path: str | Path,
         eval_path: str | Path | None = None,
         output: str | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
     ):
         # DEC-006 (#146 US-007) + #162 US-001: load the spec FIRST so
         # the auth-guard dispatch can read ``eval_spec.grading_provider``
@@ -448,6 +501,15 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
         # no-op when provider resolves to OpenAI (no CLI transport).
         # Distinct ``except`` branches per
         # ``.claude/rules/multi-provider-dispatch.md``.
+        #
+        # US-003 of #155 (DEC-007): operator-intent precedence —
+        # factory kwarg > pytest CLI option. The kwarg wins at the
+        # call site; either feeds into ``provider_override`` /
+        # ``model_override`` below, which then thread through the
+        # helpers as ``cli_override`` to the pure resolver.
+        provider_override = provider or pytest_provider_option
+        model_override = model or pytest_model_option
+
         spec = clauditor_spec(skill_path, eval_path)
         # Validate spec shape BEFORE the auth dispatch (CodeRabbit
         # finding on PR #163): otherwise a missing/invalid auth key
@@ -457,20 +519,25 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
         _dispatch_fixture_auth_guard(
-            spec.eval_spec, "grader", model_override
+            spec.eval_spec,
+            "grader",
+            model_override,
+            provider_override=provider_override,
         )
-        provider = _resolve_fixture_provider(
-            spec.eval_spec, model_override
+        resolved_provider = _resolve_fixture_provider(
+            spec.eval_spec,
+            model_override,
+            provider_override=provider_override,
         )
         # Provider-aware model defaulting (QG pass 1): explicit CLI
         # override > spec.grading_model > per-provider default. Avoids
         # passing an Anthropic-default model into an OpenAI-graded
         # spec.
         from clauditor._providers import resolve_grading_model
-        model = (
+        resolved_model = (
             model_override
             or spec.eval_spec.grading_model
-            or resolve_grading_model(spec.eval_spec, provider)
+            or resolve_grading_model(spec.eval_spec, resolved_provider)
         )
         if output is None:
             result = spec.run()
@@ -487,8 +554,8 @@ def clauditor_grader(request: pytest.FixtureRequest, clauditor_spec):
             grade_quality(
                 output,
                 spec.eval_spec,
-                model,
-                provider=provider,
+                resolved_model,
+                provider=resolved_provider,
                 harness=harness,
             )
         )

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -683,6 +683,15 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
     lacks an eval spec or ``user_prompt`` is empty; the exception is
     propagated untouched so tests can assert on it.
 
+    Factory kwargs (US-004 of #155):
+
+    - ``provider``: override the grading provider for this call.
+      Sits at the top of the operator-intent precedence stack
+      (kwarg > ``--clauditor-grading-provider`` > env > spec) per
+      DEC-007 of ``plans/super/155-pytest-fixtures-parametrize.md``.
+    - ``model``: override the grading model for this call. Wins over
+      ``--clauditor-model``.
+
     Model precedence (highest → lowest):
 
     1. Explicit ``model=`` kwarg on this factory call.
@@ -695,12 +704,18 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
 
     from clauditor.quality_grader import BlindReport, blind_compare_from_spec
 
+    pytest_model_option = request.config.getoption("--clauditor-model")
+    pytest_provider_option = request.config.getoption(
+        "--clauditor-grading-provider"
+    )
+
     def _factory(
         skill_path: str | Path,
         output_a: str,
         output_b: str,
         eval_path: str | Path | None = None,
         *,
+        provider: str | None = None,
         model: str | None = None,
     ) -> BlindReport:
         # DEC-006 (#146 US-007) + #162 US-001: load spec first so the
@@ -714,16 +729,27 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
         spec = clauditor_spec(skill_path, eval_path)
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
-        effective_model = model or request.config.getoption("--clauditor-model")
+        # US-004 of #155 (DEC-007): operator-intent precedence —
+        # factory kwarg > pytest CLI option. The kwarg wins at the
+        # call site; either feeds into ``provider_override`` /
+        # ``model_override`` below, which then thread through the
+        # helpers as ``cli_override`` to the pure resolver.
+        provider_override = provider or pytest_provider_option
+        effective_model = model or pytest_model_option
         # Per CodeRabbit finding on PR #164: thread the operator-intent
         # model (``model=`` kwarg or ``--clauditor-model``) into auth
         # dispatch + provider resolution so an OpenAI model on a
         # default spec routes to OpenAI auth, not Anthropic.
         _dispatch_fixture_auth_guard(
-            spec.eval_spec, "blind_compare", effective_model
+            spec.eval_spec,
+            "blind_compare",
+            effective_model,
+            provider_override=provider_override,
         )
-        provider = _resolve_fixture_provider(
-            spec.eval_spec, effective_model
+        resolved_provider = _resolve_fixture_provider(
+            spec.eval_spec,
+            effective_model,
+            provider_override=provider_override,
         )
         return asyncio.run(
             blind_compare_from_spec(
@@ -731,7 +757,7 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
                 output_a,
                 output_b,
                 model=effective_model,
-                provider=provider,
+                provider=resolved_provider,
             )
         )
 

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -740,20 +740,46 @@ def clauditor_blind_compare(request: pytest.FixtureRequest, clauditor_spec):
 
 @pytest.fixture
 def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
-    """Fixture factory for trigger precision testing."""
+    """Fixture factory for trigger precision testing.
+
+    Factory kwargs (US-005 of #155):
+
+    - ``provider``: override the grading provider for this call.
+      Sits at the top of the operator-intent precedence stack
+      (kwarg > ``--clauditor-grading-provider`` > env > spec) per
+      DEC-007 of ``plans/super/155-pytest-fixtures-parametrize.md``.
+    - ``model``: override the grading model for this call. Wins over
+      ``--clauditor-model`` pytest option.
+    """
     import asyncio
 
     from clauditor.triggers import test_triggers as run_triggers
 
-    model_override = request.config.getoption("--clauditor-model")
+    pytest_model_option = request.config.getoption("--clauditor-model")
+    pytest_provider_option = request.config.getoption(
+        "--clauditor-grading-provider"
+    )
 
     def _factory(
-        skill_path: str | Path, eval_path: str | Path | None = None
+        skill_path: str | Path,
+        eval_path: str | Path | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
     ):
         # DEC-006 (#146 US-007) + #162 US-001: load spec first so the
         # dispatch can read ``eval_spec.grading_provider`` /
         # ``grading_model``. See :func:`clauditor_grader` for rationale.
         # The guard still fires before any SDK call.
+        #
+        # US-005 of #155 (DEC-007): operator-intent precedence —
+        # factory kwarg > pytest CLI option. The kwarg wins at the
+        # call site; either feeds into ``provider_override`` /
+        # ``model_override`` below, which then thread through the
+        # helpers as ``cli_override`` to the pure resolver.
+        provider_override = provider or pytest_provider_option
+        model_override = model or pytest_model_option
+
         spec = clauditor_spec(skill_path, eval_path)
         # Validate spec shape BEFORE the auth dispatch (CodeRabbit
         # finding on PR #163): a missing/invalid auth key would
@@ -763,18 +789,27 @@ def clauditor_triggers(request: pytest.FixtureRequest, clauditor_spec):
         if spec.eval_spec is None:
             raise ValueError(f"No eval spec found for {skill_path}")
         _dispatch_fixture_auth_guard(
-            spec.eval_spec, "triggers", model_override
+            spec.eval_spec,
+            "triggers",
+            model_override,
+            provider_override=provider_override,
         )
-        provider = _resolve_fixture_provider(
-            spec.eval_spec, model_override
+        resolved_provider = _resolve_fixture_provider(
+            spec.eval_spec,
+            model_override,
+            provider_override=provider_override,
         )
         # Provider-aware model defaulting (QG pass 1).
         from clauditor._providers import resolve_grading_model
-        model = (
+        resolved_model = (
             model_override
             or spec.eval_spec.grading_model
-            or resolve_grading_model(spec.eval_spec, provider)
+            or resolve_grading_model(spec.eval_spec, resolved_provider)
         )
-        return asyncio.run(run_triggers(spec.eval_spec, model, provider=provider))
+        return asyncio.run(
+            run_triggers(
+                spec.eval_spec, resolved_model, provider=resolved_provider
+            )
+        )
 
     return _factory

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -93,11 +93,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=_harness_choice,
         default=None,
         help=(
-            "Override the harness used by clauditor fixtures "
-            "({claude-code, codex, auto}). Operator-intent precedence: "
-            "factory kwarg > pytest CLI > CLAUDITOR_HARNESS env > "
-            "EvalSpec.harness > default 'auto'. See DEC-008 of "
-            "plans/super/155-pytest-fixtures-parametrize.md."
+            "Override the harness used by clauditor_runner "
+            "({claude-code, codex, auto}). Only consulted by the "
+            "clauditor_runner fixture (no spec layer). "
+            "Operator-intent precedence: factory kwarg > pytest CLI "
+            "> CLAUDITOR_HARNESS env > default 'auto'. See DEC-007 "
+            "of plans/super/155-pytest-fixtures-parametrize.md. "
+            "clauditor_spec honors EvalSpec.harness only — set the "
+            "harness field in eval.json for per-skill author intent."
         ),
     )
     group.addoption(
@@ -109,7 +112,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "({anthropic, openai, auto}). Operator-intent precedence: "
             "factory kwarg > pytest CLI > CLAUDITOR_GRADING_PROVIDER "
             "env > EvalSpec.grading_provider > default 'auto'. See "
-            "DEC-008 of plans/super/155-pytest-fixtures-parametrize.md."
+            "DEC-007 of plans/super/155-pytest-fixtures-parametrize.md."
         ),
     )
 
@@ -151,9 +154,11 @@ def clauditor_runner(request: pytest.FixtureRequest):
     to get the runner. This is a hard break — see CHANGELOG (US-007)
     for migration notes.
 
-    Harness resolution composes three of the four CLI precedence layers
-    (the fourth, ``EvalSpec.harness``, is meaningless at the runner
-    seam since no spec is loaded here):
+    Harness resolution stacks four operator-intent + default layers
+    (``EvalSpec.harness`` is intentionally omitted — no spec is loaded
+    at this seam, so the spec-author layer is structurally absent
+    rather than silently skipped; see Shape A of
+    ``.claude/rules/spec-cli-precedence.md``):
 
     1. Factory ``harness=`` kwarg (operator intent at the call site).
     2. ``--clauditor-harness`` pytest option (operator intent at
@@ -181,6 +186,7 @@ def clauditor_runner(request: pytest.FixtureRequest):
     """
     from clauditor._harnesses import construct_harness
     from clauditor._providers import resolve_harness
+    from clauditor._providers._auth import announce_auto_codex_harness
 
     def _factory(harness: str | None = None) -> SkillRunner:
         # Precedence: factory kwarg > pytest option > env > default.
@@ -192,9 +198,16 @@ def clauditor_runner(request: pytest.FixtureRequest):
             env_value = None
 
         # No EvalSpec at the runner seam — pass spec_value=None.
-        name, _auto_resolved_to = resolve_harness(
+        name, auto_resolved_to = resolve_harness(
             cli_override, env_value, None
         )
+
+        # Mirror the CLI seam's one-time stderr notice when auto
+        # resolution picks codex (per `centralized-sdk-call.md`
+        # implicit-coupling announcement family). Fires once per
+        # process via the print-and-flip flag inside the helper.
+        if auto_resolved_to == "codex":
+            announce_auto_codex_harness()
 
         # DEC-005: eager codex auth guard. Surfaces as
         # CodexAuthMissingError (sibling of Exception per DEC-008) so
@@ -360,6 +373,18 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
                     if harness_name_override is not None
                     else spec_harness_override
                 )
+                # Mirror the fixture-construction-time codex guard for
+                # caller-selected runs (CodeRabbit finding on PR #172).
+                # Without this, ``spec.run(harness_name_override="codex")``
+                # bypasses the eager guard and falls through to a deeper
+                # subprocess/SDK failure instead of the promised
+                # ``CodexAuthMissingError``. Idempotent: when the spec
+                # author also declared ``harness="codex"``, the
+                # construction-time guard already fired and the env
+                # state has not changed since — re-running the env-var
+                # check is cheap and never raises spuriously.
+                if effective_harness == "codex":
+                    check_codex_auth("spec")
                 # Caller-provided ``env_override`` wins. Otherwise, when
                 # ``--clauditor-no-api-key`` is set, compute the scrub
                 # using the harness that will actually run the skill so

--- a/src/clauditor/pytest_plugin.py
+++ b/src/clauditor/pytest_plugin.py
@@ -278,6 +278,24 @@ def clauditor_spec(request: pytest.FixtureRequest, tmp_path: Path):
 
     def _factory(skill_path: str | Path, eval_path: str | Path | None = None):
         spec = SkillSpec.from_file(skill_path, eval_path=eval_path, runner=runner)
+        # DEC-005 (#155 US-006): when the spec author declares
+        # ``eval_spec.harness == "codex"``, eagerly fire the
+        # :func:`check_codex_auth` guard BEFORE returning the wrapped
+        # spec. Mirrors the runner-side guard in ``clauditor_runner``
+        # (US-002) so any test that uses either fixture sees the same
+        # crisp ``CodexAuthMissingError`` (a sibling of ``Exception``,
+        # NOT ``pytest.skip``) instead of a deep subprocess error
+        # later. The fixture does not auto-resolve harness from PATH —
+        # ``"auto"`` (and unset) leaves the guard unfired so the
+        # CLI/resolver layer remains the single seam for auto
+        # resolution.
+        if (
+            spec.eval_spec is not None
+            and spec.eval_spec.harness == "codex"
+        ):
+            from clauditor._providers import check_codex_auth
+
+            check_codex_auth("spec")
         has_input_files = (
             spec.eval_spec is not None and bool(spec.eval_spec.input_files)
         )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2341,6 +2341,13 @@ class TestClauditorRunnerFactory:
         pytest CLI option is second.
         """
         monkeypatch.setenv("CODEX_API_KEY", "x")
+        # Strip the autouse env pin so the only env-layer signal is the
+        # factory kwarg. Without this, kwarg=codex agreeing with env=
+        # would not isolate the kwarg-vs-pytest-option claim (the env
+        # layer could be doing the work). Per
+        # ``.claude/rules/test-infra-shutil-which-coupling.md``, tests
+        # that exercise a non-env precedence layer must delenv first.
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
         request = self._request(harness_option="claude-code")
         factory = clauditor_runner.__wrapped__(request)
         runner = factory(harness="codex")
@@ -2900,8 +2907,10 @@ class TestClauditorBlindCompareFactoryKwargs:
         self, tmp_path, monkeypatch
     ):
         """``provider=`` kwarg threads through to
-        ``blind_compare_from_spec(provider=...)``, so the resulting
-        ``BlindReport.provider_source`` reflects the resolved provider.
+        ``blind_compare_from_spec(provider=...)``. Asserts on the call
+        kwargs only — the ``BlindReport.provider_source`` propagation
+        is owned by ``blind_compare_from_spec`` and verified in its
+        own test suite (``tests/test_quality_grader.py``).
         """
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
@@ -3213,3 +3222,101 @@ class TestClauditorSpecCodexGuard:
         ):
             result = factory("some/skill.md")
         assert result is mock_spec
+
+
+class TestClauditorSpecNoApiKeyHarnessAwareness:
+    """B1 of #155 QG pass 4: ``--clauditor-no-api-key`` + codex harness
+    must preserve ``OPENAI_API_KEY`` in the subprocess env.
+
+    Pre-fix, ``clauditor_spec`` precomputed ``fixture_env_override =
+    env_without_api_key()`` once at fixture setup, defaulting to
+    claude-code semantics that strip ``OPENAI_API_KEY``. When the spec
+    declared ``harness="codex"``, the codex subprocess received an env
+    without ``OPENAI_API_KEY`` even though ``check_codex_auth`` had
+    accepted it from ``os.environ`` moments earlier — launching codex
+    without usable auth.
+
+    Fix: defer the ``env_without_api_key`` call until inside
+    ``_run_with_overrides`` so ``harness_name=`` reflects the resolved
+    harness for this particular ``spec.run`` call.
+    """
+
+    def _request_with_options(
+        self, *, no_api_key: bool, project_dir: Path | None = None
+    ):
+        request = MagicMock()
+        request.config.getoption.side_effect = lambda opt: {
+            "--clauditor-project-dir": project_dir,
+            "--clauditor-timeout": 300,
+            "--clauditor-claude-bin": "claude",
+            "--clauditor-no-api-key": no_api_key,
+        }.get(opt)
+        return request
+
+    def test_no_api_key_codex_preserves_openai_key(
+        self, tmp_path, monkeypatch
+    ):
+        """When ``no_api_key=True`` AND ``eval_spec.harness="codex"``,
+        the env passed to ``spec.run`` retains ``OPENAI_API_KEY``."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex-test")
+
+        request = self._request_with_options(no_api_key=True)
+
+        mock_spec = MagicMock()
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.harness = "codex"
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = MagicMock()
+        mock_spec.run = original_run
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            factory = clauditor_spec.__wrapped__(request, tmp_path)
+            spec = factory("some/skill.md")
+
+        # spec.run was wrapped — invoke it and inspect the env_override
+        # that propagates to original_run.
+        spec.run("some args")
+        env_passed = original_run.call_args.kwargs["env_override"]
+        assert env_passed is not None
+        assert "OPENAI_API_KEY" in env_passed
+        assert env_passed["OPENAI_API_KEY"] == "sk-openai-test"
+        # Anthropic keys still stripped (codex doesn't need them).
+        assert "ANTHROPIC_API_KEY" not in env_passed
+        assert "ANTHROPIC_AUTH_TOKEN" not in env_passed
+
+    def test_no_api_key_claude_code_strips_openai_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Default (claude-code) path retains today's behavior: strip
+        ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, OPENAI_API_KEY."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        request = self._request_with_options(no_api_key=True)
+
+        mock_spec = MagicMock()
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.harness = "claude-code"
+        mock_eval_spec.input_files = []
+        mock_spec.eval_spec = mock_eval_spec
+        original_run = MagicMock()
+        mock_spec.run = original_run
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            factory = clauditor_spec.__wrapped__(request, tmp_path)
+            spec = factory("some/skill.md")
+
+        spec.run("some args")
+        env_passed = original_run.call_args.kwargs["env_override"]
+        assert env_passed is not None
+        assert "OPENAI_API_KEY" not in env_passed
+        assert "ANTHROPIC_API_KEY" not in env_passed

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2100,6 +2100,29 @@ class TestFixtureModelOverrideThreading:
         # Should not raise — key is set so check_any_auth_available passes.
         _dispatch_fixture_auth_guard(None, "grader")
 
+    def test_dispatch_fixture_auth_guard_none_eval_spec_provider_override_openai(
+        self, monkeypatch
+    ):
+        """``eval_spec=None`` + ``provider_override="openai"`` routes
+        to the OpenAI auth guard.
+
+        DEC-007 of #155: operator-intent ``provider_override`` is the
+        highest-precedence layer and must be honored even when there is
+        no eval spec to read. Covers the openai short-circuit branch
+        in the eval_spec-is-None arm.
+        """
+        from clauditor.pytest_plugin import _dispatch_fixture_auth_guard
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        # Should not raise — OPENAI_API_KEY is set; check_openai_auth
+        # passes; the early-return after ``return`` covers the
+        # previously-missing line.
+        _dispatch_fixture_auth_guard(
+            None, "grader", provider_override="openai"
+        )
+
     def test_dispatch_fixture_auth_guard_normalizes_whitespace_env(
         self, monkeypatch
     ):
@@ -2318,7 +2341,7 @@ class TestClauditorRunnerFactory:
     Per DEC-002 / DEC-003 / DEC-004 / DEC-005 / DEC-007 / DEC-008 of
     ``plans/super/155-pytest-fixtures-parametrize.md``, the
     pre-#155 value-fixture form was replaced by a factory accepting an
-    optional ``harness=`` kwarg with three-layer precedence (factory
+    optional ``harness=`` kwarg with four-layer precedence (factory
     kwarg > pytest option > env var > default ``"auto"`` PATH lookup).
     """
 
@@ -2446,6 +2469,68 @@ class TestClauditorRunnerFactory:
         factory = clauditor_runner.__wrapped__(request)
         runner = factory()
         assert runner.harness.name == "claude-code"
+
+    def test_whitespace_only_env_var_normalizes_to_none(self, monkeypatch):
+        """Whitespace-only ``CLAUDITOR_HARNESS`` env var is treated as unset.
+
+        Defensive normalization — a stray ``export CLAUDITOR_HARNESS=" "``
+        in a shell rc must not override every layer below it. The
+        fixture strips the value before passing to ``resolve_harness``,
+        falling through to the next precedence layer.
+        """
+        import shutil as _shutil_mod
+
+        from clauditor import _providers as _providers_mod
+
+        monkeypatch.setenv("CLAUDITOR_HARNESS", "   ")
+        # Pin PATH so the auto branch resolves to ``"claude-code"``
+        # deterministically — proves the env layer was stripped (else
+        # ``resolve_harness`` would raise on a whitespace-only value).
+        monkeypatch.setattr(
+            _providers_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/claude" if name == "claude" else None,
+        )
+        assert _shutil_mod is not None
+        request = self._request(harness_option=None)
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory()
+        assert runner.harness.name == "claude-code"
+
+    def test_auto_resolution_to_codex_fires_announcement(self, monkeypatch):
+        """When auto picks codex, fire the one-time stderr announcement.
+
+        Mirrors the CLI seam's ``announce_auto_codex_harness`` notice
+        (per ``centralized-sdk-call.md`` implicit-coupling
+        announcement family). Resetting the module-level flag in the
+        helper's home module is the canonical reset shape.
+        """
+        from clauditor import _providers as _providers_mod
+        from clauditor._providers import _auth as _auth_mod
+
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        # Provide codex auth so the eager guard does not raise.
+        monkeypatch.setenv("CODEX_API_KEY", "x")
+        # Pin PATH to skip claude and find codex.
+        monkeypatch.setattr(
+            _providers_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        # Reset the print-and-flip flag so the announcement fires.
+        monkeypatch.setattr(
+            _auth_mod, "_announced_auto_codex_harness", False
+        )
+        # Patch the helper to verify the call rather than capturing
+        # stderr — the helper itself is unit-tested elsewhere.
+        with patch.object(
+            _auth_mod, "announce_auto_codex_harness"
+        ) as mock_announce:
+            request = self._request(harness_option=None)
+            factory = clauditor_runner.__wrapped__(request)
+            runner = factory()
+        assert runner.harness.name == "codex"
+        mock_announce.assert_called_once()
 
 
 class TestClauditorGraderFactoryKwargs:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2289,3 +2289,270 @@ class TestFixtureHonorsHarness:
         # current harness AND there are no other reasons for wrapping
         # (no input_files, no --clauditor-no-api-key).
         assert result.run is original_run
+
+
+class TestClauditorGraderFactoryKwargs:
+    """US-003 of #155: ``clauditor_grader`` factory accepts ``provider=``
+    and ``model=`` kwargs that sit at the top of the operator-intent
+    precedence stack (kwarg > pytest CLI option > env > spec).
+
+    Traces to DEC-007 of ``plans/super/155-pytest-fixtures-parametrize.md``.
+    """
+
+    def _request_with_options(
+        self,
+        *,
+        model: str | None = None,
+        grading_provider: str | None = None,
+    ):
+        request = MagicMock()
+        request.config.getoption.side_effect = lambda opt: {
+            "--clauditor-model": model,
+            "--clauditor-grading-provider": grading_provider,
+        }.get(opt)
+        return request
+
+    def test_grader_factory_kwarg_provider_wins(self, tmp_path, monkeypatch):
+        """Spec has ``grading_provider="anthropic"``; pass
+        ``provider="openai"`` factory kwarg; assert OpenAI auth is
+        dispatched (raises ``OpenAIAuthMissingError`` when OPENAI key
+        is missing, proving the kwarg won over the spec).
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "anthropic"
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md", provider="openai")
+
+    def test_grader_pytest_option_provider_used_when_no_kwarg(
+        self, tmp_path, monkeypatch
+    ):
+        """``pytest --clauditor-grading-provider=openai`` honored when
+        no factory kwarg is passed.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        # pytest CLI option set, but no factory kwarg.
+        request = self._request_with_options(grading_provider="openai")
+        eval_spec = MagicMock()
+        # Default spec — no grading_provider preference.
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md")
+
+    def test_grader_env_used_when_no_kwarg_no_option(
+        self, tmp_path, monkeypatch
+    ):
+        """``CLAUDITOR_GRADING_PROVIDER=openai`` honored when neither
+        kwarg nor pytest option is set.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CLAUDITOR_GRADING_PROVIDER", "openai")
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md")
+
+    def test_grader_factory_kwarg_model_wins(self, tmp_path, monkeypatch):
+        """Factory ``model="gpt-5.4"`` overrides ``--clauditor-model``;
+        threads through to ``grade_quality(model=...)``.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        # pytest option set to a different value — kwarg should win.
+        request = self._request_with_options(model="claude-sonnet-4-6")
+        eval_spec = MagicMock()
+        # OpenAI spec so the model goes to OpenAI.
+        eval_spec.grading_provider = "openai"
+        eval_spec.grading_model = "gpt-4-turbo"  # spec value distinct again.
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.grade_quality",
+            new=AsyncMock(return_value=canned),
+        ) as mock_grade:
+            factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+            # Pass output= to skip spec.run().
+            factory(
+                tmp_path / "skill.md",
+                output="canned output",
+                model="gpt-5.4",
+            )
+
+        call = mock_grade.await_args
+        # The third positional arg to grade_quality is the resolved model.
+        # grade_quality(output, eval_spec, model, provider=..., harness=...)
+        assert call.args[2] == "gpt-5.4"
+
+    def test_grader_provider_kwarg_overrides_pytest_option(
+        self, tmp_path, monkeypatch
+    ):
+        """Both kwarg and pytest option set; kwarg wins."""
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        # pytest option says anthropic; kwarg says openai.
+        request = self._request_with_options(grading_provider="anthropic")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_grader.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md", provider="openai")
+
+    def test_resolve_fixture_provider_accepts_provider_override(
+        self, monkeypatch
+    ):
+        """``_resolve_fixture_provider`` accepts ``provider_override``
+        kwarg and threads it as ``cli_override`` to the pure resolver.
+        """
+        from clauditor.pytest_plugin import _resolve_fixture_provider
+
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "anthropic"
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        # Without override, resolves to anthropic.
+        assert _resolve_fixture_provider(eval_spec) == "anthropic"
+        # With override, openai wins.
+        assert (
+            _resolve_fixture_provider(eval_spec, provider_override="openai")
+            == "openai"
+        )
+
+    def test_resolve_fixture_provider_with_none_spec_and_override(
+        self, monkeypatch
+    ):
+        """``provider_override`` honored even when ``eval_spec is None``
+        (operator intent wins over the default-anthropic fallback).
+        """
+        from clauditor.pytest_plugin import _resolve_fixture_provider
+
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        # Without override, falls through to anthropic.
+        assert _resolve_fixture_provider(None) == "anthropic"
+        # With override, openai wins.
+        assert (
+            _resolve_fixture_provider(None, provider_override="openai")
+            == "openai"
+        )
+
+    def test_dispatch_fixture_auth_guard_with_none_spec_and_openai_override(
+        self, monkeypatch
+    ):
+        """``provider_override="openai"`` with ``eval_spec=None`` routes
+        to OpenAI auth (raises ``OpenAIAuthMissingError`` when key
+        is missing).
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+        from clauditor.pytest_plugin import _dispatch_fixture_auth_guard
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        with pytest.raises(OpenAIAuthMissingError):
+            _dispatch_fixture_auth_guard(
+                None, "grader", provider_override="openai"
+            )
+
+    def test_dispatch_fixture_auth_guard_with_none_spec_and_anthropic_override(
+        self, monkeypatch
+    ):
+        """``provider_override="anthropic"`` with ``eval_spec=None``
+        falls through to the existing Anthropic strict-vs-relaxed split.
+        """
+        from clauditor._providers import AnthropicAuthMissingError
+        from clauditor.pytest_plugin import _dispatch_fixture_auth_guard
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_FIXTURE_ALLOW_CLI", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        with pytest.raises(AnthropicAuthMissingError):
+            _dispatch_fixture_auth_guard(
+                None, "grader", provider_override="anthropic"
+            )
+
+    def test_dispatch_fixture_auth_guard_accepts_provider_override(
+        self, monkeypatch
+    ):
+        """``_dispatch_fixture_auth_guard`` accepts ``provider_override``
+        kwarg; routes auth check through that provider.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+        from clauditor.pytest_plugin import _dispatch_fixture_auth_guard
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "anthropic"
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        # Without override, uses spec's anthropic — no raise.
+        _dispatch_fixture_auth_guard(eval_spec, "grader")
+
+        # With override, routes to OpenAI auth — raises.
+        with pytest.raises(OpenAIAuthMissingError):
+            _dispatch_fixture_auth_guard(
+                eval_spec, "grader", provider_override="openai"
+            )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -543,6 +543,7 @@ def _blind_compare_factory(tmp_path: Path, *, cli_model: str | None = None):
             "--clauditor-claude-bin": "claude",
             "--clauditor-model": cli_model,
             "--clauditor-no-api-key": False,
+            "--clauditor-grading-provider": None,
         }[opt]
     )
     spec_factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -2691,3 +2692,232 @@ class TestClauditorGraderFactoryKwargs:
             _dispatch_fixture_auth_guard(
                 eval_spec, "grader", provider_override="openai"
             )
+
+
+class TestClauditorBlindCompareFactoryKwargs:
+    """US-004 of #155: ``clauditor_blind_compare`` factory accepts
+    ``provider=`` kwarg (and verifies the existing ``model=`` kwarg's
+    precedence chain) — operator-intent precedence (kwarg > pytest CLI
+    option > env > spec).
+
+    Traces to DEC-007 of ``plans/super/155-pytest-fixtures-parametrize.md``.
+    """
+
+    def _request_with_options(
+        self,
+        *,
+        model: str | None = None,
+        grading_provider: str | None = None,
+    ):
+        request = MagicMock()
+        request.config.getoption.side_effect = lambda opt: {
+            "--clauditor-model": model,
+            "--clauditor-grading-provider": grading_provider,
+        }.get(opt)
+        return request
+
+    def test_blind_compare_factory_kwarg_provider_wins(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec has ``grading_provider="anthropic"``; pass
+        ``provider="openai"`` factory kwarg; assert OpenAI auth is
+        dispatched (raises ``OpenAIAuthMissingError`` when OPENAI key
+        is missing, proving the kwarg won over the spec).
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "anthropic"
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_blind_compare.__wrapped__(
+            request, fake_clauditor_spec
+        )
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(
+                tmp_path / "skill.md",
+                "output A",
+                "output B",
+                provider="openai",
+            )
+
+    def test_blind_compare_pytest_option_provider_used_when_no_kwarg(
+        self, tmp_path, monkeypatch
+    ):
+        """``pytest --clauditor-grading-provider=openai`` honored when
+        no factory kwarg is passed.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        # pytest CLI option set, but no factory kwarg.
+        request = self._request_with_options(grading_provider="openai")
+        eval_spec = MagicMock()
+        # Default spec — no grading_provider preference.
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_blind_compare.__wrapped__(
+            request, fake_clauditor_spec
+        )
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md", "output A", "output B")
+
+    def test_blind_compare_env_used_when_no_kwarg_no_option(
+        self, tmp_path, monkeypatch
+    ):
+        """``CLAUDITOR_GRADING_PROVIDER=openai`` honored when neither
+        kwarg nor pytest option is set.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CLAUDITOR_GRADING_PROVIDER", "openai")
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_blind_compare.__wrapped__(
+            request, fake_clauditor_spec
+        )
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md", "output A", "output B")
+
+    def test_blind_compare_factory_kwarg_model_wins(
+        self, tmp_path, monkeypatch
+    ):
+        """Factory ``model="gpt-5.4"`` overrides ``--clauditor-model``;
+        threads through to ``blind_compare_from_spec(model=...)``.
+        Verifies the precedence chain explicitly.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        # pytest option set to a different value — kwarg should win.
+        request = self._request_with_options(model="claude-sonnet-4-6")
+        eval_spec = MagicMock()
+        # OpenAI spec so the model goes to OpenAI.
+        eval_spec.grading_provider = "openai"
+        eval_spec.grading_model = "gpt-4-turbo"  # spec value distinct.
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.blind_compare_from_spec",
+            new=AsyncMock(return_value=canned),
+        ) as mock_blind:
+            factory = clauditor_blind_compare.__wrapped__(
+                request, fake_clauditor_spec
+            )
+            factory(
+                tmp_path / "skill.md",
+                "output A",
+                "output B",
+                model="gpt-5.4",
+            )
+
+        call = mock_blind.await_args
+        assert call.kwargs["model"] == "gpt-5.4"
+
+    def test_blind_compare_provider_kwarg_overrides_pytest_option(
+        self, tmp_path, monkeypatch
+    ):
+        """Both kwarg and pytest option set; kwarg wins."""
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        # pytest option says anthropic; kwarg says openai.
+        request = self._request_with_options(grading_provider="anthropic")
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_blind_compare.__wrapped__(
+            request, fake_clauditor_spec
+        )
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(
+                tmp_path / "skill.md",
+                "output A",
+                "output B",
+                provider="openai",
+            )
+
+    def test_blind_compare_provider_kwarg_threads_to_blind_compare_from_spec(
+        self, tmp_path, monkeypatch
+    ):
+        """``provider=`` kwarg threads through to
+        ``blind_compare_from_spec(provider=...)``, so the resulting
+        ``BlindReport.provider_source`` reflects the resolved provider.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        # Spec defaults to anthropic — kwarg should override.
+        eval_spec.grading_provider = "anthropic"
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.quality_grader.blind_compare_from_spec",
+            new=AsyncMock(return_value=canned),
+        ) as mock_blind:
+            factory = clauditor_blind_compare.__wrapped__(
+                request, fake_clauditor_spec
+            )
+            factory(
+                tmp_path / "skill.md",
+                "output A",
+                "output B",
+                provider="openai",
+            )
+
+        call = mock_blind.await_args
+        assert call.kwargs["provider"] == "openai"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2168,7 +2168,7 @@ class TestFixtureHonorsHarness:
         )
         return request
 
-    def test_codex_spec_threads_harness_override(self, tmp_path):
+    def test_codex_spec_threads_harness_override(self, tmp_path, monkeypatch):
         """``eval_spec.harness == "codex"`` threads
         ``harness_name_override="codex"`` into ``original_run``.
 
@@ -2176,6 +2176,12 @@ class TestFixtureHonorsHarness:
         automatically when ``spec.run()`` is called from the fixture.
         """
         from clauditor.spec import SkillSpec
+
+        # #155 US-006: spec factory eagerly fires ``check_codex_auth``
+        # for ``eval_spec.harness == "codex"``. Set a Codex env var so
+        # the strict-OR guard passes and the test exercises the
+        # harness-override threading rather than the auth-missing path.
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex-test")
 
         request = self._request()
         factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -2230,12 +2236,20 @@ class TestFixtureHonorsHarness:
         # other reasons (no input_files, no --clauditor-no-api-key).
         assert result.run is original_run
 
-    def test_caller_harness_override_wins_over_spec(self, tmp_path):
+    def test_caller_harness_override_wins_over_spec(
+        self, tmp_path, monkeypatch
+    ):
         """Caller-provided ``harness_name_override=`` (operator intent)
         wins over ``eval_spec.harness`` (author intent), mirroring the
         ``env_override`` / ``timeout_override`` precedence shape.
         """
         from clauditor.spec import SkillSpec
+
+        # #155 US-006: ``eval_spec.harness == "codex"`` triggers the
+        # eager Codex auth guard inside the spec factory. Set
+        # ``CODEX_API_KEY`` so the strict-OR check passes and the test
+        # exercises the operator-intent precedence.
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex-test")
 
         request = self._request()
         factory = clauditor_spec.__wrapped__(request, tmp_path)
@@ -2691,3 +2705,142 @@ class TestClauditorGraderFactoryKwargs:
             _dispatch_fixture_auth_guard(
                 eval_spec, "grader", provider_override="openai"
             )
+
+
+class TestClauditorSpecCodexGuard:
+    """Tests for the eager Codex auth guard in ``clauditor_spec`` (#155 US-006).
+
+    Per DEC-005 of ``plans/super/155-pytest-fixtures-parametrize.md``,
+    when the loaded spec has ``eval_spec.harness == "codex"``, the
+    factory eagerly calls
+    :func:`clauditor._providers.check_codex_auth` BEFORE returning
+    the wrapped :class:`SkillSpec` so missing Codex auth surfaces as
+    :class:`CodexAuthMissingError` (a sibling of :class:`Exception`)
+    at fixture-setup time rather than as a deep subprocess error
+    later. Mirrors the runner-side guard from US-002.
+    """
+
+    def _request(self):
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": 300,
+                "--clauditor-claude-bin": "claude",
+                "--clauditor-no-api-key": False,
+            }[opt]
+        )
+        return request
+
+    def test_spec_factory_codex_auth_missing(self, tmp_path, monkeypatch):
+        """``eval_spec.harness == "codex"`` with no Codex env vars
+        raises :class:`CodexAuthMissingError`.
+
+        DEC-005: eager guard at the spec seam (NOT ``pytest.skip``).
+        """
+        from clauditor._providers import CodexAuthMissingError
+        from clauditor.spec import SkillSpec
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "codex"
+        mock_spec.eval_spec = mock_eval_spec
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            with pytest.raises(CodexAuthMissingError):
+                factory("some/skill.md")
+
+    def test_spec_factory_claude_code_no_guard(self, tmp_path, monkeypatch):
+        """``eval_spec.harness == "claude-code"`` does NOT fire the
+        Codex guard — missing OpenAI/Codex keys are irrelevant.
+
+        Acceptance criterion: zero behavior change for the
+        ``claude-code`` path.
+        """
+        from clauditor.spec import SkillSpec
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "claude-code"
+        mock_spec.eval_spec = mock_eval_spec
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            # No raise — Codex guard does not fire on claude-code.
+            result = factory("some/skill.md")
+        assert result is mock_spec
+
+    def test_spec_factory_codex_with_key_no_raise(
+        self, tmp_path, monkeypatch
+    ):
+        """``eval_spec.harness == "codex"`` with ``CODEX_API_KEY``
+        set passes the strict-OR guard — no raise.
+        """
+        from clauditor.spec import SkillSpec
+
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "codex"
+        mock_spec.eval_spec = mock_eval_spec
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+        assert result is mock_spec
+
+    def test_spec_factory_codex_with_openai_key_no_raise(
+        self, tmp_path, monkeypatch
+    ):
+        """``eval_spec.harness == "codex"`` with ``OPENAI_API_KEY``
+        set (instead of ``CODEX_API_KEY``) also passes — Codex's
+        strict-OR auth accepts either env var per
+        :func:`clauditor._providers.check_codex_auth`.
+        """
+        from clauditor.spec import SkillSpec
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+
+        request = self._request()
+        factory = clauditor_spec.__wrapped__(request, tmp_path)
+
+        mock_spec = MagicMock(spec=SkillSpec)
+        mock_eval_spec = MagicMock()
+        mock_eval_spec.input_files = []
+        mock_eval_spec.harness = "codex"
+        mock_spec.eval_spec = mock_eval_spec
+
+        with patch(
+            "clauditor.pytest_plugin.SkillSpec.from_file",
+            return_value=mock_spec,
+        ):
+            result = factory("some/skill.md")
+        assert result is mock_spec

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2691,3 +2691,142 @@ class TestClauditorGraderFactoryKwargs:
             _dispatch_fixture_auth_guard(
                 eval_spec, "grader", provider_override="openai"
             )
+
+
+class TestClauditorTriggersFactoryKwargs:
+    """US-005 of #155: ``clauditor_triggers`` factory accepts ``provider=``
+    and ``model=`` kwargs that sit at the top of the operator-intent
+    precedence stack (kwarg > pytest CLI option > env > spec).
+
+    Mirrors the US-003 ``TestClauditorGraderFactoryKwargs`` shape, applied
+    to the triggers fixture. Traces to DEC-007 of
+    ``plans/super/155-pytest-fixtures-parametrize.md``.
+    """
+
+    def _request_with_options(
+        self,
+        *,
+        model: str | None = None,
+        grading_provider: str | None = None,
+    ):
+        request = MagicMock()
+        request.config.getoption.side_effect = lambda opt: {
+            "--clauditor-model": model,
+            "--clauditor-grading-provider": grading_provider,
+        }.get(opt)
+        return request
+
+    def test_triggers_factory_kwarg_provider_wins(self, tmp_path, monkeypatch):
+        """Spec has ``grading_provider="anthropic"``; pass
+        ``provider="openai"`` factory kwarg; assert OpenAI auth is
+        dispatched (raises ``OpenAIAuthMissingError`` when OPENAI key
+        is missing, proving the kwarg won over the spec).
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = "anthropic"
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md", provider="openai")
+
+    def test_triggers_pytest_option_provider_used_when_no_kwarg(
+        self, tmp_path, monkeypatch
+    ):
+        """``pytest --clauditor-grading-provider=openai`` honored when
+        no factory kwarg is passed.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        # pytest CLI option set, but no factory kwarg.
+        request = self._request_with_options(grading_provider="openai")
+        eval_spec = MagicMock()
+        # Default spec — no grading_provider preference.
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md")
+
+    def test_triggers_env_used_when_no_kwarg_no_option(
+        self, tmp_path, monkeypatch
+    ):
+        """``CLAUDITOR_GRADING_PROVIDER=openai`` honored when neither
+        kwarg nor pytest option is set.
+        """
+        from clauditor._providers import OpenAIAuthMissingError
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CLAUDITOR_GRADING_PROVIDER", "openai")
+
+        request = self._request_with_options()
+        eval_spec = MagicMock()
+        eval_spec.grading_provider = None
+        eval_spec.grading_model = "claude-sonnet-4-6"
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            spec = MagicMock()
+            spec.eval_spec = eval_spec
+            return spec
+
+        factory = clauditor_triggers.__wrapped__(request, fake_clauditor_spec)
+        with pytest.raises(OpenAIAuthMissingError):
+            factory(tmp_path / "skill.md")
+
+    def test_triggers_factory_kwarg_model_wins(self, tmp_path, monkeypatch):
+        """Factory ``model="gpt-5.4"`` overrides ``--clauditor-model``;
+        threads through to ``run_triggers(model=...)``.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("CLAUDITOR_GRADING_PROVIDER", raising=False)
+
+        # pytest option set to a different value — kwarg should win.
+        request = self._request_with_options(model="claude-sonnet-4-6")
+        eval_spec = MagicMock()
+        # OpenAI spec so the model goes to OpenAI.
+        eval_spec.grading_provider = "openai"
+        eval_spec.grading_model = "gpt-4-turbo"  # spec value distinct again.
+
+        mock_spec = MagicMock()
+        mock_spec.eval_spec = eval_spec
+
+        def fake_clauditor_spec(skill_path, eval_path=None):
+            return mock_spec
+
+        canned = MagicMock()
+        with patch(
+            "clauditor.triggers.test_triggers",
+            new=AsyncMock(return_value=canned),
+        ) as mock_run_triggers:
+            factory = clauditor_triggers.__wrapped__(
+                request, fake_clauditor_spec
+            )
+            factory(tmp_path / "skill.md", model="gpt-5.4")
+
+        call = mock_run_triggers.await_args
+        # run_triggers(eval_spec, model, provider=...). Second positional
+        # arg is the resolved model.
+        assert call.args[1] == "gpt-5.4"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -86,6 +86,108 @@ class TestPytestPlugin:
         result = pytester.runpytest_inprocess()
         result.assert_outcomes(passed=1)
 
+    def test_clauditor_harness_option_accepts_codex(self, pytester):
+        """--clauditor-harness=codex parses cleanly."""
+        pytester.makepyfile("""
+            def test_harness_option(request):
+                assert request.config.getoption("--clauditor-harness") == "codex"
+        """)
+        result = pytester.runpytest_inprocess("--clauditor-harness=codex")
+        result.assert_outcomes(passed=1)
+
+    def test_clauditor_harness_option_accepts_claude_code(self, pytester):
+        """--clauditor-harness=claude-code parses cleanly."""
+        pytester.makepyfile("""
+            def test_harness_option(request):
+                assert (
+                    request.config.getoption("--clauditor-harness") == "claude-code"
+                )
+        """)
+        result = pytester.runpytest_inprocess("--clauditor-harness=claude-code")
+        result.assert_outcomes(passed=1)
+
+    def test_clauditor_harness_option_accepts_auto(self, pytester):
+        """--clauditor-harness=auto parses cleanly."""
+        pytester.makepyfile("""
+            def test_harness_option(request):
+                assert request.config.getoption("--clauditor-harness") == "auto"
+        """)
+        result = pytester.runpytest_inprocess("--clauditor-harness=auto")
+        result.assert_outcomes(passed=1)
+
+    def test_clauditor_harness_option_rejects_invalid(self, pytester):
+        """--clauditor-harness=invalid is rejected by argparse."""
+        pytester.makepyfile("""
+            def test_noop():
+                pass
+        """)
+        result = pytester.runpytest_inprocess("--clauditor-harness=invalid")
+        # argparse error → pytest exits with usage error code (4)
+        assert result.ret != 0
+
+    def test_clauditor_grading_provider_accepts_openai(self, pytester):
+        """--clauditor-grading-provider=openai parses cleanly."""
+        pytester.makepyfile("""
+            def test_provider_option(request):
+                assert (
+                    request.config.getoption("--clauditor-grading-provider")
+                    == "openai"
+                )
+        """)
+        result = pytester.runpytest_inprocess(
+            "--clauditor-grading-provider=openai"
+        )
+        result.assert_outcomes(passed=1)
+
+    def test_clauditor_grading_provider_accepts_anthropic(self, pytester):
+        """--clauditor-grading-provider=anthropic parses cleanly."""
+        pytester.makepyfile("""
+            def test_provider_option(request):
+                assert (
+                    request.config.getoption("--clauditor-grading-provider")
+                    == "anthropic"
+                )
+        """)
+        result = pytester.runpytest_inprocess(
+            "--clauditor-grading-provider=anthropic"
+        )
+        result.assert_outcomes(passed=1)
+
+    def test_clauditor_grading_provider_accepts_auto(self, pytester):
+        """--clauditor-grading-provider=auto parses cleanly."""
+        pytester.makepyfile("""
+            def test_provider_option(request):
+                assert (
+                    request.config.getoption("--clauditor-grading-provider")
+                    == "auto"
+                )
+        """)
+        result = pytester.runpytest_inprocess(
+            "--clauditor-grading-provider=auto"
+        )
+        result.assert_outcomes(passed=1)
+
+    def test_clauditor_grading_provider_rejects_invalid(self, pytester):
+        """--clauditor-grading-provider=invalid is rejected by argparse."""
+        pytester.makepyfile("""
+            def test_noop():
+                pass
+        """)
+        result = pytester.runpytest_inprocess(
+            "--clauditor-grading-provider=invalid"
+        )
+        assert result.ret != 0
+
+    def test_clauditor_harness_appears_in_help(self, pytester):
+        """--clauditor-harness shows up in pytest --help output."""
+        result = pytester.runpytest_inprocess("--help")
+        result.stdout.fnmatch_lines(["*--clauditor-harness*"])
+
+    def test_clauditor_grading_provider_appears_in_help(self, pytester):
+        """--clauditor-grading-provider shows up in pytest --help output."""
+        result = pytester.runpytest_inprocess("--help")
+        result.stdout.fnmatch_lines(["*--clauditor-grading-provider*"])
+
 
 class TestPluginFunctionsDirect:
     """Direct unit tests for plugin functions to ensure coverage."""
@@ -99,7 +201,7 @@ class TestPluginFunctionsDirect:
         parser.getgroup.assert_called_once_with(
             "clauditor", "Claude Code skill testing"
         )
-        assert group.addoption.call_count == 6
+        assert group.addoption.call_count == 8
         # Verify option names
         option_names = [call.args[0] for call in group.addoption.call_args_list]
         assert "--clauditor-project-dir" in option_names
@@ -108,6 +210,8 @@ class TestPluginFunctionsDirect:
         assert "--clauditor-grade" in option_names
         assert "--clauditor-model" in option_names
         assert "--clauditor-no-api-key" in option_names
+        assert "--clauditor-harness" in option_names
+        assert "--clauditor-grading-provider" in option_names
 
     def test_pytest_configure_adds_marker(self):
         """pytest_configure registers the clauditor_grade, network, and slow markers."""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -60,19 +60,21 @@ class TestPytestPlugin:
         result.assert_outcomes(passed=1)
 
     def test_runner_fixture_available(self, pytester):
-        """The clauditor_runner fixture is available and non-None."""
+        """The clauditor_runner factory is available and callable."""
         pytester.makepyfile("""
             def test_runner(clauditor_runner):
-                assert clauditor_runner is not None
+                runner = clauditor_runner()
+                assert runner is not None
         """)
         result = pytester.runpytest_inprocess()
         result.assert_outcomes(passed=1)
 
     def test_cli_options_passed(self, pytester):
-        """CLI options are forwarded to fixture-created objects."""
+        """CLI options are forwarded to factory-created objects."""
         pytester.makepyfile("""
             def test_timeout(clauditor_runner):
-                assert clauditor_runner.timeout == 42
+                runner = clauditor_runner()
+                assert runner.timeout == 42
         """)
         result = pytester.runpytest_inprocess("--clauditor-timeout=42")
         result.assert_outcomes(passed=1)
@@ -263,16 +265,18 @@ class TestPluginFunctionsDirect:
         item.add_marker.assert_not_called()
 
     def test_runner_fixture_returns_skill_runner(self):
-        """clauditor_runner fixture returns a configured SkillRunner."""
+        """clauditor_runner factory returns a configured SkillRunner."""
         request = MagicMock()
         request.config.getoption.side_effect = (
             lambda opt: {
                 "--clauditor-project-dir": None,
                 "--clauditor-timeout": 60,
                 "--clauditor-claude-bin": "claude",
+                "--clauditor-harness": None,
             }[opt]
         )
-        runner = clauditor_runner.__wrapped__(request)
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory()
         assert runner.timeout == 60
         # ``claude_bin`` moved from ``SkillRunner`` to the harness in
         # US-004 of issue #148; the default ``ClaudeCodeHarness``
@@ -1149,9 +1153,11 @@ class TestClauditorNoApiKeyOption:
                 "--clauditor-timeout": 99,
                 "--clauditor-claude-bin": "claude",
                 "--clauditor-no-api-key": False,
+                "--clauditor-harness": None,
             }[opt]
         )
-        runner = clauditor_runner.__wrapped__(request)
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory()
         assert runner.timeout == 99
         # And clauditor_spec must not wrap spec.run when the option is
         # off AND input_files is empty (pre-US-007 behavior preserved).
@@ -2289,3 +2295,132 @@ class TestFixtureHonorsHarness:
         # current harness AND there are no other reasons for wrapping
         # (no input_files, no --clauditor-no-api-key).
         assert result.run is original_run
+
+
+class TestClauditorRunnerFactory:
+    """Tests for the ``clauditor_runner`` factory shape (#155 US-002).
+
+    Per DEC-002 / DEC-003 / DEC-004 / DEC-005 / DEC-007 / DEC-008 of
+    ``plans/super/155-pytest-fixtures-parametrize.md``, the
+    pre-#155 value-fixture form was replaced by a factory accepting an
+    optional ``harness=`` kwarg with three-layer precedence (factory
+    kwarg > pytest option > env var > default ``"auto"`` PATH lookup).
+    """
+
+    def _request(self, *, harness_option=None, timeout=300, claude_bin="claude"):
+        request = MagicMock()
+        request.config.getoption.side_effect = (
+            lambda opt: {
+                "--clauditor-project-dir": None,
+                "--clauditor-timeout": timeout,
+                "--clauditor-claude-bin": claude_bin,
+                "--clauditor-harness": harness_option,
+            }[opt]
+        )
+        return request
+
+    def test_factory_kwarg_wins_over_pytest_option(self, monkeypatch):
+        """Factory ``harness="codex"`` overrides ``--clauditor-harness=claude-code``.
+
+        DEC-007 precedence: factory kwarg is the highest layer; the
+        pytest CLI option is second.
+        """
+        monkeypatch.setenv("CODEX_API_KEY", "x")
+        request = self._request(harness_option="claude-code")
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory(harness="codex")
+        assert runner.harness.name == "codex"
+
+    def test_pytest_option_used_when_no_kwarg(self, monkeypatch):
+        """``--clauditor-harness=codex`` resolves to codex when factory kwarg unset.
+
+        DEC-007 precedence: with no factory kwarg, the pytest CLI
+        option wins over env / default.
+        """
+        monkeypatch.setenv("CODEX_API_KEY", "x")
+        # Override the autouse env pin so the pytest option layer
+        # is the active source.
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        request = self._request(harness_option="codex")
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory()
+        assert runner.harness.name == "codex"
+
+    def test_env_var_used_when_no_kwarg_no_option(self, monkeypatch):
+        """``CLAUDITOR_HARNESS=codex`` resolves to codex when other layers unset."""
+        monkeypatch.setenv("CODEX_API_KEY", "x")
+        monkeypatch.setenv("CLAUDITOR_HARNESS", "codex")
+        request = self._request(harness_option=None)
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory()
+        assert runner.harness.name == "codex"
+
+    def test_codex_auth_missing_raises(self, monkeypatch):
+        """Resolved codex with no Codex env vars raises ``CodexAuthMissingError``.
+
+        DEC-005: eager auth guard at the runner seam (NOT
+        ``pytest.skip`` — silent skips hide CI misconfig).
+        """
+        from clauditor._providers import CodexAuthMissingError
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        request = self._request(harness_option=None)
+        factory = clauditor_runner.__wrapped__(request)
+        with pytest.raises(CodexAuthMissingError):
+            factory(harness="codex")
+
+    def test_class_identity_codex_auth_missing(self):
+        """``CodexAuthMissingError`` is a sibling of ``Exception``.
+
+        DEC-008: must NOT be a subclass of
+        :class:`AnthropicAuthMissingError` or any helper-error class —
+        a shared ancestor would defeat the structural-routing
+        invariant per
+        ``.claude/rules/multi-provider-dispatch.md``.
+        """
+        from clauditor._providers import (
+            AnthropicAuthMissingError,
+            CodexAuthMissingError,
+            OpenAIAuthMissingError,
+        )
+
+        assert CodexAuthMissingError is not AnthropicAuthMissingError
+        assert CodexAuthMissingError is not OpenAIAuthMissingError
+        assert not issubclass(
+            CodexAuthMissingError, AnthropicAuthMissingError
+        )
+        assert not issubclass(CodexAuthMissingError, OpenAIAuthMissingError)
+        # Direct subclass of ``Exception`` (not a deeper type tree).
+        assert CodexAuthMissingError.__bases__ == (Exception,)
+
+    def test_auto_resolution_path_lookup(self, monkeypatch):
+        """The auto branch consults ``shutil.which`` for PATH discovery.
+
+        Per ``.claude/rules/test-infra-shutil-which-coupling.md``: the
+        autouse fixture pins ``CLAUDITOR_HARNESS=claude-code`` and
+        patches ``_anthropic.shutil.which → None``. To exercise the
+        auto branch we delete the env pin AND patch ``shutil.which``
+        on the module the resolver actually consults
+        (``clauditor._providers``) so the auto branch finds ``claude``.
+        """
+        import shutil as _shutil_mod
+
+        from clauditor import _providers as _providers_mod
+
+        monkeypatch.delenv("CLAUDITOR_HARNESS", raising=False)
+        # Pin the resolver's ``shutil.which`` to find ``claude`` so
+        # the auto branch resolves to ``"claude-code"`` deterministically.
+        monkeypatch.setattr(
+            _providers_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/claude" if name == "claude" else None,
+        )
+        # Sanity: also pin the stdlib lookup the same way (defensive).
+        assert _providers_mod.shutil.which("claude") == "/usr/bin/claude"
+        assert _shutil_mod is not None  # keep the import live
+
+        request = self._request(harness_option=None)
+        factory = clauditor_runner.__wrapped__(request)
+        runner = factory()
+        assert runner.harness.name == "claude-code"


### PR DESCRIPTION
## Summary
Implementation of #155 — extend `pytest_plugin.py` so test suites can parametrize across `{harness × provider}`.

**Phase:** devolved (implementation complete; merging now)
**Stories:** 7 implementation + Quality Gate + Patterns & Memory = 9
**Decisions:** 12 captured (DEC-001 through DEC-012)

## Plan document
See `plans/super/155-pytest-fixtures-parametrize.md`.

## Highlights
- `clauditor_runner` becomes a factory (pre-1.0 hard break, CHANGELOG note)
- `clauditor_grader` / `_blind_compare` / `_triggers` accept `provider=` and `model=` factory kwargs (operator-intent layer atop existing four-layer resolution)
- New pytest options: `--clauditor-harness`, `--clauditor-grading-provider`
- Eager `check_codex_auth` from BOTH `clauditor_runner` and `clauditor_spec` seams (and from `_run_with_overrides` for caller-selected harness overrides)
- `CLAUDITOR_FIXTURE_ALLOW_OPENAI` intentionally **not** introduced (no relaxed-auth concept on the OpenAI side per #145 DEC-002)

## Bead epic
- `clauditor-6fy` (closed); 9 user stories shipped.

## Test plan
- [x] `uv run pytest --cov=clauditor` — 3586 passed, 86% coverage
- [x] `uv run ruff check src/ tests/` — clean
- [x] `pytest_plugin.py` at 100% line coverage