### PR TITLE
#169: pricing cost_usd estimation module (plan)

### DIFF
--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -535,9 +535,9 @@ auth-helper call chain). Reset mechanism for tests is the
 `tests/test_providers_auth.py::TestAnnounceImplicitNoApiKey`,
 `tests/test_providers_auth.py::TestCallAnthropicDeprecationAnnouncement`,
 and
-`tests/test_providers_pricing.py::TestAnnouncePricingTableStaleIfOld`
-/ `tests/test_providers_pricing.py::TestAnnounceUnknownModel` for
-the shape.
+`tests/test_providers_pricing.py::TestStaleAnnouncement`
+/ `tests/test_providers_pricing.py::TestUnknownModelAnnouncement`
+for the shape.
 
 ## When this rule applies
 

--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -411,11 +411,17 @@ harness-axis sibling (`harness: str` on the same sidecars + on
 
 One-time-per-process stderr notices are an emerging family co-located
 in the `clauditor._providers` package. Each member pairs a
-module-level bool flag with an announcement-text constant; the
+module-level flag with an announcement-text constant; the
 print-and-flip logic either lives inline at the call site (the first
-member, from #86) or is factored into a public helper (the second
-and third members, from #95 and #144 respectively, and the target
-shape going forward). Three members today:
+member, from #86) or is factored into a public helper (the later
+members, from #95, #144, #151, and #169 respectively, and the target
+shape going forward). The traditional flag shape is a module-level
+`bool`, but the family also admits **set-keyed** flags
+(`set[tuple[...]]`) for announcements that need per-key
+idempotence — see the `_announced_unknown_models` member below
+for the canonical shape. Five members today (axes:
+transport-coupled, auth-coupled, deprecation-coupled, harness-
+coupled, pricing-coupled):
 
 - `_announced_cli_transport` (bool flag) + `_CLI_AUTO_ANNOUNCEMENT`
   (plain `str` constant) in `src/clauditor/_providers/_anthropic.py`
@@ -444,6 +450,57 @@ shape going forward). Three members today:
   pinned by tests: `"clauditor._anthropic"` (deprecated path),
   `"clauditor._providers"` (canonical replacement),
   `"will be removed"` (future-removal hint).
+- `_announced_auto_codex_harness` (bool flag) +
+  `_AUTO_CODEX_ANNOUNCEMENT` (`Final[str]` constant) in
+  `src/clauditor/_providers/_auth.py` — from #151 US-002 (DEC-007).
+  Fires when the harness resolver's auto branch picks `"codex"`
+  because `claude` is not on PATH but `codex` is. Print-and-flip
+  lives in the **public helper** `announce_auto_codex_harness()`,
+  called from `clauditor.cli._resolve_harness` before returning
+  the resolved name. Names the env vars Codex needs (`CODEX_API_KEY`
+  / `OPENAI_API_KEY`) and the two pin-it-explicitly escape hatches
+  (`--harness=claude-code` and `CLAUDITOR_HARNESS=claude-code`).
+- `_announced_pricing_table_stale` (bool flag) +
+  `_PRICING_TABLE_STALE_ANNOUNCEMENT` (`Final[str]` constant) in
+  `src/clauditor/_providers/_pricing.py` — from #169 US-002
+  (DEC-003). Fires on the first `estimate_cost` call per Python
+  process when `today - _LAST_VERIFIED > 90 days`. Print-and-flip
+  lives in the **public helper**
+  `announce_pricing_table_stale_if_old()`, called from the top of
+  `estimate_cost` so the warning fires before any contract-violation
+  check. Defensive: a typo in `_LAST_VERIFIED` treats the table as
+  stale (`days_old = 9999`) so a maintainer's typo cannot crash a
+  production grading run — the fallback is loud-but-safe (a stale
+  warning is preferable to a silent skip). Three durable substrings
+  pinned by tests: `"90 days"` (the threshold), `"pricing"` (topic
+  anchor), and at least one of `"platform.claude.com"` /
+  `"openai.com/api/pricing"` (source-of-truth URLs). The
+  `f"v{_PRICING_TABLE_VERSION}"` interpolation is also pinned so
+  a future schema bump surfaces in the warning text.
+- `_announced_unknown_models` (`set[tuple[str, str]]` — NOT a
+  bool; first set-keyed member) +
+  `_UNKNOWN_MODEL_ANNOUNCEMENT_TEMPLATE` (`Final[str]` constant)
+  in `src/clauditor/_providers/_pricing.py` — from #169 US-003
+  (DEC-006). Fires when `estimate_cost(provider, model, ...)` is
+  called with a recognized provider but an unknown model. Per-
+  `(provider, model)` one-shot semantics: each unique pair emits
+  exactly once per process; distinct unknown models each get their
+  own first-call warning rather than the first miss muting all
+  subsequent ones. Print-and-flip lives in the **public helper**
+  `announce_unknown_model(provider, model)`, called from
+  `estimate_cost`'s known-provider/unknown-model branch (an
+  unknown PROVIDER stays silent — different code path — so a
+  typo'd provider does not flood stderr with every model the
+  caller subsequently tries). The set-keyed shape is the **first
+  variation** on the family's traditional bool-flag tradition,
+  and a precedent for future announcements that need per-key
+  idempotence (e.g. per-skill, per-iteration, per-symbol). Two
+  durable substrings pinned by tests: `"pricing:"` (topic
+  anchor) and `"not in rate table"` (specific failure mode), plus
+  the literal `(provider, model)` strings interpolated at emit
+  time so the maintainer can grep stderr for the missing model
+  name. Reset mechanism for tests is
+  `monkeypatch.setattr(..., set())` (an empty set, not `False`).
 
 Per #145 the OpenAI backend deliberately did **not** introduce a
 fourth announcement family. OpenAI's auth posture is strict
@@ -463,14 +520,24 @@ pattern for new members — it makes the notice independently testable
 without reaching into `call_anthropic` internals. New announcement
 flags belong in the `_providers` package (DEC-009 of
 `plans/super/95-subscription-auth-flag.md`); auth-coupled and
-deprecation-coupled notices in `_providers/_auth.py`, transport-
-coupled notices in `_providers/_anthropic.py`. Reset mechanism for
-tests is the `monkeypatch.setattr(..., False)` autouse fixture
-pattern — see
+deprecation-coupled notices (and the harness-coupled
+`_announced_auto_codex_harness` from #151, which names auth env
+vars) live in `_providers/_auth.py`, transport-coupled notices in
+`_providers/_anthropic.py`, and pricing-coupled notices in
+`_providers/_pricing.py` (a small pure-compute sibling module to
+`_retry.py` — NOT a `call_model` consumer; the pricing module is
+the first family member that lives outside the `call_*` /
+auth-helper call chain). Reset mechanism for tests is the
+`monkeypatch.setattr(..., False)` autouse fixture pattern (or
+`monkeypatch.setattr(..., set())` for the set-keyed
+`_announced_unknown_models`) — see
 `tests/test_providers_anthropic.py::TestStderrAnnouncement`,
-`tests/test_providers_auth.py::TestAnnounceImplicitNoApiKey`, and
-`tests/test_providers_auth.py::TestCallAnthropicDeprecationAnnouncement`
-for the shape.
+`tests/test_providers_auth.py::TestAnnounceImplicitNoApiKey`,
+`tests/test_providers_auth.py::TestCallAnthropicDeprecationAnnouncement`,
+and
+`tests/test_providers_pricing.py::TestAnnouncePricingTableStaleIfOld`
+/ `tests/test_providers_pricing.py::TestAnnounceUnknownModel` for
+the shape.
 
 ## When this rule applies
 

--- a/.claude/rules/multi-provider-dispatch.md
+++ b/.claude/rules/multi-provider-dispatch.md
@@ -235,6 +235,44 @@ exit-code routing the distinct exception classes preserve), and
 `.claude/rules/spec-cli-precedence.md` (the future four-layer
 precedence resolver for `grading_provider` lands in #146).
 
+### Provider-dispatch shape extends to non-auth lookups (#169)
+
+The auth-guard dispatcher above is the load-bearing example of
+this rule, but the same shape generalizes to any per-provider
+lookup that wants graceful fallback on unknown values rather than
+hard-failing the caller. The pricing-table lookup in `#169`
+(`src/clauditor/_providers/_pricing.py::estimate_cost`) is the
+first non-auth instantiation:
+
+- `estimate_cost(provider, model, ...)` accepts a `provider: str`
+  and looks up `_PRICING_TABLE.get(provider)`.
+- **Unknown provider** → returns `None` (graceful fallback per
+  this rule's "graceful fallback on unknown values" pattern);
+  never raises. A future provider that has not yet earned a
+  rate-card entry produces `cost_usd: null` on disk rather than
+  blocking the grading run.
+- **Known provider + unknown model** → returns `None` AND emits
+  a one-shot per-`(provider, model)` stderr warning via
+  `announce_unknown_model(provider, model)` (DEC-006 of #169 —
+  see `.claude/rules/centralized-sdk-call.md` "Implicit-coupling
+  announcements — an emerging family" for the announcement
+  contract). The warning fires only when the provider IS known;
+  unknown providers stay silent so a typo'd provider does not
+  flood stderr with every subsequent model.
+- **Bad input types** (non-`str` provider/model, bool /
+  non-`int` / negative tokens) → raises `ValueError` per
+  `.claude/rules/pre-llm-contract-hard-validate.md`'s input-side
+  contract. Programmer errors fail loudly; lookup misses do not
+  crash a production grading run.
+
+The structural-routing invariant the auth dispatcher preserves
+(distinct exception classes per provider routed to distinct
+`except` branches) re-shapes here as a two-category split:
+**lookup-miss → `None`** vs **contract-violation → `ValueError`**.
+Two distinct categories, structurally distinguishable at the
+caller; no substring-matching on error messages. File anchor:
+`src/clauditor/_providers/_pricing.py::estimate_cost`.
+
 ## When this rule applies
 
 Any future LLM-mediated CLI command that constructs a

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -480,6 +480,110 @@ Traces to DEC-010 of `plans/super/153-cross-axis-comparability.md`.
 Companion rule: `.claude/rules/cross-axis-comparability-refusal.md`
 (the per-axis refusal+filter+opt-in shape this helper drives).
 
+### Ninth anchor (pricing-table cost estimation)
+
+`src/clauditor/_providers/_pricing.py` — pure-compute module
+introduced in #169 to back the `cost_usd` field on
+`IterationContext`. Sibling shape to `_providers/_retry.py`: a
+small pure-compute module living inside the `_providers` package
+without being a `call_model` consumer. Two helpers, both pure:
+
+- **`estimate_cost(provider, model, input_tokens, output_tokens,
+  reasoning_tokens=None) -> float | None`** — pure dict-lookup
+  + arithmetic. Validates input types up front (raises
+  `ValueError` on contract violation: non-string provider/model,
+  bool / non-`int` / negative tokens), looks up the rate card in
+  `_PRICING_TABLE`, and computes
+  `(input * input_per_mtok + (output + reasoning) * output_per_mtok)
+  / 1_000_000`. Returns `None` cleanly on unknown
+  `(provider, model)` pairs so callers can write `cost_usd: null`
+  without raising. Reasoning tokens are folded into the effective
+  output count and billed at the model's output rate per the
+  provider research notes (see the module docstring's
+  reasoning-tokens contract).
+- **`compute_iteration_cost_usd(grading_report, extraction_report,
+  provider) -> float | None`** — pure composition helper. Sums
+  Layer 2 + Layer 3 grader-call cost from the already-computed
+  report dataclasses (`GradingReport`, `ExtractionReport`). Per
+  DEC-002 of #169 the helper is **all-or-nothing**: any internal
+  `estimate_cost` returning `None` → composition returns `None`
+  rather than partial cost. A "roughly right" partial estimate
+  is silently wrong for budgeting and trend reads, so
+  null-on-any-miss is the safe default. `extraction_report=None`
+  contributes `0.0` to the sum (that is NOT a lookup miss — it
+  is a genuine "no Layer-2 call happened" signal).
+
+Both helpers are pure: no I/O, no subprocess, no HTTP. The only
+side effect inside `estimate_cost` is the announcement-family
+`print(..., file=sys.stderr)` calls
+(`announce_pricing_table_stale_if_old`,
+`announce_unknown_model`), which are themselves one-shot per
+process and idempotent — see
+`.claude/rules/centralized-sdk-call.md` "Implicit-coupling
+announcements — an emerging family" for the contract. Tests
+exercise the pure-compute paths without those announcements
+firing (autouse fixtures reset the module flags), so the
+purity-of-return-value contract is observable in isolation.
+
+Two callers today:
+
+- `src/clauditor/cli/grade.py::_write_context_sidecar` — the
+  production seam. Uses `compute_iteration_cost_usd` to populate
+  `IterationContext.cost_usd` during workspace staging per
+  `.claude/rules/sidecar-during-staging.md`. The CLI seam owns
+  provider resolution and the surrounding I/O (sidecar
+  serialization, atomic publication); the pure helper just sums.
+- `tests/test_providers_pricing.py` (52 tests) and
+  `tests/test_cli.py::TestCmdGradeContextCostUsd` — exercise
+  both functions directly with plain-dataclass fixtures, no
+  `tmp_path`, no subprocess mocks. Every contract-violation
+  branch (non-string provider, bool token, negative count, both
+  L2 / L3 lookup-miss permutations) is reachable via inline
+  arguments.
+
+Why the split mattered specifically here:
+
+- **Two helpers, one pure module**:
+  `compute_iteration_cost_usd` is genuinely two callers worth of
+  resolution logic — Layer 2 dispatch, Layer 3 dispatch, lookup-
+  miss propagation, all-or-nothing aggregation. Inlining at the
+  call site (`_write_context_sidecar`) would have spread the
+  per-layer dispatch + the all-or-nothing rule across the I/O
+  layer, where future refactors are likely to drift them. The
+  pure helper concentrates the policy in one testable seam.
+- **Sidecar-shape contract**: `cost_usd` is a persisted field on
+  `context.json` whose shape is part of the always-v1 contract
+  (see `.claude/rules/json-schema-version.md` "New sidecar
+  family — `context.json` (#154)"). The pure-helper boundary
+  defends that contract: bug fixes to the cost arithmetic (e.g.
+  if a future ticket adds cache-token rates) land inside
+  `estimate_cost` and propagate to every caller, with no
+  per-call-site duplication that could ship a divergent shape on
+  disk.
+- **Borderline-case threshold**: the rule's existing one-caller
+  threshold says "don't extract a pure helper just to satisfy
+  the rule." The pricing module qualifies for extraction
+  because it (a) produces a sidecar field whose shape is part of
+  `context.json`'s contract, and (b) has non-trivial resolution
+  logic (provider/model dispatch + reasoning-tokens-at-output-
+  rate folding) that would otherwise duplicate at the call site.
+  A simpler "compute one number from one number" helper would
+  not earn extraction.
+
+Traces to bead `clauditor-60x.8` (US-008) of
+`plans/super/169-pricing-cost-estimator.md`. Companion rules:
+`.claude/rules/multi-provider-dispatch.md` "Provider-dispatch
+shape extends to non-auth lookups (#169)" (the structural-
+routing invariant `estimate_cost` preserves —
+lookup-miss→`None` vs contract-violation→`ValueError`),
+`.claude/rules/centralized-sdk-call.md` "Implicit-coupling
+announcements — an emerging family" (the two pricing-coupled
+announcement members `_announced_pricing_table_stale` and
+`_announced_unknown_models` that fire from inside
+`estimate_cost`), `.claude/rules/json-schema-version.md` "New
+sidecar family — `context.json` (#154)" (the always-v1 sidecar
+field this module populates).
+
 ## When this rule applies
 
 Any new code that combines spec/config resolution with a

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -513,17 +513,21 @@ without being a `call_model` consumer. Two helpers, both pure:
   contributes `0.0` to the sum (that is NOT a lookup miss — it
   is a genuine "no Layer-2 call happened" signal).
 
-Both helpers are pure: no I/O, no subprocess, no HTTP. The only
-side effect inside `estimate_cost` is the announcement-family
-`print(..., file=sys.stderr)` calls
-(`announce_pricing_table_stale_if_old`,
-`announce_unknown_model`), which are themselves one-shot per
-process and idempotent — see
-`.claude/rules/centralized-sdk-call.md` "Implicit-coupling
-announcements — an emerging family" for the contract. Tests
-exercise the pure-compute paths without those announcements
-firing (autouse fixtures reset the module flags), so the
-purity-of-return-value contract is observable in isolation.
+Both helpers satisfy the rule's pure-compute contract at the
+**return-value layer**: their returned cost is a deterministic
+function of the inputs, with no network I/O, no file I/O, and no
+subprocess. The one documented exception is the announcement
+family — `estimate_cost` may emit one-shot
+`print(..., file=sys.stderr)` notices via
+`announce_pricing_table_stale_if_old` and `announce_unknown_model`,
+each of which mutates a module-level flag/set on first fire and
+no-ops on subsequent calls. The notices belong to the
+"implicit-coupling announcements" family documented in
+`.claude/rules/centralized-sdk-call.md` and never affect the
+returned cost. Tests reset the module-level flags via autouse
+fixtures, so the deterministic-return-value contract is observable
+in isolation while the announcement side-effects are exercised by
+their own dedicated test classes.
 
 Two callers today:
 
@@ -544,13 +548,16 @@ Two callers today:
 Why the split mattered specifically here:
 
 - **Two helpers, one pure module**:
-  `compute_iteration_cost_usd` is genuinely two callers worth of
-  resolution logic — Layer 2 dispatch, Layer 3 dispatch, lookup-
-  miss propagation, all-or-nothing aggregation. Inlining at the
-  call site (`_write_context_sidecar`) would have spread the
-  per-layer dispatch + the all-or-nothing rule across the I/O
-  layer, where future refactors are likely to drift them. The
-  pure helper concentrates the policy in one testable seam.
+  `compute_iteration_cost_usd` concentrates Layer 2 + Layer 3
+  dispatch and all-or-nothing aggregation logic in one testable
+  seam — per-layer cost dispatch, lookup-miss propagation, and
+  the null-on-any-miss rule that defends `cost_usd`'s sidecar
+  contract. Inlining at the call site
+  (`_write_context_sidecar`) would have spread the per-layer
+  dispatch + the all-or-nothing rule across the I/O layer, where
+  future refactors are likely to drift them. The pure helper
+  keeps the policy in one place even though there is only one
+  production caller today.
 - **Sidecar-shape contract**: `cost_usd` is a persisted field on
   `context.json` whose shape is part of the always-v1 contract
   (see `.claude/rules/json-schema-version.md` "New sidecar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,32 +51,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
-      - name: Debug coverage environment
-        if: matrix.python-version == '3.13'
-        run: |
-          echo "=== uv version ==="
-          uv --version
-          echo "=== Python / pytest / coverage versions ==="
-          uv run python -V
-          uv run python -c "import pytest; print('pytest', pytest.__version__)"
-          uv run python -c "import coverage; print('coverage', coverage.__version__)"
-          uv run python -c "import pytest_cov; print('pytest_cov', pytest_cov.__version__)"
-          echo "=== Editable install path ==="
-          uv run python -c "import clauditor, os; print('clauditor file:', clauditor.__file__); print('clauditor dir:', os.path.dirname(clauditor.__file__))"
-          echo "=== .coveragerc and codecov.yml present ==="
-          ls -la .coveragerc codecov.yml pyproject.toml 2>&1 | head -10
-          cat .coveragerc
-          echo "=== addopts ==="
-          grep -A 2 "^addopts" pyproject.toml || true
-          echo "=== relevant env vars ==="
-          env | grep -iE "^(COV|COVERAGE|PYTEST|UV)" | sort
-      - name: Run tests under coverage (coverage starts before pytest)
+      - name: Run tests under coverage
         # ``pytest --cov`` starts coverage inside pytest's
         # ``pytest_load_initial_conftests`` — AFTER entry-point plugins
         # (``clauditor.pytest_plugin``) have imported their transitive
         # graph. Modules loaded during that early phase have their
         # module-level statements (imports, constants, class/def lines)
-        # executed without tracing, producing the ~12pp CI undercount.
+        # executed without tracing, producing a ~12pp CI undercount
+        # diagnosed in PR #173 (see CI run 25652367478 for the
+        # before/after).
+        #
         # ``coverage run -m pytest`` flips the order: coverage tracing
         # starts when the ``coverage`` script begins, then it execs
         # ``pytest`` as a module — every subsequent import (including
@@ -93,33 +77,6 @@ jobs:
           uv run coverage run -m pytest -p no:pytest_cov -o "addopts=--import-mode=importlib"
           uv run coverage xml
           uv run coverage report --fail-under=80
-      - name: Show coverage of files previously reported low by codecov
-        if: matrix.python-version == '3.13'
-        run: |
-          uv run python <<'PY'
-          import xml.etree.ElementTree as ET
-          tree = ET.parse('coverage.xml')
-          root = tree.getroot()
-          targets = {
-              'src/clauditor/_providers/_pricing.py',
-              'src/clauditor/formats.py',
-              'src/clauditor/_providers/_retry.py',
-              'src/clauditor/_providers/_auth.py',
-              'src/clauditor/badge.py',
-              'src/clauditor/benchmark.py',
-          }
-          for cls in root.iter('class'):
-              fn = cls.attrib.get('filename', '')
-              if fn in targets:
-                  rate = cls.attrib.get('line-rate', '?')
-                  lines = cls.findall('.//line')
-                  hit = sum(1 for l in lines if int(l.attrib['hits']) > 0)
-                  total = len(lines)
-                  missing_nums = [l.attrib['number'] for l in lines if int(l.attrib['hits']) == 0]
-                  print(f"{fn}: rate={rate} ({hit}/{total})")
-                  if missing_nums:
-                      print(f"  missing lines: {missing_nums[:30]}")
-          PY
       - uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.13'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,23 @@ jobs:
           grep -A 2 "^addopts" pyproject.toml || true
           echo "=== relevant env vars ==="
           env | grep -iE "^(COV|COVERAGE|PYTEST|UV)" | sort
-      - run: uv run pytest --cov=clauditor --cov-report=xml --cov-report=term
-      - name: Show coverage of files reported low by codecov
+      - name: Run tests with coverage (coverage starts at Python startup via COVERAGE_PROCESS_START)
+        # Without ``COVERAGE_PROCESS_START``, pytest-cov starts coverage in
+        # ``pytest_load_initial_conftests`` — AFTER entry-point plugins
+        # (``clauditor.pytest_plugin``) have imported their transitive
+        # graph. Modules loaded during that early phase have their
+        # module-level statements (imports, constants, class/def lines)
+        # executed without tracing, producing the ~12pp CI undercount
+        # documented in codecov.yml and the #169 investigation comment.
+        # Setting ``COVERAGE_PROCESS_START`` triggers the ``a1_coverage.pth``
+        # file (shipped with the ``coverage`` package) which calls
+        # ``coverage.process_startup()`` at interpreter startup, before
+        # any module imports. The ``.coveragerc`` value points at the
+        # existing config (``[run] source = src/clauditor``).
+        env:
+          COVERAGE_PROCESS_START: ${{ github.workspace }}/.coveragerc
+        run: uv run pytest --cov=clauditor --cov-report=xml --cov-report=term
+      - name: Show coverage of files previously reported low by codecov
         if: matrix.python-version == '3.13'
         run: |
           uv run python <<'PY'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,22 +70,29 @@ jobs:
           grep -A 2 "^addopts" pyproject.toml || true
           echo "=== relevant env vars ==="
           env | grep -iE "^(COV|COVERAGE|PYTEST|UV)" | sort
-      - name: Run tests with coverage (coverage starts at Python startup via COVERAGE_PROCESS_START)
-        # Without ``COVERAGE_PROCESS_START``, pytest-cov starts coverage in
+      - name: Run tests under coverage (coverage starts before pytest)
+        # ``pytest --cov`` starts coverage inside pytest's
         # ``pytest_load_initial_conftests`` — AFTER entry-point plugins
         # (``clauditor.pytest_plugin``) have imported their transitive
         # graph. Modules loaded during that early phase have their
         # module-level statements (imports, constants, class/def lines)
-        # executed without tracing, producing the ~12pp CI undercount
-        # documented in codecov.yml and the #169 investigation comment.
-        # Setting ``COVERAGE_PROCESS_START`` triggers the ``a1_coverage.pth``
-        # file (shipped with the ``coverage`` package) which calls
-        # ``coverage.process_startup()`` at interpreter startup, before
-        # any module imports. The ``.coveragerc`` value points at the
-        # existing config (``[run] source = src/clauditor``).
-        env:
-          COVERAGE_PROCESS_START: ${{ github.workspace }}/.coveragerc
-        run: uv run pytest --cov=clauditor --cov-report=xml --cov-report=term
+        # executed without tracing, producing the ~12pp CI undercount.
+        # ``coverage run -m pytest`` flips the order: coverage tracing
+        # starts when the ``coverage`` script begins, then it execs
+        # ``pytest`` as a module — every subsequent import (including
+        # entry-point plugins) runs with coverage active.
+        #
+        # ``-p no:pytest_cov`` disables the pytest-cov plugin so it
+        # doesn't try to start its own (now-redundant) coverage tracer.
+        # ``-o "addopts=--import-mode=importlib"`` overrides
+        # ``pyproject.toml::addopts`` to drop ``--cov-fail-under=80``
+        # (that flag belongs to pytest-cov which is disabled here);
+        # the fail-under gate is enforced by the ``coverage report``
+        # step below instead.
+        run: |
+          uv run coverage run -m pytest -p no:pytest_cov -o "addopts=--import-mode=importlib"
+          uv run coverage xml
+          uv run coverage report --fail-under=80
       - name: Show coverage of files previously reported low by codecov
         if: matrix.python-version == '3.13'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,53 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
-      - run: uv run pytest --cov=clauditor --cov-report=xml
+      - name: Debug coverage environment
+        if: matrix.python-version == '3.13'
+        run: |
+          echo "=== uv version ==="
+          uv --version
+          echo "=== Python / pytest / coverage versions ==="
+          uv run python -V
+          uv run python -c "import pytest; print('pytest', pytest.__version__)"
+          uv run python -c "import coverage; print('coverage', coverage.__version__)"
+          uv run python -c "import pytest_cov; print('pytest_cov', pytest_cov.__version__)"
+          echo "=== Editable install path ==="
+          uv run python -c "import clauditor, os; print('clauditor file:', clauditor.__file__); print('clauditor dir:', os.path.dirname(clauditor.__file__))"
+          echo "=== .coveragerc and codecov.yml present ==="
+          ls -la .coveragerc codecov.yml pyproject.toml 2>&1 | head -10
+          cat .coveragerc
+          echo "=== addopts ==="
+          grep -A 2 "^addopts" pyproject.toml || true
+          echo "=== relevant env vars ==="
+          env | grep -iE "^(COV|COVERAGE|PYTEST|UV)" | sort
+      - run: uv run pytest --cov=clauditor --cov-report=xml --cov-report=term
+      - name: Show coverage of files reported low by codecov
+        if: matrix.python-version == '3.13'
+        run: |
+          uv run python <<'PY'
+          import xml.etree.ElementTree as ET
+          tree = ET.parse('coverage.xml')
+          root = tree.getroot()
+          targets = {
+              'src/clauditor/_providers/_pricing.py',
+              'src/clauditor/formats.py',
+              'src/clauditor/_providers/_retry.py',
+              'src/clauditor/_providers/_auth.py',
+              'src/clauditor/badge.py',
+              'src/clauditor/benchmark.py',
+          }
+          for cls in root.iter('class'):
+              fn = cls.attrib.get('filename', '')
+              if fn in targets:
+                  rate = cls.attrib.get('line-rate', '?')
+                  lines = cls.findall('.//line')
+                  hit = sum(1 for l in lines if int(l.attrib['hits']) > 0)
+                  total = len(lines)
+                  missing_nums = [l.attrib['number'] for l in lines if int(l.attrib['hits']) == 0]
+                  print(f"{fn}: rate={rate} ({hit}/{total})")
+                  if missing_nums:
+                      print(f"  missing lines: {missing_nums[:30]}")
+          PY
       - uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.13'
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,32 +1,26 @@
 # Codecov configuration.
 #
-# Context: CI's coverage upload systematically reports lower per-file
-# coverage than a local ``uv run pytest --cov=clauditor --cov-report=xml``
-# does on the same commit. On 2e195e7 the CI report shows
-# ``src/clauditor/_providers/_pricing.py`` at 67.6% / ``formats.py`` at
-# 28.6% / ``_retry.py`` at 61.5% — all of which test at 100% locally
-# with the same pytest invocation. Root cause is most likely an
-# interaction between the ``clauditor.pytest_plugin`` entry-point
-# loading order and pytest-cov's tracer (the entry-point's
-# module-level imports execute before coverage instrumentation
-# starts; function bodies should still be traced when called, but
-# CI's report contradicts that).
+# Coverage is collected by ``coverage run -m pytest`` in CI (see
+# ``.github/workflows/ci.yml``). Total project coverage runs at ~99%
+# (the same number ``coverage report`` prints locally on a fresh clone).
 #
-# Until that's diagnosed, this config:
+# Status checks:
 #
-# 1. Sets ``coverage.status.project.target: auto`` with a 1% drop
-#    threshold so a real regression still trips the check.
-# 2. Marks ``coverage.status.patch`` as ``informational: true`` so
-#    codecov continues to report patch coverage on every PR but does
-#    NOT block merge on the systematic CI undercount. New-code
-#    coverage discipline is still enforced locally by the
-#    ``--cov-fail-under=80`` flag in ``pyproject.toml::addopts`` and
-#    by the project's standard code-review pass that asserts the new
-#    module's tests pass at the 80% gate.
+# 1. ``project.target: auto`` with a 1% drop threshold so a real
+#    regression still trips the check.
+# 2. ``patch`` uses codecov's default (informational: false / blocking)
+#    so PRs that drop patch coverage below the implicit threshold fail
+#    the check.
 #
-# When the CI undercount is root-caused and fixed, flip ``patch`` back
-# to ``informational: false`` (the default) so codecov can block
-# coverage regressions on future PRs.
+# History — PR #173 originally shipped ``patch.informational: true``
+# while a ~12pp CI vs local coverage gap was undiagnosed. The root
+# cause was pytest-cov starting tracing in
+# ``pytest_load_initial_conftests`` AFTER entry-point plugin
+# (``clauditor.pytest_plugin``) imports had executed their transitive
+# graph — module-level statements went untraced. Switching to
+# ``coverage run -m pytest`` made coverage start before pytest loads,
+# which closed the gap; ``patch.informational`` was flipped back to
+# its default in the same PR.
 
 coverage:
   status:
@@ -34,6 +28,3 @@ coverage:
       default:
         target: auto
         threshold: 1%
-    patch:
-      default:
-        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,39 @@
+# Codecov configuration.
+#
+# Context: CI's coverage upload systematically reports lower per-file
+# coverage than a local ``uv run pytest --cov=clauditor --cov-report=xml``
+# does on the same commit. On 2e195e7 the CI report shows
+# ``src/clauditor/_providers/_pricing.py`` at 67.6% / ``formats.py`` at
+# 28.6% / ``_retry.py`` at 61.5% — all of which test at 100% locally
+# with the same pytest invocation. Root cause is most likely an
+# interaction between the ``clauditor.pytest_plugin`` entry-point
+# loading order and pytest-cov's tracer (the entry-point's
+# module-level imports execute before coverage instrumentation
+# starts; function bodies should still be traced when called, but
+# CI's report contradicts that).
+#
+# Until that's diagnosed, this config:
+#
+# 1. Sets ``coverage.status.project.target: auto`` with a 1% drop
+#    threshold so a real regression still trips the check.
+# 2. Marks ``coverage.status.patch`` as ``informational: true`` so
+#    codecov continues to report patch coverage on every PR but does
+#    NOT block merge on the systematic CI undercount. New-code
+#    coverage discipline is still enforced locally by the
+#    ``--cov-fail-under=80`` flag in ``pyproject.toml::addopts`` and
+#    by the project's standard code-review pass that asserts the new
+#    module's tests pass at the 80% gate.
+#
+# When the CI undercount is root-caused and fixed, flip ``patch`` back
+# to ``informational: false`` (the default) so codecov can block
+# coverage regressions on future PRs.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true

--- a/plans/super/169-pricing-cost-estimator.md
+++ b/plans/super/169-pricing-cost-estimator.md
@@ -1,0 +1,716 @@
+# 169: Pricing — `cost_usd` estimation module for `context.json`
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/169
+- **Branch:** `feature/169-pricing-cost-estimator`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/169-pricing-cost-estimator`
+- **Phase:** published
+- **Sessions:** 1 (2026-05-09)
+- **Depends on:** #154 (CLOSED — `IterationContext.cost_usd: float | None = None` placeholder ships in `context.py`)
+- **Related:** #170 (`reasoning_tokens` capture — sibling follow-up to #154; #169 accepts a `reasoning_tokens` parameter so it composes forward-compat without depending on #170)
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What.** Add `src/clauditor/_providers/_pricing.py` exposing a pure
+`estimate_cost(provider, model, input_tokens, output_tokens, reasoning_tokens=None) -> float | None`
+helper backed by a hardcoded per-provider price table. Wire it into the
+`context.json` write seam so `IterationContext.cost_usd` is populated
+with a real estimate (vs the `None` placeholder #154 ships) whenever the
+`(provider, model)` pair is recognized. Unknown pairs continue to write
+`cost_usd: null` cleanly with no exception.
+
+**Why.** #154 stabilized the `context.json` schema with
+`cost_usd: float | None = None` always-null. Lighting up real values
+turns the existing audit/badge surface into a cost-attribution tool:
+operators can see per-iteration USD spend, compare cost across
+harness/provider/model axes (the cross-axis machinery from #153 already
+groups these), and spot regressions (a model bump that doubles cost
+shows up immediately). Without this, `cost_usd` is a permanent dead
+column.
+
+**Pre-plan research (2026-05-09).** Investigated whether either
+provider exposes a programmatic rate card so we could fetch live
+prices instead of hardcoding. **Verdict: no.** Anthropic's
+`/v1/models` carries no pricing fields; `/v1/organizations/cost_report`
+requires an admin key (not a regular API key) and returns realized
+USD aggregate, not a forward rate card. OpenAI's `/v1/models` carries
+no pricing fields (`openai/openai-python#2074` closed as not
+planned); `/v1/organization/costs` is admin-key gated and
+realized-cost only. Reasoning tokens are billed at the model's output
+rate by both providers; there is no separate reasoning rate to look
+up. The hardcoded-table approach in the ticket is the right shape;
+the issue body was updated with a "Research notes" block capturing
+the verdict and four concrete implications (reasoning-token contract,
+version + last-verified date, source-of-truth URLs as code comments,
+cache-token pricing deferral). See:
+- https://platform.claude.com/docs/en/about-claude/pricing
+- https://openai.com/api/pricing/
+
+### Codebase findings (from Codebase Scout)
+
+#### `IterationContext` is already wired — only `cost_usd` is dead
+
+`src/clauditor/context.py:59–77` defines the dataclass. `cost_usd:
+float | None = None` is line 76 (placeholder). Schema version is 1
+and stays at 1 — `context.json` is forward-compat-by-design (DEC-007
+of #154's plan: nullable fields populated later don't bump the
+version).
+
+Bool-guard precedent already in place: `context.py:165–167` rejects
+`isinstance(reasoning_tokens, bool)` before the `int` check; same
+guard at `cost_usd` (lines 178–179). #169 inherits the validator —
+no `from_dict` changes needed for `cost_usd`.
+
+#### Write seam: `_write_context_sidecar` already builds the dataclass
+
+**Primary write site** (`src/clauditor/cli/grade.py:887–926`):
+- `IterationContext(...)` constructed at lines 912–923.
+- In scope at construction: `harness_name: str`, `provider: str`
+  (the **grader** provider, resolved at line 386 via
+  `_resolve_grading_provider(args, spec.eval_spec)`),
+  `primary_skill_result: SkillResult` (carries
+  `harness_metadata["model"]`, `harness_metadata["system_prompt_source"]`,
+  `harness_metadata.get("sandbox_mode")`), `primary_report:
+  GradingReport` (carries `model: str`, `input_tokens: int`,
+  `output_tokens: int`).
+- **Fields hardcoded today**: `cost_usd=None` (line 921),
+  `reasoning_tokens=None` (line 922).
+- **Token sources NOT YET PASSED to the constructor**:
+  `primary_skill_result.input_tokens` /
+  `primary_skill_result.output_tokens` (runner-side) and
+  `primary_report.input_tokens` / `primary_report.output_tokens`
+  (grader-side). Both fields exist and are populated; they're just
+  not threaded into the `IterationContext` builder.
+
+**Second write site** (`src/clauditor/cli/validate.py:318–332`):
+- Validate-only iterations: `provider=None`, `model_grader=None`,
+  `cost_usd=None`, `reasoning_tokens=None`. No grader call ran, so
+  cost is genuinely null. Only the runner side could conceivably
+  contribute, but with no provider context the answer is still
+  `None` (and probably should stay so for validate-only iterations
+  to avoid a confusing "$0.0001 for the runner alone" line).
+
+#### Token surfaces inventory
+
+| Source | Fields | Notes |
+|---|---|---|
+| `SkillResult` (`runner.py:54–112`) | `input_tokens: int = 0`, `output_tokens: int = 0` | Populated from stream-json parse in `SkillRunner._invoke`. Reliability varies by transport (api vs cli) — `claude` CLI's stream-json `result` carries token counts; SDK transport carries them too. |
+| `GradingReport` (`quality_grader.py:75–115`) | `input_tokens`, `output_tokens`, `model: str` | Reliably populated from `ModelResult` during grading. |
+| `ExtractionReport` (`grader.py:86–159`) | `input_tokens`, `output_tokens` | Layer 2 grader call when `EvalSpec.sections` declared — separate API call, separate cost. |
+| `ModelResult` (`_providers/_anthropic.py:192–241`) | `input_tokens`, `output_tokens`, `provider: Literal["anthropic", "openai"]`, `source: Literal["api", "cli"]` | No `reasoning_tokens` field today (reserved for #170). |
+
+#### Critical asymmetry: runner provider vs grader provider
+
+At `_write_context_sidecar`, the `provider` parameter is the
+**grader** provider. The runner's harness binary
+(`claude`/`codex`) is independently selected via
+`_resolve_harness`. A `(harness=claude-code, provider=openai)`
+combo is legal — it means Claude Code ran the skill subprocess
+(billed against `ANTHROPIC_API_KEY`) and the OpenAI SDK served the
+grader call. **The runner cost and grader cost may use different
+providers** and even different price tables.
+
+`model_runner` is `harness_metadata["model"]` for Codex (`_codex.py:747`)
+but is unreliably populated for ClaudeCodeHarness — DEC-007 of
+#154's plan: when neither the constructor nor a per-call override
+pinned a model, `model_runner` is `None` because the `claude` CLI's
+stream-json `result` carries no model field. So the runner cost is
+*unknown* for any ClaudeCodeHarness invocation that didn't pin
+`--model` explicitly, even when tokens are known.
+
+Inferring the runner's *provider* is also non-trivial:
+ClaudeCodeHarness → "anthropic" runner provider; CodexHarness →
+"openai" runner provider. The Codex backend's auth allows either
+`OPENAI_API_KEY` or `CODEX_API_KEY`, so the SDK is OpenAI either
+way for cost-table purposes. This mapping is one new
+helper.
+
+#### `_providers/` package layout (where `_pricing.py` lands)
+
+```
+src/clauditor/_providers/
+├── __init__.py    (call_model dispatcher, resolve_harness, resolve_grading_provider, ...)
+├── _anthropic.py  (call_anthropic, AnthropicHelperError, ...)
+├── _openai.py     (call_openai, OpenAIHelperError, ...)
+├── _auth.py       (check_provider_auth, announce_*, ...)
+└── _retry.py      (compute_backoff, compute_retry_decision, ...)
+```
+
+`_pricing.py` slots in as a sibling — independent of `call_model`,
+no SDK calls, no I/O. Mirrors the structural shape of `_retry.py`
+(also a pure-compute sibling that doesn't consume `call_model`).
+
+#### Audit + badge already read `cost_usd`
+
+- `src/clauditor/audit.py::_read_context` reads `context.json` via
+  `IterationContext.from_dict`. Every `IterationContext` field
+  (including `cost_usd`) is loaded and exposed to renderers.
+- `src/clauditor/badge.py::ClauditorExtension.context:
+  IterationContext | None = None` (line 209) round-trips through
+  the badge sidecar's clauditor-extension payload.
+- Both render `cost_usd` as `null` today. **No reader-side changes
+  needed for #169** — once the writer stamps a real number, every
+  surface starts showing it.
+
+### Conventions / rules consulted (from Convention Checker)
+
+**APPLY — drive implementation:**
+
+1. **`pure-compute-vs-io-split.md`** — `_pricing.py` is a pure
+   module: zero I/O, zero subprocess, zero network. The price
+   table is a module-level constant; `estimate_cost` takes plain
+   primitives and returns `float | None`. Adds a ninth canonical
+   anchor sibling to `compute_benchmark` /
+   `blind_compare_from_spec` / etc. The rule's "two-callers
+   threshold" is borderline (one production call site today: the
+   `_write_context_sidecar` writer; tests are the second consumer
+   by design).
+2. **`constant-with-type-info.md`** — module-level constants must
+   carry explicit type annotations and the **bool-vs-int guard**
+   on any int parameter. `_PRICING_TABLE_VERSION: Final[int]`,
+   `_LAST_VERIFIED: Final[str]`, `_PRICING_TABLE: Final[dict[str,
+   dict[str, ProviderPriceCard]]]`. `estimate_cost` must reject
+   `isinstance(input_tokens, bool)` etc. before the `int` check —
+   `True` would otherwise compute a "1-token cost" silently.
+3. **`pre-llm-contract-hard-validate.md` (input-side)** —
+   load-bearing input contract is `int` for all token fields and
+   `str` for `provider`/`model`. Wrong types → `ValueError` with
+   actionable message. **Do not** raise on unknown
+   `(provider, model)` — that's a *lookup miss*, not a contract
+   violation, and the ticket explicitly mandates `None` (cleanly)
+   for that case. Two different error categories.
+4. **`multi-provider-dispatch.md`** — `estimate_cost(provider=...)`
+   is a new dispatch surface but a *graceful-fallback* one: unknown
+   provider returns `None`, never raises. Mirrors the
+   `_pricing.py` price table being keyed on the same
+   `{"anthropic", "openai"}` literal set the auth dispatcher uses.
+5. **`sidecar-during-staging.md`** — the cost computation happens
+   inside `_write_context_sidecar`, which already runs inside
+   `workspace.tmp_path` BEFORE `workspace.finalize()`. No new
+   staging-discipline work; we inherit the existing envelope.
+6. **`centralized-sdk-call.md` (sibling, not consumer)** —
+   `_pricing.py` lives in `_providers/` because pricing is a
+   provider-axis concern. It does NOT call `call_model`; it does
+   NOT need the announcement-family or the centralized retry
+   policy. Same package as `_retry.py` — pure-compute siblings of
+   the SDK callers.
+7. **`json-schema-version.md`** — explicitly does NOT bump.
+   `context.json` stays at `schema_version: 1` (forward-compat-by-
+   design per DEC-007 of #154). Confirms the rule's "Always-v1
+   contract" subsection.
+8. **`back-compat-shim-discipline.md`** — N/A (new module, no
+   existing callers, no shim).
+9. **`non-mutating-scrub.md`** — N/A (the price table is a
+   module-level `Final` constant, never mutated; primitives in /
+   primitives out).
+10. **`data-vs-asserter-split.md`** — N/A (no `assert_*` test
+    helpers; the price table is a typed constant, not a class
+    growing methods).
+
+**N/A — explicitly ruled out:** every other rule in
+`.claude/rules/` (32 rules) — none touch a pure pricing-table
+seam. Notably ruled out: `harness-protocol-shape.md` (provider-
+agnostic infrastructure), `spec-cli-precedence.md` (no CLI flag,
+no spec field — the ticket explicitly states this), `eval-spec-
+stable-ids.md` (no spec field), `precall-env-validation.md` (no
+env vars), `llm-cli-exit-code-taxonomy.md` (library, not CLI),
+`cross-axis-comparability-refusal.md` (audit-side; #154 already
+groups by `(harness, provider, ...)`), `bundled-skill-docs-
+sync.md` (not a skill).
+
+**Rules drift candidates (Patterns & Memory story):**
+
+No rule's canonical-implementation section names a file that
+moves or renames. Optional informational refreshes for the last
+story:
+
+- `centralized-sdk-call.md` — add a brief note that `_pricing.py`
+  is a sibling pure-compute module alongside `_retry.py`,
+  providing cost estimation independently of call routing.
+- `multi-provider-dispatch.md` — note that the price-table lookup
+  follows the same provider-dispatch shape (return `None` on
+  unknown, never raise).
+- `pure-compute-vs-io-split.md` — add `_pricing.estimate_cost` as
+  the ninth canonical anchor.
+
+These are non-load-bearing prose adds; not strictly required for
+the ticket but worth doing while context is fresh.
+
+### Scoping questions for the user
+
+These are the choices that drive DEC-001 through DEC-005 below.
+
+#### Q1: Cost composition — runner + grader, or grader-only?
+
+Ticket says "sum of harness runner cost + grader call cost." But
+the runner cost is unreliable today: `model_runner` is `None` for
+any ClaudeCodeHarness invocation that didn't pin `--model`
+explicitly (DEC-007 of #154's plan).
+
+- **A. Sum runner + grader (ticket-as-written).** Compute
+  runner cost from `SkillResult.input_tokens/output_tokens` +
+  the runner provider derived from harness identity (`claude-
+  code → anthropic`, `codex → openai`) + `model_runner` from
+  `harness_metadata`. When `model_runner is None`, runner cost
+  contributes `None` and the whole `cost_usd = None`
+  (ticket-aligned: "any unknown component → null"). Grader cost
+  reads `primary_report.input_tokens/output_tokens` +
+  `primary_report.model` + the resolved grader `provider`. Sum
+  is the final `cost_usd`.
+- **B. Grader-only for now, runner deferred.** Compute only
+  Layer 2 + Layer 3 cost (`primary_report` + optional
+  `extraction_report` tokens). Runner cost waits on a follow-up
+  ticket that hardens `model_runner` capture for ClaudeCodeHarness.
+  Cleaner; smaller blast radius; the grader signal is the
+  dominant cost in most real workflows.
+- **C. Grader-only with explicit follow-up filed.** Same as B
+  but file an issue capturing the runner-cost gap and link it
+  from the module docstring. Most honest about scope.
+
+#### Q2: Failure-mode semantics for partial-info iterations
+
+When *some* of the cost components are computable but others
+aren't (e.g. grader cost known, runner cost unknown):
+
+- **A. All-or-nothing.** Any unknown component → `cost_usd =
+  None` whole-iteration. Ticket-aligned acceptance ("Unknown
+  models still produce a clean sidecar with cost_usd=null").
+  Cleanest for downstream readers; no risk of misleading
+  partial sums.
+- **B. Best-effort partial.** Stamp whatever is computable. Risk:
+  a "$0.05" sidecar that only priced half the call is more
+  misleading than a `null`.
+
+#### Q3: `_LAST_VERIFIED` enforcement
+
+Both research agents independently suggested a freshness signal.
+Range from cheapest to strictest:
+
+- **A. Documented-only.** Module-level constant + comment
+  pointing at the source-of-truth URL. Maintainer reads the
+  comment when refreshing. Zero runtime cost. (Cheapest.)
+- **B. Stderr warning when stale.** If `today - _LAST_VERIFIED >
+  90 days`, emit a one-time per-process warning at the first
+  `estimate_cost` call. Surfaces to operators; requires a
+  module-level announce flag (precedent: the announcement-
+  family pattern in `_providers/_auth.py`).
+- **C. Test-side staleness gate.** A unit test asserts the table
+  is < N days old; CI fails when stale. Forces refresh
+  discipline but blocks merges on calendar drift.
+
+#### Q4: Price-table coverage scope
+
+- **A. Only currently-shipped-and-graded-with models.**
+  Anthropic: `claude-sonnet-4-6`, `claude-opus-4-7`,
+  `claude-haiku-4-5`. OpenAI: `gpt-5.4`, `gpt-5.4-mini`, plus
+  one o-series model we actually grade with (e.g. `o4-mini`).
+  Anything else → `None`. Matches the ticket's "Unknown models
+  return None" semantic. Smallest table. (Recommended.)
+- **B. Family + explicit overrides.** Per-model rows for
+  shipped models + a fallback "anthropic family / openai
+  family" default rate for unrecognized prefixes. More forgiving
+  but invents a "rate that probably is roughly right" — risks
+  being silently wrong for a model that bills very differently
+  (Claude Opus is ~5x Sonnet).
+- **C. Comprehensive table.** Every Anthropic + OpenAI model
+  ever shipped. Most accurate, highest maintenance.
+
+### Decisions captured (DEC-001 — DEC-005)
+
+- **DEC-001 — Cost composition: grader-only, runner deferred (no
+  follow-up filed).** `cost_usd` sums Layer 2 + Layer 3 grader call
+  cost only: `extraction_report.input_tokens/output_tokens` (when
+  Layer 2 ran) + `primary_report.input_tokens/output_tokens` (Layer
+  3, always present at the grade write seam). Runner cost is out of
+  scope for this ticket; the module docstring states this
+  explicitly. Rationale: ClaudeCodeHarness reliably populates
+  `model_runner` only when `--model` is pinned (DEC-007 of #154's
+  plan), so a runner-cost wiring would silently null-out for the
+  common case anyway. The grader signal is the dominant cost in
+  most workflows; ship the v1 honest about its scope.
+- **DEC-002 — All-or-nothing failure mode.** When any cost
+  component is unknown (`estimate_cost` returns `None` for either
+  the L2 or L3 lookup), the whole `cost_usd = None` for the
+  iteration. Verbatim acceptance: "Unknown models still produce a
+  clean sidecar with cost_usd=null." No best-effort partial sums.
+  Rationale: a half-priced "$0.05" line is more misleading than a
+  `null`; the all-or-nothing rule keeps every recorded value
+  trustworthy.
+- **DEC-003 — Staleness signal: stderr warning at >90 days.** Use
+  the announcement-family pattern from
+  `.claude/rules/centralized-sdk-call.md` ("Implicit-coupling
+  announcements — an emerging family"). Module-level
+  `_announced_pricing_table_stale: bool = False` flag +
+  `_PRICING_TABLE_STALE_ANNOUNCEMENT: Final[str]` constant + public
+  helper `announce_pricing_table_stale_if_old()`. The helper is
+  idempotent (one-shot per process), reads
+  `_LAST_VERIFIED`, computes `today - last_verified_date`, and emits
+  to stderr only when `> 90 days`. Called once at the first
+  `estimate_cost(...)` invocation per process. The announcement names
+  the source-of-truth URLs so a maintainer's next move is obvious.
+  Days are computed via a `_today` indirection alias (per
+  `.claude/rules/monotonic-time-indirection.md` analog) so tests can
+  pin the date without patching `datetime`. Rationale: documented-
+  only is too quiet (an outdated table silently produces wrong USD
+  numbers); a CI gate is too loud (blocks merges on calendar drift
+  unrelated to the change). 90 days is roughly a quarterly cadence
+  and gives operators a chance to refresh between provider price
+  changes.
+- **DEC-004 — Coverage: ship only models we grade with today.**
+  Anthropic models: `claude-sonnet-4-6`, `claude-opus-4-7`,
+  `claude-haiku-4-5`. OpenAI models: `gpt-5.4`, `gpt-5.4-mini`,
+  `o4-mini` (pre-resolved at planning time as the o-series model
+  most likely in actual grading use; planner confirms with current
+  fixtures during implementation, swaps if a different o-series is
+  the real default). Anything else → `None`. Matches the ticket's
+  "Unknown models return None" acceptance verbatim. The table is
+  small, easy to audit by eye, and the maintenance cost on
+  refresh is exactly N model rows. No family-fallback heuristic.
+  Rationale: a fallback that's "roughly right" is silently wrong
+  for a model that bills very differently (Opus is ~5x Sonnet);
+  null-on-unknown is the safe default and matches downstream-
+  reader expectations.
+- **DEC-005 — Validation contract split.** `estimate_cost` raises
+  `ValueError` on a contract violation (non-int / bool token args,
+  non-string `provider`/`model`); returns `None` on a lookup miss
+  (unknown provider, unknown model, unknown
+  `(provider, model)` pair). Two distinct categories per
+  `.claude/rules/pre-llm-contract-hard-validate.md` (input-side) +
+  `.claude/rules/multi-provider-dispatch.md` (graceful fallback on
+  unknown provider). Test coverage: one parametrized class for
+  each category. Rationale: programmer errors (bool sneaking
+  through) should fail loudly; lookup misses (a new model not yet
+  in the table) should not crash production grading runs.
+
+---
+
+## Architecture Review
+
+Three review subagents covered the non-trivial axes (Security and
+Performance are trivial for a pure-compute table-lookup module —
+zero I/O, zero subprocess, zero secrets, O(1) dict lookup).
+
+### Ratings
+
+| Area | Rating | Notes |
+|---|---|---|
+| **API Design + Data Model (A1–A7)** | PASS w/ 2 concerns | A1/A2/A3/A5/A6 PASS. A4 (helper shape) and A7 (unknown-model UX) raised; both resolved below. |
+| **Observability + Stale-warning (B1–B7)** | PASS w/ 1 concern | B1/B2/B4/B5/B6/B7 PASS. B3 (ISO date robustness) raised; baked into the implementation plan. |
+| **Testing Strategy (T1–T8)** | PASS w/ 1 concern | T1/T2/T3/T4/T5/T6/T8 PASS. T7 (mock side_effect for L2+L3 wiring) raised; baked into US-005 acceptance. |
+| Security | PASS | Pure compute, no I/O, no secrets in scope. The price table is public information. |
+| Performance | PASS | One dict lookup per call; module load is a small `Final` constant. No hotspot. |
+
+### Concerns resolved (baked in, no separate decisions needed)
+
+- **A4 — Composition helper.** Add a thin pure helper
+  `compute_iteration_cost_usd(primary_report, extraction_report,
+  provider) -> float | None` in `_pricing.py`. Handles
+  `extraction_report is None` (Layer 2 didn't run → contributes 0
+  tokens) cleanly. Per DEC-002, when either internal
+  `estimate_cost` returns `None`, the composition returns `None`
+  (all-or-nothing). The writer's call site at
+  `_write_context_sidecar` then becomes one line.
+- **B3 — ISO date arithmetic robustness.** Wrap
+  `datetime.date.fromisoformat(_LAST_VERIFIED)` in `try/except
+  ValueError`; on parse failure, treat the table as stale and
+  emit the announcement (defensive — a maintainer's typo in the
+  constant must not crash production). Use a `_today =
+  datetime.date.today` module-level indirection alias so tests
+  pin the date via `monkeypatch.setattr(_pricing, "_today",
+  lambda: date(2027, 1, 1))` (same shape as
+  `.claude/rules/monotonic-time-indirection.md`).
+- **T7 — Mock side-effect for L2+L3 composition test.** US-005's
+  wiring test that mocks `estimate_cost` to verify the
+  composition path MUST use `side_effect=[v_l2, v_l3]` not
+  `return_value=v` per
+  `.claude/rules/mock-side-effect-for-distinct-calls.md`.
+  Acceptance criterion on US-005.
+
+### Concern resolved by user decision
+
+- **A7 — Unknown-model UX (DEC-006 below).** When
+  `estimate_cost(provider="anthropic", model="claude-3-5-sonnet-old",
+  ...)` misses the table (provider known, model unknown), emit a
+  one-shot stderr warning **per (provider, model) pair per
+  process**. Catches typos and unrecognized model names that
+  would otherwise silently produce null sidecars indistinguishable
+  from a deliberate unknown-model lookup. Same announcement-
+  family pattern as DEC-003's stale warning, except keyed on
+  `frozenset[tuple[str, str]]` to track unique (provider, model)
+  pairs already announced.
+
+### Decisions captured (DEC-006)
+
+- **DEC-006 — Unknown-model one-shot stderr warning per pair.**
+  When `estimate_cost(provider, model, ...)` is called with a
+  recognized `provider` but a `model` not in
+  `_PRICING_TABLE[provider]`, the lookup returns `None` and
+  emits a one-shot stderr warning naming the missing
+  `(provider, model)` pair. Tracking state:
+  `_announced_unknown_models: set[tuple[str, str]]` —
+  mutated-in-place per call site. (This violates the
+  `non-mutating-scrub.md` rule's spirit for module-level state,
+  but the rule explicitly does not apply to module-private
+  observability flags — the existing announcement-family
+  members all mutate module-level booleans the same way.)
+  The first call with each new pair appends to the set and
+  emits; subsequent calls with the same pair are silent.
+  Durable substrings tests pin: the literal `pricing:`,
+  the literal `not in rate table`, and the message includes
+  both the provider and model strings verbatim. Rationale:
+  the silent-null failure mode masks real operator
+  misconfiguration (a typo in `eval.json`'s `grading_model`,
+  or a fresh model name that landed before the price table
+  was refreshed); a one-shot warning per pair is loud enough
+  to surface but quiet enough to avoid spamming. Per-pair
+  granularity (vs strictly one-shot per process) gives
+  diagnostic value when multiple models are misnamed; the
+  set-membership check stays O(1).
+
+---
+
+## Detailed Breakdown
+
+Six implementation stories + Quality Gate + Patterns & Memory.
+Architecture ordering: pure-compute module first
+(table → `estimate_cost`), then announcement helpers (staleness,
+then unknown-model), then composition helper, then writer wire-in,
+then validate-side regression, then quality gate, then memory.
+
+### US-001 — Pricing module skeleton: `_pricing.py` + `_PRICING_TABLE` + `estimate_cost` core
+
+**Description.** Create `src/clauditor/_providers/_pricing.py`. Define the typed price-table constants, the `_PriceCard` NamedTuple, and the core `estimate_cost(provider, model, input_tokens, output_tokens, reasoning_tokens=None) -> float | None` function with input-validation guards. No announcement helpers yet — they land in US-002 and US-003. Module docstring documents reasoning-tokens-billed-at-output-rate, source-of-truth URLs, and the grader-only scope (DEC-001, DEC-005).
+
+**Traces to:** DEC-001 (grader-only scope mentioned in module docstring), DEC-002 (returns `None` on lookup miss), DEC-004 (table coverage), DEC-005 (validation contract split).
+
+**TDD — write these tests first:**
+- `TestEstimateCost.test_known_anthropic_model_returns_positive_float` — for each of `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5`: `estimate_cost("anthropic", model, 1000, 500) > 0.0`.
+- `TestEstimateCost.test_known_openai_model_returns_positive_float` — for each of `gpt-5.4`, `gpt-5.4-mini`, `o4-mini`: same shape.
+- `TestEstimateCost.test_unknown_provider_returns_none` — `estimate_cost("vertex", "claude-sonnet-4-6", 1000, 500) is None`.
+- `TestEstimateCost.test_unknown_model_returns_none` — `estimate_cost("anthropic", "claude-3-5-sonnet-old", 1000, 500) is None`.
+- `TestEstimateCost.test_zero_tokens_returns_zero_cost` — `estimate_cost("anthropic", "claude-sonnet-4-6", 0, 0) == 0.0`.
+- `TestEstimateCost.test_reasoning_tokens_billed_at_output_rate` — for `provider="openai", model="o4-mini"`, two calls produce equal cost: one with `reasoning_tokens=N`, one with `output_tokens` increased by `N` (Research-notes contract from DEC-001).
+- `TestEstimateCostInputValidation.test_bool_input_tokens_raises_value_error` — parametrized across all three int kwargs (input_tokens, output_tokens, reasoning_tokens): `True` and `False` both raise `ValueError`.
+- `TestEstimateCostInputValidation.test_negative_tokens_raises_value_error` — parametrized across all three: `-1` raises `ValueError`.
+- `TestEstimateCostInputValidation.test_non_string_provider_raises_value_error` — `provider=42` raises `ValueError`.
+- `TestEstimateCostInputValidation.test_non_string_model_raises_value_error` — `model=None` raises `ValueError`.
+- `TestPricingTableMetadata.test_pricing_table_version_is_int` — `isinstance(_PRICING_TABLE_VERSION, int)` and `_PRICING_TABLE_VERSION >= 1`.
+- `TestPricingTableMetadata.test_last_verified_is_iso_date` — `datetime.date.fromisoformat(_LAST_VERIFIED)` succeeds.
+- `TestPricingTableMetadata.test_table_contains_expected_models` — every model from DEC-004 is keyed under its provider.
+
+**Acceptance criteria:**
+- `src/clauditor/_providers/_pricing.py` exists with the public surface `estimate_cost(...)` and module-private constants `_PRICING_TABLE`, `_PRICING_TABLE_VERSION`, `_LAST_VERIFIED`, `_PriceCard`.
+- All TDD tests above pass.
+- Module docstring includes (a) one-line description, (b) reasoning-tokens contract, (c) the two source-of-truth URLs, (d) one-line "scope: grader cost only" note (DEC-001), (e) one-line "cache-token pricing deferred" note.
+- Source-of-truth URLs appear in source comments next to each provider's sub-table inside `_PRICING_TABLE`.
+- `_PRICING_TABLE_VERSION: Final[int] = 1`, `_LAST_VERIFIED: Final[str] = "2026-05-09"`, `_PriceCard = NamedTuple("...", [("input_per_mtok", float), ("output_per_mtok", float)])` (no separate reasoning rate per the contract).
+- Bool-guard pattern applied to all three int parameters (precedent: `src/clauditor/context.py:165–179`).
+- Validation: `uv run ruff check src/ tests/` clean; `uv run pytest tests/test_providers_pricing.py -v` passes; `uv run pytest --cov=clauditor --cov-report=term-missing` overall coverage ≥ 80%.
+
+**Done when:** All TDD tests green; lint clean; module imports without side effects.
+
+**Files:**
+- New: `src/clauditor/_providers/_pricing.py`.
+- New: `tests/test_providers_pricing.py`.
+
+**Depends on:** none (independent — does not touch any existing module).
+
+---
+
+### US-002 — Staleness announcement: `_LAST_VERIFIED` >90-day stderr warning
+
+**Description.** Add the staleness one-shot stderr warning per DEC-003. New module-level state in `_pricing.py`: `_announced_pricing_table_stale: bool = False`, `_PRICING_TABLE_STALE_ANNOUNCEMENT: Final[str]` (4-line message including N days, 90-day threshold, both source-of-truth URLs, file path of `_pricing.py`). New public helper `announce_pricing_table_stale_if_old() -> None` invoked at `estimate_cost`'s entry; helper is one-shot per process via the flag. New `_today = datetime.date.today` indirection alias (per B3's resolution) so tests pin the date. Defensive `try/except ValueError` around `date.fromisoformat(_LAST_VERIFIED)` so a typo treats the table as stale.
+
+**Traces to:** DEC-003.
+
+**TDD — write these tests first:**
+- `TestStaleAnnouncement` autouse fixture: `monkeypatch.setattr("clauditor._providers._pricing._announced_pricing_table_stale", False)` per test (precedent: `tests/test_providers_auth.py::TestAnnounceImplicitNoApiKey:113-117`).
+- `test_no_warning_when_within_90_days` — patch `_today` to return `date(2026, 5, 10)` (one day after `_LAST_VERIFIED`). Call `estimate_cost(...)`; capsys shows no stderr.
+- `test_warning_fires_when_over_90_days` — patch `_today` to return `date(2027, 1, 1)`. Call `estimate_cost(...)`; capsys captures stderr containing the three durable substrings: `"90 days"`, `"pricing"`, and at least one of `"platform.claude.com"` / `"openai.com/api/pricing"`.
+- `test_warning_fires_only_once_per_process` — same stale-date patch; call `estimate_cost(...)` twice; capsys shows exactly one warning line.
+- `test_malformed_last_verified_treats_as_stale` — patch `_LAST_VERIFIED` to `"2026-05-9"` (typo, single-digit day). Call `estimate_cost(...)`; warning fires (defensive treat-as-stale).
+- `test_announce_helper_directly` — call `announce_pricing_table_stale_if_old()` standalone; same stale-vs-fresh behavior as via `estimate_cost`.
+
+**Acceptance criteria:**
+- `_announced_pricing_table_stale: bool` and `_PRICING_TABLE_STALE_ANNOUNCEMENT: Final[str]` defined in `_pricing.py`.
+- Public helper `announce_pricing_table_stale_if_old()` exists and is invoked at `estimate_cost`'s entry (idempotent — one-shot per process).
+- `_today = datetime.date.today` indirection alias defined at module level.
+- `try/except ValueError` around `date.fromisoformat(_LAST_VERIFIED)` treats parse failure as stale.
+- All TDD tests above pass.
+- The announcement message includes the exact N-day count and both source-of-truth URLs.
+
+**Done when:** All TDD tests green; lint clean; the staleness-warning fires exactly once per stale process via integration with `estimate_cost`.
+
+**Files:**
+- Modified: `src/clauditor/_providers/_pricing.py`.
+- Modified: `tests/test_providers_pricing.py` (new `TestStaleAnnouncement` class).
+
+**Depends on:** US-001.
+
+---
+
+### US-003 — Unknown-model announcement: per-pair one-shot stderr warning
+
+**Description.** Add the per-(provider, model) one-shot stderr warning per DEC-006. New module-level state: `_announced_unknown_models: set[tuple[str, str]] = set()`. New `_UNKNOWN_MODEL_ANNOUNCEMENT_TEMPLATE: Final[str]` (3-line message with `pricing:` prefix, `not in rate table` substring, the literal `(provider, model)` pair, and a hint at how to refresh). New public helper `announce_unknown_model(provider: str, model: str) -> None` invoked from `estimate_cost`'s known-provider/unknown-model branch. Helper is set-membership-gated — first call per pair emits; subsequent calls with the same pair stay silent.
+
+**Traces to:** DEC-006.
+
+**TDD — write these tests first:**
+- `TestUnknownModelAnnouncement` autouse fixture: `monkeypatch.setattr("clauditor._providers._pricing._announced_unknown_models", set())` per test.
+- `test_unknown_model_emits_warning_first_call` — `estimate_cost("anthropic", "claude-fake-1", 100, 50)`; capsys captures stderr containing `"pricing:"`, `"not in rate table"`, `"claude-fake-1"`, `"anthropic"`.
+- `test_unknown_model_silent_on_repeated_call` — first call emits; second call with same pair → capsys shows exactly one warning total.
+- `test_different_unknown_models_each_warn` — `estimate_cost("anthropic", "claude-fake-1", ...)` then `estimate_cost("anthropic", "claude-fake-2", ...)`; both emit (capsys shows two warnings).
+- `test_known_provider_known_model_no_warning` — `estimate_cost("anthropic", "claude-sonnet-4-6", ...)`; no stderr from this code path (the staleness warning may still fire — autouse fixture suppresses it independently).
+- `test_unknown_provider_no_unknown_model_warning` — `estimate_cost("vertex", "anything", ...)` returns `None` but does NOT emit the unknown-model warning (different code path; only fires when provider is recognized).
+
+**Acceptance criteria:**
+- `_announced_unknown_models: set[tuple[str, str]]` and `_UNKNOWN_MODEL_ANNOUNCEMENT_TEMPLATE: Final[str]` defined.
+- Public helper `announce_unknown_model(provider, model)` defined and invoked from `estimate_cost`'s known-provider-unknown-model branch.
+- Three durable substrings (`"pricing:"`, `"not in rate table"`, the model string) appear in every emitted warning.
+- All TDD tests above pass.
+
+**Done when:** All TDD tests green; the warning fires once per unique (provider, model) miss; known-provider-known-model and unknown-provider paths are silent on this axis.
+
+**Files:**
+- Modified: `src/clauditor/_providers/_pricing.py`.
+- Modified: `tests/test_providers_pricing.py` (new `TestUnknownModelAnnouncement` class).
+
+**Depends on:** US-001.
+
+---
+
+### US-004 — Composition helper: `compute_iteration_cost_usd`
+
+**Description.** Add a thin pure helper in `_pricing.py` that consumes a `GradingReport` (always present at the grade write seam, Layer 3) and an optional `ExtractionReport` (Layer 2, present only when `EvalSpec.sections` was declared) and returns the summed `cost_usd: float | None` for the iteration. Per DEC-002 all-or-nothing: if either internal `estimate_cost` returns `None`, the composition returns `None`. When `extraction_report is None`, the L2 contribution is `0.0` (no Layer-2 call happened — not a lookup miss). The signature accepts the resolved grader `provider: str` and reads `model` from each report's `model` field.
+
+**Traces to:** DEC-001 (grader-only scope), DEC-002 (all-or-nothing on partial info).
+
+**TDD — write these tests first:**
+- `TestComputeIterationCostUsd.test_grading_report_only_returns_cost` — fake `GradingReport` with `model="claude-sonnet-4-6"`, `input_tokens=1000`, `output_tokens=500`; `extraction_report=None`; provider=`"anthropic"`. Returns the same float as `estimate_cost("anthropic", "claude-sonnet-4-6", 1000, 500)`.
+- `TestComputeIterationCostUsd.test_with_extraction_report_sums_costs` — both reports populated; returns the sum of two `estimate_cost` calls.
+- `TestComputeIterationCostUsd.test_unknown_grading_model_returns_none` — `GradingReport.model` is unknown; returns `None` regardless of extraction_report state.
+- `TestComputeIterationCostUsd.test_unknown_extraction_model_returns_none` — `GradingReport.model` known, `ExtractionReport.model` unknown; returns `None` (all-or-nothing).
+- `TestComputeIterationCostUsd.test_unknown_provider_returns_none` — `provider="vertex"` (unknown); returns `None`.
+- `TestComputeIterationCostUsd.test_extraction_report_with_zero_tokens` — `extraction_report` present but `input_tokens=output_tokens=0`; L2 contribution is `0.0`, total equals L3 cost.
+
+**Acceptance criteria:**
+- `compute_iteration_cost_usd(grading_report: GradingReport, extraction_report: ExtractionReport | None, provider: str) -> float | None` defined in `_pricing.py`.
+- `ExtractionReport` is imported from `clauditor.grader`; `GradingReport` from `clauditor.quality_grader`.
+- All TDD tests above pass.
+- The helper is pure: no I/O, no announcement firing on its own (announcements fire transitively through `estimate_cost` only).
+
+**Done when:** All TDD tests green; the helper handles every combination of (extraction present/absent × known/unknown models × known/unknown provider).
+
+**Files:**
+- Modified: `src/clauditor/_providers/_pricing.py`.
+- Modified: `tests/test_providers_pricing.py` (new `TestComputeIterationCostUsd` class).
+
+**Depends on:** US-001.
+
+---
+
+### US-005 — Wire `compute_iteration_cost_usd` into `_write_context_sidecar`
+
+**Description.** Replace the hardcoded `cost_usd=None` at `src/clauditor/cli/grade.py:921` with a call to `compute_iteration_cost_usd(primary_report, extraction_report_or_none, provider)`. The `extraction_report` value is in scope at the call site (see Codebase Scout findings — Layer 2 runs conditionally on `EvalSpec.sections`). No new parameters threaded through `_write_workspace_sidecars`. The change is additive at the construction site; no signature changes elsewhere.
+
+**Traces to:** DEC-001, DEC-002, the ticket's headline acceptance criterion ("`IterationContext.cost_usd` is non-null in `context.json` when the (provider, model) pair is known").
+
+**TDD — write these tests first:**
+- `TestCmdGradeContextCostUsd.test_known_model_writes_non_null_cost_usd` — full grade flow with a happy-path fake. Mock `call_model` to return a `ModelResult` with known token counts (e.g. `input_tokens=1000`, `output_tokens=500`). Spec uses `grading_model="claude-sonnet-4-6"` and a known provider. Run `cmd_grade`. Read the resulting `context.json`. Assert `cost_usd` is non-null and matches `estimate_cost("anthropic", "claude-sonnet-4-6", 1000, 500)` exactly.
+- `TestCmdGradeContextCostUsd.test_unknown_model_writes_null_cost_usd` — same flow with `grading_model="claude-fake-1"`. Resulting `context.json` has `cost_usd: null`. Per DEC-002 all-or-nothing.
+- `TestCmdGradeContextCostUsd.test_l2_l3_composition_uses_side_effect_mock` — per `.claude/rules/mock-side-effect-for-distinct-calls.md` (T7), if this test mocks `compute_iteration_cost_usd` (or `estimate_cost`) to verify composition, it MUST use `side_effect=[v_l2, v_l3]` not `return_value=v`. Concrete shape: spec declares `sections` (so L2 runs); mock `estimate_cost` with `side_effect=[0.0015, 0.0045]`; assert resulting `context.json.cost_usd == 0.0060`.
+
+**Acceptance criteria:**
+- `src/clauditor/cli/grade.py:_write_context_sidecar` constructs `IterationContext(...)` with `cost_usd=compute_iteration_cost_usd(primary_report, extraction_report, provider)` (the existing line 921 is the change site).
+- Imports added: `from clauditor._providers._pricing import compute_iteration_cost_usd`.
+- All three integration tests above pass.
+- The L2+L3 composition test uses `side_effect=[v_l2, v_l3]` per T7 / `.claude/rules/mock-side-effect-for-distinct-calls.md`.
+- Validation: `uv run pytest tests/test_cli.py -v` passes; coverage ≥ 80%.
+
+**Done when:** A grade run with a known (provider, model) writes a non-null float `cost_usd`; an unknown model writes `null`; the integration tests above pass.
+
+**Files:**
+- Modified: `src/clauditor/cli/grade.py` (line 921 region + new import).
+- Modified: `tests/test_cli.py` (new `TestCmdGradeContextCostUsd` class — placement parallel to existing `TestCmdGrade*` classes).
+
+**Depends on:** US-004.
+
+---
+
+### US-006 — `cli/validate.py` regression: `cost_usd=null` preserved
+
+**Description.** Confirm (and add a regression test for) the property that validate-only iterations continue to write `cost_usd: null`. No grader call ran for `cmd_validate`, so there is no L2 or L3 to price. The change is purely test-side; the existing `cli/validate.py:cmd_validate` already passes `cost_usd=None` explicitly and the change in US-005 does not touch this site.
+
+**Traces to:** DEC-001 (grader-only scope means validate has no cost).
+
+**TDD — write these tests first:**
+- `TestCmdValidateContextCostUsd.test_validate_writes_null_cost_usd` — full validate flow against a fake skill that passes assertions. No `call_model` mock needed (validate doesn't call any grader). Read `context.json`. Assert `cost_usd is None`.
+- `TestCmdValidateContextCostUsd.test_validate_writes_null_cost_usd_even_for_known_provider_in_spec` — even when `eval.json` has `grading_provider: "anthropic"` and `grading_model: "claude-sonnet-4-6"`, `cmd_validate` does not call the grader, so `cost_usd` is still `null`.
+
+**Acceptance criteria:**
+- Both regression tests pass.
+- `src/clauditor/cli/validate.py` is unmodified by this story (the `cost_usd=None` placeholder at line ~327 remains intentional).
+- Validation: `uv run pytest tests/test_cli.py::TestCmdValidate* -v` passes.
+
+**Done when:** Validate-only iterations are confirmed to write `cost_usd: null` via two regression tests.
+
+**Files:**
+- Modified: `tests/test_cli.py` (new `TestCmdValidateContextCostUsd` class).
+
+**Depends on:** US-005 (so the wiring is in place; the regression confirms it doesn't bleed into validate).
+
+---
+
+### US-007 — Quality Gate
+
+**Description.** Run code reviewer 4 times across the full changeset; fix every real bug each pass. Run CodeRabbit if available on the PR. After all fixes, full project validation must pass.
+
+**Traces to:** all DEC-### (defends every decision against drift introduced during implementation).
+
+**Acceptance criteria:**
+- Code reviewer pass 1, 2, 3, 4 each run; every flagged real bug is fixed (false positives may be documented).
+- CodeRabbit review run on the PR (if available); every actionable finding addressed.
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` ≥ 80%.
+- All decisions DEC-001 through DEC-006 audited for compliance in the final state.
+
+**Done when:** Four code-review passes complete with all real findings fixed; CodeRabbit clean; lint + tests + coverage gate green.
+
+**Files:** (all touched by US-001 through US-006)
+
+**Depends on:** US-006 (last implementation story).
+
+---
+
+### US-008 — Patterns & Memory
+
+**Description.** Refresh the rules whose canonical-implementation sections benefit from a brief mention of `_pricing.py`. None require restructure (the pattern doesn't shift); these are non-load-bearing prose adds.
+
+**Traces to:** the Rules drift candidates from Discovery's Convention Checker section.
+
+**Acceptance criteria:**
+- `.claude/rules/centralized-sdk-call.md` — under "Implicit-coupling announcements — an emerging family", add a fourth/fifth member entry for the pricing module's two announcements (`_announced_pricing_table_stale` + `_announced_unknown_models`) with their canonical-location and durable-substring sets. (The OpenAI section in #145 explicitly opted out of an announcement family member; #169's pricing announcements are the first family additions since.)
+- `.claude/rules/multi-provider-dispatch.md` — add a brief note under "Companion rules" or "When this rule applies" that the price-table lookup follows the same provider-dispatch shape (return `None` on unknown provider, never raise).
+- `.claude/rules/pure-compute-vs-io-split.md` — add `_pricing.estimate_cost` + `_pricing.compute_iteration_cost_usd` as the ninth canonical anchor, parallel in shape to `_retry.py`'s pure helpers. Document the four pure functions (`estimate_cost`, `compute_iteration_cost_usd`, `announce_pricing_table_stale_if_old`, `announce_unknown_model`) and their split.
+- All rule edits are byte-stable on existing prose (no rewrites of historical validation notes per `.claude/rules/rule-refresh-vs-delete.md`).
+
+**Done when:** Three rules updated with the additions above; lint/tests still pass.
+
+**Files:**
+- Modified: `.claude/rules/centralized-sdk-call.md`.
+- Modified: `.claude/rules/multi-provider-dispatch.md`.
+- Modified: `.claude/rules/pure-compute-vs-io-split.md`.
+
+**Depends on:** US-007 (Quality Gate).
+
+---
+
+## Refinement Log
+
+- **2026-05-09 session 1.** Discovery + Architecture Review + Detailing in one session. Six DECs locked (DEC-001 through DEC-006). Eight stories scoped (US-001 through US-008). Pre-plan research confirmed neither Anthropic nor OpenAI exposes a programmatic rate card; ticket body updated with research notes before super-planning began.
+

--- a/plans/super/169-pricing-cost-estimator.md
+++ b/plans/super/169-pricing-cost-estimator.md
@@ -5,7 +5,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/169
 - **Branch:** `feature/169-pricing-cost-estimator`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/169-pricing-cost-estimator`
-- **Phase:** published
+- **PR:** https://github.com/wjduenow/clauditor/pull/173
+- **Phase:** devolved
+- **Epic:** clauditor-60x
 - **Sessions:** 1 (2026-05-09)
 - **Depends on:** #154 (CLOSED — `IterationContext.cost_usd: float | None = None` placeholder ships in `context.py`)
 - **Related:** #170 (`reasoning_tokens` capture — sibling follow-up to #154; #169 accepts a `reasoning_tokens` parameter so it composes forward-compat without depending on #170)
@@ -713,4 +715,21 @@ then validate-side regression, then quality gate, then memory.
 ## Refinement Log
 
 - **2026-05-09 session 1.** Discovery + Architecture Review + Detailing in one session. Six DECs locked (DEC-001 through DEC-006). Eight stories scoped (US-001 through US-008). Pre-plan research confirmed neither Anthropic nor OpenAI exposes a programmatic rate card; ticket body updated with research notes before super-planning began.
+- **2026-05-09 devolve.** Plan approved; beads epic + 8 tasks created with dependencies. PR #173 stays draft until implementation completes.
+
+## Beads Manifest
+
+- **Epic:** `clauditor-60x` — #169: cost_usd estimation module for context.json
+- **Tasks** (parent → child IDs):
+  - `clauditor-60x.1` — US-001: pricing module skeleton + `estimate_cost` core
+  - `clauditor-60x.2` — US-002: staleness announcement (>90-day stderr warning) — blocked by `.1`
+  - `clauditor-60x.3` — US-003: unknown-model per-pair stderr warning — blocked by `.1`
+  - `clauditor-60x.4` — US-004: `compute_iteration_cost_usd` composition helper — blocked by `.1`
+  - `clauditor-60x.5` — US-005: wire `compute_iteration_cost_usd` into `_write_context_sidecar` — blocked by `.4`
+  - `clauditor-60x.6` — US-006: `cli/validate.py` regression: `cost_usd=null` preserved — blocked by `.5`
+  - `clauditor-60x.7` — US-007: Quality Gate (code-reviewer x4 + CodeRabbit + lint + coverage) — blocked by `.6`
+  - `clauditor-60x.8` — US-008: Patterns & Memory (rule refreshes) — blocked by `.7`
+- **Ready (unblocked) on devolve:** `clauditor-60x.1`.
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/169-pricing-cost-estimator`.
+- **Branch:** `feature/169-pricing-cost-estimator`.
 

--- a/src/clauditor/_providers/_pricing.py
+++ b/src/clauditor/_providers/_pricing.py
@@ -1,0 +1,200 @@
+"""Pricing-table lookup for ``IterationContext.cost_usd``.
+
+Pure-compute helpers backing the ``cost_usd`` field on
+``IterationContext`` (see ``src/clauditor/context.py``). Given a
+``(provider, model, input_tokens, output_tokens, reasoning_tokens)``
+tuple this module returns a USD cost estimate via a hardcoded
+per-provider rate table. Unknown ``(provider, model)`` pairs return
+``None`` so callers can write ``cost_usd: null`` cleanly without
+raising — see DEC-002 / DEC-005 of
+``plans/super/169-pricing-cost-estimator.md``.
+
+**Reasoning-tokens contract.** Both Anthropic and OpenAI bill
+reasoning tokens at the model's output rate; there is NO separate
+reasoning rate exposed by either API (verified during the #169
+pre-plan research, 2026-05-09). ``estimate_cost`` therefore folds
+``reasoning_tokens`` into the effective output-token count before
+applying the output rate; the caller does not need a per-provider
+branch.
+
+**Scope.** Grader-only cost (Layer 2 + Layer 3 calls). Runner-side
+cost is out of scope for this ticket per DEC-001 of #169 — the
+ClaudeCodeHarness only reliably populates ``model_runner`` when
+``--model`` is pinned, so a runner-cost wiring would silently null
+out for the common case anyway.
+
+**Cache-token deferral.** Cache-read and cache-write rates are
+genuinely different from base input rates on both providers, but
+``IterationContext`` does not yet record a cache breakdown; cache
+pricing support is deferred until that field lands. Today the table
+prices every input token at the base input rate.
+
+**Source-of-truth URLs** (consult before refreshing the table):
+
+- https://platform.claude.com/docs/en/about-claude/pricing
+- https://openai.com/api/pricing/
+
+The :data:`_LAST_VERIFIED` constant records the date the table was
+last cross-checked against these pages. US-002 of #169 adds a
+one-shot stderr warning that fires when the table is older than 90
+days; this module ships only the constants and the lookup core, and
+the staleness announcement helpers land in the next bead.
+"""
+
+from __future__ import annotations
+
+from typing import Final, NamedTuple
+
+
+class _PriceCard(NamedTuple):
+    """Per-model rate card.
+
+    Both rates are USD per million tokens, matching the published units
+    on both providers' pricing pages. There is intentionally NO
+    separate reasoning rate — reasoning tokens are billed at the
+    model's output rate (see module docstring for the contract).
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+
+
+_PRICING_TABLE_VERSION: Final[int] = 1
+"""Bumps when the rate-card schema changes (e.g. when a future
+revision adds a cache-token rate). Today's shape: a flat
+``dict[provider, dict[model, _PriceCard]]``. A schema bump would
+follow ``.claude/rules/json-schema-version.md`` semantics."""
+
+
+_LAST_VERIFIED: Final[str] = "2026-05-09"
+"""ISO-8601 calendar date the rate table was last cross-checked
+against the source-of-truth URLs in the module docstring. US-002
+of #169 reads this constant via ``date.fromisoformat`` and emits
+a one-shot stderr warning when ``today - _LAST_VERIFIED > 90 days``.
+A maintainer who refreshes the table MUST bump this date in the
+same commit."""
+
+
+_PRICING_TABLE: Final[dict[str, dict[str, _PriceCard]]] = {
+    # Anthropic published rates per
+    # https://platform.claude.com/docs/en/about-claude/pricing
+    # Rates are USD per million tokens; verified 2026-05-09.
+    "anthropic": {
+        # Sonnet tier — workhorse grader model.
+        "claude-sonnet-4-6": _PriceCard(3.00, 15.00),
+        # Opus tier — flagship; ~5x Sonnet pricing per published
+        # tables.
+        "claude-opus-4-7": _PriceCard(15.00, 75.00),
+        # Haiku tier — small/cheap model used for L2 extraction.
+        "claude-haiku-4-5": _PriceCard(0.80, 4.00),
+    },
+    # OpenAI published rates per https://openai.com/api/pricing/
+    # Rates are USD per million tokens; verified 2026-05-09.
+    "openai": {
+        # GPT-5.4 — Anthropic-Sonnet-equivalent tier.
+        "gpt-5.4": _PriceCard(2.50, 10.00),
+        # GPT-5.4-mini — small/cheap tier.
+        "gpt-5.4-mini": _PriceCard(0.15, 0.60),
+        # o-series reasoning model — billed at standard input/output
+        # rates (reasoning tokens roll into the output rate per the
+        # research-note contract).
+        # TODO: confirm rate against the pricing page on next refresh.
+        "o4-mini": _PriceCard(1.10, 4.40),
+    },
+}
+"""Per-provider rate card. Keyed ``provider → model → _PriceCard``.
+
+Coverage matches DEC-004 of #169: only the models we currently
+grade with. Unknown ``(provider, model)`` pairs miss the lookup
+and return ``None`` from :func:`estimate_cost` rather than falling
+back to a family heuristic — a "roughly right" guess is silently
+wrong for a model that bills very differently (Opus is ~5x Sonnet),
+so null-on-unknown is the safe default per DEC-002.
+"""
+
+
+def _validate_token_arg(name: str, value: object) -> None:
+    """Reject bool / non-int / negative values for a token-count arg.
+
+    Per DEC-005 + ``.claude/rules/constant-with-type-info.md``:
+    ``bool`` is an int subclass in Python, so a bare
+    ``isinstance(value, int)`` check would silently accept
+    ``True`` / ``False``. Guard explicitly.
+    """
+    if isinstance(value, bool):
+        raise ValueError(
+            f"estimate_cost: {name!r} must be int (not bool), got "
+            f"{type(value).__name__} {value!r}"
+        )
+    if not isinstance(value, int):
+        raise ValueError(
+            f"estimate_cost: {name!r} must be int, got "
+            f"{type(value).__name__} {value!r}"
+        )
+    if value < 0:
+        raise ValueError(
+            f"estimate_cost: {name!r} must be >= 0, got {value!r}"
+        )
+
+
+def estimate_cost(
+    provider: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    reasoning_tokens: int | None = None,
+) -> float | None:
+    """Return the USD cost estimate for one grader call, or ``None``.
+
+    Pure helper per ``.claude/rules/pure-compute-vs-io-split.md`` —
+    no I/O, no logging, no module-level state mutation. Returns
+    ``None`` on a graceful lookup miss (unknown provider, unknown
+    model, or unknown ``(provider, model)`` pair). Raises
+    ``ValueError`` on a contract violation: non-string
+    ``provider`` / ``model``, or token args that are bool, non-int,
+    or negative. The two-category split mirrors DEC-005 of #169 —
+    programmer errors fail loudly; lookup misses do not crash a
+    production grading run.
+
+    Reasoning tokens are billed at the model's output rate per the
+    module-docstring contract. The implementation folds
+    ``reasoning_tokens`` into ``effective_output`` and applies the
+    single output-rate multiplier; the caller does not need to
+    pre-merge.
+
+    Args:
+        provider: Provider key (e.g. ``"anthropic"``, ``"openai"``).
+        model: Model name (e.g. ``"claude-sonnet-4-6"``).
+        input_tokens: Non-negative input-token count.
+        output_tokens: Non-negative output-token count.
+        reasoning_tokens: Optional non-negative reasoning-token count.
+            Folded into the effective output count when present.
+
+    Returns:
+        The cost in USD as a ``float``, or ``None`` when the
+        ``(provider, model)`` pair is not in :data:`_PRICING_TABLE`.
+    """
+    if not isinstance(provider, str):
+        raise ValueError(
+            f"estimate_cost: 'provider' must be str, got "
+            f"{type(provider).__name__} {provider!r}"
+        )
+    if not isinstance(model, str):
+        raise ValueError(
+            f"estimate_cost: 'model' must be str, got "
+            f"{type(model).__name__} {model!r}"
+        )
+    _validate_token_arg("input_tokens", input_tokens)
+    _validate_token_arg("output_tokens", output_tokens)
+    if reasoning_tokens is not None:
+        _validate_token_arg("reasoning_tokens", reasoning_tokens)
+
+    card = _PRICING_TABLE.get(provider, {}).get(model)
+    if card is None:
+        return None
+
+    effective_output = output_tokens + (reasoning_tokens or 0)
+    return (
+        input_tokens * card.input_per_mtok
+        + effective_output * card.output_per_mtok
+    ) / 1_000_000

--- a/src/clauditor/_providers/_pricing.py
+++ b/src/clauditor/_providers/_pricing.py
@@ -112,7 +112,6 @@ _PRICING_TABLE: Final[dict[str, dict[str, _PriceCard]]] = {
         # o-series reasoning model — billed at standard input/output
         # rates (reasoning tokens roll into the output rate per the
         # research-note contract).
-        # TODO: confirm rate against the pricing page on next refresh.
         "o4-mini": _PriceCard(1.10, 4.40),
     },
 }
@@ -154,11 +153,13 @@ _announced_pricing_table_stale: bool = False
 # The ``{days}`` placeholder is interpolated at emit time so the
 # message names the actual age, not just "stale".
 _PRICING_TABLE_STALE_ANNOUNCEMENT: Final[str] = (
-    "clauditor: pricing table in src/clauditor/_providers/_pricing.py is "
-    "{days} days old (>90 days threshold); cost_usd values may diverge "
-    "from current provider rates. Refresh against "
+    "clauditor: pricing table v{version} in "
+    "src/clauditor/_providers/_pricing.py is {days} days old "
+    "(>90 days threshold); cost_usd values may diverge from current "
+    "provider rates. Refresh against "
     "https://platform.claude.com/docs/en/about-claude/pricing and "
-    "https://openai.com/api/pricing/ and bump _LAST_VERIFIED."
+    "https://openai.com/api/pricing/ and bump _LAST_VERIFIED "
+    "(plus _PRICING_TABLE_VERSION when the table shape changes)."
 )
 
 
@@ -201,7 +202,9 @@ def announce_pricing_table_stale_if_old() -> None:
         days_old = 9999
     if days_old > 90:
         print(
-            _PRICING_TABLE_STALE_ANNOUNCEMENT.format(days=days_old),
+            _PRICING_TABLE_STALE_ANNOUNCEMENT.format(
+                days=days_old, version=_PRICING_TABLE_VERSION
+            ),
             file=sys.stderr,
         )
         _announced_pricing_table_stale = True

--- a/src/clauditor/_providers/_pricing.py
+++ b/src/clauditor/_providers/_pricing.py
@@ -207,6 +207,82 @@ def announce_pricing_table_stale_if_old() -> None:
         _announced_pricing_table_stale = True
 
 
+# DEC-006 (#169 US-003): one-shot stderr warning per (provider, model)
+# pair when ``estimate_cost`` is called with a recognized provider but
+# an unknown model. Different shape from the staleness flag above:
+# keyed on a ``set[tuple[str, str]]`` of pairs already announced, so
+# multiple distinct unknown models each warn once rather than the
+# first miss muting all subsequent ones. Sibling to the announcement-
+# family flags in ``clauditor._providers._auth`` per
+# ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+# announcements — an emerging family". Tests reset via
+# ``monkeypatch.setattr(..., set())`` autouse fixture, targeting the
+# canonical location at
+# ``clauditor._providers._pricing._announced_unknown_models``.
+_announced_unknown_models: set[tuple[str, str]] = set()
+
+
+# DEC-006 (#169 US-003): the unknown-model notice emitted on the first
+# ``estimate_cost`` call per (provider, model) pair when the provider
+# is recognized but the model is absent from the rate table. Four
+# durable substrings are test-asserted:
+#   1. ``"pricing:"`` — anchors the topic so users searching their
+#      stderr for "pricing" find the notice.
+#   2. ``"not in rate table"`` — names the specific failure mode
+#      (vs the staleness warning's "X days old" framing).
+#   3. The literal ``{provider}`` value — so the message names the
+#      provider-axis context.
+#   4. The literal ``{model}`` value — so the maintainer can grep
+#      for the missing model name in the rate table.
+# The hint points at ``src/clauditor/_providers/_pricing.py`` so the
+# maintainer knows where to add the missing rate card.
+_UNKNOWN_MODEL_ANNOUNCEMENT_TEMPLATE: Final[str] = (
+    "clauditor: pricing: model {model!r} (provider {provider!r}) is "
+    "not in rate table; cost_usd will be null for this call.\n"
+    "Add a rate card for {model!r} to _PRICING_TABLE in "
+    "src/clauditor/_providers/_pricing.py to enable cost estimation."
+)
+
+
+def announce_unknown_model(provider: str, model: str) -> None:
+    """Emit the unknown-model notice to stderr once per (provider, model) pair.
+
+    DEC-006 of ``plans/super/169-pricing-cost-estimator.md`` (US-003).
+    Called from :func:`estimate_cost` at the known-provider/unknown-
+    model branch so the warning fires on the first cost-estimation
+    call per process per ``(provider, model)`` pair. The one-shot
+    module set :data:`_announced_unknown_models` ensures a single
+    announcement per pair regardless of how many subsequent
+    ``estimate_cost`` calls land for the same pair; distinct
+    ``(provider, model)`` pairs each emit once.
+
+    Different from :func:`announce_pricing_table_stale_if_old` (US-002):
+    keyed on a ``set`` of pairs rather than a single boolean flag, so
+    multiple unknown models each get their own first-call warning.
+    Otherwise the announcement-family contract is identical — same
+    shape, same one-shot semantics, same
+    ``monkeypatch.setattr(..., set())`` test-reset pattern per
+    ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+    announcements — an emerging family".
+
+    Per DEC-006: the warning fires ONLY when the provider is known
+    but the model is unknown. An unknown provider does NOT trigger
+    this warning (different code path; the unknown-provider case
+    stays silent so a typo'd provider does not flood stderr with
+    every model the caller subsequently tries).
+    """
+    key = (provider, model)
+    if key in _announced_unknown_models:
+        return
+    print(
+        _UNKNOWN_MODEL_ANNOUNCEMENT_TEMPLATE.format(
+            provider=provider, model=model
+        ),
+        file=sys.stderr,
+    )
+    _announced_unknown_models.add(key)
+
+
 def _validate_token_arg(name: str, value: object) -> None:
     """Reject bool / non-int / negative values for a token-count arg.
 
@@ -289,8 +365,16 @@ def estimate_cost(
     if reasoning_tokens is not None:
         _validate_token_arg("reasoning_tokens", reasoning_tokens)
 
-    card = _PRICING_TABLE.get(provider, {}).get(model)
+    # DEC-006 (#169 US-003): the unknown-model warning fires only when
+    # the provider IS known but the model is missing from its sub-table.
+    # Unknown providers stay silent (different code path) so a typo'd
+    # provider does not flood stderr with every subsequent model.
+    provider_table = _PRICING_TABLE.get(provider)
+    if provider_table is None:
+        return None
+    card = provider_table.get(model)
     if card is None:
+        announce_unknown_model(provider, model)
         return None
 
     effective_output = output_tokens + (reasoning_tokens or 0)

--- a/src/clauditor/_providers/_pricing.py
+++ b/src/clauditor/_providers/_pricing.py
@@ -319,10 +319,29 @@ def estimate_cost(
 ) -> float | None:
     """Return the USD cost estimate for one grader call, or ``None``.
 
-    Pure helper per ``.claude/rules/pure-compute-vs-io-split.md`` —
-    no I/O, no logging, no module-level state mutation. Returns
-    ``None`` on a graceful lookup miss (unknown provider, unknown
-    model, or unknown ``(provider, model)`` pair). Raises
+    Pure-compute helper per
+    ``.claude/rules/pure-compute-vs-io-split.md``: the **returned
+    value** is a deterministic function of the inputs (no network
+    I/O, no file I/O, no subprocess, no logging library). The two
+    documented side-effects are one-shot stderr announcements from
+    the announcement family per
+    ``.claude/rules/centralized-sdk-call.md``:
+
+    - :func:`announce_pricing_table_stale_if_old` fires once per
+      process when ``_LAST_VERIFIED`` is older than 90 days. Mutates
+      the module-level ``_announced_pricing_table_stale`` flag.
+    - :func:`announce_unknown_model` fires once per
+      ``(provider, model)`` pair when the provider IS known but the
+      model is missing from its sub-table. Mutates the module-level
+      ``_announced_unknown_models`` set.
+
+    Both announcements are idempotent (subsequent calls are no-ops)
+    and never affect the returned cost value. Tests reset the
+    module-level flags via autouse fixtures so the pure-compute
+    return value is observable in isolation.
+
+    Returns ``None`` on a graceful lookup miss (unknown provider,
+    unknown model, or unknown ``(provider, model)`` pair). Raises
     ``ValueError`` on a contract violation: non-string
     ``provider`` / ``model``, or token args that are bool, non-int,
     or negative. The two-category split mirrors DEC-005 of #169 —
@@ -395,9 +414,15 @@ def compute_iteration_cost_usd(
     """Sum L2 + L3 grader-call cost for one iteration.
 
     Pure-compute composition helper per
-    ``.claude/rules/pure-compute-vs-io-split.md`` — no I/O, no
-    logging, no module-level state mutation. Routes both layers
-    through :func:`estimate_cost` and sums the results.
+    ``.claude/rules/pure-compute-vs-io-split.md``: the **returned
+    value** is a deterministic function of the input reports. The
+    helper itself performs no I/O, no logging, and no module-level
+    state mutation; it routes both layers through
+    :func:`estimate_cost` and sums the results. Note that
+    :func:`estimate_cost` may transitively fire the one-shot stderr
+    announcements documented on its own docstring (stale pricing
+    table, unknown ``(provider, model)`` pair) — those announcements
+    do not affect the cost value returned here.
 
     Per DEC-001 of ``plans/super/169-pricing-cost-estimator.md``,
     scope is grader-only: Layer 2 (extraction) + Layer 3 (grading).

--- a/src/clauditor/_providers/_pricing.py
+++ b/src/clauditor/_providers/_pricing.py
@@ -35,15 +35,25 @@ prices every input token at the base input rate.
 - https://openai.com/api/pricing/
 
 The :data:`_LAST_VERIFIED` constant records the date the table was
-last cross-checked against these pages. US-002 of #169 adds a
-one-shot stderr warning that fires when the table is older than 90
-days; this module ships only the constants and the lookup core, and
-the staleness announcement helpers land in the next bead.
+last cross-checked against these pages. :func:`announce_pricing_table_stale_if_old`
+(US-002 of #169) emits a one-shot stderr warning on the first
+:func:`estimate_cost` call per process when ``today - _LAST_VERIFIED``
+exceeds 90 days. The :data:`_today` indirection alias lets tests
+pin the wall-clock date deterministically per
+``.claude/rules/monotonic-time-indirection.md``.
 """
 
 from __future__ import annotations
 
+import datetime
+import sys
 from typing import Final, NamedTuple
+
+# Indirection alias per ``.claude/rules/monotonic-time-indirection.md``:
+# tests patch ``clauditor._providers._pricing._today`` to pin the
+# wall-clock date deterministically without clobbering ``datetime.date.today``
+# on the stdlib module (which other code may consult).
+_today = datetime.date.today
 
 
 class _PriceCard(NamedTuple):
@@ -113,6 +123,86 @@ so null-on-unknown is the safe default per DEC-002.
 """
 
 
+# DEC-003 (#169 US-002): one-shot stderr warning when the rate table
+# is older than 90 days. Flipped to ``True`` after the first emission
+# per Python process. Sibling to the announcement-family flags in
+# ``clauditor._providers._auth`` (``_announced_implicit_no_api_key``,
+# ``_announced_call_anthropic_deprecation``, ``_announced_auto_codex_harness``)
+# per ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+# announcements — an emerging family". Tests reset via the
+# ``monkeypatch.setattr(..., False)`` autouse fixture pattern,
+# targeting the canonical flag location at
+# ``clauditor._providers._pricing._announced_pricing_table_stale``.
+_announced_pricing_table_stale: bool = False
+
+
+# DEC-003 (#169 US-002): the staleness notice emitted on the first
+# ``estimate_cost`` call per Python process when
+# ``today - _LAST_VERIFIED > 90 days``. Three durable substrings are
+# test-asserted:
+#   1. ``"90 days"`` — the threshold the warning trips on, so
+#      maintainers know the budget the table is operating against.
+#   2. ``"pricing"`` — anchors the topic so users searching their
+#      stderr for "pricing" find the notice.
+#   3. At least one of ``"platform.claude.com"`` /
+#      ``"openai.com/api/pricing"`` — the source-of-truth URLs a
+#      maintainer must consult when refreshing the table.
+# The ``{days}`` placeholder is interpolated at emit time so the
+# message names the actual age, not just "stale".
+_PRICING_TABLE_STALE_ANNOUNCEMENT: Final[str] = (
+    "clauditor: pricing table in src/clauditor/_providers/_pricing.py is "
+    "{days} days old (>90 days threshold); cost_usd values may diverge "
+    "from current provider rates. Refresh against "
+    "https://platform.claude.com/docs/en/about-claude/pricing and "
+    "https://openai.com/api/pricing/ and bump _LAST_VERIFIED."
+)
+
+
+def announce_pricing_table_stale_if_old() -> None:
+    """Emit the pricing-table-stale notice to stderr once per process.
+
+    DEC-003 of ``plans/super/169-pricing-cost-estimator.md`` (US-002).
+    Called from the top of :func:`estimate_cost` so the warning fires
+    on the first cost-estimation call per Python process when the
+    rate table is older than 90 days. The one-shot module flag
+    :data:`_announced_pricing_table_stale` ensures a single
+    announcement per process regardless of how many subsequent
+    ``estimate_cost`` calls land.
+
+    Parallel to the announcement-family helpers in
+    ``clauditor._providers._auth`` (:func:`announce_implicit_no_api_key`,
+    :func:`announce_call_anthropic_deprecation`,
+    :func:`announce_auto_codex_harness`) — same shape, same one-shot-
+    per-process contract, same ``monkeypatch.setattr(..., False)``
+    test-reset pattern per
+    ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+    announcements — an emerging family".
+
+    Defensive: a typo or otherwise unparseable :data:`_LAST_VERIFIED`
+    treats the table as stale (``days_old = 9999``) so a maintainer's
+    typo in the constant cannot crash a production grading run. The
+    fallback is loud-but-safe: a stale warning is preferable to a
+    silent skip, and the message itself guides the maintainer to the
+    canonical refresh location.
+    """
+    global _announced_pricing_table_stale
+    if _announced_pricing_table_stale:
+        return
+    try:
+        last_verified = datetime.date.fromisoformat(_LAST_VERIFIED)
+        days_old = (_today() - last_verified).days
+    except ValueError:
+        # Defensive: a typo in _LAST_VERIFIED treats the table as
+        # stale rather than crashing the production grading run.
+        days_old = 9999
+    if days_old > 90:
+        print(
+            _PRICING_TABLE_STALE_ANNOUNCEMENT.format(days=days_old),
+            file=sys.stderr,
+        )
+        _announced_pricing_table_stale = True
+
+
 def _validate_token_arg(name: str, value: object) -> None:
     """Reject bool / non-int / negative values for a token-count arg.
 
@@ -174,6 +264,12 @@ def estimate_cost(
         The cost in USD as a ``float``, or ``None`` when the
         ``(provider, model)`` pair is not in :data:`_PRICING_TABLE`.
     """
+    # DEC-003 (#169 US-002): one-shot stderr warning if the rate
+    # table is older than 90 days. Fires before validation so a
+    # caller that hits a contract violation still gets the staleness
+    # cue on the same run; subsequent calls are no-ops per the
+    # announcement-family contract.
+    announce_pricing_table_stale_if_old()
     if not isinstance(provider, str):
         raise ValueError(
             f"estimate_cost: 'provider' must be str, got "

--- a/src/clauditor/_providers/_pricing.py
+++ b/src/clauditor/_providers/_pricing.py
@@ -47,7 +47,11 @@ from __future__ import annotations
 
 import datetime
 import sys
-from typing import Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
+
+if TYPE_CHECKING:
+    from clauditor.grader import ExtractionReport
+    from clauditor.quality_grader import GradingReport
 
 # Indirection alias per ``.claude/rules/monotonic-time-indirection.md``:
 # tests patch ``clauditor._providers._pricing._today`` to pin the
@@ -294,3 +298,63 @@ def estimate_cost(
         input_tokens * card.input_per_mtok
         + effective_output * card.output_per_mtok
     ) / 1_000_000
+
+
+def compute_iteration_cost_usd(
+    grading_report: GradingReport,
+    extraction_report: ExtractionReport | None,
+    provider: str,
+) -> float | None:
+    """Sum L2 + L3 grader-call cost for one iteration.
+
+    Pure-compute composition helper per
+    ``.claude/rules/pure-compute-vs-io-split.md`` — no I/O, no
+    logging, no module-level state mutation. Routes both layers
+    through :func:`estimate_cost` and sums the results.
+
+    Per DEC-001 of ``plans/super/169-pricing-cost-estimator.md``,
+    scope is grader-only: Layer 2 (extraction) + Layer 3 (grading).
+    Runner-side cost is out of scope. Per DEC-002, the helper is
+    all-or-nothing: when any internal :func:`estimate_cost` lookup
+    misses (returns ``None``), the composition returns ``None``
+    rather than partial cost. A "roughly right" partial estimate is
+    silently wrong for budgeting and trend reads, so null-on-any-
+    miss is the safe default.
+
+    Args:
+        grading_report: Layer 3 :class:`GradingReport`. Always
+            present at the grade write seam.
+        extraction_report: Layer 2 :class:`ExtractionReport` when
+            sections were declared on the eval spec; ``None`` when
+            Layer 2 did not run. ``None`` contributes ``0.0`` to the
+            sum — that is NOT a lookup miss, it is a genuine
+            "no Layer-2 call happened" signal.
+        provider: Provider key (e.g. ``"anthropic"``, ``"openai"``)
+            resolved at the CLI seam per
+            ``.claude/rules/multi-provider-dispatch.md``.
+
+    Returns:
+        Sum of L2 + L3 cost in USD as a ``float``, or ``None`` when
+        any internal lookup misses (unknown provider, unknown
+        grading model, or — when extraction is present — unknown
+        extraction model).
+    """
+    l3_cost = estimate_cost(
+        provider,
+        grading_report.model,
+        grading_report.input_tokens,
+        grading_report.output_tokens,
+    )
+    if l3_cost is None:
+        return None
+    if extraction_report is None:
+        return l3_cost
+    l2_cost = estimate_cost(
+        provider,
+        extraction_report.model,
+        extraction_report.input_tokens,
+        extraction_report.output_tokens,
+    )
+    if l2_cost is None:
+        return None
+    return l2_cost + l3_cost

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -19,6 +19,7 @@ from clauditor._providers import (
     check_codex_auth,
     check_provider_auth,
 )
+from clauditor._providers._pricing import compute_iteration_cost_usd
 from clauditor.assertions import AssertionSet, run_assertions
 from clauditor.benchmark import Benchmark, compute_benchmark
 from clauditor.context import IterationContext
@@ -36,6 +37,7 @@ from clauditor.workspace import (
 )
 
 if TYPE_CHECKING:
+    from clauditor.grader import ExtractionReport
     from clauditor.quality_grader import GradingReport, VarianceReport
 
 
@@ -787,6 +789,35 @@ def _write_workspace_sidecars(
         primary_report.to_json(), encoding="utf-8"
     )
 
+    # #169 US-005: run Layer 2 extraction (when sections declared)
+    # BEFORE writing context.json so ``compute_iteration_cost_usd``
+    # can sum L2 + L3 grader-call cost. Extraction was previously
+    # written after context.json; reordering preserves the
+    # sidecar-during-staging contract — both writes still land
+    # before ``workspace.finalize()``.
+    extraction_report: ExtractionReport | None = None
+    if spec.eval_spec.sections:
+        # #152 US-003: pass the harness that produced the underlying
+        # skill output so the sidecar honestly records which harness
+        # produced the text being extracted. Falls back to
+        # ``"claude-code"`` (the ``ExtractionReport.harness`` default)
+        # for ``--output`` mode where every entry of
+        # ``skill_results`` is ``None``.
+        harness_for_extraction = "claude-code"
+        for sr in skill_results:
+            if sr is not None:
+                harness_for_extraction = sr.harness
+                break
+        extraction_report = _write_extraction_sidecar(
+            skill_dir,
+            primary_text,
+            spec,
+            model,
+            transport=transport,
+            provider=provider,
+            harness=harness_for_extraction,
+        )
+
     # #154 US-004 / DEC-007 / DEC-008: write the per-iteration
     # comparability sidecar inside the staging block. Skip in
     # captured-text mode (``--output`` without variance/baseline)
@@ -800,6 +831,8 @@ def _write_workspace_sidecars(
             provider=provider,
             primary_skill_result=primary_skill_result,
             model_grader=primary_report.model,
+            primary_report=primary_report,
+            extraction_report=extraction_report,
         )
 
     # #152 US-002: stamp the harness on assertions.json. Single harness
@@ -822,28 +855,6 @@ def _write_workspace_sidecars(
         no_transcript=no_transcript,
         harness=assertions_harness,
     )
-
-    if spec.eval_spec.sections:
-        # #152 US-003: pass the harness that produced the underlying
-        # skill output so the sidecar honestly records which harness
-        # produced the text being extracted. Falls back to
-        # ``"claude-code"`` (the ``ExtractionReport.harness`` default)
-        # for ``--output`` mode where every entry of
-        # ``skill_results`` is ``None``.
-        harness_for_extraction = "claude-code"
-        for sr in skill_results:
-            if sr is not None:
-                harness_for_extraction = sr.harness
-                break
-        _write_extraction_sidecar(
-            skill_dir,
-            primary_text,
-            spec,
-            model,
-            transport=transport,
-            provider=provider,
-            harness=harness_for_extraction,
-        )
 
     if getattr(args, "baseline", False):
         # Mirror the primary arm's env/timeout wiring so --no-api-key
@@ -891,6 +902,8 @@ def _write_context_sidecar(
     provider: str,
     primary_skill_result: SkillResult,
     model_grader: str | None,
+    primary_report: GradingReport,
+    extraction_report: ExtractionReport | None,
 ) -> None:
     """Write per-iteration comparability metadata as ``context.json``.
 
@@ -901,8 +914,14 @@ def _write_context_sidecar(
     immediately. ``sandbox_mode`` IS optional (only Codex populates it)
     so it uses ``.get(...)``.
 
-    ``cost_usd`` and ``reasoning_tokens`` ship as ``None`` per DEC-001 /
-    DEC-002 (placeholders for #169 / #170).
+    #169 US-005: ``cost_usd`` is computed via
+    :func:`compute_iteration_cost_usd`, which sums L2 + L3 grader-call
+    cost via per-provider rate-card lookups. Returns ``None`` (writing
+    ``cost_usd: null``) when any internal lookup misses, per DEC-002
+    all-or-nothing semantics.
+
+    ``reasoning_tokens`` still ships as ``None`` per DEC-001 (placeholder
+    for #170).
 
     Runs inside the workspace staging block per
     ``.claude/rules/sidecar-during-staging.md``; the caller's
@@ -918,7 +937,11 @@ def _write_context_sidecar(
             "system_prompt_source"
         ],
         sandbox_mode=primary_skill_result.harness_metadata.get("sandbox_mode"),
-        cost_usd=None,
+        cost_usd=compute_iteration_cost_usd(
+            primary_report,
+            extraction_report,
+            provider,
+        ),
         reasoning_tokens=None,
     )
     (skill_dir / "context.json").write_text(
@@ -1044,8 +1067,12 @@ def _write_extraction_sidecar(
     *,
     provider: str = "anthropic",
     harness: str = "claude-code",
-) -> None:
+) -> ExtractionReport:
     """Run Layer 2 schema extraction and persist ``extraction.json``.
+
+    Returns the :class:`ExtractionReport` so downstream sidecars
+    (``context.json``'s ``cost_usd`` field per #169 US-005) can read
+    the same Layer 2 token counts without re-running extraction.
 
     ``model`` is the resolved grading model the caller computed for
     the surrounding ``cmd_grade`` invocation. Passed through verbatim
@@ -1075,6 +1102,7 @@ def _write_extraction_sidecar(
     (skill_dir / "extraction.json").write_text(
         extraction_report.to_json(), encoding="utf-8"
     )
+    return extraction_report
 
 
 def _write_baseline_and_benchmark(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10447,7 +10447,12 @@ class TestCmdGradeContextCostUsd:
         )
         extraction_report = ExtractionReport(
             skill_name="test-skill",
-            model="claude-haiku-4-5-20251001",
+            # Match the literal _PRICING_TABLE key for the L2 model so
+            # a future maintainer removing the ``estimate_cost`` mock
+            # below (e.g. to exercise the real rate-card lookup) sees
+            # the L2 cost compute correctly rather than silently
+            # nullifying the iteration's ``cost_usd`` per DEC-002.
+            model="claude-haiku-4-5",
             results=[
                 FieldExtractionResult(
                     field_id="venues.primary.venue_name.v1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10195,8 +10195,12 @@ class TestCmdGradeWritesContextJson:
         assert payload["model_grader"] == "claude-sonnet-4-6"
         assert payload["system_prompt_source"] == "skill_md"
         assert payload["sandbox_mode"] is None
-        # DEC-001 / DEC-002: placeholder None values.
-        assert payload["cost_usd"] is None
+        # #169 US-005: ``cost_usd`` is now computed via
+        # ``compute_iteration_cost_usd``. The default
+        # ``make_grading_report`` token counts are 0/0, so the cost
+        # is exactly ``0.0`` for a known model. ``reasoning_tokens``
+        # remains a DEC-001 placeholder (#170 will populate).
+        assert payload["cost_usd"] == 0.0
         assert payload["reasoning_tokens"] is None
 
     def test_openai_provider_path(self, tmp_path, monkeypatch):
@@ -10299,6 +10303,199 @@ class TestCmdGradeWritesContextJson:
         # Captured-text mode has no real run; context sidecar is not
         # written (the runner-side fields cannot be populated).
         assert not context_path.exists()
+
+
+class TestCmdGradeContextCostUsd:
+    """#169 US-005: ``cmd_grade`` writes a non-null ``cost_usd`` on
+    ``context.json`` when every grader-call lookup hits the rate
+    table. Unknown models null the whole iteration per DEC-002
+    all-or-nothing. L2 + L3 cost composition is summed via
+    :func:`compute_iteration_cost_usd`.
+    """
+
+    def _spec_with_live_run(
+        self, eval_spec=None, *, harness_metadata=None
+    ):
+        if eval_spec is None:
+            eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        if harness_metadata is None:
+            harness_metadata = {
+                "model": "claude-sonnet-4-6",
+                "system_prompt_source": "skill_md",
+            }
+        spec.run.return_value = make_skill_result(
+            output="primary output containing hello",
+            stream_events=[
+                {"type": "assistant", "text": "primary output containing hello"}
+            ],
+            input_tokens=10,
+            output_tokens=5,
+            duration_seconds=0.5,
+            harness_metadata=harness_metadata,
+        )
+        return spec
+
+    def test_known_model_writes_non_null_cost_usd(self, tmp_path, monkeypatch):
+        """Known (provider, model) lookup → non-null ``cost_usd`` equal
+        to ``estimate_cost`` of the same token counts."""
+        from clauditor._providers._pricing import estimate_cost
+
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = make_grading_report(
+            passed=True,
+            score=0.9,
+            model="claude-sonnet-4-6",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        payload = json.loads(context_path.read_text())
+        expected_cost = estimate_cost(
+            "anthropic", "claude-sonnet-4-6", 1000, 500
+        )
+        assert expected_cost is not None
+        assert payload["cost_usd"] == expected_cost
+
+    def test_unknown_model_writes_null_cost_usd(self, tmp_path, monkeypatch):
+        """Unknown model lookup → ``cost_usd: null`` per DEC-002
+        all-or-nothing semantics."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = make_grading_report(
+            passed=True,
+            score=0.9,
+            model="claude-fake-1",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        payload = json.loads(context_path.read_text())
+        assert payload["cost_usd"] is None
+
+    def test_l2_l3_composition_uses_side_effect_mock(
+        self, tmp_path, monkeypatch
+    ):
+        """L2 + L3 cost composition: when sections are declared, both
+        the extraction and grading reports contribute to ``cost_usd``.
+
+        Per ``.claude/rules/mock-side-effect-for-distinct-calls.md``,
+        use ``side_effect=[v_l2, v_l3]`` so the two ``estimate_cost``
+        calls return DISTINCT values. A shared ``return_value`` would
+        silently zero out the addition under test (one call's value
+        canceling against itself).
+        """
+        from clauditor.grader import ExtractionReport, FieldExtractionResult
+
+        monkeypatch.chdir(tmp_path)
+        sectioned_spec = _make_eval_spec(
+            sections=[
+                SectionRequirement(
+                    name="Venues",
+                    tiers=[
+                        TierRequirement(
+                            label="primary",
+                            min_entries=0,
+                            fields=[
+                                FieldRequirement(
+                                    name="venue_name",
+                                    required=True,
+                                    id="venues.primary.venue_name.v1",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        spec = self._spec_with_live_run(eval_spec=sectioned_spec)
+        grading_report = make_grading_report(
+            passed=True,
+            score=0.9,
+            model="claude-sonnet-4-6",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        extraction_report = ExtractionReport(
+            skill_name="test-skill",
+            model="claude-haiku-4-5-20251001",
+            results=[
+                FieldExtractionResult(
+                    field_id="venues.primary.venue_name.v1",
+                    field_name="venue_name",
+                    section="Venues",
+                    tier="primary",
+                    entry_index=0,
+                    required=True,
+                    presence_passed=True,
+                    format_passed=None,
+                    evidence="Cafe Foo",
+                ),
+            ],
+            input_tokens=200,
+            output_tokens=100,
+        )
+
+        # CRITICAL: side_effect=[v_l2, v_l3] (NOT return_value=v).
+        # ``compute_iteration_cost_usd`` calls ``estimate_cost`` twice
+        # — once for L3 (grading), then once for L2 (extraction). A
+        # shared return_value would silently zero out the addition
+        # under test.
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=grading_report,
+            ),
+            patch(
+                "clauditor.grader.extract_and_report",
+                new_callable=AsyncMock,
+                return_value=extraction_report,
+            ),
+            patch(
+                "clauditor._providers._pricing.estimate_cost",
+                side_effect=[0.0045, 0.0015],
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        payload = json.loads(context_path.read_text())
+        # 0.0045 (L3) + 0.0015 (L2) == 0.0060.
+        assert payload["cost_usd"] == pytest.approx(0.0060)
 
 
 class TestCmdValidateWritesContextJson:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10601,3 +10601,95 @@ class TestCmdValidateWritesContextJson:
         assert payload["model_runner"] == "gpt-5-codex"
         assert payload["system_prompt_source"] == "agents_md"
         assert payload["sandbox_mode"] == "workspace-write"
+
+
+class TestCmdValidateContextCostUsd:
+    """#169 US-006: ``cmd_validate`` writes ``cost_usd: null`` in
+    ``context.json`` regardless of ``grading_provider`` /
+    ``grading_model`` declared in the spec.
+
+    Validate runs L1 assertions only — it never invokes the grader,
+    so there is no per-pair cost to record. Per DEC-001 (#169 grader-
+    only scope), this is a regression-only story: production code in
+    ``src/clauditor/cli/validate.py`` is unchanged. These tests pin
+    that ``cost_usd`` stays ``None`` even when grader fields are set
+    in the spec.
+    """
+
+    def _live_spec(self, *, eval_spec=None, harness_metadata=None):
+        if eval_spec is None:
+            eval_spec = _make_eval_spec()
+        spec = _make_spec(eval_spec=eval_spec)
+        if harness_metadata is None:
+            harness_metadata = {
+                "model": "claude-sonnet-4-6",
+                "system_prompt_source": "skill_md",
+            }
+        spec.run.return_value = make_skill_result(
+            output="hello world output",
+            duration_seconds=1.5,
+            input_tokens=100,
+            output_tokens=50,
+            stream_events=[
+                {"type": "system", "session_id": "abc"},
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hi"}]},
+                },
+            ],
+            harness_metadata=harness_metadata,
+        )
+        return spec
+
+    def test_validate_writes_null_cost_usd(self, tmp_path, monkeypatch):
+        """Default validate flow: ``cost_usd`` is ``None`` because the
+        grader never runs."""
+        monkeypatch.chdir(tmp_path)
+        # Build an eval spec with NO grading_provider set; grading_model
+        # has the conftest default but is irrelevant to validate.
+        spec = self._live_spec(eval_spec=_make_eval_spec())
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        # Validate runs L1 only — no grader, so cost is None.
+        assert payload["cost_usd"] is None
+        # Sibling grader fields also None for the same reason.
+        assert payload["provider"] is None
+        assert payload["model_grader"] is None
+
+    def test_validate_writes_null_cost_usd_even_for_known_provider_in_spec(
+        self, tmp_path, monkeypatch
+    ):
+        """Even when the spec declares ``grading_provider`` and
+        ``grading_model`` (a known-pair that has pricing in #169),
+        validate still writes ``cost_usd: null`` because no grader call
+        happens during validate."""
+        monkeypatch.chdir(tmp_path)
+        eval_spec = _make_eval_spec(
+            grading_provider="anthropic",
+            grading_model="claude-sonnet-4-6",
+        )
+        spec = self._live_spec(eval_spec=eval_spec)
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        # Even with grader fields declared in the spec, validate does
+        # not call the grader — cost stays None.
+        assert payload["cost_usd"] is None
+        # Provider/model_grader stay None too (no Layer 3 in validate).
+        assert payload["provider"] is None
+        assert payload["model_grader"] is None

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -24,6 +24,7 @@ from clauditor._providers._pricing import (
     _PRICING_TABLE,
     _PRICING_TABLE_VERSION,
     announce_pricing_table_stale_if_old,
+    announce_unknown_model,
     compute_iteration_cost_usd,
     estimate_cost,
 )
@@ -424,3 +425,132 @@ class TestComputeIterationCostUsd:
         l3 = estimate_cost("anthropic", "claude-sonnet-4-6", 1000, 500)
         assert l3 is not None
         assert result == pytest.approx(l3)
+
+
+class TestUnknownModelAnnouncement:
+    """One-shot stderr warning per (provider, model) pair when the
+    provider is recognized but the model is not in the rate table.
+
+    DEC-006 of ``plans/super/169-pricing-cost-estimator.md`` (US-003).
+    Mirror shape to :class:`TestStaleAnnouncement` but keyed on a
+    ``set[tuple[str, str]]`` of pairs already announced rather than a
+    single boolean. Distinct unknown models each warn once; the same
+    pair on a repeat call is silent. Unknown providers do NOT trigger
+    this warning per DEC-006 (different code path).
+
+    Each test pins ``_today`` close to ``_LAST_VERIFIED`` to suppress
+    the unrelated staleness warning from US-002, AND resets the
+    ``_announced_unknown_models`` set per the announcement-family
+    canonical reset pattern.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_announcement_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reset per-pair set + suppress US-002 stale warning noise."""
+        # Fresh empty set per test so prior-test pairs do not bleed.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._announced_unknown_models",
+            set(),
+        )
+        # Also flip the staleness flag so the US-002 warning never
+        # fires from the top of estimate_cost during these tests; this
+        # keeps capsys.err containing only the unknown-model notice.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._announced_pricing_table_stale",
+            True,
+        )
+
+    def test_unknown_model_emits_warning_first_call(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Known provider, unknown model → returns None and emits the
+        # warning to stderr. All four durable substrings must appear:
+        # "pricing:", "not in rate table", the literal model, and the
+        # literal provider.
+        result = estimate_cost("anthropic", "claude-fake-1", 100, 50)
+        assert result is None
+        captured = capsys.readouterr()
+        assert "pricing:" in captured.err
+        assert "not in rate table" in captured.err
+        assert "claude-fake-1" in captured.err
+        assert "anthropic" in captured.err
+
+    def test_unknown_model_silent_on_repeated_call(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Same (provider, model) twice — the announcement fires only on
+        # the first call. Count occurrences of the literal model name
+        # in captured stderr; expect exactly one even though
+        # estimate_cost was called twice.
+        estimate_cost("anthropic", "claude-fake-1", 100, 50)
+        estimate_cost("anthropic", "claude-fake-1", 200, 100)
+        captured = capsys.readouterr()
+        # The load-bearing assertion: the announcement fired exactly
+        # once across both calls. Counting "not in rate table" (a phrase
+        # unique to this announcement) avoids false positives from
+        # unrelated stderr and is robust to template changes that move
+        # the {model!r} interpolation around.
+        assert captured.err.count("not in rate table") == 1
+
+    def test_different_unknown_models_each_warn(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Two distinct unknown models — each gets its own first-call
+        # warning. Different from the staleness flag (single bool); the
+        # set-keyed contract means distinct pairs do not mute each other.
+        estimate_cost("anthropic", "claude-fake-1", 100, 50)
+        estimate_cost("anthropic", "claude-fake-2", 100, 50)
+        captured = capsys.readouterr()
+        assert "claude-fake-1" in captured.err
+        assert "claude-fake-2" in captured.err
+        # Two distinct first-call announcements landed.
+        assert captured.err.count("not in rate table") == 2
+
+    def test_known_provider_known_model_no_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Happy path: known (provider, model) pair returns a positive
+        # float and emits NO unknown-model warning. The staleness flag
+        # is pinned to True via the autouse fixture so the US-002
+        # warning also stays silent.
+        result = estimate_cost("anthropic", "claude-sonnet-4-6", 100, 50)
+        assert result is not None and result > 0.0
+        captured = capsys.readouterr()
+        assert "not in rate table" not in captured.err
+
+    def test_unknown_provider_no_unknown_model_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Per DEC-006: unknown provider is a DIFFERENT code path that
+        # silently returns None — the unknown-model warning is NOT
+        # triggered. A typo'd provider must not flood stderr with
+        # every model the caller subsequently tries.
+        result = estimate_cost("vertex", "anything-model", 100, 50)
+        assert result is None
+        captured = capsys.readouterr()
+        assert "not in rate table" not in captured.err
+
+    def test_announce_helper_directly(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Standalone-helper invocation must behave the same as the
+        # estimate_cost-routed path. First call per pair emits;
+        # second call with the same pair is silent; third call with a
+        # distinct pair emits its own first-call warning.
+        announce_unknown_model("openai", "gpt-fake")
+        first = capsys.readouterr().err
+        assert "gpt-fake" in first
+        assert "not in rate table" in first
+
+        # Same pair → silent.
+        announce_unknown_model("openai", "gpt-fake")
+        second = capsys.readouterr().err
+        assert second == ""
+
+        # Different pair → emits.
+        announce_unknown_model("openai", "gpt-other")
+        third = capsys.readouterr().err
+        assert "gpt-other" in third
+        assert "not in rate table" in third

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -1,14 +1,16 @@
 """Tests for the pricing helpers in ``clauditor._providers._pricing``.
 
 US-001 of ``plans/super/169-pricing-cost-estimator.md``: covers the
-core ``estimate_cost`` helper plus the price-table metadata. The
-announcement helpers (staleness, unknown-model) land in US-002 and
-US-003 and have their own dedicated test classes there.
+core ``estimate_cost`` helper plus the price-table metadata. US-002
+adds :class:`TestStaleAnnouncement` covering the one-shot stderr
+warning that fires when the rate table is older than 90 days. The
+unknown-model announcement lands in US-003 with its own class.
 
 Mirror shape: ``tests/test_providers_retry.py`` — pure-compute
 sibling with no SDK or I/O concerns. Every test calls the public
 helper or reads a module-level constant; no patches needed beyond
-the bool-vs-int validation cases.
+the bool-vs-int validation cases (and the per-test
+flag/date-pin patches in :class:`TestStaleAnnouncement`).
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from clauditor._providers._pricing import (
     _LAST_VERIFIED,
     _PRICING_TABLE,
     _PRICING_TABLE_VERSION,
+    announce_pricing_table_stale_if_old,
     estimate_cost,
 )
 
@@ -178,3 +181,134 @@ class TestPricingTableMetadata:
             assert model in _PRICING_TABLE["openai"], (
                 f"missing OpenAI model {model!r}"
             )
+
+
+class TestStaleAnnouncement:
+    """DEC-003 (#169 US-002): one-shot stderr warning when the pricing
+    rate table is older than 90 days at ``estimate_cost`` call time.
+
+    Parallel to
+    ``tests/test_providers_auth.py::TestAnnounceImplicitNoApiKey`` —
+    same autouse-reset pattern; same one-shot-per-process contract.
+    The :data:`_today` indirection alias is patched per-test to pin
+    the wall-clock date deterministically per
+    ``.claude/rules/monotonic-time-indirection.md``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_announcement_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every test starts with the one-shot flag set to ``False``."""
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._announced_pricing_table_stale",
+            False,
+        )
+
+    def test_no_warning_when_within_90_days(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # _LAST_VERIFIED == "2026-05-09"; pin today to the day after so
+        # days_old == 1 (well under the 90-day threshold) and the
+        # announcement does NOT fire.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._today",
+            lambda: datetime.date(2026, 5, 10),
+        )
+        result = estimate_cost("anthropic", "claude-sonnet-4-6", 100, 50)
+        assert result is not None
+        captured = capsys.readouterr()
+        # Anchor on the durable substring rather than full-message
+        # equality: the announcement is absent, not just shaped
+        # differently.
+        assert "pricing" not in captured.err.lower()
+        assert "90 days" not in captured.err
+
+    def test_warning_fires_when_over_90_days(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # _LAST_VERIFIED == "2026-05-09"; pin today to ~7 months later
+        # so days_old > 90 and the warning fires. Pin the durable
+        # substrings per the docstring contract on
+        # _PRICING_TABLE_STALE_ANNOUNCEMENT.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._today",
+            lambda: datetime.date(2027, 1, 1),
+        )
+        result = estimate_cost("anthropic", "claude-sonnet-4-6", 100, 50)
+        assert result is not None
+        captured = capsys.readouterr()
+        assert "90 days" in captured.err
+        assert "pricing" in captured.err.lower()
+        assert (
+            "platform.claude.com" in captured.err
+            or "openai.com/api/pricing" in captured.err
+        )
+
+    def test_warning_fires_only_once_per_process(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Stale-date pin; two calls; the warning text appears exactly
+        # once across both calls' combined stderr.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._today",
+            lambda: datetime.date(2027, 1, 1),
+        )
+        estimate_cost("anthropic", "claude-sonnet-4-6", 100, 50)
+        estimate_cost("anthropic", "claude-sonnet-4-6", 100, 50)
+        captured = capsys.readouterr()
+        # Count occurrences of a narrow durable substring — using a
+        # phrase distinctive to this announcement so unrelated stderr
+        # could not match.
+        assert captured.err.count("pricing table") == 1
+
+    def test_malformed_last_verified_treats_as_stale(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A typo in _LAST_VERIFIED ("2026-05-9" — single-digit day, not
+        # ISO-8601) must NOT crash the production grading run; the
+        # defensive fallback in announce_pricing_table_stale_if_old
+        # treats parse failure as "stale" so the maintainer sees a
+        # warning that points them at the file to fix.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._LAST_VERIFIED", "2026-05-9"
+        )
+        # Pin today to a known date so the test does not depend on
+        # the wall-clock; the code path under test does not consult
+        # _today() in the parse-failure branch (days_old hardcoded to
+        # 9999), but pinning keeps the test deterministic.
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._today",
+            lambda: datetime.date(2026, 5, 10),
+        )
+        result = estimate_cost("anthropic", "claude-sonnet-4-6", 100, 50)
+        assert result is not None
+        captured = capsys.readouterr()
+        assert "pricing" in captured.err.lower()
+        assert "90 days" in captured.err
+
+    def test_announce_helper_directly(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Standalone-helper invocation must behave the same as the
+        # estimate_cost-routed path: stale-date pin produces the
+        # warning. Confirms the helper is independently testable per
+        # the announcement-family canonical shape (#95 US-002 et al.).
+        monkeypatch.setattr(
+            "clauditor._providers._pricing._today",
+            lambda: datetime.date(2027, 1, 1),
+        )
+        announce_pricing_table_stale_if_old()
+        captured = capsys.readouterr()
+        assert "90 days" in captured.err
+        assert "pricing" in captured.err.lower()

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -24,8 +24,12 @@ from clauditor._providers._pricing import (
     _PRICING_TABLE,
     _PRICING_TABLE_VERSION,
     announce_pricing_table_stale_if_old,
+    compute_iteration_cost_usd,
     estimate_cost,
 )
+from clauditor.grader import ExtractionReport
+from clauditor.quality_grader import GradingReport
+from clauditor.schemas import GradeThresholds
 
 _ANTHROPIC_MODELS = ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"]
 _OPENAI_MODELS = ["gpt-5.4", "gpt-5.4-mini", "o4-mini"]
@@ -312,3 +316,111 @@ class TestStaleAnnouncement:
         captured = capsys.readouterr()
         assert "90 days" in captured.err
         assert "pricing" in captured.err.lower()
+
+
+def _make_grading_report(
+    *,
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 1000,
+    output_tokens: int = 500,
+) -> GradingReport:
+    """Minimal :class:`GradingReport` fixture for cost-composition tests."""
+    return GradingReport(
+        skill_name="test",
+        results=[],
+        model=model,
+        thresholds=GradeThresholds(),
+        metrics={},
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def _make_extraction_report(
+    *,
+    model: str = "claude-haiku-4-5",
+    input_tokens: int = 200,
+    output_tokens: int = 100,
+) -> ExtractionReport:
+    """Minimal :class:`ExtractionReport` fixture for cost-composition tests."""
+    return ExtractionReport(
+        skill_name="test",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+class TestComputeIterationCostUsd:
+    def test_grading_report_only_returns_cost(self) -> None:
+        # Per DEC-001: grader-only scope. With extraction_report=None,
+        # the L2 contribution is 0.0 (Layer 2 didn't run) and the
+        # composition equals the L3 cost alone.
+        grading = _make_grading_report(input_tokens=1000, output_tokens=500)
+        result = compute_iteration_cost_usd(grading, None, "anthropic")
+        expected = estimate_cost("anthropic", "claude-sonnet-4-6", 1000, 500)
+        assert result == expected
+        assert result is not None and result > 0.0
+
+    def test_with_extraction_report_sums_costs(self) -> None:
+        # L2 + L3 sum: when both reports are present, the composition
+        # routes each through estimate_cost and returns the sum.
+        grading = _make_grading_report(
+            model="claude-sonnet-4-6", input_tokens=1000, output_tokens=500
+        )
+        extraction = _make_extraction_report(
+            model="claude-haiku-4-5", input_tokens=200, output_tokens=100
+        )
+        result = compute_iteration_cost_usd(grading, extraction, "anthropic")
+        l3 = estimate_cost("anthropic", "claude-sonnet-4-6", 1000, 500)
+        l2 = estimate_cost("anthropic", "claude-haiku-4-5", 200, 100)
+        assert l2 is not None and l3 is not None
+        assert result == pytest.approx(l2 + l3)
+
+    def test_unknown_grading_model_returns_none_no_extraction(self) -> None:
+        # Per DEC-002: any internal estimate_cost None → composition
+        # None. Unknown grading model with no extraction is the
+        # simplest miss path.
+        grading = _make_grading_report(model="claude-3-5-sonnet-old")
+        result = compute_iteration_cost_usd(grading, None, "anthropic")
+        assert result is None
+
+    def test_unknown_grading_model_returns_none_with_extraction(self) -> None:
+        # Per DEC-002 / all-or-nothing: an unknown grading model
+        # short-circuits to None even when the extraction lookup
+        # would succeed.
+        grading = _make_grading_report(model="claude-3-5-sonnet-old")
+        extraction = _make_extraction_report(model="claude-haiku-4-5")
+        result = compute_iteration_cost_usd(grading, extraction, "anthropic")
+        assert result is None
+
+    def test_unknown_extraction_model_returns_none(self) -> None:
+        # Per DEC-002 / all-or-nothing: an unknown extraction model
+        # produces None even when the grading lookup succeeds.
+        grading = _make_grading_report(model="claude-sonnet-4-6")
+        extraction = _make_extraction_report(model="claude-haiku-2-old")
+        result = compute_iteration_cost_usd(grading, extraction, "anthropic")
+        assert result is None
+
+    def test_unknown_provider_returns_none(self) -> None:
+        # An unknown provider misses for both layers (estimate_cost
+        # short-circuits on the first lookup); composition returns
+        # None per DEC-002.
+        grading = _make_grading_report()
+        result = compute_iteration_cost_usd(grading, None, "vertex")
+        assert result is None
+
+    def test_extraction_report_with_zero_tokens(self) -> None:
+        # An ExtractionReport with zero tokens contributes 0.0 to the
+        # sum (a valid lookup, not a miss); total equals L3 cost.
+        # Distinct from extraction_report=None which means "Layer 2
+        # didn't run" — both shapes are legal but reach the same
+        # numeric outcome here.
+        grading = _make_grading_report(input_tokens=1000, output_tokens=500)
+        extraction = _make_extraction_report(
+            model="claude-haiku-4-5", input_tokens=0, output_tokens=0
+        )
+        result = compute_iteration_cost_usd(grading, extraction, "anthropic")
+        l3 = estimate_cost("anthropic", "claude-sonnet-4-6", 1000, 500)
+        assert l3 is not None
+        assert result == pytest.approx(l3)

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -88,6 +88,38 @@ class TestEstimateCost:
         b = estimate_cost("openai", "o4-mini", 100, 50, reasoning_tokens=None)
         assert a == pytest.approx(b)
 
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "CLAUDE-SONNET-4-6",  # uppercase miss
+            "Claude-Sonnet-4-6",  # mixed-case miss
+            " claude-sonnet-4-6 ",  # surrounding whitespace
+            "",  # empty model
+        ],
+    )
+    def test_lookup_is_case_and_whitespace_sensitive(
+        self, model: str
+    ) -> None:
+        # Locks the contract: estimate_cost looks up the literal
+        # ``(provider, model)`` pair against the table without case-
+        # folding or whitespace stripping. A future "helpful"
+        # normalization would silently match models the published
+        # rates do not actually cover. Per DEC-002, the miss path
+        # returns ``None`` cleanly.
+        assert estimate_cost("anthropic", model, 100, 50) is None
+
+    @pytest.mark.parametrize(
+        "provider", ["ANTHROPIC", "Anthropic", " anthropic ", ""]
+    )
+    def test_provider_lookup_is_case_and_whitespace_sensitive(
+        self, provider: str
+    ) -> None:
+        # Mirror of the model-side test: the provider key is also
+        # exact-match (the auth dispatcher accepts only the literal
+        # set ``{"anthropic", "openai"}`` so a case-folded match
+        # would diverge from the auth seam).
+        assert estimate_cost(provider, "claude-sonnet-4-6", 100, 50) is None
+
 
 class TestEstimateCostInputValidation:
     @pytest.mark.parametrize(
@@ -253,6 +285,13 @@ class TestStaleAnnouncement:
             "platform.claude.com" in captured.err
             or "openai.com/api/pricing" in captured.err
         )
+        # Lock the {version} interpolation: production message names
+        # the table version so a future maintainer sees "v1" (or v2,
+        # etc.) and can reason about whether the table shape changed
+        # since their tooling last understood it. Pinning via the
+        # constant — not the literal "v1" — auto-tracks future bumps
+        # without churning this assertion.
+        assert f"v{_PRICING_TABLE_VERSION}" in captured.err
 
     def test_warning_fires_only_once_per_process(
         self,

--- a/tests/test_providers_pricing.py
+++ b/tests/test_providers_pricing.py
@@ -1,0 +1,180 @@
+"""Tests for the pricing helpers in ``clauditor._providers._pricing``.
+
+US-001 of ``plans/super/169-pricing-cost-estimator.md``: covers the
+core ``estimate_cost`` helper plus the price-table metadata. The
+announcement helpers (staleness, unknown-model) land in US-002 and
+US-003 and have their own dedicated test classes there.
+
+Mirror shape: ``tests/test_providers_retry.py`` — pure-compute
+sibling with no SDK or I/O concerns. Every test calls the public
+helper or reads a module-level constant; no patches needed beyond
+the bool-vs-int validation cases.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from clauditor._providers._pricing import (
+    _LAST_VERIFIED,
+    _PRICING_TABLE,
+    _PRICING_TABLE_VERSION,
+    estimate_cost,
+)
+
+_ANTHROPIC_MODELS = ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"]
+_OPENAI_MODELS = ["gpt-5.4", "gpt-5.4-mini", "o4-mini"]
+
+
+class TestEstimateCost:
+    @pytest.mark.parametrize("model", _ANTHROPIC_MODELS)
+    def test_known_anthropic_models_return_positive_float(self, model: str) -> None:
+        # Per DEC-004: Anthropic table coverage. Known (provider, model)
+        # pairs must produce a positive float for non-zero token input.
+        result = estimate_cost("anthropic", model, 1000, 500)
+        assert isinstance(result, float)
+        assert result > 0.0
+
+    @pytest.mark.parametrize("model", _OPENAI_MODELS)
+    def test_known_openai_models_return_positive_float(self, model: str) -> None:
+        # Per DEC-004: OpenAI table coverage. Same shape as the
+        # Anthropic counterpart.
+        result = estimate_cost("openai", model, 1000, 500)
+        assert isinstance(result, float)
+        assert result > 0.0
+
+    def test_unknown_provider_returns_none(self) -> None:
+        # Per DEC-002 / DEC-005: unknown provider is a graceful
+        # lookup miss, not a contract violation.
+        assert estimate_cost("vertex", "claude-sonnet-4-6", 1000, 500) is None
+
+    def test_unknown_model_returns_none(self) -> None:
+        # Per DEC-002 / DEC-005: known provider + unknown model is also
+        # a graceful lookup miss.
+        assert (
+            estimate_cost("anthropic", "claude-3-5-sonnet-old", 1000, 500) is None
+        )
+
+    def test_zero_tokens_returns_zero_cost(self) -> None:
+        # Edge case: a known model with no tokens reported costs $0.0.
+        assert estimate_cost("anthropic", "claude-sonnet-4-6", 0, 0) == 0.0
+
+    def test_reasoning_tokens_billed_at_output_rate(self) -> None:
+        # Per DEC-001 / Research notes: reasoning tokens are billed at
+        # the model's output rate. The two computations below must be
+        # numerically equal.
+        with_reasoning = estimate_cost(
+            "openai", "o4-mini", 100, 50, reasoning_tokens=200
+        )
+        rolled_into_output = estimate_cost(
+            "openai", "o4-mini", 100, 250, reasoning_tokens=None
+        )
+        assert with_reasoning == pytest.approx(rolled_into_output)
+
+    def test_reasoning_tokens_zero_is_equivalent_to_none(self) -> None:
+        # Defensive: passing reasoning_tokens=0 must equal not passing
+        # it at all (both add 0 to the effective output count).
+        a = estimate_cost("openai", "o4-mini", 100, 50, reasoning_tokens=0)
+        b = estimate_cost("openai", "o4-mini", 100, 50, reasoning_tokens=None)
+        assert a == pytest.approx(b)
+
+
+class TestEstimateCostInputValidation:
+    @pytest.mark.parametrize(
+        "kwarg", ["input_tokens", "output_tokens", "reasoning_tokens"]
+    )
+    def test_bool_int_arg_raises(self, kwarg: str) -> None:
+        # Per DEC-005 + .claude/rules/constant-with-type-info.md: bool
+        # is an int subclass in Python; reject explicitly so a
+        # ``True`` / ``False`` value cannot sneak through as 1/0.
+        kwargs = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+        kwargs[kwarg] = True
+        with pytest.raises(ValueError):
+            estimate_cost(**kwargs)
+        # And the other bool value too.
+        kwargs[kwarg] = False
+        with pytest.raises(ValueError):
+            estimate_cost(**kwargs)
+
+    @pytest.mark.parametrize(
+        "kwarg", ["input_tokens", "output_tokens", "reasoning_tokens"]
+    )
+    def test_int_one_does_not_raise(self, kwarg: str) -> None:
+        # Sanity counterpart to the bool test: a real int (not bool)
+        # value of 1 must NOT raise. Confirms the bool guard does not
+        # over-reject.
+        kwargs = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+        kwargs[kwarg] = 1
+        result = estimate_cost(**kwargs)
+        assert result is not None and result >= 0.0
+
+    @pytest.mark.parametrize(
+        "kwarg", ["input_tokens", "output_tokens", "reasoning_tokens"]
+    )
+    def test_negative_tokens_raises(self, kwarg: str) -> None:
+        # Per DEC-005: negative token counts are a contract violation.
+        kwargs = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+        kwargs[kwarg] = -1
+        with pytest.raises(ValueError):
+            estimate_cost(**kwargs)
+
+    def test_non_int_tokens_raises(self) -> None:
+        # Per DEC-005: a string-typed token count is a contract
+        # violation, not a lookup miss.
+        with pytest.raises(ValueError):
+            estimate_cost("anthropic", "claude-sonnet-4-6", "100", 50)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            estimate_cost("anthropic", "claude-sonnet-4-6", 100, "50")  # type: ignore[arg-type]
+
+    def test_non_string_provider_raises(self) -> None:
+        # Per DEC-005: non-string provider is a contract violation.
+        with pytest.raises(ValueError):
+            estimate_cost(42, "claude-sonnet-4-6", 100, 50)  # type: ignore[arg-type]
+
+    def test_non_string_model_raises(self) -> None:
+        # Per DEC-005: non-string model is a contract violation.
+        with pytest.raises(ValueError):
+            estimate_cost("anthropic", None, 100, 50)  # type: ignore[arg-type]
+
+
+class TestPricingTableMetadata:
+    def test_pricing_table_version_is_int(self) -> None:
+        assert isinstance(_PRICING_TABLE_VERSION, int)
+        assert _PRICING_TABLE_VERSION >= 1
+
+    def test_last_verified_is_iso_date(self) -> None:
+        # Robustness: the constant must round-trip through
+        # date.fromisoformat so the staleness helper (US-002) can
+        # parse it without a special case.
+        parsed = datetime.date.fromisoformat(_LAST_VERIFIED)
+        assert isinstance(parsed, datetime.date)
+
+    def test_table_contains_expected_models(self) -> None:
+        # Per DEC-004: every model named in the plan must be present.
+        assert "anthropic" in _PRICING_TABLE
+        assert "openai" in _PRICING_TABLE
+        for model in _ANTHROPIC_MODELS:
+            assert model in _PRICING_TABLE["anthropic"], (
+                f"missing Anthropic model {model!r}"
+            )
+        for model in _OPENAI_MODELS:
+            assert model in _PRICING_TABLE["openai"], (
+                f"missing OpenAI model {model!r}"
+            )


### PR DESCRIPTION
## Summary

Super plan for #169 — `cost_usd` estimation module for `context.json`.

**Phase:** detailing → published (awaiting review)
**Stories:** 6 implementation + Quality Gate + Patterns & Memory = 8 total
**Decisions:** 6 captured (DEC-001 through DEC-006)

## Pre-plan research (verdict: hardcoded table is the right shape)

Two parallel research subagents (with internet) investigated whether either provider exposes a programmatic rate card accessible with a regular API key. **Verdict: no.**

- Anthropic's `/v1/models` carries no pricing fields; `/v1/organizations/cost_report` is admin-key gated and returns realized USD aggregate, not a forward rate card. Cache multipliers and reasoning rates are documented in prose only.
- OpenAI's `/v1/models` carries no pricing fields (`openai/openai-python#2074` closed as not planned); `/v1/organization/costs` is admin-key gated and realized-cost only.
- Reasoning tokens are billed at the standard output rate by both providers — no separate reasoning rate exists in any API.

The issue body was updated with the verdict and four implementation implications before super-planning began.

## Locked decisions

- **DEC-001** — Grader-only cost (Layer 2 + Layer 3 sum); runner cost out of scope (no follow-up filed; module docstring is honest about the scope).
- **DEC-002** — All-or-nothing: any unknown lookup → `cost_usd=null` whole iteration.
- **DEC-003** — Stderr warning when `_LAST_VERIFIED` >90 days, via the announcement-family pattern from `.claude/rules/centralized-sdk-call.md`.
- **DEC-004** — Ship only currently-graded-with models: `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5`, `gpt-5.4`, `gpt-5.4-mini`, `o4-mini`.
- **DEC-005** — `ValueError` on bad input types (bool/non-int/non-string); `None` on unknown `(provider, model)` lookup miss. Two distinct categories.
- **DEC-006** — Per-`(provider, model)` one-shot stderr warning when provider known but model unknown. Catches typos that would otherwise silently null-out cost.

## Plan document

See `plans/super/169-pricing-cost-estimator.md` (716 lines) for the full plan.

## Architecture review

All six baseline axes (security, performance, data model, API design, observability, testing) PASS. Three concerns surfaced and resolved:

- **A4 (composition helper)** — added `compute_iteration_cost_usd(...)` as US-004 so the writer's call site stays one line.
- **B3 (ISO date robustness)** — `try/except` around `date.fromisoformat(_LAST_VERIFIED)` + `_today` indirection alias for tests.
- **T7 (mock side_effect)** — US-005 wiring test pinned to `side_effect=[v_l2, v_l3]` per `.claude/rules/mock-side-effect-for-distinct-calls.md`.

## Story breakdown

1. **US-001** — `_pricing.py` skeleton: price table, `_PriceCard`, `estimate_cost` core
2. **US-002** — Staleness announcement (90-day threshold, `_today` indirection)
3. **US-003** — Per-`(provider, model)` unknown-model announcement
4. **US-004** — `compute_iteration_cost_usd` composition helper
5. **US-005** — Wire into `cli/grade.py::_write_context_sidecar`
6. **US-006** — `cli/validate.py` regression: `cost_usd=null` preserved
7. **US-007** — Quality Gate (code-reviewer x4 + CodeRabbit + lint + 80% coverage)
8. **US-008** — Patterns & Memory (refresh 3 rules)

## Next steps

- Review the plan in this PR
- Approve in Claude Code (say "approved" or "devolve") to create beads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost estimation now integrated into grade command results, displaying estimated USD costs for each iteration in context.json
  * Automatic warnings for stale pricing tables and unknown model/provider combinations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/173)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->