### PR TITLE
#170: reasoning tokens capture (plan)

### DIFF
--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -212,14 +212,51 @@ async def call_openai(
   `response_text`, per-block `text_blocks`, `input_tokens`,
   `output_tokens`, `raw_message`, plus `provider` (`"anthropic"`
   or `"openai"`) and `source` (`"api"` or `"cli"`) so callers can
-  stamp per-call provenance on their reports. Callers that want
-  to distinguish "no text" from "empty text" check `text_blocks`;
-  callers that want refusal handling read `raw_message`; metrics
-  consumers read the token fields. One return type covers every
-  current consumer without forcing them to dig through the raw
-  SDK response. The legacy alias `AnthropicResult = ModelResult`
+  stamp per-call provenance on their reports. Plus
+  `reasoning_tokens: int | None` (#170) carrying the per-call
+  separately-billed reasoning / thinking-token count when the
+  provider exposes one. Callers that want to distinguish "no
+  text" from "empty text" check `text_blocks`; callers that want
+  refusal handling read `raw_message`; metrics consumers read
+  the token fields. One return type covers every current
+  consumer without forcing them to dig through the raw SDK
+  response. The legacy alias `AnthropicResult = ModelResult`
   is preserved so existing test fixtures and docstrings keep
   working.
+- **Asymmetric `reasoning_tokens` capture per provider** (#170).
+  The two backends populate `reasoning_tokens` differently
+  because the underlying SDKs surface different things, NOT as a
+  consistency lapse:
+  - **Anthropic always returns `None`** (DEC-001 of
+    `plans/super/170-reasoning-tokens-capture.md`).
+    `anthropic.types.Usage` carries no separately-billed
+    thinking-token field; for extended-thinking models (Opus 4.x,
+    Sonnet 4.x with `thinking={"type":"enabled",...}`) the
+    thinking tokens are ALREADY INCLUDED in `output_tokens`. The
+    construction site at `_providers/_anthropic.py::_extract_result`
+    hardcodes `reasoning_tokens=None` with an inline comment
+    citing DEC-001 so future contributors don't copy-paste a
+    `usage.<something>` shape from the OpenAI side. A
+    drift-guard test in `tests/test_providers_anthropic.py`
+    asserts `result.reasoning_tokens is None` for both a
+    normal mock and a thinking-style mock.
+  - **OpenAI extracts via a pure helper** (DEC-002, DEC-006).
+    `_providers/_openai.py::_extract_reasoning_tokens(usage)`
+    defensively reads `usage.output_tokens_details.reasoning_tokens`
+    and returns the int (including `0`) or `None` on any
+    malformed shape (`usage is None`, missing
+    `output_tokens_details`, missing field, non-int, `bool`,
+    any attribute-access exception). `0` is preserved as a
+    real signal ("model didn't reason on this call"); `None`
+    means "couldn't read" — conflating the two would lose the
+    per-call signal. The explicit `isinstance(value, bool)`
+    guard precedes the `int` check per
+    `.claude/rules/constant-with-type-info.md` (Python's
+    `isinstance(True, int)` is `True`).
+  Sum semantics across multi-call grader runs are codified in
+  `quality_grader.py::_sum_optional_reasoning_tokens` and
+  documented under the "Schema version bumps for #170"
+  subsection of `.claude/rules/json-schema-version.md`.
 - **Asymmetric transport: anthropic supports `{api,cli,auto}`,
   openai always `source="api"`.** Per DEC-002 of
   `plans/super/145-openai-provider.md`, OpenAI has no CLI

--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -367,6 +367,120 @@ Writers and readers (post-#152):
   and `"auto"`) / `read_records` (defaults missing `harness` to
   `"claude-code"` for v1/v2 reads).
 
+### Schema version bumps for #170 (`reasoning_tokens` field)
+
+`#170` added `reasoning_tokens: int | None` — the per-call
+separately-billed reasoning / thinking-token count surfaced by
+the grader's `ModelResult` chain — to the persisted token-totals
+surface. The field rides alongside the existing `input_tokens` /
+`output_tokens` totals on `GradingReport` / `ExtractionReport`,
+sums across multi-call grader runs (variance, parse-retry,
+blind-compare's two parallel calls), and threads from
+`primary_report.reasoning_tokens` into the
+`IterationContext.reasoning_tokens` placeholder that `#154`
+pre-declared as nullable in v1.
+
+Three schema bumps shipped together in #170 — and **two
+deliberate non-bumps** that demonstrate the always-v1 pattern
+paying off:
+
+- **`grading.json` v4 → v5** — adds nullable top-level
+  `reasoning_tokens` field (placed after `output_tokens` in
+  canonical key order). Per DEC-004 of
+  `plans/super/170-reasoning-tokens-capture.md`.
+- **`extraction.json` v4 → v5** — same shape (DEC-004).
+- **audit `MAX_SCHEMA_VERSION`** bumped:
+  `{"assertions.json": 2, "extraction.json": 5, "grading.json": 5,
+  "context.json": 1}`.
+- **`BlindReport` stays at `schema_version: 1`** per DEC-005.
+  `BlindReport` has `to_json()` but no `from_json()` reader (no
+  CLI command writes it as a sidecar today), so the additive
+  nullable `reasoning_tokens` field has no legacy-read compat
+  surface to maintain. This is the **always-v1-by-design**
+  pattern (same as `context.json` itself) applied to a second
+  artifact: when the only persistence path is `to_json()` and no
+  reader exists, a nullable additive field is forward-compat-safe
+  at the existing version.
+- **`IterationContext` stays at `schema_version: 1`** by design.
+  This is **the canonical example of the always-v1 contract
+  paying off** that the `#154` subsection above predicted: the
+  `reasoning_tokens: int \| None` placeholder pre-declared in v1
+  is now populated by production writers, with zero schema bump
+  and zero loader-side default-on-read churn. The on-disk shape
+  is byte-identical between a pre-#170 `context.json` (with
+  `"reasoning_tokens": null`) and a post-#170 `context.json`
+  (with `"reasoning_tokens": 42`). Future tickets that wire up
+  `cost_usd` (#169) will inherit the same property.
+
+`audit.py::_records_from_*` helpers do NOT need to read the new
+field — `reasoning_tokens` is a per-iteration concern (single
+value per `IterationContext`), not a per-record concern. The
+existing per-record loaders consume the v5 sidecars unchanged
+because the field is additive at the top level only.
+
+**Loader-side default-on-read.** `GradingReport.from_json` and
+`ExtractionReport.from_json` default missing `reasoning_tokens`
+to `None` for v1/v2/v3/v4 reads (mirrors the
+`provider_source`-defaults-to-`"anthropic"` and
+`harness`-defaults-to-`"claude-code"` patterns from #147 / #152).
+Per DEC-007: the default `None` correctly represents "we don't
+know whether reasoning happened" for pre-#170 history, which is
+semantically distinct from `0` ("provider surfaced a count of
+zero — model chose not to reason").
+
+**`from_json` reader carries an explicit `bool` guard** per
+`.claude/rules/constant-with-type-info.md` and symmetric with the
+writer-side `_extract_reasoning_tokens` discipline (DEC-006). A
+malformed sidecar carrying `"reasoning_tokens": true` would
+otherwise silently coerce to `1` because Python's
+`isinstance(True, int)` is `True`. The reader pattern is:
+
+```python
+raw_reasoning = parsed.get("reasoning_tokens")
+reasoning_tokens: int | None
+if raw_reasoning is None or isinstance(raw_reasoning, bool):
+    reasoning_tokens = None
+elif isinstance(raw_reasoning, int):
+    reasoning_tokens = raw_reasoning
+else:
+    reasoning_tokens = None
+```
+
+This was added during #170's Quality Gate after a code-review
+pass surfaced the asymmetry between writer-side (which has the
+guard via `_extract_reasoning_tokens`) and reader-side (which
+originally accepted any truthy int-like value). The guard now
+fires symmetrically on both sides of the on-disk boundary.
+
+**Writers and readers (post-#170):**
+
+- `src/clauditor/quality_grader.py::GradingReport.to_json` /
+  `GradingReport.from_json` — emits `schema_version: 5`; reader
+  defaults missing `reasoning_tokens` to `None` and rejects
+  `bool` values defensively.
+- `src/clauditor/grader.py::ExtractionReport.to_json` /
+  `ExtractionReport.from_json` — same shape.
+- `src/clauditor/quality_grader.py::BlindReport.to_json` —
+  schema_version stays `1`; emits `reasoning_tokens` field
+  additively; no `from_json` reader to update.
+- `src/clauditor/quality_grader.py::_sum_optional_reasoning_tokens`
+  — pure helper computing the all-None→None / mixed→sum-of-non-
+  None semantic across the multi-call grader chain.
+- `src/clauditor/_providers/_openai.py::_extract_reasoning_tokens`
+  — pure helper extracting the field from the OpenAI usage
+  shape with the bool guard.
+- `src/clauditor/_providers/_anthropic.py::_extract_result` —
+  hardcodes `reasoning_tokens=None` per DEC-001 (no SDK field
+  to read).
+- `src/clauditor/cli/grade.py::_write_context_sidecar` — reads
+  `primary_report.reasoning_tokens` (was hardcoded `None`
+  pre-#170) and threads into `IterationContext.reasoning_tokens`.
+  `cli/validate.py` keeps the `None` hardcode — `validate` has
+  no LLM grader, so the value is structurally `None` (DEC-008).
+- `src/clauditor/audit.py::MAX_SCHEMA_VERSION` — single-number
+  edit per DEC-008 of #147 lifted both `extraction.json` and
+  `grading.json` from `4` to `5`.
+
 ## When this rule applies
 
 Any new persisted JSON file whose shape may evolve. Internal-only debug

--- a/.claude/rules/json-schema-version.md
+++ b/.claude/rules/json-schema-version.md
@@ -380,16 +380,18 @@ blind-compare's two parallel calls), and threads from
 `IterationContext.reasoning_tokens` placeholder that `#154`
 pre-declared as nullable in v1.
 
-Three schema bumps shipped together in #170 — and **two
-deliberate non-bumps** that demonstrate the always-v1 pattern
-paying off:
+Two schema bumps shipped together in #170 — accompanied by an
+audit-loader range update and **two deliberate non-bumps** that
+demonstrate the always-v1 pattern paying off:
 
 - **`grading.json` v4 → v5** — adds nullable top-level
   `reasoning_tokens` field (placed after `output_tokens` in
   canonical key order). Per DEC-004 of
   `plans/super/170-reasoning-tokens-capture.md`.
 - **`extraction.json` v4 → v5** — same shape (DEC-004).
-- **audit `MAX_SCHEMA_VERSION`** bumped:
+- **audit `MAX_SCHEMA_VERSION` map widened** to accept the new
+  v5 sidecars (not itself a `schema_version` bump — just the
+  reader's accepted-range table tracking the writer-side bumps):
   `{"assertions.json": 2, "extraction.json": 5, "grading.json": 5,
   "context.json": 1}`.
 - **`BlindReport` stays at `schema_version: 1`** per DEC-005.

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -688,16 +688,17 @@ Why the split mattered specifically here:
   the way back in. Symmetric guards on both sides of the I/O
   boundary keep the discipline structural.
 - **Future nullable-token-style fields plug in trivially**:
-  `#169` (`cost_usd: float | None`) will use the same shape —
+  `#169` (`cost_usd: float | None`) shipped using the same shape —
   per-provider defensive extractor (with a parallel `bool`/`int`
   guard, since Python's `bool` is a subclass of `int` — NOT of
   `float` — and `True`/`False` therefore pass any broad numeric
   check like `isinstance(x, (int, float))` without an explicit
   bool guard ahead of the int/float check), chain-level
   `_sum_optional_cost_usd` aggregator with the same
-  all-None-stays-None semantic. The 9th anchor here documents
-  the recipe so that future ticket inherits it without
-  rediscovering.
+  all-None-stays-None semantic. The Ninth anchor (pricing-table
+  cost estimation) above documents how `#169` applied this
+  recipe; this Tenth anchor codifies the recipe itself so future
+  nullable-token fields inherit it without rediscovering.
 
 Traces to DEC-001, DEC-002, DEC-003, DEC-006 of
 `plans/super/170-reasoning-tokens-capture.md`. Companion rules:

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -480,6 +480,122 @@ Traces to DEC-010 of `plans/super/153-cross-axis-comparability.md`.
 Companion rule: `.claude/rules/cross-axis-comparability-refusal.md`
 (the per-axis refusal+filter+opt-in shape this helper drives).
 
+### Ninth anchor (defensive SDK extraction + nullable-aware aggregation)
+
+The #170 `reasoning_tokens` work introduced two pure helpers that
+together codify the **defensive-extract → nullable-aware-sum**
+pipeline shape: a per-provider extractor that maps a raw SDK
+shape to `int | None` with a load-bearing `bool`-guard, and a
+chain-level aggregator that distinguishes "no source surfaced a
+count" (all-None → None) from "sources surfaced zero" (mixed or
+all-int → real sum). The two helpers live in different modules
+(provider-side vs report-side) but solve a coupled concern; both
+are unit-testable in isolation without `AsyncMock`, subprocess
+patches, or any SDK import:
+
+- `src/clauditor/_providers/_openai.py::_extract_reasoning_tokens(usage:
+  Any) -> int | None` — defensive read of
+  `usage.output_tokens_details.reasoning_tokens`. Returns the
+  integer (including `0` — preserved as a real "model didn't
+  reason" signal per DEC-002 of `#170`); returns `None` for
+  `usage is None`, missing nested attribute, missing field,
+  non-int value, `bool` value (the guard), or any
+  attribute-access exception. The bool-vs-int guard precedes
+  the `isinstance(value, int)` check per
+  `.claude/rules/constant-with-type-info.md` because Python's
+  `isinstance(True, int)` returns `True` — without the explicit
+  `isinstance(value, bool) → return None` arm, a future SDK
+  surfacing `reasoning_tokens=True` would silently coerce to
+  `1`. Anthropic does NOT get an analogous helper: per DEC-001
+  the SDK has no separately-billed reasoning-token field, so
+  the construction site at
+  `src/clauditor/_providers/_anthropic.py::_extract_result`
+  hardcodes `reasoning_tokens=None` with an inline comment
+  citing the rationale. The asymmetry is structural ("when the
+  SDK doesn't expose it, return None — don't approximate"),
+  not an oversight.
+- `src/clauditor/quality_grader.py::_sum_optional_reasoning_tokens(values:
+  list[int | None]) -> int | None` — chain-level aggregator
+  that filters out `None`s and returns `sum(present) if present
+  else None`. The semantic teaching is novel: a single `None`
+  component does NOT poison a sum that has at least one real
+  value (`[None, 42]` → `42`, NOT `0` and NOT `None`), and an
+  all-`None` chain stays `None` rather than collapsing to `0`.
+  This preserves the provider-attribution distinction across
+  the multi-call grader chain — variance reps, parse-retry
+  attempts, blind-compare's two parallel calls, mixed
+  Anthropic+OpenAI grader pairs all aggregate cleanly. The
+  `or None` shorthand on an empty `present` list collapses the
+  empty-sum-equals-zero foot-gun. Per DEC-003 of #170.
+
+Both tested directly via dedicated test classes
+(`TestExtractReasoningTokens` in `tests/test_providers_openai.py`,
+`TestSumOptionalReasoningTokens` in
+`tests/test_quality_grader.py`) that pass plain `MagicMock` /
+list literals and assert on the return value — no `AsyncMock`,
+no `patch("subprocess.Popen")`, no Responses-API stubs. Every
+edge case (missing attribute, `0`-vs-`None`, bool guard, mixed
+all-None / mixed-non-None / all-int chains) is one inline
+assertion away.
+
+The orchestrator-side wiring is the canonical thin shape:
+`grader.py::extract_and_grade` and `quality_grader.py::grade_quality`
+each collect per-attempt `ModelResult.reasoning_tokens` into a
+list (`reasoning_attempts.append(api_result.reasoning_tokens)`),
+then hand the list to `_sum_optional_reasoning_tokens(...)` for
+the final report field. None of the verdict logic, coercion
+discipline, or aggregation semantics live inside the
+orchestrator; both helpers stay at the boundary.
+
+Why the split mattered specifically here:
+
+- **One bool-guard, one place per provider**: had the bool guard
+  been inlined at every `ModelResult` construction site (one per
+  provider × one per code path × one per retry branch), it
+  would have drifted within weeks. Centralizing it inside
+  `_extract_reasoning_tokens` means a future SDK shape change
+  edits one helper, and every call path inherits the fix.
+- **The `0`-vs-`None` distinction survives all aggregation
+  layers**: the per-call extractor preserves `0`, and the
+  chain-level aggregator preserves the all-None→None semantic.
+  Together they thread an honest signal from the SDK boundary
+  through to `IterationContext.reasoning_tokens` without any
+  layer collapsing the distinction. A future audit/trend
+  consumer can compare "no reasoning-capable call ran" against
+  "reasoning-capable calls ran but model used zero tokens"
+  cleanly.
+- **Symmetric reader-side bool-guard in
+  `from_json`**: the same defensive pattern applies on the
+  on-disk read side. Both `GradingReport.from_json` and
+  `ExtractionReport.from_json` carry a parallel
+  `if raw_reasoning is None or isinstance(raw_reasoning, bool):
+  reasoning_tokens = None` branch per the
+  `.claude/rules/json-schema-version.md` "Schema version bumps
+  for #170" subsection. The on-disk JSON boundary is a
+  serialize-then-parse roundtrip; a malformed sidecar with
+  `"reasoning_tokens": true` would otherwise coerce to `1` on
+  the way back in. Symmetric guards on both sides of the I/O
+  boundary keep the discipline structural.
+- **Future nullable-token-style fields plug in trivially**:
+  `#169` (`cost_usd: float | None`) will use the same shape —
+  per-provider defensive extractor (with a parallel `bool`/`int`
+  guard, since Python's `bool` is also a subclass of `float`),
+  chain-level `_sum_optional_cost_usd` aggregator with the same
+  all-None-stays-None semantic. The 9th anchor here documents
+  the recipe so that future ticket inherits it without
+  rediscovering.
+
+Traces to DEC-001, DEC-002, DEC-003, DEC-006 of
+`plans/super/170-reasoning-tokens-capture.md`. Companion rules:
+`.claude/rules/centralized-sdk-call.md` (the asymmetric per-
+provider population that `_extract_reasoning_tokens` lives
+inside),
+`.claude/rules/json-schema-version.md` (the schema-bump and
+loader-side-bool-guard contract that mirrors the writer-side
+discipline this anchor codifies),
+`.claude/rules/constant-with-type-info.md` (the bool-vs-int
+discipline this helper enforces at the SDK boundary).
+
 ## When this rule applies
 
 Any new code that combines spec/config resolution with a

--- a/.claude/rules/pure-compute-vs-io-split.md
+++ b/.claude/rules/pure-compute-vs-io-split.md
@@ -690,8 +690,11 @@ Why the split mattered specifically here:
 - **Future nullable-token-style fields plug in trivially**:
   `#169` (`cost_usd: float | None`) will use the same shape —
   per-provider defensive extractor (with a parallel `bool`/`int`
-  guard, since Python's `bool` is also a subclass of `float`),
-  chain-level `_sum_optional_cost_usd` aggregator with the same
+  guard, since Python's `bool` is a subclass of `int` — NOT of
+  `float` — and `True`/`False` therefore pass any broad numeric
+  check like `isinstance(x, (int, float))` without an explicit
+  bool guard ahead of the int/float check), chain-level
+  `_sum_optional_cost_usd` aggregator with the same
   all-None-stays-None semantic. The 9th anchor here documents
   the recipe so that future ticket inherits it without
   rediscovering.

--- a/plans/super/170-reasoning-tokens-capture.md
+++ b/plans/super/170-reasoning-tokens-capture.md
@@ -130,8 +130,8 @@ These shape DEC-001 through DEC-005.
 - **Q1 → A.** Anthropic always returns `None`. No SDK round-trip; no char-count heuristic. Document the rationale.
 - **Q2 → A.** OpenAI: `0` is a real value (model didn't reason); `None` only when SDK shape is malformed/absent.
 - **Q3 → A.** Sum across all grader calls in the iteration. `None` if every component is `None`; otherwise sum of non-None values.
-- **Q4 → C.** Persist on `GradingReport`/`ExtractionReport` (schema bump v4→v5 on both) AND wire to `BlindReport`. Symmetric with input/output token persistence.
-- **Q5 → A** (folded into Q4=C). BlindReport gets the field too. Note: BlindReport has `to_json()` but no CLI command writes it to disk today (`grep` confirms); BlindReport.to_json() is invoked by tests / programmatic callers only. No `from_json()` exists. Adding `reasoning_tokens` to its `to_json()` payload is safe at the existing schema_version=1 (always-v1-by-design pattern, mirroring IterationContext) — the absence of a `from_json()` reader means there is no legacy-read compat to worry about.
+- **Q4 → A.** Persist on `GradingReport`/`ExtractionReport` (schema bump v4→v5 on both) AND wire to `BlindReport`. Symmetric with input/output token persistence.
+- **Q5 → A** (folded into Q4=A). BlindReport gets the field too. Note: BlindReport has `to_json()` but no CLI command writes it to disk today (`grep` confirms); BlindReport.to_json() is invoked by tests / programmatic callers only. No `from_json()` exists. Adding `reasoning_tokens` to its `to_json()` payload is safe at the existing schema_version=1 (always-v1-by-design pattern, mirroring IterationContext) — the absence of a `from_json()` reader means there is no legacy-read compat to worry about.
 
 ---
 

--- a/plans/super/170-reasoning-tokens-capture.md
+++ b/plans/super/170-reasoning-tokens-capture.md
@@ -5,8 +5,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/170
 - **Branch:** `feature/170-reasoning-tokens-capture`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/170-reasoning-tokens-capture`
-- **PR:** _(pending)_
-- **Phase:** detailing
+- **PR:** https://github.com/wjduenow/clauditor/pull/174
+- **Phase:** devolved
+- **Epic:** clauditor-o7u
 - **Sessions:** 1 (2026-05-09)
 - **Total decisions:** 8 (DEC-001 through DEC-008)
 - **Depends on:** #154 (CLOSED — `context.json` sidecar with `reasoning_tokens: int | None = None` placeholder)
@@ -342,4 +343,18 @@ Re-sequenced for dependency correctness:
 
 ## Beads Manifest
 
-_(filled in at devolve time)_
+- **Epic:** `clauditor-o7u` — 170: Reasoning tokens — capture separately-billed reasoning tokens in ModelResult
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/170-reasoning-tokens-capture`
+- **Branch:** `feature/170-reasoning-tokens-capture`
+- **PR:** https://github.com/wjduenow/clauditor/pull/174
+
+| Story | Bead ID | Depends on |
+|---|---|---|
+| US-001 — Add reasoning_tokens field to ModelResult | `clauditor-oynv` | (none — ready) |
+| US-002 — OpenAI backend extracts reasoning_tokens | `clauditor-s0vu` | US-001 |
+| US-003 — Anthropic backend documents always-None | `clauditor-3wdi` | US-001 |
+| US-004 — Add field to reports + sum logic | `clauditor-4l6s` | US-002, US-003 |
+| US-005 — `_write_context_sidecar` reads from report | `clauditor-3k5b` | US-004 |
+| US-006 — Audit loader bumps + v4 default-on-read | `clauditor-0mv1` | US-004 |
+| Quality Gate — code review x4 + CodeRabbit | `clauditor-q54i` | US-001..US-006 |
+| Patterns & Memory | `clauditor-rzif` | Quality Gate |

--- a/plans/super/170-reasoning-tokens-capture.md
+++ b/plans/super/170-reasoning-tokens-capture.md
@@ -1,0 +1,345 @@
+# 170: Reasoning tokens — capture separately-billed reasoning tokens in `ModelResult`
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/170
+- **Branch:** `feature/170-reasoning-tokens-capture`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/170-reasoning-tokens-capture`
+- **PR:** _(pending)_
+- **Phase:** detailing
+- **Sessions:** 1 (2026-05-09)
+- **Total decisions:** 8 (DEC-001 through DEC-008)
+- **Depends on:** #154 (CLOSED — `context.json` sidecar with `reasoning_tokens: int | None = None` placeholder)
+- **Sibling:** #169 (cost_usd capture — same shape, different field)
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** Light up the `IterationContext.reasoning_tokens` placeholder field that #154 shipped. Capture separately-billed reasoning tokens from the LLM grader call(s) and surface the value into `context.json` at sidecar-write time.
+
+**Scope (verbatim from ticket):**
+- Add `reasoning_tokens: int | None` field to `ModelResult`.
+- Anthropic backend: surface from `Message.usage` if a thinking-token field is present.
+- OpenAI backend: surface from the API's reasoning-token usage section for o-series and GPT-5 reasoning models.
+- Wire the value through to `IterationContext.reasoning_tokens` at sidecar-write time.
+- Defensive: missing field → `None`, never raises.
+- Tests: stubbed API response with reasoning tokens → field populated; legacy response without → `None`.
+
+**Out of scope (per ticket):**
+- Reasoning-token cost calculation (lives in #169 `cost_usd`).
+- Aggregation / trend analysis of reasoning tokens (separate concern).
+
+### Codebase findings
+
+**`ModelResult` dataclass** — defined at `src/clauditor/_providers/_anthropic.py:192–241` (NOT `__init__.py` — actually lives in the Anthropic-specific module for historical reasons; re-exported from `_providers/__init__.py:200`). Current shape: 9 fields. No `reasoning_tokens`. Back-compat alias `AnthropicResult = ModelResult`. Defined at `_anthropic.py:220` per the convention checker.
+
+**Anthropic backend** (`src/clauditor/_providers/_anthropic.py`):
+- Usage extraction: lines 289–297 — extracts `usage.input_tokens` / `usage.output_tokens` only. No reasoning fields read.
+- ModelResult construction: lines 299–306.
+- **SDK reality (research finding):** `anthropic.types.Usage` has NO dedicated `thinking_tokens` / `reasoning_tokens` field. The fields are: `cache_creation`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `inference_geo`, `input_tokens`, `output_tokens`, `server_tool_use`, `service_tier`. For extended-thinking models (Opus 4.x with `thinking={"type":"enabled",...}`), `output_tokens` ALREADY INCLUDES the thinking tokens — they are NOT counted separately by the SDK. Thinking content surfaces as `ThinkingBlock` entries inside `Message.content` but those carry text only, not a count.
+- **Implication:** Honest Anthropic capture is `None` (no separately-billed field exists today). To get a separate number we would need to call `client.messages.count_tokens(...)` on each `ThinkingBlock.thinking` string — extra round-trip per call.
+
+**OpenAI backend** (`src/clauditor/_providers/_openai.py`):
+- Usage extraction: `_extract_openai_result` at lines 220–228 — `input_tokens` / `output_tokens` only.
+- ModelResult construction: lines 485–492 (approx).
+- **SDK reality:** `openai.types.responses.ResponseUsage` carries `output_tokens_details: OutputTokensDetails`, which has `reasoning_tokens: int` (typed non-optional). Always present for Responses API calls. `0` for non-reasoning models, real count for o-series / GPT-5 reasoning. Note: `output_tokens` already INCLUDES `reasoning_tokens` (breakdown, not additive).
+
+**`IterationContext`** (`src/clauditor/context.py:58–211`):
+- Already carries `reasoning_tokens: int | None = None` (DEC-002 of #154).
+- `to_json()` emits `"reasoning_tokens": self.reasoning_tokens` (line 89).
+- `from_dict()` validates `int | None` with `bool` guard (lines 161–172).
+- Always-v1 contract per `json-schema-version.md` — populating this field does NOT bump schema.
+
+**Sidecar write sites:**
+- `src/clauditor/cli/grade.py:887` — `_write_context_sidecar(...)`. Currently passes `reasoning_tokens=None` hardcoded (line 921). Called at line 797 with `model_grader=primary_report.model`. Has access to `primary_skill_result` and `primary_report` (a `GradingReport`).
+- `src/clauditor/cli/validate.py:318–329` — `validate` command writes the sidecar with `reasoning_tokens=None` hardcoded; no LLM grader involved, so reasoning is structurally `None` for this path.
+
+**Token plumbing in graders:**
+- `GradingReport` (`quality_grader.py:94`) carries `input_tokens` / `output_tokens` as summed totals (across retries, blind-compare's two calls, etc.). Persisted to `grading.json`.
+- `ExtractionReport` (`grader.py:139`) — same.
+- Internal helpers fan out via tuples like `(text, source, provider, input_tokens, output_tokens)` (`grader.py:842`, `quality_grader.py:635`).
+- Sum sites: `grader.py:870`, `quality_grader.py:660`, `quality_grader.py:1228`. All sum across multiple `ModelResult`s into the report's totals.
+
+**Audit / badge readers** (downstream of `IterationContext.reasoning_tokens`):
+- `audit.py:868` — display in context table.
+- `audit.py:1155` — JSON export.
+- `badge.py` — no read today.
+
+**Test fixtures:**
+- `tests/test_providers_anthropic.py:37–59` — `_mock_response` builds a MagicMock with `usage = MagicMock(input_tokens=..., output_tokens=...)`. No reasoning field.
+- `tests/test_providers_openai.py:30–67` — same pattern.
+
+### Conventions / rules consulted
+
+**Apply — drive implementation:**
+
+1. **`json-schema-version.md`** — `IterationContext` stays at `schema_version: 1`; the field was pre-declared nullable in v1 specifically so this PR can populate it without bumping. ALSO: if we add `reasoning_tokens` to `GradingReport` / `ExtractionReport` (a real on-disk shape change), THOSE files would need bumps (`grading.json` v4→v5, `extraction.json` v4→v5). DEC needed on whether to persist there.
+2. **`centralized-sdk-call.md`** — `ModelResult` is the right home for the new field. Both `call_anthropic` and `call_openai` must populate it independently. Per DEC-007 of #149, `harness_metadata` is the forward-compat surface for harness-shape data — but reasoning_tokens is a model-call concern, not harness-shape, so it lives on `ModelResult`, not `harness_metadata`.
+3. **`back-compat-shim-discipline.md`** Pattern 2 — `AnthropicResult = ModelResult` is an alias re-exported through `clauditor._anthropic`. Adding a field is safe (the alias is `is`-identical), but a regression test asserting `clauditor._anthropic.AnthropicResult is clauditor._providers.ModelResult` should remain green. The existing `tests/test_providers_auth.py::TestExceptionClassIdentity` covers this; verify no breakage.
+4. **`pure-compute-vs-io-split.md`** — Defensive extraction belongs in a pure helper (small `_extract_reasoning_tokens(usage) -> int | None` function in each provider module), called inside the SDK-result extractor. Sixth or seventh anchor candidate for the rule.
+5. **`pre-llm-contract-hard-validate.md`** + **`stream-json-schema.md`** (defensive-read shape only) — `getattr(usage, "output_tokens_details", None)` then `getattr(details, "reasoning_tokens", None)`, `isinstance(value, int) and not isinstance(value, bool)` per `constant-with-type-info.md`. Returns `None` on any malformed input; never raises.
+6. **`constant-with-type-info.md`** — `bool is not int` guard applies; `True` would otherwise pass `isinstance(value, int)` and corrupt the count.
+7. **`mock-side-effect-for-distinct-calls.md`** — When tests verify summing across multiple grader calls (e.g. blind-compare's two), use `side_effect=[result1, result2]` with distinct `reasoning_tokens` values so the sum arithmetic is actually exercised.
+8. **`rule-refresh-vs-delete.md`** — `centralized-sdk-call.md`'s `ModelResult` field list (cited verbatim in the rule's "Why this shape" section) needs a one-line refresh to mention the new field.
+
+**N/A:**
+
+`stream-json-schema.md` for non-defensive purposes (reasoning tokens come from SDK, not stream-json), `non-mutating-scrub.md`, `multi-provider-dispatch.md` (no auth/dispatch change), `subprocess-cwd.md`, `path-validation.md`, `eval-spec-stable-ids.md`, `spec-cli-precedence.md`, `dual-version-external-schema-embed.md`, `llm-cli-exit-code-taxonomy.md`, `monotonic-time-indirection.md`, `bundled-skill-docs-sync.md`, `readme-promotion-recipe.md`, `positional-id-zip-validation.md`, `pytester-inprocess-coverage-hazard.md`, `in-memory-dict-loader-path.md`, `precall-env-validation.md`, `per-type-drift-hints.md`, `permissive-parser-strict-validator.md`, `internal-skill-live-test-tmp-symlink.md`, `skill-identity-from-frontmatter.md`, `test-infra-shutil-which-coupling.md`, `llm-judge-prompt-injection.md`, `project-root-home-exclusion.md`, `harness-protocol-shape.md`, `cross-axis-comparability-refusal.md`, `data-vs-asserter-split.md`, `sidecar-during-staging.md` (no new sidecar; existing write site already follows the pattern).
+
+### Scoping questions
+
+These shape DEC-001 through DEC-005.
+
+**Q1: Anthropic capture strategy.** No separately-billed reasoning-token field exists in `anthropic.types.Usage`. For extended-thinking models, `output_tokens` already INCLUDES thinking tokens. Options:
+
+- **A.** Always return `None` for Anthropic. Document that Anthropic bundles thinking into `output_tokens`. (Simplest. Honest. Means GPT-5 grading shows real numbers, Claude Opus 4.x thinking grading shows `None`.)
+- **B.** Approximate by calling `client.messages.count_tokens(thinking_text)` on each `ThinkingBlock` after the response returns. (Adds 1 SDK round-trip per grader call; defeats the purpose of free-feeling token capture.)
+- **C.** Approximate by char-count / 4 of the thinking block text. (Fast but inaccurate; misleading number.)
+- **D.** Same as A, but ALSO surface a separate `thinking_block_count: int` (number of thinking blocks present) on `ModelResult` as a proxy signal. (Adds scope.)
+
+**Q2: 0-vs-None semantic for OpenAI.** OpenAI Responses API always returns `output_tokens_details.reasoning_tokens: int` — `0` for non-reasoning models, real count for reasoning. Options:
+
+- **A.** Treat `0` as a real value: store `0` for non-reasoning calls. `None` only when SDK shape is malformed/absent. (Distinguishes "model didn't reason" from "couldn't read.")
+- **B.** Coerce `0 → None`: only store positive counts. (Loses the "we measured zero" signal but makes "reasoning happened" a simple `is not None` check.)
+- **C.** Always store `0` (never `None`) for OpenAI when SDK is well-formed. Keep the malformed branch as `None`. (Same as A in practice.)
+
+**Q3: Sum-vs-pick across multiple grader calls.** A grading run can issue several model calls (extract, grade, blind-compare = 2 calls). `IterationContext.reasoning_tokens` is a single `int | None`. Options:
+
+- **A.** Sum across all grader calls in the iteration (parallels how `GradingReport.input_tokens` / `output_tokens` are summed). `None` if every component is `None`; otherwise sum of non-None values.
+- **B.** Pick a specific call (e.g. just the L3 grading call, ignore extraction). Simpler but loses extraction signal.
+- **C.** Sum but track whether ANY component was None (mixed-source ambiguity). Out of scope for v1.
+
+**Q4: Where does `reasoning_tokens` live on the report side?** Need a path from grader's `ModelResult` chain to `_write_context_sidecar`. Options:
+
+- **A.** Add `reasoning_tokens: int | None` field to `GradingReport` and `ExtractionReport`. Persist to `grading.json` / `extraction.json`. **Cost:** schema bump on both files (v4→v5). **Benefit:** symmetric with input/output token persistence; future audit tooling can read it directly.
+- **B.** Add to `GradingReport` / `ExtractionReport` as in-memory-only fields (NOT in `to_json` / `from_json`). No schema bump. **Cost:** asymmetric (other token totals persist, this one doesn't); future tooling cannot read it from sidecars.
+- **C.** Skip the report entirely; thread reasoning_tokens out-of-band as a new return value from grader entry points. **Cost:** signature churn on every grader entry point + every call site; back-compat shim concerns.
+- **D.** Same as A but use the "always-vN-by-design pre-declare nullable" trick — add the field to GradingReport/ExtractionReport but pre-declare `cost_usd_grader: float | None = None` at the same time so the `cost_usd` (#169) follow-up doesn't bump again. **Cost:** speculative-field whiff, but matches the IterationContext shape.
+
+**Q5: Blind-compare scope.** `blind_compare_from_spec` produces a `BlindReport`. Does this PR populate `reasoning_tokens` for blind-compare runs too?
+
+- **A.** Yes — add to `BlindReport` and thread through. Blind-compare doesn't write `IterationContext` today, but the field would be available in-memory and via `to_json()`.
+- **B.** Defer. Skip BlindReport for this PR.
+
+### Scoping answers (2026-05-09)
+
+- **Q1 → A.** Anthropic always returns `None`. No SDK round-trip; no char-count heuristic. Document the rationale.
+- **Q2 → A.** OpenAI: `0` is a real value (model didn't reason); `None` only when SDK shape is malformed/absent.
+- **Q3 → A.** Sum across all grader calls in the iteration. `None` if every component is `None`; otherwise sum of non-None values.
+- **Q4 → C.** Persist on `GradingReport`/`ExtractionReport` (schema bump v4→v5 on both) AND wire to `BlindReport`. Symmetric with input/output token persistence.
+- **Q5 → A** (folded into Q4=C). BlindReport gets the field too. Note: BlindReport has `to_json()` but no CLI command writes it to disk today (`grep` confirms); BlindReport.to_json() is invoked by tests / programmatic callers only. No `from_json()` exists. Adding `reasoning_tokens` to its `to_json()` payload is safe at the existing schema_version=1 (always-v1-by-design pattern, mirroring IterationContext) — the absence of a `from_json()` reader means there is no legacy-read compat to worry about.
+
+---
+
+## Architecture Review
+
+| Area | Rating | Notes |
+|---|---|---|
+| Security | **pass** | Token counts are non-sensitive observability data. No new I/O surface. Test fixtures use mock SDK responses (no live keys). |
+| Performance | **pass** | One additional `getattr` per `_extract_openai_result` call. Anthropic path adds nothing (always returns `None`). No new I/O, no network round-trips. |
+| Data model | **pass** | Two schema bumps (`grading.json` v4→v5, `extraction.json` v4→v5) follow the established pattern from #147 and #152. Loaders default missing `reasoning_tokens` to `None` for v4 reads. `IterationContext` stays at v1 (always-v1 contract). `BlindReport` stays at v1 (no `from_json` reader → no legacy concern; field is additive in `to_json`). |
+| API design | **pass** | `ModelResult` adds one kwarg-only field after existing fields. All call sites use kwargs (verified — no positional `ModelResult(...)` in tests). Back-compat alias `AnthropicResult is ModelResult` preserved (alias is `is`-identical, no separate class). |
+| Observability | **pass** | New field flows through `IterationContext.reasoning_tokens` to `audit.py:868` (display) and `audit.py:1155` (JSON export) — already wired by #154. |
+| Testing | **concern** | Three-state semantic (`None`/`0`/`positive`) requires explicit tests for each case in OpenAI extraction. Sum logic needs the "all-None → None, mixed → sum-of-non-None" edge case covered. Legacy-read tests for v4 grading.json/extraction.json must default `reasoning_tokens` to `None`. Mitigated: existing test patterns from `provider_source` v3-vs-v4 and the canonical mock-side-effect pattern apply directly. |
+| Back-compat | **pass** | `clauditor._anthropic.ModelResult is clauditor._providers.ModelResult` identity test already exists (`test_providers_auth.py:491`); will continue to pass. No positional-kwarg breakage since all callers use kwargs. |
+
+No blockers. Two concerns folded into the test plan (US-005, US-006).
+
+---
+
+## Refinement Log
+
+### Decisions
+
+- **DEC-001: Anthropic always returns `None` for `reasoning_tokens`.**
+  Rationale: `anthropic.types.Usage` carries no separately-billed thinking-token field. For extended-thinking models, `output_tokens` already includes thinking tokens. Approximating via `count_tokens` round-trip would defeat the free-feeling capture; char-count heuristics are inaccurate. Honest `None` is the only correct representation. (Q1=A.)
+
+- **DEC-002: OpenAI stores `0` as a real value; `None` only on SDK malformation.**
+  Rationale: `Response.usage.output_tokens_details.reasoning_tokens` is typed `int` (Stainless-generated, always present). `0` means "model didn't reason" (a real per-call signal). `None` means "couldn't read." Conflating loses the signal. (Q2=A.)
+
+- **DEC-003: Sum across all grader calls in an iteration.**
+  Rationale: Parallels existing summing of `input_tokens` / `output_tokens` at `quality_grader.py:1228` and `grader.py:870`. The semantic for sum: `None` if every component is `None` (no reasoning-capable call happened); otherwise `sum(r.reasoning_tokens for r in results if r.reasoning_tokens is not None)`. A single `None` component does not poison a sum that has at least one real value. (Q3=A.)
+
+- **DEC-004: Persist `reasoning_tokens` on `GradingReport` and `ExtractionReport`; bump both schemas v4→v5.**
+  Rationale: Symmetric with `input_tokens` / `output_tokens` persistence. Future audit tooling can read from sidecars without re-running graders. Loader pattern follows #152's `harness` v3→v4 default-on-read shape. `MAX_SCHEMA_VERSION` bumps via the one-number-per-file edit established by DEC-008 of #147. (Q4=C, half 1.)
+
+- **DEC-005: Wire `reasoning_tokens` into `BlindReport.to_json()` at the existing `schema_version: 1`.**
+  Rationale: `BlindReport` has `to_json()` but no `from_json()` reader, no CLI command writes it as a sidecar (grep-verified), and the `.claude/rules/json-schema-version.md` "always-v1 by design" pattern (same as `context.json`) applies — additive nullable fields in v1 do not require a bump. The field is available in-memory for programmatic callers. No legacy-read compat surface to maintain. (Q4=C, half 2.)
+
+- **DEC-006: Defensive extraction lives in pure helpers per provider.**
+  Rationale: `_providers/_openai.py::_extract_reasoning_tokens(usage) -> int | None` is pure, testable in isolation, and follows the sixth-anchor pattern from `pure-compute-vs-io-split.md` (the runner classification helpers). The `bool is not int` guard is enforced per `constant-with-type-info.md`. Anthropic does not get an analogous helper (always-`None` is one line in `_extract_result`).
+
+- **DEC-007: Loaders default missing `reasoning_tokens` to `None` for v4 reads.**
+  Rationale: Mirrors #147's `provider_source` default-to-`"anthropic"` and #152's `harness` default-to-`"claude-code"` for legacy reads. The default `None` correctly represents "we don't know whether reasoning happened" for pre-#170 history. Per the `_check_schema_version` "version-and-up" loader pattern.
+
+- **DEC-008: `IterationContext.reasoning_tokens` sources from `primary_report.reasoning_tokens`.**
+  Rationale: `_write_context_sidecar` already reads `model_grader=primary_report.model`. The reasoning-tokens source is the same dataclass — no new threading required. Validation paths (`_write_context_sidecar` call site at `cli/grade.py:797`) only need to swap `reasoning_tokens=None` (line 921) for `reasoning_tokens=primary_report.reasoning_tokens`. The `validate` command's path stays `None` (no LLM grader → structurally `None`).
+
+---
+
+## Detailed Breakdown
+
+The natural ordering: provider extractors first (US-001 OpenAI, US-002 Anthropic), then `ModelResult` field (US-003 — actually goes first since both extractors populate it), then the report dataclasses + sums (US-004), then the CLI seam wiring (US-005), then the schema bumps + loader compat (US-006), then test gap closure (US-007), then Quality Gate + Patterns & Memory.
+
+Re-sequenced for dependency correctness:
+
+### US-001: Add `reasoning_tokens: int | None = None` to `ModelResult`
+
+- **Description:** Add the new optional field to `ModelResult`. Kwarg-only, default `None`, placed after existing fields. Update the back-compat alias `AnthropicResult` (no change required — it's `= ModelResult`). Verify `clauditor._anthropic.ModelResult is clauditor._providers.ModelResult` still holds.
+- **Traces to:** DEC-001, DEC-002, DEC-006.
+- **Acceptance Criteria:**
+  - `ModelResult.reasoning_tokens: int | None = None` field present in `src/clauditor/_providers/_anthropic.py`.
+  - All existing tests pass (no positional-kwarg breakage).
+  - Class-identity test `tests/test_providers_auth.py::TestExceptionClassIdentity` continues to pass.
+  - `uv run ruff check src/ tests/` clean. `uv run pytest --cov=clauditor --cov-report=term-missing` passes (≥80%).
+- **Done when:** Field is on the dataclass; existing test suite green; identity test still passes.
+- **Files:**
+  - `src/clauditor/_providers/_anthropic.py` (add field to `ModelResult` ~line 192).
+- **Depends on:** none.
+- **TDD:** Add a small test asserting `ModelResult().reasoning_tokens is None` and `ModelResult(reasoning_tokens=42).reasoning_tokens == 42`. Identity test (`AnthropicResult is ModelResult`) remains unchanged.
+
+### US-002: OpenAI backend extracts `reasoning_tokens` from `output_tokens_details`
+
+- **Description:** Add a pure helper `_extract_reasoning_tokens(usage) -> int | None` in `_providers/_openai.py` that defensively reads `usage.output_tokens_details.reasoning_tokens`. Returns the int (including `0`), or `None` on any malformed input (missing attribute, wrong type, bool, exception). Wire into `_extract_openai_result` so the returned `ModelResult` carries the field. Per DEC-002, `0` is preserved (NOT coerced to `None`).
+- **Traces to:** DEC-002, DEC-006.
+- **Acceptance Criteria:**
+  - `_extract_reasoning_tokens(usage)` is a module-level pure function (no I/O, never raises).
+  - Returns `int` (including `0`) for well-formed input.
+  - Returns `None` for: `usage is None`, missing `output_tokens_details`, missing `reasoning_tokens`, non-int value, `bool` value (per `constant-with-type-info.md`), any exception during read.
+  - `call_openai` populates `ModelResult.reasoning_tokens` via this helper.
+  - `uv run ruff check src/ tests/` clean.
+- **Done when:** Helper exists, is unit-tested in isolation, and `call_openai`'s `ModelResult` carries the field on every code path.
+- **Files:**
+  - `src/clauditor/_providers/_openai.py` (add helper; thread into `_extract_openai_result` ~line 220).
+- **Depends on:** US-001.
+- **TDD:**
+  - `_extract_reasoning_tokens(None) is None`.
+  - `_extract_reasoning_tokens(usage_with_42) == 42`.
+  - `_extract_reasoning_tokens(usage_with_0) == 0` (the load-bearing zero-vs-None test for DEC-002).
+  - `_extract_reasoning_tokens(usage_missing_details) is None`.
+  - `_extract_reasoning_tokens(usage_with_bool) is None` (bool guard).
+  - `_extract_reasoning_tokens(usage_with_string) is None`.
+  - End-to-end: `call_openai` with mock response carrying `reasoning_tokens=99` → `result.reasoning_tokens == 99`.
+  - End-to-end: `call_openai` with mock response carrying `reasoning_tokens=0` → `result.reasoning_tokens == 0`.
+
+### US-003: Anthropic backend documents `reasoning_tokens` always returns `None`
+
+- **Description:** In `_providers/_anthropic.py::_extract_result` (or wherever `ModelResult` is constructed), explicitly populate `reasoning_tokens=None` with a brief inline comment citing DEC-001. No SDK reading required. Add a unit test asserting this invariant so a future contributor doesn't accidentally wire it up via a copy-paste from the OpenAI side.
+- **Traces to:** DEC-001.
+- **Acceptance Criteria:**
+  - `call_anthropic` populates `ModelResult.reasoning_tokens` as `None` on every code path (success, retry, both transports).
+  - One inline comment in the construction site naming DEC-001 + the rationale ("Anthropic SDK has no separately-billed reasoning-token field; output_tokens already includes thinking").
+  - Test asserts `result.reasoning_tokens is None` for both a normal mock and a thinking-style mock.
+- **Done when:** Anthropic backend always returns `None`; test guards against future drift.
+- **Files:**
+  - `src/clauditor/_providers/_anthropic.py` (~line 299 ModelResult construction).
+- **Depends on:** US-001.
+- **TDD:**
+  - `test_anthropic_reasoning_tokens_always_none` — mock response with `usage = MagicMock(input_tokens=10, output_tokens=5)` → `result.reasoning_tokens is None`.
+  - `test_anthropic_reasoning_tokens_none_for_thinking_style_response` — mock response with `content=[ThinkingBlock-like, TextBlock]` → still `None`.
+
+### US-004: Add `reasoning_tokens` to `GradingReport`, `ExtractionReport`, `BlindReport` + sum logic
+
+- **Description:** Add `reasoning_tokens: int | None = None` field to all three report dataclasses. Update the existing token-summing sites to compute `reasoning_tokens` per DEC-003: `sum(r.reasoning_tokens for r in results if r.reasoning_tokens is not None) or None` (the `or None` collapses an empty sum to `None`). Wire through every report constructor that today accepts `input_tokens=` / `output_tokens=`. Bump `GradingReport.schema_version` and `ExtractionReport.schema_version` from 4 to 5; emit the field in `to_json()` AFTER existing fields. `BlindReport.to_json()` adds the field at the existing `schema_version: 1` per DEC-005.
+- **Traces to:** DEC-003, DEC-004, DEC-005.
+- **Acceptance Criteria:**
+  - `GradingReport.reasoning_tokens: int | None = None` field present; `to_json` emits it; `schema_version` bumped to 5.
+  - `ExtractionReport.reasoning_tokens: int | None = None` field present; `to_json` emits it; `schema_version` bumped to 5.
+  - `BlindReport.reasoning_tokens: int | None = None` field present; `to_json` emits it; `schema_version` stays 1.
+  - All sum sites (`quality_grader.py:1228`, `quality_grader.py:660`, `grader.py:870`, blind-compare two-call site at `quality_grader.py:757`) sum reasoning tokens with the all-None→None semantic.
+  - Per `mock-side-effect-for-distinct-calls.md`: tests covering the sum logic use `side_effect=[result_with_none, result_with_42]` to verify mixed-component summing.
+- **Done when:** All three reports carry the field; sums work correctly across multi-call scenarios; tests for None/0/sum semantics pass.
+- **Files:**
+  - `src/clauditor/quality_grader.py` (`GradingReport` ~line 81, `BlindReport` ~line 242, sum sites at ~660, ~757, ~1228).
+  - `src/clauditor/grader.py` (`ExtractionReport` ~line 131, sum site at ~870).
+- **Depends on:** US-002, US-003.
+- **TDD:**
+  - `test_grading_report_reasoning_tokens_default_none`.
+  - `test_grading_report_reasoning_tokens_round_trips_42`.
+  - `test_grading_report_to_json_emits_schema_version_5`.
+  - `test_grading_report_sum_all_none_returns_none` (two `ModelResult`s each with `reasoning_tokens=None` → final `report.reasoning_tokens is None`).
+  - `test_grading_report_sum_mixed_returns_sum_of_non_none` (`[None, 42]` → `42`, NOT `0`).
+  - `test_grading_report_sum_two_ints_returns_sum` (`[10, 20]` → `30`).
+  - Mirror tests for `ExtractionReport` (schema_version 5) and `BlindReport` (schema_version stays 1).
+  - Blind-compare-specific: two parallel `call_anthropic` results with `reasoning_tokens=15` and `reasoning_tokens=20` → `BlindReport.reasoning_tokens == 35`.
+
+### US-005: `_write_context_sidecar` reads `primary_report.reasoning_tokens`
+
+- **Description:** Update `cli/grade.py::_write_context_sidecar` (line 887) to read `reasoning_tokens=primary_report.reasoning_tokens` instead of the hardcoded `None`. The call site at line 797 already has `primary_report` in scope. `cli/validate.py` stays hardcoded `None` (no LLM grader for that command — structurally None per DEC-008). Add an integration-shape test verifying the wired value reaches `context.json` on disk.
+- **Traces to:** DEC-008.
+- **Acceptance Criteria:**
+  - `_write_context_sidecar` accepts `reasoning_tokens` from caller (or pulls from `primary_report` directly — simplest is direct read).
+  - `cli/grade.py:921` no longer has `reasoning_tokens=None` hardcoded; reads from `primary_report.reasoning_tokens`.
+  - `cli/validate.py` still passes `reasoning_tokens=None` (validate has no grader call; field is structurally None).
+  - Integration test: a graded run with a mocked OpenAI grader returning `reasoning_tokens=50` produces a `context.json` with `"reasoning_tokens": 50`.
+  - Integration test: a graded run with mocked Anthropic grader produces `context.json` with `"reasoning_tokens": null`.
+- **Done when:** Real value flows from `ModelResult` → grader sum → `GradingReport.reasoning_tokens` → `IterationContext.reasoning_tokens` → `context.json`.
+- **Files:**
+  - `src/clauditor/cli/grade.py` (~line 797 call site, ~line 887 helper signature, ~line 921 hardcoded value).
+- **Depends on:** US-004.
+- **TDD:**
+  - `test_write_context_sidecar_reads_reasoning_tokens_from_report`.
+  - `test_grade_command_e2e_openai_writes_reasoning_tokens_to_context_json` (with mocked grader).
+  - `test_grade_command_e2e_anthropic_writes_null_reasoning_tokens_to_context_json`.
+  - `test_validate_command_writes_null_reasoning_tokens_to_context_json` (no grader → structurally None).
+
+### US-006: Audit loader compat — bump `MAX_SCHEMA_VERSION` and verify v4 default-on-read
+
+- **Description:** Bump `audit.py::MAX_SCHEMA_VERSION` to `{"grading.json": 5, "extraction.json": 5}` (assertions.json and context.json unchanged). Verify `GradingReport.from_json` and `ExtractionReport.from_json` default missing `reasoning_tokens` to `None` for v4 reads (mirrors the `provider_source`/`harness` legacy-default pattern). Audit's `_records_from_grading` / `_records_from_extraction` do NOT need to read `reasoning_tokens` (per the data-model review — reasoning_tokens is per-iteration, not per-record).
+- **Traces to:** DEC-004, DEC-007.
+- **Acceptance Criteria:**
+  - `MAX_SCHEMA_VERSION["grading.json"] == 5` and `["extraction.json"] == 5`.
+  - `GradingReport.from_json` accepts v1/v2/v3/v4/v5 payloads; v1-v4 default `reasoning_tokens` to `None`.
+  - `ExtractionReport.from_json` mirrors.
+  - `_records_from_grading` / `_records_from_extraction` unchanged (no new field consumed).
+  - Existing `tests/test_audit.py` continues to pass.
+- **Done when:** Audit reads pre-#170 history without warnings; new history round-trips through v5 cleanly.
+- **Files:**
+  - `src/clauditor/audit.py` (`MAX_SCHEMA_VERSION` table).
+  - `src/clauditor/quality_grader.py` (`GradingReport.from_json` legacy-default).
+  - `src/clauditor/grader.py` (`ExtractionReport.from_json` legacy-default).
+- **Depends on:** US-004.
+- **TDD:**
+  - `test_grading_report_from_json_v4_defaults_reasoning_tokens_to_none`.
+  - `test_grading_report_from_json_v5_round_trip_with_reasoning_tokens_42`.
+  - Mirror two tests for `ExtractionReport`.
+  - `test_audit_max_schema_version_grading_is_5` / `_extraction_is_5`.
+
+### US-007: Quality Gate — code review x4 + CodeRabbit + project validation
+
+- **Description:** Run code-reviewer agent four times across the full changeset, fixing all real bugs found each pass. Run CodeRabbit if available. Project validation (`uv run ruff check src/ tests/`, `uv run pytest --cov=clauditor --cov-report=term-missing` ≥80%) must pass after all fixes. Verify no positional-arg breakage in test suites; verify legacy-read tests for v4 sidecars all pass.
+- **Traces to:** All DECs (verifies the implementation honors them).
+- **Acceptance Criteria:**
+  - 4 passes of code review with all real bugs fixed.
+  - CodeRabbit (if available) findings addressed.
+  - `uv run ruff check src/ tests/` clean.
+  - `uv run pytest --cov=clauditor --cov-report=term-missing` ≥80%.
+  - All schema-bump regression tests pass.
+- **Done when:** All quality gates green, no real findings outstanding.
+- **Files:** Any file touched by US-001 through US-006.
+- **Depends on:** US-001, US-002, US-003, US-004, US-005, US-006.
+
+### US-008: Patterns & Memory — update conventions and docs
+
+- **Description:** Update `.claude/rules/centralized-sdk-call.md` to include `reasoning_tokens` in the `ModelResult` field-list reference. Update `.claude/rules/json-schema-version.md` "Schema version bumps for #147" / "for #152" precedent with a short "Schema version bumps for #170" subsection documenting `grading.json` v4→v5, `extraction.json` v4→v5, BlindReport stays v1, IterationContext stays v1. Update `.claude/rules/pure-compute-vs-io-split.md` if `_extract_reasoning_tokens` warrants a new anchor (probably folds into the existing seventh anchor — Codex helpers — since it's the same pattern, just a one-line addition to the existing anchor). Add a "honest None for Anthropic" note to relevant rules. No new rule file needed.
+- **Traces to:** All DECs (codifies the patterns for future tickets).
+- **Acceptance Criteria:**
+  - `centralized-sdk-call.md` updated with new field reference.
+  - `json-schema-version.md` updated with #170 schema-bump precedent.
+  - `pure-compute-vs-io-split.md` reviewed; updated if a new anchor is warranted.
+  - Per `rule-refresh-vs-delete.md`: refresh-in-place, no parallel rule files.
+- **Done when:** Memory and rules reflect the new patterns; future contributors will inherit the discipline.
+- **Files:**
+  - `.claude/rules/centralized-sdk-call.md`.
+  - `.claude/rules/json-schema-version.md`.
+  - `.claude/rules/pure-compute-vs-io-split.md` (light touch if any).
+- **Depends on:** US-007.
+
+---
+
+## Beads Manifest
+
+_(filled in at devolve time)_

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -234,12 +234,18 @@ class ModelResult:
             "the provider did not surface a reasoning-token count"
             (no thinking block, transport that strips it, a backend
             without a reasoning concept) — distinct from ``0`` which
-            would assert "the call ran but used zero reasoning
-            tokens". Per-backend population lands in subsequent #170
-            stories (US-002 wires the Anthropic backend; US-003 wires
-            the OpenAI backend); this US-001 carrier-only addition
-            keeps the field None for every existing caller. DEC-001 /
-            DEC-002 of ``plans/super/170-reasoning-tokens-capture.md``.
+            asserts "the call ran but used zero reasoning tokens".
+            Per-backend population (#170): the **Anthropic backend
+            unconditionally returns ``None``** because the SDK has no
+            separately-billed thinking-token field — extended-thinking
+            counts are folded into ``output_tokens`` already. The
+            **OpenAI backend** populates this from
+            ``usage.output_tokens_details.reasoning_tokens`` via the
+            defensive helper ``_extract_reasoning_tokens`` (returns
+            ``0`` for non-reasoning models, the real count for o-series
+            / GPT-5 reasoning models, and ``None`` only on
+            malformed/absent SDK shape). DEC-001 / DEC-002 of
+            ``plans/super/170-reasoning-tokens-capture.md``.
     """
 
     response_text: str

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -229,6 +229,17 @@ class ModelResult:
             pre-#144 caller; the future OpenAI backend (#145) sets
             ``"openai"``. DEC-006 of
             ``plans/super/144-providers-call-model.md``.
+        reasoning_tokens: Per-call reasoning / thinking token count
+            reported by the provider, when available. ``None`` means
+            "the provider did not surface a reasoning-token count"
+            (no thinking block, transport that strips it, a backend
+            without a reasoning concept) — distinct from ``0`` which
+            would assert "the call ran but used zero reasoning
+            tokens". Per-backend population lands in subsequent #170
+            stories (US-002 wires the Anthropic backend; US-003 wires
+            the OpenAI backend); this US-001 carrier-only addition
+            keeps the field None for every existing caller. DEC-001 /
+            DEC-002 of ``plans/super/170-reasoning-tokens-capture.md``.
     """
 
     response_text: str
@@ -239,6 +250,7 @@ class ModelResult:
     source: Literal["api", "cli"] = "api"
     duration_seconds: float = 0.0
     provider: Literal["anthropic", "openai"] = "anthropic"
+    reasoning_tokens: int | None = None
 
 
 # Back-compat alias (DEC-006 of #144): the legacy name stays callable

--- a/src/clauditor/_providers/_anthropic.py
+++ b/src/clauditor/_providers/_anthropic.py
@@ -315,6 +315,18 @@ def _extract_result(response: Any) -> ModelResult:
         output_tokens=output_tokens,
         raw_message=response,
         source="api",
+        # DEC-001 of plans/super/170-reasoning-tokens-capture.md:
+        # ``anthropic.types.Usage`` carries no separately-billed
+        # reasoning-token field. For extended-thinking models
+        # (Opus 4.x, Sonnet 4.x with ``thinking={"type":"enabled",...}``)
+        # the thinking tokens are ALREADY INCLUDED in
+        # ``output_tokens``; there is no separate count to surface.
+        # Honest ``None`` is the only correct representation —
+        # distinct from ``0``, which would falsely assert "the call
+        # ran but used zero reasoning tokens". Do NOT copy-paste a
+        # ``reasoning_tokens=usage.<something>`` shape from the
+        # OpenAI backend here; the SDK simply does not expose one.
+        reasoning_tokens=None,
     )
 
 
@@ -761,6 +773,13 @@ async def _call_via_claude_cli(
                 raw_message=None,
                 source="cli",
                 duration_seconds=duration,
+                # DEC-001 of #170 — see ``_extract_result`` for the
+                # full rationale. Parity with the SDK branch: the
+                # ``claude -p`` subprocess stream-json carries no
+                # separately-billed reasoning-token field either,
+                # and ``InvokeResult.output_tokens`` already includes
+                # any thinking tokens for extended-thinking models.
+                reasoning_tokens=None,
             )
 
         # Decide retry vs raise using the shared ladder.

--- a/src/clauditor/_providers/_openai.py
+++ b/src/clauditor/_providers/_openai.py
@@ -139,9 +139,69 @@ class OpenAIHelperError(Exception):
     """
 
 
+def _extract_reasoning_tokens(usage: Any) -> int | None:
+    """Defensively read ``usage.output_tokens_details.reasoning_tokens``.
+
+    Pure helper per ``.claude/rules/pure-compute-vs-io-split.md``:
+    no I/O, never raises, returns ``int | None``.
+
+    Bead clauditor-s0vu (US-002 of #170). The OpenAI Responses-API
+    ``usage`` object on reasoning-capable models surfaces a nested
+    ``output_tokens_details`` carrying ``reasoning_tokens: int`` —
+    the count of "thinking" tokens charged on top of the
+    user-visible ``output_tokens``. Older / non-reasoning models
+    omit the nested object entirely.
+
+    Per **DEC-002** of ``plans/super/170-reasoning-tokens-capture.md``,
+    ``0`` is preserved (the model chose not to reason on this call)
+    and is structurally distinct from ``None`` (the SDK didn't
+    surface the field at all). Both states are valid on disk; the
+    distinction matters when callers aggregate over many calls.
+
+    Per **DEC-006**, the explicit ``isinstance(val, bool)`` guard
+    is load-bearing: in Python ``isinstance(True, int)`` returns
+    ``True``, so a future SDK that surfaced ``reasoning_tokens=True``
+    would silently coerce to ``1`` without it. See
+    ``.claude/rules/constant-with-type-info.md`` for the canonical
+    bool-vs-int discipline.
+
+    Args:
+        usage: The Responses-API ``response.usage`` object (or any
+            duck-typed stand-in). May be ``None``.
+
+    Returns:
+        ``int`` (including ``0``) when a well-formed
+        ``reasoning_tokens`` field is present on
+        ``usage.output_tokens_details``; otherwise ``None``.
+        ``None`` is returned for: ``usage is None``, missing
+        ``output_tokens_details``, missing or ``None`` /
+        non-int / ``bool`` ``reasoning_tokens``, or any
+        attribute-access exception.
+    """
+    if usage is None:
+        return None
+    try:
+        details = getattr(usage, "output_tokens_details", None)
+    except Exception:  # noqa: BLE001 — defensive against SDK quirks
+        return None
+    if details is None:
+        return None
+    try:
+        value = getattr(details, "reasoning_tokens", None)
+    except Exception:  # noqa: BLE001 — defensive against SDK quirks
+        return None
+    # Bool guard MUST precede the int check because ``isinstance(True, int)``
+    # is ``True`` in Python — see .claude/rules/constant-with-type-info.md.
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int):
+        return None
+    return value
+
+
 def _extract_openai_result(
     response: Any,
-) -> tuple[str, list[str], int, int, dict]:
+) -> tuple[str, list[str], int, int, dict, int | None]:
     """Project a Responses-API response into the ``ModelResult`` payload.
 
     Pure helper per ``.claude/rules/pure-compute-vs-io-split.md``:
@@ -165,7 +225,7 @@ def _extract_openai_result(
 
     Returns:
         Tuple of ``(response_text, text_blocks, input_tokens,
-        output_tokens, raw_message)``:
+        output_tokens, raw_message, reasoning_tokens)``:
 
         - ``response_text`` prefers ``response.output_text`` (the
           SDK's joined-message-text convenience accessor). Falls
@@ -179,6 +239,12 @@ def _extract_openai_result(
           fall back to 0 on missing/null/non-numeric values.
         - ``raw_message`` is ``response.model_dump()`` (Pydantic-v2
           dict) when available, else ``{}``.
+        - ``reasoning_tokens`` is the per-call reasoning-token
+          count read from
+          ``response.usage.output_tokens_details.reasoning_tokens``
+          via :func:`_extract_reasoning_tokens`. ``0`` is preserved;
+          ``None`` means the field was absent / malformed (DEC-002
+          of #170).
     """
     # Walk response.output[], filtering to message items and
     # collecting per-message joined text. Non-message items
@@ -241,7 +307,20 @@ def _extract_openai_result(
         if isinstance(dumped, dict):
             raw_message = dumped
 
-    return output_text, text_blocks, input_tokens, output_tokens, raw_message
+    # Reasoning-token extraction (#170 US-002, DEC-002): pure
+    # helper reads ``usage.output_tokens_details.reasoning_tokens``
+    # defensively — ``0`` (model didn't reason) is preserved
+    # distinct from ``None`` (couldn't read).
+    reasoning_tokens = _extract_reasoning_tokens(usage)
+
+    return (
+        output_text,
+        text_blocks,
+        input_tokens,
+        output_tokens,
+        raw_message,
+        reasoning_tokens,
+    )
 
 
 async def call_openai(
@@ -480,6 +559,7 @@ async def call_openai(
             input_tokens,
             output_tokens,
             raw_message,
+            reasoning_tokens,
         ) = _extract_openai_result(response)
 
         return ModelResult(
@@ -491,4 +571,5 @@ async def call_openai(
             source="api",
             duration_seconds=duration,
             provider="openai",
+            reasoning_tokens=reasoning_tokens,
         )

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -35,15 +35,20 @@ from clauditor.context import IterationContext
 from clauditor.paths import resolve_clauditor_dir
 
 # US-002 / #147 / DEC-008: per-sidecar maximum accepted schema version.
-# Grading and extraction sidecars accept v1..v3:
+# Grading and extraction sidecars accept v1..v5:
 #   - v1: original shape;
 #   - v2 (#86, US-006 of ``plans/super/86-claude-cli-transport.md``):
 #     adds ``transport_source``; loader defaults missing field to
 #     ``"api"`` at read time;
 #   - v3 (#147, US-001): adds ``provider_source``; loader defaults
-#     missing field to ``"anthropic"`` at read time.
-# Assertions sidecars stay at v1 (no transport_source/provider_source
-# fields for L1 assertions).
+#     missing field to ``"anthropic"`` at read time;
+#   - v4 (#152): adds ``harness``; loader defaults missing field to
+#     ``"claude-code"`` at read time;
+#   - v5 (#170, US-004 / US-006): adds nullable ``reasoning_tokens``;
+#     loader defaults missing field to ``None`` at read time.
+# Assertions sidecars accept v1..v2 (#152 added the ``harness`` field
+# for L1; no transport_source/provider_source/reasoning_tokens — L1
+# makes no LLM call).
 #
 # This is the canonical map; the pure helper :func:`_is_accepted_version`
 # answers ``1 <= version <= MAX_SCHEMA_VERSION[base]`` for any

--- a/src/clauditor/audit.py
+++ b/src/clauditor/audit.py
@@ -53,8 +53,14 @@ from clauditor.paths import resolve_clauditor_dir
 # ``plans/super/147-sidecar-provider-field.md``.
 MAX_SCHEMA_VERSION: dict[str, int] = {
     "assertions.json": 2,
-    "extraction.json": 4,
-    "grading.json": 4,
+    # #170 US-004 / US-006: extraction.json bumped 4 → 5 with nullable
+    # ``reasoning_tokens`` field. Loader defaults missing field to
+    # ``None`` for legacy v1..v4 reads.
+    "extraction.json": 5,
+    # #170 US-004 / US-006: grading.json bumped 4 → 5 with nullable
+    # ``reasoning_tokens`` field. Loader defaults missing field to
+    # ``None`` for legacy v1..v4 reads.
+    "grading.json": 5,
     # #154 US-005 / DEC-010: context.json is a new sidecar family;
     # always-v1 (the v1 dataclass already ships nullable fields for the
     # observability surface, so future ``reasoning_tokens`` /

--- a/src/clauditor/cli/grade.py
+++ b/src/clauditor/cli/grade.py
@@ -800,6 +800,7 @@ def _write_workspace_sidecars(
             provider=provider,
             primary_skill_result=primary_skill_result,
             model_grader=primary_report.model,
+            reasoning_tokens=primary_report.reasoning_tokens,
         )
 
     # #152 US-002: stamp the harness on assertions.json. Single harness
@@ -891,6 +892,7 @@ def _write_context_sidecar(
     provider: str,
     primary_skill_result: SkillResult,
     model_grader: str | None,
+    reasoning_tokens: int | None,
 ) -> None:
     """Write per-iteration comparability metadata as ``context.json``.
 
@@ -901,8 +903,14 @@ def _write_context_sidecar(
     immediately. ``sandbox_mode`` IS optional (only Codex populates it)
     so it uses ``.get(...)``.
 
-    ``cost_usd`` and ``reasoning_tokens`` ship as ``None`` per DEC-001 /
-    DEC-002 (placeholders for #169 / #170).
+    ``reasoning_tokens`` is threaded from the primary
+    :class:`GradingReport` per #170 US-005 (sum-of-non-None semantics
+    across grader attempts; see DEC-003 of
+    ``plans/super/170-reasoning-tokens-capture.md``). ``None`` means
+    "no provider call surfaced a reasoning-token count" — distinct
+    from ``0``.
+
+    ``cost_usd`` ships as ``None`` per DEC-001 (placeholder for #169).
 
     Runs inside the workspace staging block per
     ``.claude/rules/sidecar-during-staging.md``; the caller's
@@ -919,7 +927,7 @@ def _write_context_sidecar(
         ],
         sandbox_mode=primary_skill_result.harness_metadata.get("sandbox_mode"),
         cost_usd=None,
-        reasoning_tokens=None,
+        reasoning_tokens=reasoning_tokens,
     )
     (skill_dir / "context.json").write_text(
         context.to_json(), encoding="utf-8"

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -310,9 +310,13 @@ def cmd_validate(args: argparse.Namespace) -> int:
             # #154 US-004 / DEC-007 / DEC-008: write the per-iteration
             # comparability sidecar inside the staging block. Validate
             # has no Layer 3 grading, so ``provider`` and ``model_grader``
-            # stay ``None``; ``cost_usd`` and ``reasoning_tokens`` are
-            # ``None`` per DEC-001 / DEC-002 (placeholders for #169 /
-            # #170). ``model``/``system_prompt_source`` are unguarded
+            # stay ``None``; ``cost_usd`` is ``None`` per DEC-001
+            # (placeholder for #169). ``reasoning_tokens`` is
+            # structurally ``None`` for this path per DEC-008 of
+            # ``plans/super/170-reasoning-tokens-capture.md``: validate
+            # makes no LLM grader call, so there is no per-call
+            # reasoning-token count to surface.
+            # ``model``/``system_prompt_source`` are unguarded
             # subscripts per the harness contract; ``sandbox_mode`` IS
             # optional (Codex-only).
             context = IterationContext(

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -157,6 +157,19 @@ class ExtractionReport:
     # audit loader defaults missing ``harness`` to ``"claude-code"``
     # when reading legacy v1/v2/v3 sidecars.
     harness: str = "claude-code"
+    # ``reasoning_tokens`` records the per-call reasoning / thinking
+    # token count summed across every extractor call this report
+    # aggregates (parse-retry attempts). ``None`` means "no provider
+    # call surfaced a reasoning-token count" — distinct from ``0``
+    # which would assert "calls ran but used zero reasoning tokens".
+    # Populated by sum-of-non-None semantics per DEC-003 of
+    # ``plans/super/170-reasoning-tokens-capture.md``: all-None inputs
+    # → ``None``; mixed ``[None, 42]`` → ``42``; all-int ``[10, 20]``
+    # → ``30``. Persisted into ``extraction.json`` at
+    # ``schema_version=5`` per US-004 of #170; the audit loader
+    # defaults missing ``reasoning_tokens`` to ``None`` when reading
+    # legacy v1/v2/v3/v4 sidecars.
+    reasoning_tokens: int | None = None
 
     @property
     def passed(self) -> bool:
@@ -167,14 +180,15 @@ class ExtractionReport:
     def to_json(self) -> str:
         """Serialize the report to a JSON string.
 
-        Emits ``schema_version: 4`` as the first key per
-        ``.claude/rules/json-schema-version.md``. Version 4 adds the
-        ``harness`` field on disk (v3 added ``provider_source``, v2
-        added ``transport_source``); the audit loader accepts
-        ``{1, 2, 3, 4}`` and defaults missing ``transport_source`` to
-        ``"api"``, missing ``provider_source`` to ``"anthropic"``, and
-        missing ``harness`` to ``"claude-code"`` when reading legacy
-        v1/v2/v3 sidecars.
+        Emits ``schema_version: 5`` as the first key per
+        ``.claude/rules/json-schema-version.md``. Version 5 adds the
+        ``reasoning_tokens`` field on disk (v4 added ``harness``, v3
+        added ``provider_source``, v2 added ``transport_source``); the
+        audit loader accepts ``{1, 2, 3, 4, 5}`` and defaults missing
+        ``transport_source`` to ``"api"``, missing ``provider_source``
+        to ``"anthropic"``, missing ``harness`` to ``"claude-code"``,
+        and missing ``reasoning_tokens`` to ``None`` when reading
+        legacy sidecars.
         """
         by_id: dict[str, list[dict]] = {}
         # Pre-populate every declared field id with an empty list so the
@@ -187,7 +201,7 @@ class ExtractionReport:
                 {k: v for k, v in r.to_dict().items() if k != "field_id"}
             )
         payload = {
-            "schema_version": 4,
+            "schema_version": 5,
             "skill_name": self.skill_name,
             "model": self.model,
             "transport_source": self.transport_source,
@@ -195,6 +209,7 @@ class ExtractionReport:
             "harness": self.harness,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
             "parse_errors": list(self.parse_errors),
             "fields": by_id,
         }
@@ -204,12 +219,13 @@ class ExtractionReport:
     def from_json(cls, text: str) -> ExtractionReport:
         """Deserialize an ExtractionReport from a JSON string.
 
-        Tolerates schema versions ``1``, ``2``, ``3``, and ``4``. A
-        missing ``transport_source`` defaults to ``"api"`` so pre-#86
-        sidecars load cleanly; a missing ``provider_source`` defaults
-        to ``"anthropic"`` so pre-#147 sidecars load cleanly; a
-        missing ``harness`` defaults to ``"claude-code"`` so
-        pre-#152 sidecars load cleanly.
+        Tolerates schema versions ``1``, ``2``, ``3``, ``4``, and
+        ``5``. A missing ``transport_source`` defaults to ``"api"`` so
+        pre-#86 sidecars load cleanly; a missing ``provider_source``
+        defaults to ``"anthropic"`` so pre-#147 sidecars load cleanly;
+        a missing ``harness`` defaults to ``"claude-code"`` so
+        pre-#152 sidecars load cleanly; a missing ``reasoning_tokens``
+        defaults to ``None`` so pre-#170 sidecars load cleanly.
         """
         data = json.loads(text)
         results: list[FieldExtractionResult] = []
@@ -230,6 +246,17 @@ class ExtractionReport:
                         evidence=entry.get("evidence"),
                     )
                 )
+        # ``reasoning_tokens`` is nullable: explicit ``None`` (or
+        # missing key for legacy sidecars) → ``None``; explicit int
+        # → preserve as int. Per US-004 of #170 / DEC-003: ``None`` is
+        # semantically distinct from ``0`` ("provider didn't surface
+        # a count" vs "provider surfaced a count of zero").
+        raw_reasoning = data.get("reasoning_tokens")
+        reasoning_tokens: int | None
+        if raw_reasoning is None:
+            reasoning_tokens = None
+        else:
+            reasoning_tokens = int(raw_reasoning)
         return cls(
             skill_name=data.get("skill_name", ""),
             model=data.get("model", ""),
@@ -243,6 +270,7 @@ class ExtractionReport:
                 data.get("provider_source") or "anthropic"
             ),
             harness=str(data.get("harness") or "claude-code"),
+            reasoning_tokens=reasoning_tokens,
         )
 
 
@@ -258,6 +286,7 @@ def build_extraction_report(
     transport_source: str = "api",
     provider_source: str = "anthropic",
     harness: str = "claude-code",
+    reasoning_tokens: int | None = None,
 ) -> ExtractionReport:
     """Build a field-id-keyed ``ExtractionReport`` from extracted output.
 
@@ -348,6 +377,7 @@ def build_extraction_report(
         transport_source=transport_source,
         provider_source=provider_source,
         harness=harness,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -770,6 +800,7 @@ def build_extraction_report_from_text(
     transport_source: str = "api",
     provider_source: str = "anthropic",
     harness: str = "claude-code",
+    reasoning_tokens: int | None = None,
 ) -> ExtractionReport:
     """Parse ``response_text`` into an :class:`ExtractionReport`.
 
@@ -793,6 +824,7 @@ def build_extraction_report_from_text(
             transport_source=transport_source,
             provider_source=provider_source,
             harness=harness,
+            reasoning_tokens=reasoning_tokens,
         )
 
     parse = parse_extraction_response(response_text, eval_spec)
@@ -813,6 +845,7 @@ def build_extraction_report_from_text(
             transport_source=transport_source,
             provider_source=provider_source,
             harness=harness,
+            reasoning_tokens=reasoning_tokens,
         )
     return build_extraction_report(
         parse.extracted,
@@ -825,6 +858,7 @@ def build_extraction_report_from_text(
         transport_source=transport_source,
         provider_source=provider_source,
         harness=harness,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -836,26 +870,32 @@ async def _extract_call_with_retry(
     transport: str,
     ctx: str,
     provider: str,
-) -> tuple[str, str, str, int, int]:
+) -> tuple[str, str, str, int, int, int | None]:
     """Issue the extraction model call with parse retry.
 
-    Returns ``(response_text, source, provider, input_tokens, output_tokens)``
-    — the final attempt's response text, the transport source, the
-    provider that produced the response, and cumulative token counts
-    across attempts. Routes through ``call_model`` per the
-    caller-resolved provider (#146 US-006), so the retry semantics
-    apply to whichever backend handles the call. One retry on
-    ``kind == "json"`` (true decode failures + empty-after-fence-strip)
-    per clauditor-6cf / #94; no retry on ``kind == "shape"`` (valid
-    JSON, wrong top-level type) or ``kind == "flat_list"`` (section
-    tiering missing) — both indicate a model-protocol bug rather than
-    a transient hiccup.
+    Returns ``(response_text, source, provider, input_tokens,
+    output_tokens, reasoning_tokens)`` — the final attempt's response
+    text, the transport source, the provider that produced the
+    response, and cumulative token counts across attempts
+    (``reasoning_tokens`` per DEC-003 of #170: sum-of-non-None across
+    attempts; ``None`` when every attempt's count was ``None``).
+    Routes through ``call_model`` per the caller-resolved provider
+    (#146 US-006), so the retry semantics apply to whichever backend
+    handles the call. One retry on ``kind == "json"`` (true decode
+    failures + empty-after-fence-strip) per clauditor-6cf / #94; no
+    retry on ``kind == "shape"`` (valid JSON, wrong top-level type) or
+    ``kind == "flat_list"`` (section tiering missing) — both indicate
+    a model-protocol bug rather than a transient hiccup.
     """
     from clauditor._providers import call_model
-    from clauditor.quality_grader import _emit_parse_retry_notice
+    from clauditor.quality_grader import (
+        _emit_parse_retry_notice,
+        _sum_optional_reasoning_tokens,
+    )
 
     total_input = 0
     total_output = 0
+    reasoning_attempts: list[int | None] = []
     last_text = ""
     last_source = "api"
     last_provider = provider
@@ -869,6 +909,7 @@ async def _extract_call_with_retry(
         )
         total_input += api_result.input_tokens
         total_output += api_result.output_tokens
+        reasoning_attempts.append(api_result.reasoning_tokens)
         last_source = api_result.source
         last_provider = api_result.provider
         last_text = (
@@ -890,7 +931,14 @@ async def _extract_call_with_retry(
             _emit_parse_retry_notice(
                 ctx, attempt + 2, _GRADER_PARSE_RETRY_LIMIT
             )
-    return last_text, last_source, last_provider, total_input, total_output
+    return (
+        last_text,
+        last_source,
+        last_provider,
+        total_input,
+        total_output,
+        _sum_optional_reasoning_tokens(reasoning_attempts),
+    )
 
 
 async def extract_and_grade(
@@ -920,19 +968,24 @@ async def extract_and_grade(
     Requires the 'grader' extra: pip install clauditor[grader]
     """
     prompt = build_extraction_prompt(eval_spec, output)
-    response_text, _source, _provider, input_tokens, output_tokens = (
-        await _extract_call_with_retry(
-            prompt, eval_spec,
-            model=model, transport=transport,
-            ctx="extract_and_grade",
-            provider=provider,
-        )
+    (
+        response_text,
+        _source,
+        _provider,
+        input_tokens,
+        output_tokens,
+        _reasoning_tokens,
+    ) = await _extract_call_with_retry(
+        prompt, eval_spec,
+        model=model, transport=transport,
+        ctx="extract_and_grade",
+        provider=provider,
     )
-    # Note: AssertionSet does not carry transport_source / provider_source —
-    # extract_and_grade's sidecar (``assertions.json``) is unaffected by
-    # US-006 / #144. The transport / provider source for the Layer 2
-    # Haiku call is only persisted through ``extract_and_report`` →
-    # ``ExtractionReport``.
+    # Note: AssertionSet does not carry transport_source / provider_source /
+    # reasoning_tokens — extract_and_grade's sidecar (``assertions.json``)
+    # is unaffected by US-006 / #144 / #170. The transport / provider /
+    # reasoning attribution for the Layer 2 Haiku call is only persisted
+    # through ``extract_and_report`` → ``ExtractionReport``.
     return build_extraction_assertion_set(
         response_text,
         eval_spec,
@@ -970,13 +1023,18 @@ async def extract_and_report(
     ``iteration-N/<skill>/extraction.json``.
     """
     prompt = build_extraction_prompt(eval_spec, output)
-    response_text, source, last_provider, input_tokens, output_tokens = (
-        await _extract_call_with_retry(
-            prompt, eval_spec,
-            model=model, transport=transport,
-            ctx="extract_and_report",
-            provider=provider,
-        )
+    (
+        response_text,
+        source,
+        last_provider,
+        input_tokens,
+        output_tokens,
+        reasoning_tokens,
+    ) = await _extract_call_with_retry(
+        prompt, eval_spec,
+        model=model, transport=transport,
+        ctx="extract_and_report",
+        provider=provider,
     )
     return build_extraction_report_from_text(
         response_text,
@@ -988,4 +1046,5 @@ async def extract_and_report(
         transport_source=source,
         provider_source=last_provider,
         harness=harness,
+        reasoning_tokens=reasoning_tokens,
     )

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -92,7 +92,7 @@ class ExtractionReport:
     .. code-block:: json
 
         {
-          "schema_version": 4,
+          "schema_version": 5,
           "skill_name": "...",
           "model": "...",
           "transport_source": "api",
@@ -250,13 +250,20 @@ class ExtractionReport:
         # missing key for legacy sidecars) → ``None``; explicit int
         # → preserve as int. Per US-004 of #170 / DEC-003: ``None`` is
         # semantically distinct from ``0`` ("provider didn't surface
-        # a count" vs "provider surfaced a count of zero").
+        # a count" vs "provider surfaced a count of zero"). Bool
+        # values are rejected per ``.claude/rules/constant-with-type-info.md``
+        # (Python's ``isinstance(True, int)`` is ``True``); a malformed
+        # sidecar with ``"reasoning_tokens": true`` would otherwise
+        # silently coerce to ``1``. Symmetric with the writer-side
+        # ``_extract_reasoning_tokens`` discipline (DEC-006).
         raw_reasoning = data.get("reasoning_tokens")
         reasoning_tokens: int | None
-        if raw_reasoning is None:
+        if raw_reasoning is None or isinstance(raw_reasoning, bool):
             reasoning_tokens = None
+        elif isinstance(raw_reasoning, int):
+            reasoning_tokens = raw_reasoning
         else:
-            reasoning_tokens = int(raw_reasoning)
+            reasoning_tokens = None
         return cls(
             skill_name=data.get("skill_name", ""),
             model=data.get("model", ""),

--- a/src/clauditor/grader.py
+++ b/src/clauditor/grader.py
@@ -100,6 +100,7 @@ class ExtractionReport:
           "harness": "claude-code",
           "input_tokens": 0,
           "output_tokens": 0,
+          "reasoning_tokens": null,
           "parse_errors": [],
           "fields": {
             "<field_id>": [
@@ -126,11 +127,16 @@ class ExtractionReport:
     ``harness`` records which skill harness produced the underlying
     skill output that was extracted — ``"claude-code"`` (current
     default) or ``"codex"`` (#149+) (added in v4 per DEC-004 /
-    DEC-006 of ``plans/super/152-sidecar-harness-field.md``). The
-    audit loader accepts ``{1, 2, 3, 4}`` and defaults missing
+    DEC-006 of ``plans/super/152-sidecar-harness-field.md``).
+    ``reasoning_tokens`` records the per-call reasoning / thinking
+    token count summed across grader attempts — ``int`` or
+    ``null`` (added in v5 per DEC-004 of
+    ``plans/super/170-reasoning-tokens-capture.md``). The audit
+    loader accepts ``{1, 2, 3, 4, 5}`` and defaults missing
     ``transport_source`` to ``"api"``, missing ``provider_source``
-    to ``"anthropic"``, and missing ``harness`` to ``"claude-code"``
-    when reading legacy v1/v2/v3 sidecars.
+    to ``"anthropic"``, missing ``harness`` to ``"claude-code"``,
+    and missing ``reasoning_tokens`` to ``None`` when reading
+    legacy v1/v2/v3/v4 sidecars.
     """
 
     skill_name: str

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -242,13 +242,20 @@ class GradingReport:
         # missing key for legacy sidecars) → ``None``; explicit int
         # → preserve as int. Per US-004 of #170 / DEC-003: ``None`` is
         # semantically distinct from ``0`` ("provider didn't surface
-        # a count" vs "provider surfaced a count of zero").
+        # a count" vs "provider surfaced a count of zero"). Bool
+        # values are rejected per ``.claude/rules/constant-with-type-info.md``
+        # (Python's ``isinstance(True, int)`` is ``True``); a malformed
+        # sidecar with ``"reasoning_tokens": true`` would otherwise
+        # silently coerce to ``1``. Symmetric with the writer-side
+        # ``_extract_reasoning_tokens`` discipline (DEC-006).
         raw_reasoning = parsed.get("reasoning_tokens")
         reasoning_tokens: int | None
-        if raw_reasoning is None:
+        if raw_reasoning is None or isinstance(raw_reasoning, bool):
             reasoning_tokens = None
+        elif isinstance(raw_reasoning, int):
+            reasoning_tokens = raw_reasoning
         else:
-            reasoning_tokens = int(raw_reasoning)
+            reasoning_tokens = None
         return cls(
             skill_name=parsed.get("skill_name", ""),
             results=results,

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -50,6 +50,20 @@ _monotonic = time.monotonic
 _GRADER_PARSE_RETRY_LIMIT = 2
 
 
+def _sum_optional_reasoning_tokens(values: list[int | None]) -> int | None:
+    """Sum the non-None reasoning-token counts in ``values``.
+
+    Pure helper. Returns ``None`` when every entry is ``None`` (so the
+    aggregate distinguishes "no provider call surfaced a count" from
+    "calls surfaced zero"). Returns the integer sum of the non-None
+    entries otherwise — mixed input ``[None, 42]`` returns ``42``,
+    not ``0`` and not ``None``. Per DEC-003 of
+    ``plans/super/170-reasoning-tokens-capture.md``.
+    """
+    present = [v for v in values if v is not None]
+    return sum(present) if present else None
+
+
 @dataclass
 class GradingResult:
     """Result of a single rubric criterion evaluation.
@@ -113,6 +127,19 @@ class GradingReport:
     # ``harness`` to ``"claude-code"`` when reading legacy v1/v2/v3
     # sidecars.
     harness: str = "claude-code"
+    # ``reasoning_tokens`` records the per-call reasoning / thinking
+    # token count summed across every grader call this report
+    # aggregates (variance / parse-retry attempts). ``None`` means
+    # "no provider call surfaced a reasoning-token count" — distinct
+    # from ``0`` which would assert "calls ran but used zero
+    # reasoning tokens". Populated by sum-of-non-None semantics per
+    # DEC-003 of ``plans/super/170-reasoning-tokens-capture.md``:
+    # all-None inputs → ``None``; mixed ``[None, 42]`` → ``42``;
+    # all-int ``[10, 20]`` → ``30``. Persisted into ``grading.json``
+    # at ``schema_version=5`` per US-004 of #170; the audit loader
+    # defaults missing ``reasoning_tokens`` to ``None`` when reading
+    # legacy v1/v2/v3/v4 sidecars.
+    reasoning_tokens: int | None = None
 
     @property
     def passed(self) -> bool:
@@ -140,17 +167,18 @@ class GradingReport:
     def to_json(self) -> str:
         """Serialize the report to a JSON string.
 
-        Emits ``schema_version: 4`` as the first key per
-        ``.claude/rules/json-schema-version.md``. Version 4 adds the
-        ``harness`` field on disk (v3 added ``provider_source``, v2
-        added ``transport_source``); the audit loader accepts
-        ``{1, 2, 3, 4}`` and defaults missing ``transport_source`` to
-        ``"api"``, missing ``provider_source`` to ``"anthropic"``,
-        and missing ``harness`` to ``"claude-code"`` when reading
+        Emits ``schema_version: 5`` as the first key per
+        ``.claude/rules/json-schema-version.md``. Version 5 adds the
+        ``reasoning_tokens`` field on disk (v4 added ``harness``, v3
+        added ``provider_source``, v2 added ``transport_source``); the
+        audit loader accepts ``{1, 2, 3, 4, 5}`` and defaults missing
+        ``transport_source`` to ``"api"``, missing ``provider_source``
+        to ``"anthropic"``, missing ``harness`` to ``"claude-code"``,
+        and missing ``reasoning_tokens`` to ``None`` when reading
         legacy sidecars.
         """
         data = {
-            "schema_version": 4,
+            "schema_version": 5,
             "skill_name": self.skill_name,
             "model": self.model,
             "transport_source": self.transport_source,
@@ -159,6 +187,7 @@ class GradingReport:
             "duration_seconds": self.duration_seconds,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
             "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
             "results": [
                 {
@@ -184,12 +213,13 @@ class GradingReport:
     def from_json(cls, data: str) -> GradingReport:
         """Deserialize a GradingReport from a JSON string.
 
-        Tolerates schema versions ``1``, ``2``, ``3``, and ``4``. A
-        missing ``transport_source`` defaults to ``"api"`` so pre-#86
-        sidecars load cleanly; a missing ``provider_source`` defaults
-        to ``"anthropic"`` so pre-#147 sidecars load cleanly; a
-        missing ``harness`` defaults to ``"claude-code"`` so pre-#152
-        sidecars load cleanly.
+        Tolerates schema versions ``1``, ``2``, ``3``, ``4``, and
+        ``5``. A missing ``transport_source`` defaults to ``"api"`` so
+        pre-#86 sidecars load cleanly; a missing ``provider_source``
+        defaults to ``"anthropic"`` so pre-#147 sidecars load cleanly;
+        a missing ``harness`` defaults to ``"claude-code"`` so pre-#152
+        sidecars load cleanly; a missing ``reasoning_tokens`` defaults
+        to ``None`` so pre-#170 sidecars load cleanly.
         """
         parsed = json.loads(data)
         results = [
@@ -208,6 +238,17 @@ class GradingReport:
             min_pass_rate=float(t.get("min_pass_rate", 0.7)),
             min_mean_score=float(t.get("min_mean_score", 0.5)),
         )
+        # ``reasoning_tokens`` is nullable: explicit ``None`` (or
+        # missing key for legacy sidecars) → ``None``; explicit int
+        # → preserve as int. Per US-004 of #170 / DEC-003: ``None`` is
+        # semantically distinct from ``0`` ("provider didn't surface
+        # a count" vs "provider surfaced a count of zero").
+        raw_reasoning = parsed.get("reasoning_tokens")
+        reasoning_tokens: int | None
+        if raw_reasoning is None:
+            reasoning_tokens = None
+        else:
+            reasoning_tokens = int(raw_reasoning)
         return cls(
             skill_name=parsed.get("skill_name", ""),
             results=results,
@@ -222,6 +263,7 @@ class GradingReport:
                 parsed.get("provider_source") or "anthropic"
             ),
             harness=str(parsed.get("harness") or "claude-code"),
+            reasoning_tokens=reasoning_tokens,
         )
 
     def summary(self) -> str:
@@ -274,13 +316,25 @@ class BlindReport:
     # is in-memory only — :meth:`to_json` does NOT include it; #147
     # owns the on-disk schema bump that lights it up in the sidecar.
     provider_source: str = "anthropic"
+    # ``reasoning_tokens`` records the per-call reasoning / thinking
+    # token count summed across the two parallel judge calls (sum of
+    # non-None values per DEC-003 of #170). ``None`` means "neither
+    # call surfaced a reasoning-token count" — distinct from ``0``
+    # which would assert "calls ran but used zero reasoning tokens".
+    # Per DEC-005 of #170 the ``BlindReport`` schema_version stays at
+    # ``1`` (always-v1 pattern; this additive nullable field is
+    # forward-compat-safe; there is no ``from_json`` reader to break).
+    reasoning_tokens: int | None = None
 
     def to_json(self) -> str:
         """Serialize the report to a JSON string.
 
         Emits ``schema_version: 1`` as the first key (DEC-018 — the
         inaugural version for this report type) per
-        ``.claude/rules/json-schema-version.md``.
+        ``.claude/rules/json-schema-version.md``. Per DEC-005 of #170
+        the version stays at ``1`` even after the ``reasoning_tokens``
+        field is added: the field is nullable and additive, and there
+        is no ``from_json`` reader to break (always-v1 pattern).
         """
         data = {
             "schema_version": 1,
@@ -294,6 +348,7 @@ class BlindReport:
             "transport_source": self.transport_source,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
             "duration_seconds": self.duration_seconds,
             "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
         }
@@ -465,6 +520,7 @@ def combine_blind_results(
     duration_seconds: float,
     transport_source: str = "api",
     provider_source: str = "anthropic",
+    reasoning_tokens: int | None = None,
 ) -> BlindReport:
     """Combine two parsed judge verdicts into a canonical :class:`BlindReport`.
 
@@ -499,6 +555,7 @@ def combine_blind_results(
             duration_seconds=duration_seconds,
             transport_source=transport_source,
             provider_source=provider_source,
+            reasoning_tokens=reasoning_tokens,
         )
 
     if parsed1 is None or parsed2 is None:
@@ -532,6 +589,7 @@ def combine_blind_results(
             duration_seconds=duration_seconds,
             transport_source=transport_source,
             provider_source=provider_source,
+            reasoning_tokens=reasoning_tokens,
         )
 
     winner1, conf1, sa1, sb1, reason1 = _translate_blind_result(
@@ -572,6 +630,7 @@ def combine_blind_results(
         duration_seconds=duration_seconds,
         transport_source=transport_source,
         provider_source=provider_source,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -629,21 +688,24 @@ async def _call_blind_side_with_retry(
     transport: str,
     side_label: str,
     provider: str = "anthropic",
-) -> tuple[dict | None, str, str, str, int, int]:
+) -> tuple[dict | None, str, str, str, int, int, int | None]:
     """Run one side of a blind-compare judge with parse retry.
 
     Returns ``(parsed, text, source, provider, input_tokens,
-    output_tokens)`` — the parsed verdict dict (or ``None`` on shape
-    failure), the final attempt's response text, the transport source,
-    the provider that produced the response, and the cumulative token
-    counts across attempts. One retry on JSON decode failure per
-    clauditor-6cf / #94; no retry on shape failure (missing required
-    keys) since that indicates a model-protocol bug.
+    output_tokens, reasoning_tokens)`` — the parsed verdict dict (or
+    ``None`` on shape failure), the final attempt's response text, the
+    transport source, the provider that produced the response, and the
+    cumulative token counts across attempts (``reasoning_tokens`` per
+    DEC-003 of #170: sum-of-non-None across attempts; ``None`` when
+    every attempt's count was ``None``). One retry on JSON decode
+    failure per clauditor-6cf / #94; no retry on shape failure
+    (missing required keys) since that indicates a model-protocol bug.
     """
     from clauditor._providers import call_model
 
     total_input = 0
     total_output = 0
+    reasoning_attempts: list[int | None] = []
     last_text = ""
     last_source = "api"
     last_provider = provider
@@ -658,6 +720,7 @@ async def _call_blind_side_with_retry(
         )
         total_input += r.input_tokens
         total_output += r.output_tokens
+        reasoning_attempts.append(r.reasoning_tokens)
         last_source = r.source
         last_provider = r.provider
         last_text = r.text_blocks[0] if r.text_blocks else ""
@@ -683,6 +746,7 @@ async def _call_blind_side_with_retry(
         last_provider,
         total_input,
         total_output,
+        _sum_optional_reasoning_tokens(reasoning_attempts),
     )
 
 
@@ -738,8 +802,8 @@ async def blind_compare(
         ),
     )
     duration = _monotonic() - start
-    parsed1, t1, src1, prov1, in1, out1 = side1
-    parsed2, t2, src2, prov2, in2, out2 = side2
+    parsed1, t1, src1, prov1, in1, out1, rt1 = side1
+    parsed2, t2, src2, prov2, in2, out2, rt2 = side2
     # DEC-018: transport_source reflects the underlying Anthropic call(s).
     # When the two parallel judges disagree (API + CLI — unlikely but
     # possible in an ``auto`` fallback race), stamp ``"mixed"`` so the
@@ -759,6 +823,7 @@ async def blind_compare(
         duration_seconds=duration,
         transport_source=transport_source,
         provider_source=provider_source,
+        reasoning_tokens=_sum_optional_reasoning_tokens([rt1, rt2]),
     )
 
 
@@ -1048,6 +1113,7 @@ def _grading_failure_report(
     transport_source: str = "api",
     provider_source: str = "anthropic",
     harness: str = "claude-code",
+    reasoning_tokens: int | None = None,
 ) -> GradingReport:
     """Build a failed :class:`GradingReport` for a parse/alignment failure.
 
@@ -1074,6 +1140,7 @@ def _grading_failure_report(
         transport_source=transport_source,
         provider_source=provider_source,
         harness=harness,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -1089,6 +1156,7 @@ def build_grading_report(
     transport_source: str = "api",
     provider_source: str = "anthropic",
     harness: str = "claude-code",
+    reasoning_tokens: int | None = None,
 ) -> GradingReport:
     """Parse ``response_text`` into a :class:`GradingReport`.
 
@@ -1114,6 +1182,7 @@ def build_grading_report(
         "transport_source": transport_source,
         "provider_source": provider_source,
         "harness": harness,
+        "reasoning_tokens": reasoning_tokens,
     }
     if not response_text:
         return _grading_failure_report(
@@ -1157,6 +1226,7 @@ def build_grading_report(
         transport_source=transport_source,
         provider_source=provider_source,
         harness=harness,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -1214,6 +1284,11 @@ async def grade_quality(
     start = _monotonic()
     total_input_tokens = 0
     total_output_tokens = 0
+    # Per DEC-003 of #170: accumulate per-attempt reasoning_tokens via
+    # sum-of-non-None semantics so the aggregate distinguishes
+    # "no provider call surfaced a count" (None) from "calls surfaced
+    # zero" (0).
+    reasoning_token_attempts: list[int | None] = []
     last_response_text = ""
     last_source = "api"
     last_provider = provider
@@ -1227,6 +1302,7 @@ async def grade_quality(
         )
         total_input_tokens += api_result.input_tokens
         total_output_tokens += api_result.output_tokens
+        reasoning_token_attempts.append(api_result.reasoning_tokens)
         last_source = api_result.source
         last_provider = api_result.provider
         last_response_text = (
@@ -1277,6 +1353,9 @@ async def grade_quality(
         transport_source=last_source,
         provider_source=last_provider,
         harness=harness,
+        reasoning_tokens=_sum_optional_reasoning_tokens(
+            reasoning_token_attempts
+        ),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1044,6 +1044,7 @@ def make_grading_report(
     duration_seconds: float = 1.0,
     thresholds: GradeThresholds | None = None,
     extra_results: list[GradingResult] | None = None,
+    reasoning_tokens: int | None = None,
 ) -> GradingReport:
     """Build a GradingReport with one criterion result (extra_results appended)."""
     actual_score = score if score is not None else (0.9 if passed else 0.3)
@@ -1067,6 +1068,7 @@ def make_grading_report(
         metrics={},
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        reasoning_tokens=reasoning_tokens,
     )
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -763,33 +763,39 @@ class TestIsAcceptedVersion:
     branch and the unknown-filename ``KeyError`` contract.
     """
 
-    def test_is_accepted_version_grading_json_accepts_1_2_3_4(self) -> None:
+    def test_is_accepted_version_grading_json_accepts_1_2_3_4_5(self) -> None:
+        # #170 US-004 / US-006 bumped grading.json from v4 → v5 with
+        # the ``reasoning_tokens`` field.
         from clauditor.audit import _is_accepted_version
 
         assert _is_accepted_version("grading.json", 1) is True
         assert _is_accepted_version("grading.json", 2) is True
         assert _is_accepted_version("grading.json", 3) is True
         assert _is_accepted_version("grading.json", 4) is True
+        assert _is_accepted_version("grading.json", 5) is True
 
-    def test_is_accepted_version_grading_json_rejects_5(self) -> None:
+    def test_is_accepted_version_grading_json_rejects_6(self) -> None:
         from clauditor.audit import _is_accepted_version
 
-        assert _is_accepted_version("grading.json", 5) is False
+        assert _is_accepted_version("grading.json", 6) is False
 
-    def test_is_accepted_version_extraction_json_accepts_1_2_3(self) -> None:
+    def test_is_accepted_version_extraction_json_accepts_1_2_3_4_5(self) -> None:
+        # #170 US-004 / US-006 bumped extraction.json from v4 → v5 with
+        # the ``reasoning_tokens`` field.
         from clauditor.audit import _is_accepted_version
 
         assert _is_accepted_version("extraction.json", 1) is True
         assert _is_accepted_version("extraction.json", 2) is True
         assert _is_accepted_version("extraction.json", 3) is True
         assert _is_accepted_version("extraction.json", 4) is True
+        assert _is_accepted_version("extraction.json", 5) is True
 
-    def test_is_accepted_version_extraction_json_rejects_5(self) -> None:
-        # #152 US-003 bumped extraction.json from v3 → v4. The next
-        # un-accepted version is now 5.
+    def test_is_accepted_version_extraction_json_rejects_6(self) -> None:
+        # #170 US-004 / US-006 bumped extraction.json from v4 → v5. The
+        # next un-accepted version is now 6.
         from clauditor.audit import _is_accepted_version
 
-        assert _is_accepted_version("extraction.json", 5) is False
+        assert _is_accepted_version("extraction.json", 6) is False
 
     def test_is_accepted_version_assertions_json_accepts_1_and_2(self) -> None:
         """#152 US-002: assertions.json bumped 1 → 2 with top-level
@@ -834,7 +840,10 @@ class TestIsAcceptedVersion:
         assert _is_accepted_version("baseline_assertions.json", 3) is False
         # #152 US-004: grading.json now accepts v4 (harness field).
         assert _is_accepted_version("baseline_grading.json", 4) is True
-        assert _is_accepted_version("baseline_grading.json", 5) is False
+        # #170 US-006: grading.json now accepts v5 (reasoning_tokens
+        # field). v6 still rejected.
+        assert _is_accepted_version("baseline_grading.json", 5) is True
+        assert _is_accepted_version("baseline_grading.json", 6) is False
 
     def test_is_accepted_version_unknown_filename_raises_key_error(
         self,
@@ -1045,13 +1054,13 @@ class TestAuditLegacyCompat:
         self, tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """A grading.json with ``schema_version=5`` (out of accepted
-        range 1..4 post-#152 / DEC-008 of #147) must be skipped with a
-        stderr warning."""
+        """A grading.json with ``schema_version=6`` (out of accepted
+        range 1..5 post-#170 US-006 / DEC-008 of #147) must be skipped
+        with a stderr warning."""
         clauditor_dir = tmp_path / ".clauditor"
         skill_dir = clauditor_dir / "iteration-1" / "s"
         self._write_grading_sidecar(
-            skill_dir, version=5, transport_source="api"
+            skill_dir, version=6, transport_source="api"
         )
         records, skipped, _ctx = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
@@ -1059,19 +1068,19 @@ class TestAuditLegacyCompat:
         assert records == []
         assert skipped == 1
         err = capsys.readouterr().err
-        assert "schema_version=5" in err
+        assert "schema_version=6" in err
 
     def test_extraction_unknown_schema_version_still_skipped(
         self, tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """An extraction.json with ``schema_version=5`` (out of accepted
-        range 1..4 — #152 US-003 bumped the max to 4) must be skipped
+        """An extraction.json with ``schema_version=6`` (out of accepted
+        range 1..5 — #170 US-006 bumped the max to 5) must be skipped
         with a stderr warning."""
         clauditor_dir = tmp_path / ".clauditor"
         skill_dir = clauditor_dir / "iteration-1" / "s"
         self._write_extraction_sidecar(
-            skill_dir, version=5, transport_source="api"
+            skill_dir, version=6, transport_source="api"
         )
         records, skipped, _ctx = load_iterations(
             "s", last=5, clauditor_dir=clauditor_dir
@@ -1079,15 +1088,15 @@ class TestAuditLegacyCompat:
         assert records == []
         assert skipped == 1
         err = capsys.readouterr().err
-        assert "schema_version=5" in err
+        assert "schema_version=6" in err
 
-    def test_baseline_sidecar_v5_skipped_with_baseline_prefix_stripped(
+    def test_baseline_sidecar_v6_skipped_with_baseline_prefix_stripped(
         self, tmp_path: Path,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        """A ``baseline_grading.json`` with v5 must be skipped with the
-        same warning as canonical ``grading.json`` (post-#152 grading
-        max is 4). Exercises the ``base.startswith("baseline_")``
+        """A ``baseline_grading.json`` with v6 must be skipped with the
+        same warning as canonical ``grading.json`` (post-#170 grading
+        max is 5). Exercises the ``base.startswith("baseline_")``
         branch in ``_check_schema_version`` so the rejection-path's
         ``MAX_SCHEMA_VERSION[base]`` lookup uses the family's max
         rather than crashing on an unknown ``baseline_*`` key."""
@@ -1096,7 +1105,7 @@ class TestAuditLegacyCompat:
         skill_dir = clauditor_dir / "iteration-1" / "s"
         skill_dir.mkdir(parents=True)
         payload = {
-            "schema_version": 5,
+            "schema_version": 6,
             "skill_name": "s",
             "model": "claude-sonnet-4-6",
             "transport_source": "api",
@@ -1110,7 +1119,150 @@ class TestAuditLegacyCompat:
         )
         assert records == []
         err = capsys.readouterr().err
-        assert "schema_version=5" in err
+        assert "schema_version=6" in err
+
+    # ----------------------------------------------------------------- #
+    # #170 US-006: v5 grading/extraction sidecars (with reasoning_tokens)
+    # ----------------------------------------------------------------- #
+
+    def test_loads_v5_grading_with_reasoning_tokens(
+        self, tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """#170 US-006: a v5 grading.json sidecar (with
+        ``reasoning_tokens: 42``) loads cleanly through the audit
+        reader, NOT warn-and-skipped. Audit aggregation does not
+        consume the field (per data-model review: per-iteration, not
+        per-record), but the loader must accept the schema version."""
+        import json
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        skill_dir.mkdir(parents=True)
+        payload = {
+            "schema_version": 5,
+            "skill_name": "s",
+            "model": "claude-sonnet-4-6",
+            "transport_source": "api",
+            "provider_source": "anthropic",
+            "harness": "claude-code",
+            "reasoning_tokens": 42,
+            "results": [
+                {
+                    "id": "quality",
+                    "criterion": "is good",
+                    "passed": True,
+                    "score": 0.9,
+                    "evidence": "e",
+                    "reasoning": "r",
+                },
+            ],
+        }
+        (skill_dir / "grading.json").write_text(json.dumps(payload))
+        records, skipped, _ctx = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert skipped == 0
+        assert len(records) == 1
+        assert records[0].layer == "L3"
+        assert records[0].id == "quality"
+        assert records[0].passed is True
+        # No stderr warning (the v5 was accepted, not warn-and-skipped).
+        err = capsys.readouterr().err
+        assert "schema_version" not in err
+
+    def test_loads_v5_extraction_with_reasoning_tokens(
+        self, tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """#170 US-006: a v5 extraction.json sidecar (with
+        ``reasoning_tokens: 17``) loads cleanly through the audit
+        reader, NOT warn-and-skipped."""
+        import json
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        skill_dir.mkdir(parents=True)
+        payload = {
+            "schema_version": 5,
+            "skill_name": "s",
+            "model": "haiku",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "parse_errors": [],
+            "transport_source": "api",
+            "provider_source": "anthropic",
+            "harness": "claude-code",
+            "reasoning_tokens": 17,
+            "fields": {
+                "v1": [
+                    {
+                        "field_name": "a",
+                        "section": "Venues",
+                        "tier": "primary",
+                        "entry_index": 0,
+                        "required": True,
+                        "passed": True,
+                        "presence_passed": True,
+                        "format_passed": None,
+                        "evidence": "v",
+                    },
+                ],
+            },
+        }
+        (skill_dir / "extraction.json").write_text(json.dumps(payload))
+        records, skipped, _ctx = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert skipped == 0
+        assert len(records) == 1
+        assert records[0].layer == "L2"
+        # No stderr warning (the v5 was accepted, not warn-and-skipped).
+        err = capsys.readouterr().err
+        assert "schema_version" not in err
+
+    def test_loads_v4_grading_no_reasoning_tokens_defaults_none(
+        self, tmp_path: Path,
+    ) -> None:
+        """#170 US-006: a legacy v4 grading.json (no
+        ``reasoning_tokens``) still loads cleanly. The default-on-read
+        contract (``GradingReport.from_json`` returns
+        ``reasoning_tokens=None``) keeps pre-#170 history readable."""
+        import json
+
+        from clauditor.quality_grader import GradingReport
+        clauditor_dir = tmp_path / ".clauditor"
+        skill_dir = clauditor_dir / "iteration-1" / "s"
+        skill_dir.mkdir(parents=True)
+        payload = {
+            "schema_version": 4,
+            "skill_name": "s",
+            "model": "claude-sonnet-4-6",
+            "transport_source": "api",
+            "provider_source": "anthropic",
+            "harness": "claude-code",
+            "results": [
+                {
+                    "id": "quality",
+                    "criterion": "is good",
+                    "passed": True,
+                    "score": 0.9,
+                    "evidence": "e",
+                    "reasoning": "r",
+                },
+            ],
+        }
+        (skill_dir / "grading.json").write_text(json.dumps(payload))
+        records, skipped, _ctx = load_iterations(
+            "s", last=5, clauditor_dir=clauditor_dir
+        )
+        assert skipped == 0
+        assert len(records) == 1
+        # Verify the from_json default-on-read contract: a v4 sidecar
+        # parsed through GradingReport.from_json yields
+        # reasoning_tokens=None.
+        report = GradingReport.from_json(
+            (skill_dir / "grading.json").read_text()
+        )
+        assert report.reasoning_tokens is None
 
 
 class TestCmdAuditInvalidSkillName:
@@ -2994,7 +3146,13 @@ def _write_context_sidecar(
 
 class TestMaxSchemaVersion:
     """#154 US-005 / DEC-010: ``context.json`` registered at v1 in the
-    canonical ``MAX_SCHEMA_VERSION`` map."""
+    canonical ``MAX_SCHEMA_VERSION`` map.
+
+    #170 US-006: ``grading.json`` and ``extraction.json`` bumped 4 → 5
+    with the nullable ``reasoning_tokens`` field. ``assertions.json``
+    and ``context.json`` are NOT bumped (L1 makes no LLM call;
+    ``context.json`` is always-v1 by design).
+    """
 
     def test_context_json_registered_at_v1(self) -> None:
         from clauditor.audit import MAX_SCHEMA_VERSION, _is_accepted_version
@@ -3007,6 +3165,34 @@ class TestMaxSchemaVersion:
 
         assert _is_accepted_version("context.json", 999) is False
         assert _is_accepted_version("context.json", 2) is False
+
+    def test_audit_max_schema_version_grading_is_5(self) -> None:
+        """#170 US-006: ``grading.json`` accepts v5 (reasoning_tokens
+        field added by US-004)."""
+        from clauditor.audit import MAX_SCHEMA_VERSION
+
+        assert MAX_SCHEMA_VERSION["grading.json"] == 5
+
+    def test_audit_max_schema_version_extraction_is_5(self) -> None:
+        """#170 US-006: ``extraction.json`` accepts v5 (reasoning_tokens
+        field added by US-004)."""
+        from clauditor.audit import MAX_SCHEMA_VERSION
+
+        assert MAX_SCHEMA_VERSION["extraction.json"] == 5
+
+    def test_audit_max_schema_version_context_unchanged_at_1(self) -> None:
+        """#170 US-006: ``context.json`` stays at v1 (always-v1 by
+        design — nullable fields ship from day one)."""
+        from clauditor.audit import MAX_SCHEMA_VERSION
+
+        assert MAX_SCHEMA_VERSION["context.json"] == 1
+
+    def test_audit_max_schema_version_assertions_unchanged_at_2(self) -> None:
+        """#170 US-006: ``assertions.json`` stays at v2 (L1 makes no
+        LLM call → no reasoning tokens to record)."""
+        from clauditor.audit import MAX_SCHEMA_VERSION
+
+        assert MAX_SCHEMA_VERSION["assertions.json"] == 2
 
 class TestReadContext:
     """#154 US-005 / DEC-011: pure helper that reads + schema-validates

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10306,6 +10306,45 @@ class TestCmdGradeWritesContextJson:
         payload = json.loads(context_path.read_text())
         assert payload["reasoning_tokens"] == 50
 
+    def test_grade_command_writes_zero_reasoning_tokens_to_context_json(
+        self, tmp_path, monkeypatch
+    ):
+        """#170 DEC-002: ``reasoning_tokens=0`` is a real value (the
+        model didn't reason on this call) and MUST land on disk as
+        ``0``, NOT collapse to ``null`` via a truthiness coercion at
+        the sidecar-write seam. Distinguishing ``0`` (measured zero)
+        from ``None`` (couldn't measure) is the whole point of the
+        ``int | None`` axis."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = make_grading_report(
+            passed=True,
+            score=0.9,
+            model="claude-sonnet-4-6",
+            reasoning_tokens=0,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        assert payload["reasoning_tokens"] == 0
+        # Distinct from ``None`` — the JSON value is the integer 0,
+        # not the JSON ``null`` literal.
+        assert payload["reasoning_tokens"] is not None
+
     def test_grade_command_writes_null_reasoning_tokens_when_none(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10268,6 +10268,74 @@ class TestCmdGradeWritesContextJson:
         assert next(iter(payload.keys())) == "schema_version"
         assert payload["schema_version"] == 1
 
+    def test_grade_command_writes_reasoning_tokens_to_context_json(
+        self, tmp_path, monkeypatch
+    ):
+        """#170 US-005: a graded run whose ``GradingReport`` carries
+        ``reasoning_tokens=50`` lands the same value on
+        ``context.json``. Mirrors the ``model_grader`` threading
+        pattern."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = make_grading_report(
+            passed=True,
+            score=0.9,
+            model="claude-sonnet-4-6",
+            reasoning_tokens=50,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        assert payload["reasoning_tokens"] == 50
+
+    def test_grade_command_writes_null_reasoning_tokens_when_none(
+        self, tmp_path, monkeypatch
+    ):
+        """#170 US-005: a graded run whose ``GradingReport`` carries
+        ``reasoning_tokens=None`` (no grader call surfaced a count)
+        lands ``"reasoning_tokens": null`` on disk — distinct from
+        ``0`` per DEC-003."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._spec_with_live_run()
+        report = make_grading_report(
+            passed=True,
+            score=0.9,
+            model="claude-sonnet-4-6",
+            reasoning_tokens=None,
+        )
+
+        with (
+            patch("clauditor.cli.SkillSpec.from_file", return_value=spec),
+            patch(
+                "clauditor.quality_grader.grade_quality",
+                new_callable=AsyncMock,
+                return_value=report,
+            ),
+        ):
+            rc = main(["grade", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        assert payload["reasoning_tokens"] is None
+
     def test_captured_output_mode_skips_context_sidecar(
         self, tmp_path, monkeypatch
     ):
@@ -10404,3 +10472,23 @@ class TestCmdValidateWritesContextJson:
         assert payload["model_runner"] == "gpt-5-codex"
         assert payload["system_prompt_source"] == "agents_md"
         assert payload["sandbox_mode"] == "workspace-write"
+
+    def test_validate_command_writes_null_reasoning_tokens_to_context_json(
+        self, tmp_path, monkeypatch
+    ):
+        """#170 US-005 / DEC-008: validate has no LLM grader call, so
+        ``reasoning_tokens`` is structurally ``None`` on the
+        ``context.json`` sidecar."""
+        monkeypatch.chdir(tmp_path)
+        spec = self._live_spec()
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md"])
+
+        assert rc == 0
+        context_path = (
+            tmp_path / ".clauditor" / "iteration-1" / "test-skill" / "context.json"
+        )
+        assert context_path.is_file()
+        payload = json.loads(context_path.read_text())
+        assert payload["reasoning_tokens"] is None

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1168,8 +1168,9 @@ class TestExtractionReport:
             build_extraction_report(extracted, spec)
 
     def test_to_json_emits_v4_with_harness(self):
-        """#152 US-003: ``to_json`` emits ``schema_version: 4`` first
-        key and includes a top-level ``harness`` field."""
+        """#152 US-003 + #170 US-004: ``to_json`` emits
+        ``schema_version: 5`` first key (#170 bumped v4→v5 to add
+        ``reasoning_tokens``); ``harness`` field still present."""
         report = ExtractionReport(
             skill_name="s",
             model="m",
@@ -1180,7 +1181,7 @@ class TestExtractionReport:
         raw = report.to_json()
         data = json.loads(raw)
         assert next(iter(data)) == "schema_version"
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
         assert data["harness"] == "codex"
 
     def test_from_json_v4_round_trip(self):
@@ -1723,9 +1724,13 @@ class TestExtractionReportTransport:
         assert report.transport_source == "api"
 
     def test_to_json_schema_version_bumped_to_4(self):
+        # Post-#170 US-004 the on-disk version is 5 (added
+        # ``reasoning_tokens``). Test name preserved for historical
+        # regression-grep continuity; assertion tracks current
+        # MAX_SCHEMA_VERSION for extraction.json.
         report = self._report(transport_source="cli")
         data = json.loads(report.to_json())
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
 
     def test_schema_version_is_first_key(self):
         report = self._report(transport_source="cli")
@@ -1884,10 +1889,9 @@ class TestExtractionReportProviderSource:
         assert report.provider_source == "anthropic"
 
     def test_extraction_report_to_json_v4_emits_provider_source(self):
-        """v4 to_json emits ``schema_version: 4`` first key,
-        ``provider_source`` field present (#152 US-003 bumped v3→v4
-        to add the ``harness`` field; ``provider_source`` continues
-        to ride along)."""
+        """``to_json`` emits ``schema_version: 5`` first key (#170
+        US-004 bumped v4→v5 to add ``reasoning_tokens``);
+        ``provider_source`` field continues to ride along."""
         report = ExtractionReport(
             skill_name="s",
             model="m",
@@ -1898,7 +1902,7 @@ class TestExtractionReportProviderSource:
         raw = report.to_json()
         data = json.loads(raw)
         assert next(iter(data)) == "schema_version"
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
         assert data["provider_source"] == "openai"
 
     def test_extraction_report_from_json_v3_round_trips(self):
@@ -2744,3 +2748,246 @@ class TestExtractAndReportWithOpenAI:
         # Every per-field record passes presence (required fields,
         # non-empty values).
         assert all(r.presence_passed for r in report.results)
+
+
+class TestExtractionReportReasoningTokens:
+    """#170 US-004: ExtractionReport carries a nullable
+    ``reasoning_tokens`` field. ``schema_version`` bumps v4→v5 to
+    add the field on disk; legacy v1/v2/v3/v4 sidecars default
+    missing ``reasoning_tokens`` to ``None``. Sum semantics per
+    DEC-003: all-None → ``None``; mixed → sum of non-None;
+    all-int → integer sum."""
+
+    def _report(self, **overrides) -> ExtractionReport:
+        defaults = dict(
+            skill_name="reasoning-test",
+            model="haiku",
+            results=[],
+            declared_field_ids=["v1"],
+        )
+        defaults.update(overrides)
+        return ExtractionReport(**defaults)
+
+    def test_extraction_report_reasoning_tokens_default_none(self):
+        report = self._report()
+        assert report.reasoning_tokens is None
+
+    def test_extraction_report_to_json_emits_schema_version_5(self):
+        """to_json emits ``schema_version: 5`` first key (post-#170
+        US-004), ``reasoning_tokens`` field present after token
+        counts."""
+        report = self._report(reasoning_tokens=42)
+        raw = report.to_json()
+        data = json.loads(raw)
+        assert next(iter(data)) == "schema_version"
+        assert data["schema_version"] == 5
+        assert data["reasoning_tokens"] == 42
+
+    def test_extraction_report_to_json_emits_reasoning_tokens_none(self):
+        """The ``reasoning_tokens`` field is always emitted, even
+        when ``None`` (carries semantic distinction "no count
+        surfaced" vs "count was zero")."""
+        report = self._report()  # default reasoning_tokens=None
+        data = json.loads(report.to_json())
+        assert "reasoning_tokens" in data
+        assert data["reasoning_tokens"] is None
+
+    def test_extraction_report_reasoning_tokens_round_trips_42(self):
+        original = self._report(reasoning_tokens=42)
+        restored = ExtractionReport.from_json(original.to_json())
+        assert restored.reasoning_tokens == 42
+
+    def test_extraction_report_reasoning_tokens_round_trips_none(self):
+        original = self._report()
+        restored = ExtractionReport.from_json(original.to_json())
+        assert restored.reasoning_tokens is None
+
+    def test_extraction_report_from_json_v4_defaults_reasoning_tokens_to_none(
+        self,
+    ):
+        """v4 sidecars (no ``reasoning_tokens``) load with
+        ``reasoning_tokens=None`` defaulted so pre-#170 history
+        loads cleanly."""
+        v4_payload = json.dumps({
+            "schema_version": 4,
+            "skill_name": "legacy-v4",
+            "model": "haiku",
+            "transport_source": "cli",
+            "provider_source": "openai",
+            "harness": "codex",
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "parse_errors": [],
+            "fields": {},
+        })
+        restored = ExtractionReport.from_json(v4_payload)
+        assert restored.reasoning_tokens is None
+        # Other v4 fields still populate correctly.
+        assert restored.harness == "codex"
+        assert restored.provider_source == "openai"
+        assert restored.transport_source == "cli"
+
+    def test_extraction_report_from_json_v3_v2_v1_default_reasoning_tokens(
+        self,
+    ):
+        """All legacy schema versions default ``reasoning_tokens``
+        to ``None``."""
+        for version in (1, 2, 3):
+            payload = json.dumps({
+                "schema_version": version,
+                "skill_name": f"legacy-v{version}",
+                "model": "haiku",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "parse_errors": [],
+                "fields": {},
+            })
+            restored = ExtractionReport.from_json(payload)
+            assert restored.reasoning_tokens is None, (
+                f"v{version} default reasoning_tokens should be None"
+            )
+
+
+class TestExtractAndReportReasoningTokensSum:
+    """#170 US-004: ``extract_and_report`` accumulates per-attempt
+    ``ModelResult.reasoning_tokens`` via sum-of-non-None semantics
+    (DEC-003). Uses ``side_effect=[r1, r2]`` per
+    ``.claude/rules/mock-side-effect-for-distinct-calls.md``."""
+
+    def _spec(self) -> EvalSpec:
+        return EvalSpec(
+            skill_name="reasoning-extract",
+            sections=[
+                SectionRequirement(
+                    name="Items",
+                    tiers=[
+                        TierRequirement(
+                            label="default",
+                            min_entries=1,
+                            fields=[
+                                FieldRequirement(
+                                    name="title",
+                                    id="items-title",
+                                    required=True,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_reasoning_tokens_all_none(self):
+        """All attempts surface ``None`` → report aggregate is
+        ``None``. Forces a parse retry by returning malformed JSON
+        first then valid JSON."""
+        from clauditor._providers import ModelResult
+
+        spec = self._spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        good_payload = json.dumps(
+            {"Items": {"default": [{"title": "Hello"}]}}
+        )
+        good = ModelResult(
+            response_text=good_payload,
+            text_blocks=[good_payload],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await extract_and_report(
+                "output", spec, skill_name="reasoning-extract"
+            )
+        assert report.reasoning_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_reasoning_tokens_mixed(self):
+        """Mixed ``[None, 42]`` → aggregate is ``42`` (sum of
+        non-None, NOT 0, NOT None)."""
+        from clauditor._providers import ModelResult
+
+        spec = self._spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        good_payload = json.dumps(
+            {"Items": {"default": [{"title": "Hello"}]}}
+        )
+        good = ModelResult(
+            response_text=good_payload,
+            text_blocks=[good_payload],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=42,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await extract_and_report(
+                "output", spec, skill_name="reasoning-extract"
+            )
+        assert report.reasoning_tokens == 42
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_reasoning_tokens_all_int_sums(
+        self,
+    ):
+        """Two attempts with ``[10, 20]`` → aggregate is ``30``
+        (integer sum)."""
+        from clauditor._providers import ModelResult
+
+        spec = self._spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=10,
+        )
+        good_payload = json.dumps(
+            {"Items": {"default": [{"title": "Hello"}]}}
+        )
+        good = ModelResult(
+            response_text=good_payload,
+            text_blocks=[good_payload],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=20,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await extract_and_report(
+                "output", spec, skill_name="reasoning-extract"
+            )
+        assert report.reasoning_tokens == 30
+

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -2847,6 +2847,51 @@ class TestExtractionReportReasoningTokens:
                 f"v{version} default reasoning_tokens should be None"
             )
 
+    def test_extraction_report_from_json_rejects_bool_reasoning_tokens(self):
+        """Quality Gate Pass 1 fix (#170 US-007): a malformed sidecar
+        with ``"reasoning_tokens": true`` MUST default to ``None``,
+        NOT silently coerce to ``1``. Symmetric with the writer-side
+        ``_extract_reasoning_tokens`` bool guard per DEC-006 and
+        ``.claude/rules/constant-with-type-info.md`` (Python's
+        ``isinstance(True, int)`` is ``True``)."""
+        for bad_value in (True, False):
+            payload = json.dumps({
+                "schema_version": 5,
+                "skill_name": "hostile",
+                "model": "haiku",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "reasoning_tokens": bad_value,
+                "parse_errors": [],
+                "fields": {},
+            })
+            restored = ExtractionReport.from_json(payload)
+            assert restored.reasoning_tokens is None, (
+                f"bool {bad_value} must default to None, not coerce to int"
+            )
+
+    def test_extraction_report_from_json_rejects_non_int_reasoning_tokens(
+        self,
+    ):
+        """Quality Gate Pass 1 fix: non-int ``reasoning_tokens``
+        (string, float, list, dict) MUST default to ``None`` rather
+        than raise or coerce."""
+        for bad_value in ("99", 3.14, [42], {"x": 1}):
+            payload = json.dumps({
+                "schema_version": 5,
+                "skill_name": "hostile",
+                "model": "haiku",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "reasoning_tokens": bad_value,
+                "parse_errors": [],
+                "fields": {},
+            })
+            restored = ExtractionReport.from_json(payload)
+            assert restored.reasoning_tokens is None, (
+                f"non-int {bad_value!r} must default to None"
+            )
+
 
 class TestExtractAndReportReasoningTokensSum:
     """#170 US-004: ``extract_and_report`` accumulates per-attempt

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -2797,6 +2797,22 @@ class TestExtractionReportReasoningTokens:
         restored = ExtractionReport.from_json(original.to_json())
         assert restored.reasoning_tokens == 42
 
+    def test_extraction_report_reasoning_tokens_round_trips_zero(self):
+        """#170 DEC-002: ``reasoning_tokens=0`` is a real value (the
+        model didn't reason on this call) and MUST round-trip
+        through ``to_json``/``from_json`` as ``0``, NOT collapse to
+        ``None`` via a truthiness coercion. The on-disk JSON value
+        is the integer ``0``, not the JSON ``null`` literal."""
+        original = self._report(reasoning_tokens=0)
+        raw = original.to_json()
+        data = json.loads(raw)
+        # Writer emits the literal integer 0, distinct from null.
+        assert data["reasoning_tokens"] == 0
+        assert data["reasoning_tokens"] is not None
+        restored = ExtractionReport.from_json(raw)
+        assert restored.reasoning_tokens == 0
+        assert restored.reasoning_tokens is not None
+
     def test_extraction_report_reasoning_tokens_round_trips_none(self):
         original = self._report()
         restored = ExtractionReport.from_json(original.to_json())
@@ -3035,4 +3051,45 @@ class TestExtractAndReportReasoningTokensSum:
                 "output", spec, skill_name="reasoning-extract"
             )
         assert report.reasoning_tokens == 30
+
+    @pytest.mark.asyncio
+    async def test_extract_and_report_reasoning_tokens_zero_and_none(self):
+        """#170 DEC-002 + DEC-003: aggregation must treat ``0`` as a
+        real measurement, NOT as a falsy "skip me." With one
+        attempt at ``0`` and one at ``None``, the aggregate is
+        ``0`` (sum of non-None values is ``0``) — distinct from
+        the all-None → ``None`` case."""
+        from clauditor._providers import ModelResult
+
+        spec = self._spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=0,
+        )
+        good_payload = json.dumps(
+            {"Items": {"default": [{"title": "Hello"}]}}
+        )
+        good = ModelResult(
+            response_text=good_payload,
+            text_blocks=[good_payload],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await extract_and_report(
+                "output", spec, skill_name="reasoning-extract"
+            )
+        assert report.reasoning_tokens == 0
+        assert report.reasoning_tokens is not None
 

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -1540,6 +1540,31 @@ class TestModelResult:
         result = ModelResult(response_text="ok", provider="openai")
         assert result.provider == "openai"
 
+    def test_reasoning_tokens_default_none(self) -> None:
+        """A ``ModelResult`` constructed without ``reasoning_tokens``
+        defaults to ``None`` so every pre-#170 caller stays unchanged.
+
+        The field is nullable from day one (DEC-001 / DEC-002 of
+        ``plans/super/170-reasoning-tokens-capture.md``): null means
+        "the provider did not surface a reasoning-token count" (no
+        thinking block, transport that strips it, etc.) rather than
+        the misleading "0 reasoning tokens were used"."""
+        from clauditor._providers._anthropic import ModelResult
+
+        result = ModelResult(response_text="ok")
+        assert result.reasoning_tokens is None
+
+    def test_reasoning_tokens_kwarg(self) -> None:
+        """``reasoning_tokens=`` is keyword-settable to a non-negative
+        int. Future Anthropic-backend wiring (US-002) will populate
+        this from ``response.usage.cache_creation_input_tokens`` /
+        the thinking-block accounting; this test pins the field
+        carrier shape regardless of how the value is sourced."""
+        from clauditor._providers._anthropic import ModelResult
+
+        result = ModelResult(response_text="ok", reasoning_tokens=42)
+        assert result.reasoning_tokens == 42
+
 
 class TestCallModel:
     """Regression tests for the #144 US-003 ``call_model`` dispatcher.

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -171,6 +171,56 @@ class TestExtractResult:
         result = _extract_result(resp)
         assert result.raw_message is resp
 
+    def test_anthropic_reasoning_tokens_always_none(self) -> None:
+        """Drift-guard (#170 US-003 / DEC-001): the Anthropic backend's
+        ``_extract_result`` MUST stamp ``reasoning_tokens=None`` on
+        every successful response, regardless of usage shape.
+
+        ``anthropic.types.Usage`` carries no separately-billed
+        reasoning-token field — for extended-thinking models the
+        thinking tokens are already included in ``output_tokens``.
+        Honest ``None`` is the only correct representation, distinct
+        from ``0`` (which would assert "the call ran but used zero
+        reasoning tokens"). A future contributor copy-pasting the
+        OpenAI-side wiring (``reasoning_tokens=usage.something``)
+        would silently break this contract; this test catches the
+        regression at the construction site."""
+        usage = MagicMock(input_tokens=10, output_tokens=5)
+        resp = _mock_response(usage=usage)
+        result = _extract_result(resp)
+        assert result.reasoning_tokens is None
+        # Defense in depth: confirm the rest of the projection still
+        # works so a regression that nulled every field would not be
+        # mistaken for the reasoning_tokens=None contract holding.
+        assert result.input_tokens == 10
+        assert result.output_tokens == 5
+
+    def test_anthropic_reasoning_tokens_none_for_thinking_style_response(
+        self,
+    ) -> None:
+        """Drift-guard (#170 US-003 / DEC-001): a response that
+        includes a thinking-block-shaped content block (extended-
+        thinking models — Opus 4.x, Sonnet 4.x with
+        ``thinking={"type":"enabled",...}``) MUST still surface
+        ``reasoning_tokens=None``. The Anthropic SDK does not split
+        thinking tokens out of ``output_tokens``; we cannot honestly
+        report a separate count, so the field stays ``None`` even
+        when a thinking block is visibly present in ``content``."""
+        thinking_block = MagicMock(spec=["type"])
+        thinking_block.type = "thinking"
+        text_block = MagicMock(type="text", text="final answer")
+        # ``output_tokens`` here ALREADY INCLUDES the thinking-block
+        # tokens per the Anthropic API contract — there is no
+        # ``thinking_tokens`` key on ``usage`` to subtract or expose.
+        usage = MagicMock(input_tokens=20, output_tokens=150)
+        resp = _mock_response(blocks=[thinking_block, text_block], usage=usage)
+        result = _extract_result(resp)
+        assert result.reasoning_tokens is None
+        # Sanity: the text block still surfaces; the thinking block
+        # is filtered out by the ``type == "text"`` check.
+        assert result.response_text == "final answer"
+        assert result.text_blocks == ["final answer"]
+
 
 class TestBodyExcerpt:
     def test_none_body(self) -> None:
@@ -696,6 +746,24 @@ class TestCallViaClaudeCli:
             result = await call_anthropic("p", model="m", transport="cli")
         assert result.input_tokens == 123
         assert result.output_tokens == 45
+
+    @pytest.mark.asyncio
+    async def test_cli_transport_reasoning_tokens_always_none(self) -> None:
+        """Drift-guard (#170 US-003 / DEC-001): the CLI-transport
+        success path MUST also stamp ``reasoning_tokens=None``. The
+        ``claude -p`` subprocess output stream-json carries no
+        separately-billed reasoning-token field; even if the parent
+        model is an extended-thinking variant, the projected
+        ``InvokeResult.output_tokens`` already includes thinking
+        tokens. Honest ``None`` parity with the SDK branch is the
+        only correct shape."""
+        fake = _make_cli_success_popen("ok", input_tokens=7, output_tokens=11)
+        with patch(
+            "clauditor._harnesses._claude_code.subprocess.Popen",
+            return_value=fake,
+        ):
+            result = await call_anthropic("p", model="m", transport="cli")
+        assert result.reasoning_tokens is None
 
     @pytest.mark.asyncio
     async def test_rate_limit_retries_up_to_three_times(self) -> None:

--- a/tests/test_providers_anthropic.py
+++ b/tests/test_providers_anthropic.py
@@ -1624,10 +1624,13 @@ class TestModelResult:
 
     def test_reasoning_tokens_kwarg(self) -> None:
         """``reasoning_tokens=`` is keyword-settable to a non-negative
-        int. Future Anthropic-backend wiring (US-002) will populate
-        this from ``response.usage.cache_creation_input_tokens`` /
-        the thinking-block accounting; this test pins the field
-        carrier shape regardless of how the value is sourced."""
+        int. Per DEC-001 of #170 the **Anthropic backend itself
+        unconditionally hardcodes this field to ``None``** (the SDK
+        has no separately-billed thinking-token surface today —
+        thinking tokens are folded into ``output_tokens``); this
+        test pins only the dataclass field carrier shape so callers
+        and the OpenAI backend (which DOES populate it) can rely on
+        the field being settable to an int."""
         from clauditor._providers._anthropic import ModelResult
 
         result = ModelResult(response_text="ok", reasoning_tokens=42)

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -739,6 +739,25 @@ class TestExtractReasoningTokens:
 
         assert _extract_reasoning_tokens(Raising()) is None
 
+    def test_inner_attribute_access_raising_yields_none(self) -> None:
+        # Sibling of ``test_attribute_access_raising_yields_none``:
+        # the OUTER ``getattr(usage, "output_tokens_details")``
+        # succeeds, but accessing ``reasoning_tokens`` on the
+        # returned ``details`` object raises. The inner try/except
+        # MUST collapse to ``None`` rather than propagate. Covers
+        # the inner defensive branch (a future SDK shape where the
+        # nested ``output_tokens_details`` is a Pydantic-v2 model
+        # whose ``reasoning_tokens`` is a computed property that
+        # throws on missing-data inputs).
+        class RaisingDetails:
+            @property
+            def reasoning_tokens(self):
+                raise RuntimeError("nope")
+
+        usage = MagicMock()
+        usage.output_tokens_details = RaisingDetails()
+        assert _extract_reasoning_tokens(usage) is None
+
 
 # ---------------------------------------------------------------------------
 # US-004: Retry / error branches in call_openai

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -23,6 +23,7 @@ from clauditor._providers._openai import (
     OpenAIHelperError,
     _body_excerpt,
     _extract_openai_result,
+    _extract_reasoning_tokens,
     call_openai,
 )
 
@@ -33,16 +34,25 @@ def _mock_response(
     input_tokens: int = 10,
     output_tokens: int = 5,
     raw_dict: dict | None = None,
+    reasoning_tokens: int | None = None,
 ) -> MagicMock:
     """Build a MagicMock shaped like an OpenAI Responses-API response.
 
     The real ``openai.types.responses.Response`` object is a Pydantic
     model with ``output[]`` (list of output items: messages,
     reasoning, tool-use), ``output_text`` (SDK convenience accessor
-    joining message text), ``usage`` (input/output token counts),
+    joining message text), ``usage`` (input/output token counts +
+    nested ``output_tokens_details`` carrying ``reasoning_tokens``),
     and ``model_dump()`` (Pydantic v2 dict serialization). Build a
     single-message ``output[]`` mirroring ``output_text`` so the
     extractor's per-block walker yields matching ``text_blocks``.
+
+    When ``reasoning_tokens`` is non-``None``, populate
+    ``usage.output_tokens_details.reasoning_tokens`` so the #170
+    extractor can read it. Default ``None`` omits the nested
+    attribute entirely (MagicMock auto-creates attributes lazily,
+    so a `del` is needed to mimic a real SDK response that lacks
+    the field).
     """
     resp = MagicMock()
     if output_text:
@@ -58,9 +68,16 @@ def _mock_response(
     else:
         resp.output = []
     resp.output_text = output_text
-    resp.usage = MagicMock(
-        input_tokens=input_tokens, output_tokens=output_tokens
-    )
+    usage = MagicMock(input_tokens=input_tokens, output_tokens=output_tokens)
+    if reasoning_tokens is not None:
+        details = MagicMock()
+        details.reasoning_tokens = reasoning_tokens
+        usage.output_tokens_details = details
+    else:
+        # Mimic an SDK response that does not surface the nested
+        # details object (older models, non-reasoning responses).
+        del usage.output_tokens_details
+    resp.usage = usage
     resp.model_dump = MagicMock(
         return_value=raw_dict if raw_dict is not None else {"id": "resp_x"}
     )
@@ -256,6 +273,41 @@ class TestCallOpenAISuccess:
         kwargs = fake_client.responses.create.call_args.kwargs
         assert kwargs["max_output_tokens"] == 2048
 
+    @pytest.mark.asyncio
+    async def test_reasoning_tokens_populated_on_result(self) -> None:
+        # Bead clauditor-s0vu (US-002 of #170): when the SDK surfaces
+        # ``usage.output_tokens_details.reasoning_tokens=99``, the
+        # backend stamps it on ``ModelResult.reasoning_tokens``.
+        resp = _mock_response(reasoning_tokens=99)
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.reasoning_tokens == 99
+
+    @pytest.mark.asyncio
+    async def test_reasoning_tokens_zero_preserved_on_result(self) -> None:
+        # DEC-002 load-bearing: ``0`` reaches the dataclass intact —
+        # NOT collapsed to ``None``. ``0`` means "model didn't
+        # reason"; ``None`` means "couldn't read."
+        resp = _mock_response(reasoning_tokens=0)
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.reasoning_tokens == 0
+        assert result.reasoning_tokens is not None
+
+    @pytest.mark.asyncio
+    async def test_reasoning_tokens_none_when_details_absent(self) -> None:
+        # The default ``_mock_response`` shape (no ``reasoning_tokens``
+        # kwarg) deletes ``output_tokens_details`` entirely so the
+        # extractor reads ``None`` — same shape an older non-reasoning
+        # model would surface.
+        resp = _mock_response()  # default reasoning_tokens=None → del
+        ctx, _ = _patch_async_openai(resp)
+        with ctx:
+            result = await call_openai("p", model="gpt-5.4")
+        assert result.reasoning_tokens is None
+
 
 def _build_message_item(*texts: str) -> MagicMock:
     """Build a Responses-API ``message``-typed output item.
@@ -351,7 +403,7 @@ class TestExtractOpenAIResult:
             output=[_build_message_item("hello world")],
             output_text="hello world",
         )
-        text, blocks, in_t, out_t, raw = _extract_openai_result(resp)
+        text, blocks, in_t, out_t, raw, _ = _extract_openai_result(resp)
         assert blocks == ["hello world"]
         assert text == "hello world"
 
@@ -367,7 +419,7 @@ class TestExtractOpenAIResult:
             ],
             output_text="msg",
         )
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == ["msg"]
         assert text == "msg"
 
@@ -382,7 +434,7 @@ class TestExtractOpenAIResult:
             ],
             output_text="firstsecond",
         )
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == ["first", "second"]
         assert text == "firstsecond"
 
@@ -390,7 +442,7 @@ class TestExtractOpenAIResult:
         # Empty response.output[] list AND empty output_text — the
         # extractor returns empty containers without raising.
         resp = _make_response(output=[], output_text="")
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert text == ""
         assert blocks == []
 
@@ -404,7 +456,7 @@ class TestExtractOpenAIResult:
         item.type = "message"
         item.content = None
         resp = _make_response(output=[item], output_text="")
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == []
         assert text == ""
 
@@ -416,7 +468,7 @@ class TestExtractOpenAIResult:
         item.type = "message"
         item.content = []
         resp = _make_response(output=[item], output_text="")
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == []
         assert text == ""
 
@@ -431,7 +483,7 @@ class TestExtractOpenAIResult:
         refusal.refusal = "I cannot help with that."
         item.content = [refusal]
         resp = _make_response(output=[item], output_text="")
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == []
         assert text == ""
 
@@ -441,7 +493,7 @@ class TestExtractOpenAIResult:
         # default to 0.
         resp = _make_response(output=[], output_text="")
         del resp.usage
-        _, _, in_t, out_t, _ = _extract_openai_result(resp)
+        _, _, in_t, out_t, _, _ = _extract_openai_result(resp)
         assert in_t == 0
         assert out_t == 0
 
@@ -453,7 +505,7 @@ class TestExtractOpenAIResult:
         usage.input_tokens = None
         usage.output_tokens = None
         resp = _make_response(output=[], output_text="", usage=usage)
-        _, _, in_t, out_t, _ = _extract_openai_result(resp)
+        _, _, in_t, out_t, _, _ = _extract_openai_result(resp)
         assert in_t == 0
         assert out_t == 0
 
@@ -465,7 +517,7 @@ class TestExtractOpenAIResult:
         usage.input_tokens = "not a number"
         usage.output_tokens = "garbage"
         resp = _make_response(output=[], output_text="", usage=usage)
-        _, _, in_t, out_t, _ = _extract_openai_result(resp)
+        _, _, in_t, out_t, _, _ = _extract_openai_result(resp)
         assert in_t == 0
         assert out_t == 0
 
@@ -484,7 +536,7 @@ class TestExtractOpenAIResult:
         )
         resp.status = "incomplete"
         resp.incomplete_details = MagicMock(reason="max_output_tokens")
-        text, blocks, _, _, raw = _extract_openai_result(resp)
+        text, blocks, _, _, raw, _ = _extract_openai_result(resp)
         assert text == "partial"
         assert blocks == ["partial"]
         assert raw["status"] == "incomplete"
@@ -497,7 +549,7 @@ class TestExtractOpenAIResult:
         resp = _make_response(
             output=[], output_text="", raw_dict=raw
         )
-        _, _, _, _, got = _extract_openai_result(resp)
+        _, _, _, _, got, _ = _extract_openai_result(resp)
         assert got == raw
 
     def test_raw_message_fallback_on_missing_model_dump(self) -> None:
@@ -507,7 +559,7 @@ class TestExtractOpenAIResult:
         resp = _make_response(
             output=[], output_text="", has_model_dump=False
         )
-        _, _, _, _, raw = _extract_openai_result(resp)
+        _, _, _, _, raw, _ = _extract_openai_result(resp)
         assert raw == {}
 
     def test_output_text_attribute_missing_falls_back_to_blocks(
@@ -520,7 +572,7 @@ class TestExtractOpenAIResult:
             output=[_build_message_item("alpha", "beta")],
             output_text=None,
         )
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == ["alphabeta"]
         assert text == "alphabeta"
 
@@ -539,7 +591,7 @@ class TestExtractOpenAIResult:
         refusal.refusal = "I cannot help"
         msg.content = [refusal, text_block]
         resp = _make_response(output=[msg], output_text="real")
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         # Only the output_text block contributes; refusal is skipped.
         assert blocks == ["real"]
         assert text == "real"
@@ -551,7 +603,7 @@ class TestExtractOpenAIResult:
         msg.type = "message"
         msg.content = "not-a-list"
         resp = _make_response(output=[msg], output_text="")
-        text, blocks, _, _, _ = _extract_openai_result(resp)
+        text, blocks, _, _, _, _ = _extract_openai_result(resp)
         assert blocks == []
         assert text == ""
 
@@ -561,8 +613,131 @@ class TestExtractOpenAIResult:
         # back to {} rather than propagating.
         resp = _make_response(output=[], output_text="")
         resp.model_dump = MagicMock(side_effect=TypeError("boom"))
-        _, _, _, _, raw = _extract_openai_result(resp)
+        _, _, _, _, raw, _ = _extract_openai_result(resp)
         assert raw == {}
+
+    def test_reasoning_tokens_extracted_into_tuple(self) -> None:
+        # End-to-end through ``_extract_openai_result``: the helper
+        # must thread reasoning_tokens out of the
+        # ``usage.output_tokens_details.reasoning_tokens`` accessor
+        # into the 6th tuple slot so ``call_openai`` can stamp the
+        # field on the returned ``ModelResult``.
+        usage = MagicMock()
+        usage.input_tokens = 10
+        usage.output_tokens = 5
+        details = MagicMock()
+        details.reasoning_tokens = 99
+        usage.output_tokens_details = details
+        resp = _make_response(output=[], output_text="", usage=usage)
+        _, _, _, _, _, reasoning = _extract_openai_result(resp)
+        assert reasoning == 99
+
+    def test_reasoning_tokens_missing_details_yields_none(self) -> None:
+        # Sibling: a response with ``usage`` but no nested
+        # ``output_tokens_details`` (older models, non-reasoning
+        # responses) yields ``None`` — distinct from ``0`` ("model
+        # didn't reason") per DEC-002.
+        usage = MagicMock()
+        usage.input_tokens = 10
+        usage.output_tokens = 5
+        del usage.output_tokens_details
+        resp = _make_response(output=[], output_text="", usage=usage)
+        _, _, _, _, _, reasoning = _extract_openai_result(resp)
+        assert reasoning is None
+
+
+class TestExtractReasoningTokens:
+    """Pure-helper tests for ``_extract_reasoning_tokens``.
+
+    Bead clauditor-s0vu (US-002 of #170): the helper defensively
+    reads ``usage.output_tokens_details.reasoning_tokens`` and
+    returns ``int | None``. Per DEC-002, ``0`` is preserved (model
+    chose not to reason); ``None`` means "couldn't read." Per
+    DEC-006, the helper is pure: no I/O, never raises, with a
+    bool guard per ``.claude/rules/constant-with-type-info.md``
+    (Python's ``isinstance(True, int)`` is ``True``).
+    """
+
+    def test_none_usage(self) -> None:
+        assert _extract_reasoning_tokens(None) is None
+
+    def test_well_formed_int_value(self) -> None:
+        usage = MagicMock()
+        details = MagicMock()
+        details.reasoning_tokens = 42
+        usage.output_tokens_details = details
+        assert _extract_reasoning_tokens(usage) == 42
+
+    def test_zero_value_is_preserved(self) -> None:
+        # DEC-002 load-bearing: ``0`` means "model didn't reason"
+        # and MUST NOT collapse to ``None`` ("couldn't read").
+        # Distinguishing the two states is the whole point of the
+        # ``int | None`` axis.
+        usage = MagicMock()
+        details = MagicMock()
+        details.reasoning_tokens = 0
+        usage.output_tokens_details = details
+        result = _extract_reasoning_tokens(usage)
+        assert result == 0
+        assert result is not None
+
+    def test_missing_output_tokens_details(self) -> None:
+        # A real SDK response that lacks the nested ``details``
+        # object entirely (older models, non-reasoning responses)
+        # yields ``None``.
+        usage = MagicMock()
+        del usage.output_tokens_details
+        assert _extract_reasoning_tokens(usage) is None
+
+    def test_missing_reasoning_tokens_field(self) -> None:
+        # ``output_tokens_details`` exists but lacks the
+        # ``reasoning_tokens`` field — yield ``None``.
+        usage = MagicMock()
+        details = MagicMock(spec=[])  # spec=[] blocks attr auto-creation
+        usage.output_tokens_details = details
+        assert _extract_reasoning_tokens(usage) is None
+
+    def test_bool_value_rejected(self) -> None:
+        # Per .claude/rules/constant-with-type-info.md: Python's
+        # ``isinstance(True, int)`` is ``True``. A future SDK that
+        # surfaced ``reasoning_tokens=True`` would silently coerce
+        # to ``1`` if we only checked ``isinstance(val, int)``;
+        # the bool guard rejects it back to ``None``.
+        usage = MagicMock()
+        details = MagicMock()
+        details.reasoning_tokens = True
+        usage.output_tokens_details = details
+        assert _extract_reasoning_tokens(usage) is None
+
+    def test_string_value_rejected(self) -> None:
+        # Defensive: a non-int (string, float, dict, None) value
+        # yields ``None`` rather than coercing or raising.
+        usage = MagicMock()
+        details = MagicMock()
+        details.reasoning_tokens = "99"
+        usage.output_tokens_details = details
+        assert _extract_reasoning_tokens(usage) is None
+
+    def test_none_value_yields_none(self) -> None:
+        # Explicit ``reasoning_tokens=None`` (a possible SDK shape
+        # for "no reasoning tokens recorded") yields ``None``.
+        usage = MagicMock()
+        details = MagicMock()
+        details.reasoning_tokens = None
+        usage.output_tokens_details = details
+        assert _extract_reasoning_tokens(usage) is None
+
+    def test_attribute_access_raising_yields_none(self) -> None:
+        # Defensive: a future SDK shape where attribute access
+        # itself raises (a Pydantic-v2 computed field that throws,
+        # a __getattr__ that fails) must collapse to ``None``
+        # rather than propagate.
+        class Raising:
+            @property
+            def output_tokens_details(self):
+                raise RuntimeError("nope")
+
+        assert _extract_reasoning_tokens(Raising()) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -355,9 +355,13 @@ class TestGradingReportTransport:
         assert report.transport_source == "api"
 
     def test_to_json_schema_version_bumped_to_4(self):
+        # Post-#170 US-004 the on-disk version is 5 (added
+        # ``reasoning_tokens``). The test name is preserved for
+        # historical regression-grep continuity; the assertion
+        # tracks the current MAX_SCHEMA_VERSION for grading.json.
         report = self._report(transport_source="cli")
         data = json.loads(report.to_json())
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
 
     def test_schema_version_is_first_key(self):
         """Per ``.claude/rules/json-schema-version.md``, schema_version
@@ -399,9 +403,10 @@ class TestGradingReportTransport:
         original = self._report(transport_source="cli")
         restored = GradingReport.from_json(original.to_json())
         assert restored.transport_source == "cli"
-        # v4 round-trip still emits v4 (post-#152).
+        # Post-#170 US-004 the round-trip emits v5 (added
+        # ``reasoning_tokens`` field).
         data = json.loads(restored.to_json())
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
 
 
 class TestBlindReportSchema:
@@ -474,13 +479,13 @@ class TestGradingReportProviderSource:
         assert report.provider_source == "anthropic"
 
     def test_grading_report_to_json_v3_emits_provider_source(self):
-        """to_json emits ``schema_version: 4`` first key (post-#152),
-        ``provider_source`` field present."""
+        """to_json emits ``schema_version: 5`` first key (post-#170
+        US-004), ``provider_source`` field present."""
         report = self._report(provider_source="openai")
         raw = report.to_json()
         data = json.loads(raw)
         assert next(iter(data)) == "schema_version"
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
         assert data["provider_source"] == "openai"
 
     def test_grading_report_from_json_v3_round_trips(self):
@@ -550,13 +555,14 @@ class TestGradingReportHarness:
         assert report.harness == "claude-code"
 
     def test_to_json_emits_v4_with_harness(self):
-        """v4 to_json emits ``schema_version: 4`` first key,
+        """``to_json`` emits ``schema_version: 5`` first key (post-#170
+        US-004 bumped v4→v5 to add ``reasoning_tokens``),
         ``harness`` field present after ``provider_source``."""
         report = self._report(harness="codex")
         raw = report.to_json()
         data = json.loads(raw)
         assert next(iter(data)) == "schema_version"
-        assert data["schema_version"] == 4
+        assert data["schema_version"] == 5
         assert data["harness"] == "codex"
 
     def test_from_json_v4_round_trip(self):
@@ -3652,4 +3658,479 @@ class TestGradeQualityWithOpenAI:
         assert report.input_tokens == 120
         assert report.output_tokens == 240
 
+
+class TestGradingReportReasoningTokens:
+    """#170 US-004: GradingReport carries a nullable
+    ``reasoning_tokens`` field. ``schema_version`` bumps v4→v5 to
+    add the field on disk; legacy v1/v2/v3/v4 sidecars default
+    missing ``reasoning_tokens`` to ``None``. Sum semantics per
+    DEC-003: all-None inputs → ``None``; mixed → sum of non-None;
+    all-int → integer sum."""
+
+    def _report(self, **overrides) -> GradingReport:
+        defaults = dict(
+            skill_name="reasoning-test",
+            results=_make_results([True]),
+            model="claude-sonnet-4-6",
+            thresholds=GradeThresholds(),
+            metrics={},
+        )
+        defaults.update(overrides)
+        return GradingReport(**defaults)
+
+    def test_grading_report_reasoning_tokens_default_none(self):
+        report = self._report()
+        assert report.reasoning_tokens is None
+
+    def test_grading_report_to_json_emits_schema_version_5(self):
+        """to_json emits ``schema_version: 5`` first key (post-#170
+        US-004), ``reasoning_tokens`` field present after token
+        counts."""
+        report = self._report(reasoning_tokens=42)
+        raw = report.to_json()
+        data = json.loads(raw)
+        assert next(iter(data)) == "schema_version"
+        assert data["schema_version"] == 5
+        assert data["reasoning_tokens"] == 42
+
+    def test_grading_report_to_json_emits_reasoning_tokens_none(self):
+        """The ``reasoning_tokens`` field is always emitted, even
+        when ``None`` (carries semantic distinction "no count
+        surfaced" vs "count was zero")."""
+        report = self._report()  # default reasoning_tokens=None
+        data = json.loads(report.to_json())
+        assert "reasoning_tokens" in data
+        assert data["reasoning_tokens"] is None
+
+    def test_grading_report_reasoning_tokens_round_trips_42(self):
+        original = self._report(reasoning_tokens=42)
+        restored = GradingReport.from_json(original.to_json())
+        assert restored.reasoning_tokens == 42
+
+    def test_grading_report_reasoning_tokens_round_trips_none(self):
+        original = self._report()
+        restored = GradingReport.from_json(original.to_json())
+        assert restored.reasoning_tokens is None
+
+    def test_grading_report_from_json_v4_defaults_reasoning_tokens_to_none(
+        self,
+    ):
+        """v4 sidecars (no ``reasoning_tokens``) load with
+        ``reasoning_tokens=None`` defaulted so pre-#170 history
+        loads cleanly."""
+        v4_payload = json.dumps({
+            "schema_version": 4,
+            "skill_name": "legacy-v4",
+            "model": "claude-sonnet-4-6",
+            "transport_source": "cli",
+            "provider_source": "openai",
+            "harness": "codex",
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "results": [],
+        })
+        restored = GradingReport.from_json(v4_payload)
+        assert restored.reasoning_tokens is None
+        # Other v4 fields still populate correctly.
+        assert restored.harness == "codex"
+        assert restored.provider_source == "openai"
+        assert restored.transport_source == "cli"
+
+    def test_grading_report_from_json_v3_v2_v1_default_reasoning_tokens(
+        self,
+    ):
+        """All legacy schema versions default ``reasoning_tokens``
+        to ``None`` (preserves "no provider call surfaced a
+        count")."""
+        for version in (1, 2, 3):
+            payload = json.dumps({
+                "schema_version": version,
+                "skill_name": f"legacy-v{version}",
+                "model": "claude-sonnet-4-6",
+                "results": [],
+            })
+            restored = GradingReport.from_json(payload)
+            assert restored.reasoning_tokens is None, (
+                f"v{version} default reasoning_tokens should be None"
+            )
+
+
+class TestGradeQualityReasoningTokensSum:
+    """#170 US-004: ``grade_quality`` accumulates per-attempt
+    ``ModelResult.reasoning_tokens`` via sum-of-non-None semantics
+    (DEC-003). Uses ``side_effect=[r1, r2]`` per
+    ``.claude/rules/mock-side-effect-for-distinct-calls.md`` so the
+    sum arithmetic actually runs across two distinct call values."""
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_reasoning_tokens_all_none(self):
+        """Every ``ModelResult.reasoning_tokens`` is ``None`` →
+        report's aggregate is ``None`` (no provider call surfaced
+        a count)."""
+        from clauditor._providers import ModelResult
+
+        spec = _make_spec()
+        # Force a parse failure on the first attempt so the retry
+        # loop fires twice — that exercises the sum across two
+        # distinct call results.
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        good_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.85,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": True,
+                "score": 0.8,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+        ]
+        good = ModelResult(
+            response_text=json.dumps(good_data),
+            text_blocks=[json.dumps(good_data)],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await grade_quality("output", spec)
+        assert report.reasoning_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_reasoning_tokens_mixed_returns_present(
+        self,
+    ):
+        """Mixed ``[None, 42]`` → report's aggregate is ``42``
+        (sum of non-None values, NOT 0, NOT None)."""
+        from clauditor._providers import ModelResult
+
+        spec = _make_spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        good_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.85,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": True,
+                "score": 0.8,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+        ]
+        good = ModelResult(
+            response_text=json.dumps(good_data),
+            text_blocks=[json.dumps(good_data)],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=42,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await grade_quality("output", spec)
+        assert report.reasoning_tokens == 42
+
+    @pytest.mark.asyncio
+    async def test_grade_quality_reasoning_tokens_all_int_sums(self):
+        """Two attempts with ``[10, 20]`` → report's aggregate is
+        ``30`` (integer sum)."""
+        from clauditor._providers import ModelResult
+
+        spec = _make_spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=10,
+        )
+        good_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.85,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": True,
+                "score": 0.8,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+        ]
+        good = ModelResult(
+            response_text=json.dumps(good_data),
+            text_blocks=[json.dumps(good_data)],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=20,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await grade_quality("output", spec)
+        assert report.reasoning_tokens == 30
+
+
+class TestBlindReportReasoningTokens:
+    """#170 US-004: BlindReport carries a nullable
+    ``reasoning_tokens`` field. Per DEC-005 the schema_version
+    stays at ``1`` (always-v1 pattern; the additive nullable field
+    is forward-compat-safe; there is no ``from_json`` reader to
+    break). Sum semantics per DEC-003."""
+
+    def _report(self, **overrides) -> BlindReport:
+        defaults = dict(
+            preference="a",
+            confidence=0.8,
+            score_a=0.9,
+            score_b=0.6,
+            reasoning="A is better",
+            model="claude-sonnet-4-6",
+        )
+        defaults.update(overrides)
+        return BlindReport(**defaults)
+
+    def test_blind_report_reasoning_tokens_default_none(self):
+        report = self._report()
+        assert report.reasoning_tokens is None
+
+    def test_blind_report_to_json_emits_reasoning_tokens(self):
+        """``reasoning_tokens`` is emitted in to_json; schema_version
+        stays at ``1`` per DEC-005 (always-v1 pattern)."""
+        report = self._report(reasoning_tokens=35)
+        data = json.loads(report.to_json())
+        assert data["schema_version"] == 1
+        assert "reasoning_tokens" in data
+        assert data["reasoning_tokens"] == 35
+
+    def test_blind_report_to_json_emits_reasoning_tokens_none(self):
+        """The field is always emitted, even when ``None``."""
+        report = self._report()
+        data = json.loads(report.to_json())
+        assert data["reasoning_tokens"] is None
+
+    @pytest.mark.asyncio
+    async def test_blind_report_sums_reasoning_tokens_across_two_calls(
+        self,
+    ):
+        """Two parallel judge calls with ``reasoning_tokens=15``
+        and ``20`` → ``BlindReport.reasoning_tokens == 35`` (sum
+        of non-None across the two parallel calls per DEC-003)."""
+        from clauditor._providers import ModelResult
+
+        verdict = json.dumps(
+            {
+                "preference": "1",
+                "confidence": 0.8,
+                "score_1": 0.8,
+                "score_2": 0.4,
+                "reasoning": "r",
+            }
+        )
+        side1 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=15,
+        )
+        side2 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=20,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[side1, side2]),
+        ):
+            report = await blind_compare("query", "out_a", "out_b")
+        assert report.reasoning_tokens == 35
+
+    @pytest.mark.asyncio
+    async def test_blind_report_reasoning_tokens_all_none(self):
+        """Both calls report ``reasoning_tokens=None`` → aggregate
+        is ``None`` (preserves "no provider call surfaced a
+        count")."""
+        from clauditor._providers import ModelResult
+
+        verdict = json.dumps(
+            {
+                "preference": "1",
+                "confidence": 0.8,
+                "score_1": 0.8,
+                "score_2": 0.4,
+                "reasoning": "r",
+            }
+        )
+        side1 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        side2 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[side1, side2]),
+        ):
+            report = await blind_compare("query", "out_a", "out_b")
+        assert report.reasoning_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_blind_report_reasoning_tokens_mixed(self):
+        """One side ``None``, other side ``42`` → aggregate is
+        ``42`` (sum of non-None, NOT 0, NOT None)."""
+        from clauditor._providers import ModelResult
+
+        verdict = json.dumps(
+            {
+                "preference": "1",
+                "confidence": 0.8,
+                "score_1": 0.8,
+                "score_2": 0.4,
+                "reasoning": "r",
+            }
+        )
+        side1 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        side2 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=42,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[side1, side2]),
+        ):
+            report = await blind_compare("query", "out_a", "out_b")
+        assert report.reasoning_tokens == 42
+
+
+class TestSumOptionalReasoningTokens:
+    """#170 US-004 / DEC-003: pure helper for sum-of-non-None
+    semantics. Direct unit tests since the helper is consumed by
+    multiple sum sites and worth exercising in isolation."""
+
+    def test_all_none_returns_none(self):
+        from clauditor.quality_grader import _sum_optional_reasoning_tokens
+
+        assert _sum_optional_reasoning_tokens([None, None]) is None
+
+    def test_empty_list_returns_none(self):
+        from clauditor.quality_grader import _sum_optional_reasoning_tokens
+
+        assert _sum_optional_reasoning_tokens([]) is None
+
+    def test_mixed_returns_sum_of_non_none(self):
+        from clauditor.quality_grader import _sum_optional_reasoning_tokens
+
+        assert _sum_optional_reasoning_tokens([None, 42]) == 42
+        assert _sum_optional_reasoning_tokens([42, None]) == 42
+        assert _sum_optional_reasoning_tokens([None, 10, None, 20]) == 30
+
+    def test_all_int_sums(self):
+        from clauditor.quality_grader import _sum_optional_reasoning_tokens
+
+        assert _sum_optional_reasoning_tokens([10, 20]) == 30
+        assert _sum_optional_reasoning_tokens([0, 0]) == 0
+        assert _sum_optional_reasoning_tokens([100]) == 100
+
+    def test_zero_present_returns_zero_not_none(self):
+        """``[None, 0]`` returns ``0`` (the present value), NOT
+        ``None`` — distinguishes "provider surfaced a count of
+        zero" from "no provider call surfaced a count"."""
+        from clauditor.quality_grader import _sum_optional_reasoning_tokens
+
+        assert _sum_optional_reasoning_tokens([None, 0]) == 0
 

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -3754,6 +3754,45 @@ class TestGradingReportReasoningTokens:
                 f"v{version} default reasoning_tokens should be None"
             )
 
+    def test_grading_report_from_json_rejects_bool_reasoning_tokens(self):
+        """Quality Gate Pass 1 fix (#170 US-007): a malformed sidecar
+        with ``"reasoning_tokens": true`` MUST default to ``None``,
+        NOT silently coerce to ``1``. Symmetric with the writer-side
+        ``_extract_reasoning_tokens`` bool guard per DEC-006 and
+        ``.claude/rules/constant-with-type-info.md`` (Python's
+        ``isinstance(True, int)`` is ``True``)."""
+        for bad_value in (True, False):
+            payload = json.dumps({
+                "schema_version": 5,
+                "skill_name": "hostile",
+                "model": "claude-sonnet-4-6",
+                "results": [],
+                "reasoning_tokens": bad_value,
+            })
+            restored = GradingReport.from_json(payload)
+            assert restored.reasoning_tokens is None, (
+                f"bool {bad_value} must default to None, not coerce to int"
+            )
+
+    def test_grading_report_from_json_rejects_non_int_reasoning_tokens(
+        self,
+    ):
+        """Quality Gate Pass 1 fix: non-int ``reasoning_tokens``
+        (string, float, list, dict) MUST default to ``None`` rather
+        than raise or coerce."""
+        for bad_value in ("99", 3.14, [42], {"x": 1}):
+            payload = json.dumps({
+                "schema_version": 5,
+                "skill_name": "hostile",
+                "model": "claude-sonnet-4-6",
+                "results": [],
+                "reasoning_tokens": bad_value,
+            })
+            restored = GradingReport.from_json(payload)
+            assert restored.reasoning_tokens is None, (
+                f"non-int {bad_value!r} must default to None"
+            )
+
 
 class TestGradeQualityReasoningTokensSum:
     """#170 US-004: ``grade_quality`` accumulates per-attempt

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -3707,6 +3707,21 @@ class TestGradingReportReasoningTokens:
         restored = GradingReport.from_json(original.to_json())
         assert restored.reasoning_tokens == 42
 
+    def test_grading_report_reasoning_tokens_round_trips_zero(self):
+        """#170 DEC-002: ``reasoning_tokens=0`` is a real value (the
+        model didn't reason on this call) and MUST round-trip
+        through ``to_json``/``from_json`` as ``0``, NOT collapse to
+        ``None`` via a truthiness coercion. The on-disk JSON value
+        is the integer ``0``, not the JSON ``null`` literal."""
+        original = self._report(reasoning_tokens=0)
+        raw = original.to_json()
+        data = json.loads(raw)
+        assert data["reasoning_tokens"] == 0
+        assert data["reasoning_tokens"] is not None
+        restored = GradingReport.from_json(raw)
+        assert restored.reasoning_tokens == 0
+        assert restored.reasoning_tokens is not None
+
     def test_grading_report_reasoning_tokens_round_trips_none(self):
         original = self._report()
         restored = GradingReport.from_json(original.to_json())
@@ -3972,6 +3987,65 @@ class TestGradeQualityReasoningTokensSum:
             report = await grade_quality("output", spec)
         assert report.reasoning_tokens == 30
 
+    @pytest.mark.asyncio
+    async def test_grade_quality_reasoning_tokens_zero_and_none(self):
+        """#170 DEC-002 + DEC-003: aggregation must treat ``0`` as a
+        real measurement, NOT as a falsy "skip me." With one
+        attempt at ``0`` and one at ``None``, the aggregate is
+        ``0`` (sum of non-None values is ``0``) — distinct from
+        the all-None → ``None`` case."""
+        from clauditor._providers import ModelResult
+
+        spec = _make_spec()
+        bad = ModelResult(
+            response_text="not-json",
+            text_blocks=["not-json"],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=0,
+        )
+        good_data = [
+            {
+                "criterion": "Output contains actionable recommendations",
+                "passed": True,
+                "score": 0.9,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "Tone is professional and clear",
+                "passed": True,
+                "score": 0.85,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+            {
+                "criterion": "All requested topics are covered",
+                "passed": True,
+                "score": 0.8,
+                "evidence": "ev",
+                "reasoning": "r",
+            },
+        ]
+        good = ModelResult(
+            response_text=json.dumps(good_data),
+            text_blocks=[json.dumps(good_data)],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[bad, good]),
+        ):
+            report = await grade_quality("output", spec)
+        assert report.reasoning_tokens == 0
+        assert report.reasoning_tokens is not None
+
 
 class TestBlindReportReasoningTokens:
     """#170 US-004: BlindReport carries a nullable
@@ -4010,6 +4084,16 @@ class TestBlindReportReasoningTokens:
         report = self._report()
         data = json.loads(report.to_json())
         assert data["reasoning_tokens"] is None
+
+    def test_blind_report_to_json_emits_reasoning_tokens_zero(self):
+        """#170 DEC-002: ``reasoning_tokens=0`` survives through
+        ``to_json`` as the integer ``0``, distinct from
+        ``null``. Locks down the truthiness-coercion failure mode
+        on the ``BlindReport`` writer too."""
+        report = self._report(reasoning_tokens=0)
+        data = json.loads(report.to_json())
+        assert data["reasoning_tokens"] == 0
+        assert data["reasoning_tokens"] is not None
 
     @pytest.mark.asyncio
     async def test_blind_report_sums_reasoning_tokens_across_two_calls(
@@ -4134,6 +4218,49 @@ class TestBlindReportReasoningTokens:
         ):
             report = await blind_compare("query", "out_a", "out_b")
         assert report.reasoning_tokens == 42
+
+    @pytest.mark.asyncio
+    async def test_blind_report_reasoning_tokens_zero_and_none(self):
+        """#170 DEC-002 + DEC-003: with one parallel side at ``0``
+        and the other at ``None``, the aggregate is ``0`` (sum of
+        non-None values is ``0``) — ``0`` MUST NOT collapse to
+        ``None`` via a truthiness coercion at the wiring seam."""
+        from clauditor._providers import ModelResult
+
+        verdict = json.dumps(
+            {
+                "preference": "1",
+                "confidence": 0.8,
+                "score_1": 0.8,
+                "score_2": 0.4,
+                "reasoning": "r",
+            }
+        )
+        side1 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="openai",
+            reasoning_tokens=0,
+        )
+        side2 = ModelResult(
+            response_text=verdict,
+            text_blocks=[verdict],
+            input_tokens=10,
+            output_tokens=5,
+            source="api",
+            provider="anthropic",
+            reasoning_tokens=None,
+        )
+        with patch(
+            "clauditor._providers.call_model",
+            AsyncMock(side_effect=[side1, side2]),
+        ):
+            report = await blind_compare("query", "out_a", "out_b")
+        assert report.reasoning_tokens == 0
+        assert report.reasoning_tokens is not None
 
 
 class TestSumOptionalReasoningTokens:


### PR DESCRIPTION
## Summary
Super plan for #170 — capture separately-billed reasoning tokens in `ModelResult` and thread to `IterationContext.reasoning_tokens` at sidecar-write time.

**Phase:** detailing (awaiting approval)
**Stories:** 6 implementation stories + Quality Gate + Patterns & Memory
**Decisions:** 8 captured (DEC-001 through DEC-008)
**Depends on:** #154 (CLOSED — `context.json` placeholder shipped)

## Key decisions

- **DEC-001** Anthropic always returns `None` (SDK has no separately-billed reasoning-token field; `output_tokens` already includes thinking).
- **DEC-002** OpenAI: `0` is a real value ("model didn't reason"); `None` only on SDK malformation.
- **DEC-003** Sum across all grader calls; all-None → None, mixed → sum-of-non-None.
- **DEC-004** Persist on `GradingReport`/`ExtractionReport`; bump `grading.json` and `extraction.json` v4→v5.
- **DEC-005** `BlindReport.to_json()` adds field at v1 (always-v1 pattern; no `from_json` reader).
- **DEC-008** `IterationContext.reasoning_tokens` sources from `primary_report.reasoning_tokens` at write time.

## Plan document
See `plans/super/170-reasoning-tokens-capture.md` for the full plan with all 8 decisions, architecture review, and 8-story breakdown.

## Next steps
- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning tokens from AI providers are now captured and tracked separately in reports and context sidecars.
  * Anthropic integration reports no separate reasoning token counts; OpenAI extracts them from API responses.
  * Grading and extraction report schemas updated to version 5 to support nullable reasoning token fields.

* **Documentation**
  * Added comprehensive planning documentation for reasoning token capture workflow.
  * Updated architectural rules for schema versioning, defensive extraction patterns, and aggregation semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/174)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->