### PR TITLE
#176: layout-aware skill_name default in EvalSpec.from_file

### DIFF
--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -107,7 +107,14 @@ def _filesystem_eval_skill_name(eval_path: Path) -> str:
     prompts and slash-command resolution.
     """
     if eval_path.name in ("SKILL.eval.json", "eval.json"):
-        return eval_path.parent.name
+        parent_name = eval_path.parent.name
+        if parent_name:
+            return parent_name
+        # ``Path("eval.json").parent.name`` is ``""`` (parent is ``.``);
+        # same for root-level ``/eval.json``. An empty string would
+        # propagate into ``EvalSpec.from_file`` as the skill_name and
+        # break downstream prompt text / slash-command resolution.
+        # Fall through to the legacy/stem fallback below.
     # ``<name>.eval.json`` → strip the ``.eval`` suffix.
     # ``Path("foo.eval.json").suffixes == [".eval", ".json"]``.
     suffixes = eval_path.suffixes

--- a/src/clauditor/paths.py
+++ b/src/clauditor/paths.py
@@ -88,6 +88,35 @@ def _filesystem_name(skill_path: Path) -> str:
     return skill_path.stem
 
 
+def _filesystem_eval_skill_name(eval_path: Path) -> str:
+    """Return the layout-aware filesystem-derived skill name for an eval file.
+
+    Sibling of :func:`_filesystem_name`, applied to the eval-spec file.
+    Authority order (matches the JSON eval-file conventions clauditor
+    accepts on disk):
+
+    - Modern layouts (``<dir>/SKILL.eval.json`` or ``<dir>/eval.json``)
+      → ``eval_path.parent.name``.
+    - Legacy ``<name>.eval.json`` (``<name>`` != ``"SKILL"``) → strip
+      the ``.eval`` suffix and return ``<name>``.
+    - Otherwise (e.g. ``<name>.json``) → ``eval_path.stem``.
+
+    The fix codifies the convention surfaced in issue #176: the previous
+    naive ``eval_path.stem`` default produced ``"SKILL.eval"`` for the
+    canonical agentskills.io layout, which then propagated into grading
+    prompts and slash-command resolution.
+    """
+    if eval_path.name in ("SKILL.eval.json", "eval.json"):
+        return eval_path.parent.name
+    # ``<name>.eval.json`` → strip the ``.eval`` suffix.
+    # ``Path("foo.eval.json").suffixes == [".eval", ".json"]``.
+    suffixes = eval_path.suffixes
+    if len(suffixes) >= 2 and suffixes[-2:] == [".eval", ".json"]:
+        # Strip both suffixes; e.g. ``foo.eval.json`` → ``foo``.
+        return eval_path.name[: -len(".eval.json")]
+    return eval_path.stem
+
+
 def derive_skill_name(skill_path: Path, skill_md_text: str) -> str:
     """Return the resolved ``skill_name`` — pure, no I/O.
 

--- a/src/clauditor/schemas.py
+++ b/src/clauditor/schemas.py
@@ -362,12 +362,16 @@ class EvalSpec:
         path = Path(path)
         with path.open() as f:
             data = json.load(f)
-        # Preserve the prior behavior where a missing ``skill_name`` in the
-        # JSON defaults to the file stem. Injected via a new dict so the
-        # caller's data is not mutated (non-mutating rule applies to the
-        # input they own on disk, but defensive here too).
+        # Default ``skill_name`` when absent from the JSON. Layout-aware
+        # per ``_filesystem_eval_skill_name`` (#176): ``<dir>/SKILL.eval.json``
+        # and ``<dir>/eval.json`` resolve to the parent directory name;
+        # ``<name>.eval.json`` strips the ``.eval`` suffix; other shapes
+        # fall back to ``path.stem`` for back-compat. Injected via a new
+        # dict so the caller's data is not mutated.
         if isinstance(data, dict) and "skill_name" not in data:
-            data = {"skill_name": path.stem, **data}
+            from clauditor.paths import _filesystem_eval_skill_name
+
+            data = {"skill_name": _filesystem_eval_skill_name(path), **data}
         return cls.from_dict(data, spec_dir=path.parent.resolve())
 
     @classmethod

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -12,6 +12,7 @@ importlib.reload(_paths_mod)
 
 from clauditor.paths import (  # noqa: E402
     SKILL_NAME_RE,
+    _filesystem_eval_skill_name,
     derive_project_dir,
     derive_skill_name,
     resolve_agents_md,
@@ -128,6 +129,48 @@ class TestSkillNameRe:
     def test_rejects_known_bad_identifier(self):
         assert re.fullmatch(SKILL_NAME_RE, "bad;name") is None
         assert re.fullmatch(SKILL_NAME_RE, "") is None
+
+
+class TestFilesystemEvalSkillName:
+    """Unit tests for the pure ``_filesystem_eval_skill_name`` helper (#176)."""
+
+    def test_modern_layout_skill_eval_json_uses_parent_dir(self):
+        assert (
+            _filesystem_eval_skill_name(Path("/repo/find-restaurants/SKILL.eval.json"))
+            == "find-restaurants"
+        )
+
+    def test_modern_layout_eval_json_uses_parent_dir(self):
+        assert (
+            _filesystem_eval_skill_name(Path("/repo/find-restaurants/eval.json"))
+            == "find-restaurants"
+        )
+
+    def test_legacy_named_eval_json_strips_eval_suffix(self):
+        assert (
+            _filesystem_eval_skill_name(Path("/repo/my-skill.eval.json")) == "my-skill"
+        )
+
+    def test_plain_json_falls_back_to_stem(self):
+        assert _filesystem_eval_skill_name(Path("/repo/my-skill.json")) == "my-skill"
+
+    def test_relative_eval_json_with_no_parent_falls_back(self):
+        """``Path("eval.json").parent.name`` is ``""`` — must not return empty."""
+        result = _filesystem_eval_skill_name(Path("eval.json"))
+        assert result != ""
+        assert result == "eval"
+
+    def test_relative_skill_eval_json_with_no_parent_falls_back(self):
+        """``Path("SKILL.eval.json").parent.name`` is ``""`` — strip suffix instead."""
+        result = _filesystem_eval_skill_name(Path("SKILL.eval.json"))
+        assert result != ""
+        assert result == "SKILL"
+
+    def test_root_level_eval_json_falls_back(self):
+        """``Path("/eval.json").parent.name`` is ``""`` — must not return empty."""
+        result = _filesystem_eval_skill_name(Path("/eval.json"))
+        assert result != ""
+        assert result == "eval"
 
 
 class TestDeriveSkillName:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -459,7 +459,9 @@ class TestFromFile:
         assert spec.trigger_tests is None
         assert spec.variance is None
 
-    def test_from_file_empty_dict_defaults_skill_name_strips_eval_suffix(self, tmp_path):
+    def test_from_file_empty_dict_defaults_skill_name_strips_eval_suffix(
+        self, tmp_path
+    ):
         """``<name>.eval.json`` default strips the ``.eval`` suffix (#176)."""
         path = _write_json(tmp_path, {}, name="my-skill.eval.json")
         spec = EvalSpec.from_file(path)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -459,12 +459,39 @@ class TestFromFile:
         assert spec.trigger_tests is None
         assert spec.variance is None
 
-    def test_from_file_empty_dict_defaults_skill_name_to_stem(self, tmp_path):
-        """When skill_name is missing, defaults to the file stem."""
+    def test_from_file_empty_dict_defaults_skill_name_strips_eval_suffix(self, tmp_path):
+        """``<name>.eval.json`` default strips the ``.eval`` suffix (#176)."""
         path = _write_json(tmp_path, {}, name="my-skill.eval.json")
         spec = EvalSpec.from_file(path)
 
-        assert spec.skill_name == "my-skill.eval"
+        assert spec.skill_name == "my-skill"
+
+    def test_from_file_modern_layout_skill_eval_json_uses_parent_dir(self, tmp_path):
+        """``<dir>/SKILL.eval.json`` default resolves to parent dir name (#176)."""
+        skill_dir = tmp_path / "find-restaurants"
+        skill_dir.mkdir()
+        path = skill_dir / "SKILL.eval.json"
+        path.write_text("{}")
+        spec = EvalSpec.from_file(path)
+
+        assert spec.skill_name == "find-restaurants"
+
+    def test_from_file_modern_layout_eval_json_uses_parent_dir(self, tmp_path):
+        """``<dir>/eval.json`` default resolves to parent dir name (#176)."""
+        skill_dir = tmp_path / "find-restaurants"
+        skill_dir.mkdir()
+        path = skill_dir / "eval.json"
+        path.write_text("{}")
+        spec = EvalSpec.from_file(path)
+
+        assert spec.skill_name == "find-restaurants"
+
+    def test_from_file_plain_json_falls_back_to_stem(self, tmp_path):
+        """``<name>.json`` (no ``.eval`` suffix) keeps the stem (back-compat)."""
+        path = _write_json(tmp_path, {}, name="my-skill.json")
+        spec = EvalSpec.from_file(path)
+
+        assert spec.skill_name == "my-skill"
 
     def test_from_file_missing(self, tmp_path):
         """Raises FileNotFoundError for a nonexistent file."""


### PR DESCRIPTION
## Summary

- Add `paths._filesystem_eval_skill_name` mirroring `_filesystem_name` for SKILL.md
- Route `EvalSpec.from_file`'s missing-`skill_name` default through it
- 4 new tests covering the three layout cases + back-compat

Closes #176.

## Why

Modern agentskills.io layout is `<skill-dir>/SKILL.eval.json`. The naive `path.stem` default produced `skill_name == "SKILL.eval"`, which propagated into:
- Grading prompts: `evaluating ... skill called "SKILL.eval"`
- Slash-command resolution: `claude -p` got `/SKILL.eval` and failed.

Surfaced during real-world validation of #143 against `find-restaurants` skill in `../my_claude_agent/.claude/skills/`. Pre-fix dry-run:

\`\`\`
Prompt:
You are evaluating the quality of output from a Claude Code skill called "SKILL.eval".
\`\`\`

Post-fix:

\`\`\`
Prompt:
You are evaluating the quality of output from a Claude Code skill called "find-restaurants".
\`\`\`

## Test plan

- [x] `pytest tests/test_schemas.py::TestFromFile -x` — 21 pass (4 new tests + existing untouched)
- [x] Dry-run against real-world skill: `uv run clauditor grade ../my_claude_agent/.claude/skills/find-restaurants/SKILL.md --dry-run` now resolves to `find-restaurants`
- [ ] Reviewer: confirm strip-`.eval`-suffix heuristic doesn't regress legacy `<name>.eval.json` cases

## Authority order

1. JSON `skill_name` field (existing, unchanged)
2. `<dir>/SKILL.eval.json` → parent dir name
3. `<dir>/eval.json` → parent dir name
4. `<name>.eval.json` → `<name>` (strip `.eval`)
5. `<name>.json` → `path.stem` (back-compat)

Mirrors the equivalent `paths._filesystem_name` shape for SKILL.md (modern vs legacy distinction by literal filename).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill name derivation to properly strip file extensions and recognize multiple file layout conventions when determining skill names from evaluation specifications.
  * Skill names now correctly derive from parent directory names when using standard file layouts instead of including unwanted suffixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->