### PR TITLE
175: Codex ChatGPT-login auth (plan)

### DIFF
--- a/.claude/rules/centralized-sdk-call.md
+++ b/.claude/rules/centralized-sdk-call.md
@@ -451,14 +451,14 @@ in the `clauditor._providers` package. Each member pairs a
 module-level flag with an announcement-text constant; the
 print-and-flip logic either lives inline at the call site (the first
 member, from #86) or is factored into a public helper (the later
-members, from #95, #144, #151, and #169 respectively, and the target
-shape going forward). The traditional flag shape is a module-level
-`bool`, but the family also admits **set-keyed** flags
+members, from #95, #144, #151, #169, and #175 respectively, and the
+target shape going forward). The traditional flag shape is a module-
+level `bool`, but the family also admits **set-keyed** flags
 (`set[tuple[...]]`) for announcements that need per-key
 idempotence — see the `_announced_unknown_models` member below
-for the canonical shape. Five members today (axes:
+for the canonical shape. Seven members today (axes:
 transport-coupled, auth-coupled, deprecation-coupled, harness-
-coupled, pricing-coupled):
+coupled, pricing-coupled, codex-auth-coupled):
 
 - `_announced_cli_transport` (bool flag) + `_CLI_AUTO_ANNOUNCEMENT`
   (plain `str` constant) in `src/clauditor/_providers/_anthropic.py`
@@ -538,6 +538,35 @@ coupled, pricing-coupled):
   time so the maintainer can grep stderr for the missing model
   name. Reset mechanism for tests is
   `monkeypatch.setattr(..., set())` (an empty set, not `False`).
+- `_announced_codex_cli_on_path` (bool flag) +
+  `_CODEX_CLI_ON_PATH_ANNOUNCEMENT` (`Final[str]` constant) in
+  `src/clauditor/_providers/_auth.py` — from #175 US-001
+  (DEC-003 of `plans/super/175-codex-chatgpt-login-auth.md`).
+  Fires when `check_codex_auth` accepts the pre-flight via the
+  **codex-CLI-on-PATH** branch (i.e. neither `CODEX_API_KEY` nor
+  `OPENAI_API_KEY` is set, but `codex` is on PATH — typically the
+  `~/.codex/auth.json` ChatGPT-login posture). Per DEC-009 the
+  env branches (`_codex_api_key_is_set` /
+  `_openai_api_key_is_set`) short-circuit silently and do NOT
+  fire the announcement — surfacing the *implicit trust the CLI*
+  decision to the operator, not re-announcing what the operator
+  set explicitly via env. Print-and-flip lives in the **public
+  helper** `announce_codex_cli_on_path()`, called from
+  `check_codex_auth` only when the PATH branch is the accepting
+  one. Three durable substrings pinned by tests (DEC-004):
+  `"codex"` (topic anchor), `"PATH"` (the trust mechanism),
+  `"~/.codex/auth.json"` (the canonical credential file the
+  Codex CLI reads under ChatGPT-login). Re-export shape per
+  `.claude/rules/back-compat-shim-discipline.md` Pattern 1:
+  the public helper `announce_codex_cli_on_path` IS re-exported
+  from `_providers/__init__.py` (function object — safe), the
+  constant `_CODEX_CLI_ON_PATH_ANNOUNCEMENT` IS re-exported
+  (immutable `Final[str]` — safe), but the mutable flag
+  `_announced_codex_cli_on_path` is **NOT** re-exported (would
+  frozen-copy and silently diverge from the canonical location).
+  Reset mechanism for tests is
+  `monkeypatch.setattr("clauditor._providers._auth._announced_codex_cli_on_path", False)`
+  — targeting the canonical module path, not the shim.
 
 Per #145 the OpenAI backend deliberately did **not** introduce a
 fourth announcement family. OpenAI's auth posture is strict
@@ -571,6 +600,7 @@ auth-helper call chain). Reset mechanism for tests is the
 `tests/test_providers_anthropic.py::TestStderrAnnouncement`,
 `tests/test_providers_auth.py::TestAnnounceImplicitNoApiKey`,
 `tests/test_providers_auth.py::TestCallAnthropicDeprecationAnnouncement`,
+`tests/test_providers_auth.py::TestAnnounceCodexCliOnPath`,
 and
 `tests/test_providers_pricing.py::TestStaleAnnouncement`
 / `tests/test_providers_pricing.py::TestUnknownModelAnnouncement`

--- a/plans/super/175-codex-chatgpt-login-auth.md
+++ b/plans/super/175-codex-chatgpt-login-auth.md
@@ -5,8 +5,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/175
 - **Branch:** `feature/175-codex-chatgpt-login-auth`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth`
-- **PR:** (pending)
-- **Phase:** detailing
+- **PR:** https://github.com/wjduenow/clauditor/pull/179
+- **Phase:** devolved
+- **Epic:** clauditor-lacb
 - **Sessions:** 1 (2026-05-11)
 - **Total decisions:** 10 (DEC-001 through DEC-010)
 - **Depends on:** #95 (CLOSED — Anthropic relaxed-guard precedent), #149 (CLOSED — Codex harness), #151 (CLOSED — harness precedence + `check_codex_auth` dispatch)
@@ -378,7 +379,22 @@ Same as DEC-009's resolution order. Beyond the announcement-suppression rational
 
 ## Beads Manifest
 
-_Pending devolve phase. Will be filled in after the user approves the plan and says "devolve" or "ready for Ralph"._
+- **Epic:** `clauditor-lacb` — 175: Codex ChatGPT-login auth
+- **US-001:** `clauditor-v3b5` — Pure helper `_codex_cli_is_available` + 4th announcement-family member. **READY** (no blockers).
+- **US-002:** `clauditor-0oe4` — Extend `check_codex_auth` acceptance set + update error template. Blocked by US-001.
+- **US-003:** `clauditor-xf8p` — CLI end-to-end test for cached source-label production wiring. Blocked by US-002.
+- **US-004 (Quality Gate):** `clauditor-fuyz` — Code-reviewer × 4 + CodeRabbit + project validation. Blocked by US-001, US-002, US-003.
+- **US-005 (Patterns & Memory):** `clauditor-11zj` — Update rules for the new announcement family member. Blocked by US-004.
+
+**Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth`
+**Branch:** `feature/175-codex-chatgpt-login-auth`
+**Plan PR:** https://github.com/wjduenow/clauditor/pull/179
+
+### Execution
+
+1. Run Ralph: `/ralph-run`.
+2. Monitor: `bd list --status=in_progress`.
+3. After completion: `/closeout`.
 
 ---
 

--- a/plans/super/175-codex-chatgpt-login-auth.md
+++ b/plans/super/175-codex-chatgpt-login-auth.md
@@ -1,0 +1,409 @@
+# 175: Codex ChatGPT-login auth — recognize `auth_mode=chatgpt` in `check_codex_auth`
+
+## Meta
+
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/175
+- **Branch:** `feature/175-codex-chatgpt-login-auth`
+- **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth`
+- **PR:** (pending)
+- **Phase:** detailing
+- **Sessions:** 1 (2026-05-11)
+- **Total decisions:** 10 (DEC-001 through DEC-010)
+- **Depends on:** #95 (CLOSED — Anthropic relaxed-guard precedent), #149 (CLOSED — Codex harness), #151 (CLOSED — harness precedence + `check_codex_auth` dispatch)
+- **Sibling concept:** #83 (CLOSED — Anthropic subscription-auth gap, the conceptual analog this ticket fixes for Codex)
+
+---
+
+## Discovery
+
+### Ticket summary
+
+**What:** `check_codex_auth` in `src/clauditor/_providers/_auth.py:483-532` is a strict-OR over only two env vars (`CODEX_API_KEY`, `OPENAI_API_KEY`). The Codex CLI itself supports a third auth path — **ChatGPT login** — where credentials live in `~/.codex/auth.json` as `{"auth_mode": "chatgpt", "OPENAI_API_KEY": null, "tokens": {...}}` and no env var is set. A user authenticated this way can run `codex exec` directly, but every clauditor command that resolves `harness=codex` raises `CodexAuthMissingError` and exits 2 at the pre-flight before any subprocess work.
+
+**Confirmed live:** `/home/wesd/.codex/auth.json` on this machine has `auth_mode="chatgpt"`, `OPENAI_API_KEY: null`, populated `tokens`. The bug reproduces exactly as the ticket describes.
+
+**Why it matters:** This is the *first* user-visible friction in real-world cross-harness validation (`#143`). Codex users who logged in via `codex login` against ChatGPT Plus/Pro/Enterprise (the GUI-friendly default flow) get an opaque exit-2 from clauditor while `codex exec` works fine in the same shell. Symmetric UX hit to what `#83` documented for Anthropic before `#95` fixed it.
+
+### Codebase findings
+
+**Current pre-flight (`src/clauditor/_providers/_auth.py`):**
+- `check_codex_auth(cmd_name)` at lines 483-532 — strict-OR over `_codex_api_key_is_set()` and `_openai_api_key_is_set()` only.
+- Anthropic analog `check_any_auth_available(cmd_name)` at lines 214-252 — accepts `_api_key_is_set()` OR `_claude_cli_is_available()`. Per DEC-008 of #86, the CLI branch is pure PATH-presence; auth validation is deferred to the subprocess.
+- `_claude_cli_is_available()` at lines 200-211 — single-line `shutil.which("claude") is not None`. Pure helper; deliberately does NOT verify the CLI is functional or authenticated.
+- `_CODEX_AUTH_MISSING_TEMPLATE` at lines 459-466 — names `CODEX_API_KEY`, `OPENAI_API_KEY`, `platform.openai.com`. Three durable substrings pinned by tests.
+
+**Exception class:** `CodexAuthMissingError` is defined at `src/clauditor/_providers/__init__.py:112-143` as a **direct subclass of `Exception`** (NOT a subclass of `AnthropicAuthMissingError` / `OpenAIAuthMissingError`). Sibling-not-subclass shape preserves structural exit-code routing per `.claude/rules/llm-cli-exit-code-taxonomy.md` and `.claude/rules/multi-provider-dispatch.md`. Caught in four CLI commands, all routing to exit 2:
+- `cli/validate.py:191`, `cli/capture.py:159`, `cli/grade.py:421`, `cli/run.py:98`.
+
+**Critical existing precedent in CodexHarness (`src/clauditor/_harnesses/_codex.py:1334-1372`):**
+`CodexHarness._detect_auth_source()` already implements the file-detection logic for **observability/logging only** (not auth validation). Detects `cached` source via `Path("$CODEX_HOME/auth.json").exists()` (default `~/.codex/auth.json`). Returns `{"CODEX_API_KEY", "OPENAI_API_KEY", "cached", "unknown"}`. Per DEC-017 of `#149`, the `"cached"` source-name was forward-declared but **never fires today** because `check_codex_auth` blocks before the harness invokes — `#175` is what makes the `"cached"` value finally reachable.
+
+**`CodexHarness.invoke` env handling:** `strip_auth_keys` (lines 551-573) strips `CODEX_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL` only. `HOME` and `CODEX_HOME` are preserved — the cached-auth file IS accessible at subprocess time. So the only blocker is the pre-flight guard's acceptance set.
+
+**Announcement family in `_auth.py`:** Three members today, all auth-coupled, all in the rule's canonical implementation list:
+- `_announced_implicit_no_api_key` + `announce_implicit_no_api_key()` (#95 US-002).
+- `_announced_call_anthropic_deprecation` + `announce_call_anthropic_deprecation()` (#144 US-007).
+- `_announced_auto_codex_harness` + `announce_auto_codex_harness()` (#151 US-002 / DEC-007).
+
+A new ChatGPT-login announcement would be the fourth family member, same shape: module-level `bool` flag + `Final[str]` constant + public helper. Likely needed to surface "Accepted Codex ChatGPT-login auth from `~/.codex/auth.json`" once per process.
+
+**Tests:** `tests/test_providers_auth.py::TestCheckCodexAuth` (lines 897-996) covers the existing strict-OR. `TestAnnounceAutoCodexHarness` covers the existing announcement shape. `tests/test_codex_harness.py` already exercises `_detect_auth_source` including CODEX_HOME-based and default `~/.codex` paths.
+
+**No existing `auth_mode` / `chatgpt` references in clauditor code.** The detection-by-file-existence in `CodexHarness._detect_auth_source` is the only existing file-touch, and it doesn't open/parse the JSON.
+
+### `~/.codex/auth.json` schema (verified against `openai/codex` source + live file)
+
+Canonical schema from `codex-rs/login/src/auth/storage.rs::AuthDotJson`:
+
+```
+{
+  "auth_mode":      "chatgpt" | "apikey" | "chatgptAuthTokens" | "agentIdentity" | null,
+  "OPENAI_API_KEY": str | null,
+  "tokens": {                            // populated for chatgpt mode
+    "id_token":      str (JWT),
+    "access_token":  str (JWT),
+    "refresh_token": str (opaque),
+    "account_id":    str | null
+  } | null,
+  "last_refresh":   ISO-8601 datetime str | null,
+  "agent_identity": str (JWT) | null    // separate identity flow
+}
+```
+
+- **File location:** `$CODEX_HOME/auth.json`, default `~/.codex/auth.json`. The `CODEX_HOME` env var override is authoritative — any clauditor code reading the file must consult `os.environ.get("CODEX_HOME", ...)`.
+- **Permissions:** Written `0o600`. Same-user readable; safe to `Path.exists()` and parse.
+- **Storage backend can be keyring instead of file** — controlled by `AuthCredentialsStoreMode` config. In keyring mode the file may be absent even when logged in. Pure file-parse strategy false-negatives this case.
+- **`auth_mode` enum values:** Load-bearing for us are `"chatgpt"` and `"apikey"`. `"chatgptAuthTokens"` is OpenAI-internal/unstable. `"agentIdentity"` is a separate flow.
+- **Ephemeral token state:** `tokens.access_token` is a JWT expiring ~1h after `iat`; `refresh_token` rotates server-side. Codex itself handles refresh transparently and produces crisp error messages on revoked/expired refresh tokens (the four `RefreshTokenFailedReason` variants — "Please log out and sign in again"). So **file presence + valid `auth_mode` is a strong signal even without token freshness checking** — codex catches the stale case downstream with a clear message.
+- **Security:** Contents include refresh / access / id tokens and (in apikey mode) the raw API key. Reading the file to inspect `auth_mode` is safe; **never log or surface `tokens.*` or `OPENAI_API_KEY` content** in stderr / sidecars / `harness_metadata`.
+
+### Conventions / rules consulted
+
+**Hard-applies — drive design:**
+
+1. **`precall-env-validation.md`** — auth-missing exception class is a **direct subclass of `Exception`** (sibling, not subclass of other auth-missing classes). Routes to **exit 2** via the CLI's `except` ladder. Pure helper: no stderr, no `sys.exit`. CLI wrapper owns I/O. Open design question: do we keep using `CodexAuthMissingError` (extend acceptance set) or introduce a new sibling class? Strong precedent: `check_any_auth_available` extended its acceptance set without introducing a new class. Likely outcome: stay with `CodexAuthMissingError`, just expand the acceptance set + update the error template.
+
+2. **`multi-provider-dispatch.md`** — Codex is a **harness axis**, NOT a provider. `check_provider_auth` does NOT route Codex (DEC-010 of `#151`). The CLI seam directly calls `check_codex_auth` when `harness == "codex"`. **#175 does NOT touch `check_provider_auth`'s dispatcher.**
+
+3. **`centralized-sdk-call.md` — implicit-coupling announcement family.** If we want to surface "ChatGPT-login auth accepted" to surprised users (parallel to `announce_auto_codex_harness`), a fourth announcement-family member is the canonical shape: module-level `_announced_*: bool` flag + `Final[str]` constant + public helper. Reset mechanism = `monkeypatch.setattr(..., False)`. Anchor: `_providers/_auth.py`.
+
+4. **`spec-cli-precedence.md`** — `harness` resolution (CLI > env > spec > auto-PATH) already in place from `#151`. `#175` does NOT touch resolution; it only widens the auth-acceptance set inside `check_codex_auth`.
+
+**Apply — shape implementation:**
+
+5. **`pure-compute-vs-io-split.md`** — new helpers must be pure: read file / probe PATH, return bool/string, never print stderr. Caller owns I/O. The announcement helper is the sole exception (and matches the family's documented "implicit-coupling announcement" exception).
+
+6. **`stream-json-schema.md` — defensive-read posture.** If parsing `auth.json`, every field tolerated-if-missing, every malformed branch degrades to "no signal" rather than raise. Use `.get("auth_mode") != "chatgpt"` style; never crash on malformed JSON; treat the whole file as untrusted third-party shape.
+
+7. **`permissive-parser-strict-validator.md`** — if file-parse goes ahead, split into permissive parser (`_parse_codex_auth_json(path) -> dict | None`) + strict validator (`_is_chatgpt_login_acceptable(parsed) -> bool`). Both pure. The parser never raises; the validator returns bool, not raises.
+
+8. **`non-mutating-scrub.md`** — if we ever serialize parsed `auth.json` (e.g. for diagnostics / harness_metadata), scrub `tokens.*` and `OPENAI_API_KEY` content to redacted placeholders. Returns new dict, never mutates. **Better: don't serialize at all.** The `auth_mode` string is the only field we need.
+
+9. **`path-validation.md`** — reading `~/.codex/auth.json`. The rule's "When this rule does NOT apply" section covers HOME-owned files, but we still follow `resolve(strict=False)` + `is_file()` discipline before opening to avoid surprises with symlinks or stale paths. Honoring `CODEX_HOME` widens the input surface — apply the rule's recipe to the resolved path.
+
+10. **`test-infra-shutil-which-coupling.md`** — if we add a `_codex_cli_is_available()` branch via `shutil.which("codex")`, audit `tests/conftest.py` for autouse `shutil.which` pins. The existing `_force_api_transport_in_tests` autouse patches `shutil.which → None` (#86). The `#151` harness work added a parallel `CLAUDITOR_HARNESS=claude-code` env-pin at a higher precedence layer to short-circuit harness PATH lookups. We will likely need an analogous pin to short-circuit the new auth-PATH lookup (or a deliberate decision that the autouse `which → None` correctly forces the env-var branch in tests).
+
+11. **`llm-cli-exit-code-taxonomy.md`** — auth-missing routes to exit 2. No change from current behavior.
+
+12. **`back-compat-shim-discipline.md` Patterns 1 + 3** — if a new flag/helper lands, mutable flag NOT re-exported from any shim; test patches target canonical location; deferred imports if needed.
+
+**Mention briefly:**
+
+13. **`constant-with-type-info.md`** — only if we maintain a typed `auth.json` schema in clauditor (probably overkill — defensive `.get()` is enough).
+
+14. **`pre-llm-contract-hard-validate.md`** — N/A; no LLM output involved.
+
+15. **`monotonic-time-indirection.md`** — N/A; no duration tracking.
+
+**No `workflow-project.md` found anywhere in repo or `~/.claude/`.** No project-specific super-plan additions.
+
+### Proposed scope
+
+A small, well-precedented change. The shape of the fix is well-bounded by the precedents from `#95` (Anthropic relaxed guard) and `#149` (codex harness `_detect_auth_source` already does file-existence detection for the observability axis). Three implementation paths are open; the planner must choose one before stories can be written.
+
+**Implementation paths (mutually exclusive — pick one):**
+
+- **Path A — Parse `~/.codex/auth.json`:** Read file, accept if `auth_mode in {"chatgpt", "apikey"}` AND the relevant token/key field is non-empty. Honor `CODEX_HOME`. Crisp errors; tied to codex's serde schema. Misses keyring-backend users.
+- **Path B — Trust `codex` on PATH:** `shutil.which("codex") is not None` → accept. Pure mirror of `check_any_auth_available`'s Anthropic shape. Zero schema-drift risk. False-positive: `codex` installed but never logged in passes pre-flight, fails downstream with `codex`'s own (crisp) auth error.
+- **Path C — Hybrid:** PATH check AS WELL AS env-var, plus file-existence as a tie-breaker for the error message detail. Both signals fail-open into the same accept-or-reject decision; the announcement names which signal won.
+
+The Anthropic precedent (`#95`) chose pure-CLI-on-PATH (Path B). That's the strongest precedent for symmetry. Path A has a cost (binding to codex's serde shape) that doesn't pull its weight: codex itself produces crisp "log out and sign in again" messages downstream when a stale `auth.json` is present, so the pre-flight doesn't earn much by trying to validate the file ourselves.
+
+### Open questions (for refinement)
+
+1. **Which implementation path: A, B, or C?** (Recommended: B — mirrors `#95`; minimal new surface; honest about deferring to codex's own auth UX.)
+2. **One-shot announcement when the new branch fires?** Likely yes — surfaces the implicit decision to surprised users, parallel to the three existing auth-coupled announcements.
+3. **Stay with `CodexAuthMissingError`, or new sibling class?** Strong precedent says stay (just expand the acceptance set). Confirm.
+4. **Update the runner's `apiKeySource` stderr** so the forward-declared `"cached"` source value (DEC-017 of `#149`) finally fires when ChatGPT-login is the accepted path? Plausibly out-of-scope for `#175`, but adjacent enough to bundle.
+5. **Test-infra coupling:** if Path B/C, what's the autouse pin shape? Add `CODEX_API_KEY` env-pin in `conftest.py`, or rely on the existing `which → None` patch to force the env-var branch in tests?
+6. **Honor `CODEX_HOME` if Path A/C touches the file?** (Recommended: yes, mirror codex's own behavior.)
+
+---
+
+## Architecture Review
+
+| Area | Rating | Summary |
+|---|---|---|
+| Security | **pass** | PATH-attack surface is pre-existing and inherited from `_claude_cli_is_available` (`#95`). `_detect_auth_source` file probe is `os.path.isfile`-only, no shell, no path/token leak in stderr. Announcement text stays static `Final[str]` (no user-controlled interpolation). |
+| Observability | **pass with note** | Reviewer flagged the codex-side `InvokeResult.api_key_source` hardcoded `None` at `_codex.py:1179` as a structural asymmetry vs claude-code (`_claude_code.py:792`). On closer inspection this is intentional separation of channels: codex uses `harness_metadata["auth_source"]` (set in `_detect_auth_source`) and a dedicated stderr line `clauditor.runner: codex auth=<source>` at `_codex.py:719`. Both already wire `cached` correctly — proven by `tests/test_codex_harness.py:1208-1222`. The forward-declared `cached` value finally reaches production users once `#175` widens `check_codex_auth`. Typed-field symmetry on `InvokeResult.api_key_source` is out of scope (DEC-007). |
+| Testing strategy | **pass** | Conftest's autouse `_force_api_transport_in_tests` patches `shutil.which → None` globally; this is the right default (forces env-var branch in tests). The new PATH-branch tests follow the established local-override pattern from `tests/test_resolve_harness.py:24-44` — no conftest changes needed. New test surfaces: ~5 cases in `TestCheckCodexAuth`, 7-8 cases in new `TestAnnounceCodexCliOnPath`, one CLI end-to-end test for the `cached` source-label firing. |
+
+No project-specific review areas (no `workflow-project.md` found). Data-model, API-design, and migration reviews are N/A — this is a pure helper-internal acceptance-set widening with no on-disk schema changes.
+
+---
+
+## Refinement Log
+
+### DEC-001 — Path B: `shutil.which("codex")` extends the acceptance set
+
+Extend `check_codex_auth` to a three-branch strict-OR: `CODEX_API_KEY` set OR `OPENAI_API_KEY` set OR `shutil.which("codex") is not None`. Mirror of `check_any_auth_available`'s Anthropic shape from `#95` DEC-001 / DEC-009. No `auth.json` parse — trust the CLI binary on PATH; defer auth verification to codex itself, which produces crisp `"Please log out and sign in again"` errors downstream for stale tokens.
+
+### DEC-002 — Reuse `CodexAuthMissingError`; expand template
+
+Keep the existing exception class. Update `_CODEX_AUTH_MISSING_TEMPLATE` to mention the new acceptance path ("install the `codex` CLI" as a third option). Preserve the three existing durable substrings (`CODEX_API_KEY`, `OPENAI_API_KEY`, `platform.openai.com`) so pre-`#175` tests pinning them still pass. Mirrors `#95`'s decision to extend `_AUTH_MISSING_TEMPLATE` without introducing a new class.
+
+### DEC-003 — Add fourth announcement-family member
+
+Add a new auth-coupled member to the implicit-coupling announcement family documented in `.claude/rules/centralized-sdk-call.md`:
+- Module-level flag: `_announced_codex_cli_on_path: bool = False` in `_providers/_auth.py`.
+- Constant: `_CODEX_CLI_ON_PATH_ANNOUNCEMENT: Final[str]` — static text, no interpolation.
+- Public helper: `announce_codex_cli_on_path()` — print-and-flip; once-per-process.
+- Re-export the public helper from `_providers/__init__.py` (mirror existing pattern for `announce_auto_codex_harness`).
+
+Call site: inside `check_codex_auth`, fire ONLY when the PATH branch is the load-bearing acceptance signal (see DEC-009). Tests reset the flag via the standard `monkeypatch.setattr(..., False)` autouse pattern.
+
+### DEC-004 — Three durable substrings for the new announcement
+
+Pin in tests:
+1. `"codex"` — names the CLI binary involved.
+2. `"PATH"` — names the acceptance mechanism (so users grok why pre-flight passed when no env var is set).
+3. `"~/.codex/auth.json"` — names where codex itself looks for credentials; helps a user who has codex on PATH but never logged in figure out what to do next.
+
+Stylistic copy edits won't churn tests; verbatim assertions are forbidden. Same discipline as `_AUTO_CODEX_ANNOUNCEMENT`'s durable substring pinning.
+
+### DEC-005 — Verify-and-test cached source-label wiring (forward-declared in DEC-017 of `#149`)
+
+The wiring is already in place: `CodexHarness._detect_auth_source` at `_codex.py:1334-1372` correctly detects the cached file, populates `harness_metadata["auth_source"] = "cached"`, and `_codex.py:719` emits `clauditor.runner: codex auth=cached` to stderr. Proven unit-test-side by `tests/test_codex_harness.py::test_auth_source_cached_when_auth_json_exists` (line 1208-1222).
+
+**What `#175` adds:** one new CLI-end-to-end integration test that exercises the full chain (CLI seam → `check_codex_auth` passes via PATH → harness invoke → stderr emits `codex auth=cached`) so the previously-unreachable production code path is regression-pinned. This makes the DEC-017 surface finally fire in production.
+
+### DEC-006 — No conftest changes; tests of the new branch use local `shutil.which` override
+
+The existing autouse `_force_api_transport_in_tests` patches `shutil.which → None` globally (and pins `CLAUDITOR_HARNESS=claude-code` to short-circuit harness resolution). This is the correct test default: it forces the env-var branch in `check_codex_auth` for tests that don't care about the new PATH branch.
+
+Tests that exercise the new branch override locally:
+```python
+import clauditor._providers as _providers_mod
+monkeypatch.setattr(
+    _providers_mod.shutil, "which",
+    lambda name: "/usr/bin/codex" if name == "codex" else None,
+)
+```
+Proven pattern in `tests/test_resolve_harness.py:24-44`. No new autouse env-pin needed because the new branch is the *third* OR branch, not a precedence layer above PATH (per `.claude/rules/test-infra-shutil-which-coupling.md`'s "parallel pin at higher precedence" prescription, which applies when the new resolver consults the same default as the pre-existing one — here the new branch IS the PATH consumer, so the pin direction is reversed).
+
+### DEC-007 — Out of scope: typed-field symmetry on `InvokeResult.api_key_source`
+
+`CodexHarness.invoke` returns `InvokeResult(api_key_source=None, harness_metadata={"auth_source": "..."})` — the typed field is hardcoded `None`; the value lives in `harness_metadata`. Claude-code harness uses `InvokeResult.api_key_source` directly (`_claude_code.py:792`).
+
+This asymmetry is **intentional separation of channels**, not a bug:
+- `harness_metadata` is an extension point for harness-specific observability (`_codex.py` reasoning items, agent-identity flags, future codex-only fields).
+- `api_key_source` is a typed top-level field surfaced into `SkillResult` and downstream readers (sidecar columns, audit JSON).
+
+Migrating codex onto the typed field would touch sidecar schema, audit columns, and downstream test fixtures — out of `#175`'s scope. File a follow-up ticket if the symmetry matters; do not bundle here.
+
+### DEC-008 — Do NOT parse `~/.codex/auth.json`
+
+Path B's whole point is to avoid binding clauditor to codex's serde schema. The file is touched only by `_detect_auth_source` (file-existence check via `os.path.isfile`, no JSON parse, no field inspection). The pre-flight `check_codex_auth` does not open the file.
+
+This means clauditor cannot distinguish "codex installed but never logged in" from "codex logged in" at pre-flight time — but codex itself produces a crisp `"Please log out and sign in again"` error downstream when a stale or absent auth blocks `codex exec`. The eventual user error message is fine; we just pay one extra round-trip vs Path A. Trade matches the `#95` Anthropic precedent exactly.
+
+### DEC-009 — Announcement fires only when PATH branch is load-bearing
+
+Inside `check_codex_auth`:
+1. Check `_codex_api_key_is_set()` — if True, return None (silent).
+2. Check `_openai_api_key_is_set()` — if True, return None (silent).
+3. Check `_codex_cli_is_available()` — if True, fire `announce_codex_cli_on_path()`, then return None.
+4. Else raise `CodexAuthMissingError`.
+
+The announcement fires only when the PATH branch is the *load-bearing* acceptance signal. If an env var would have accepted anyway, no announcement (matches `.claude/rules/spec-cli-precedence.md`'s "implicit coupling at the operator-intent layers" subsection — announcements surface implicit decisions to surprised users, not explicit ones).
+
+### DEC-010 — Pre-flight order: env vars FIRST, PATH SECOND
+
+Same as DEC-009's resolution order. Beyond the announcement-suppression rationale, this also minimizes the surface where the new code can affect existing test posture: every test that already passes pre-flight via an env var sees the new branch as a no-op, because env-var checks short-circuit before PATH lookup. Tests that exercise the PATH branch must unset both env vars in their setup.
+
+---
+
+## Detailed Breakdown
+
+### US-001 — Pure helper `_codex_cli_is_available` + 4th announcement-family member
+
+**Description:** Add the foundational pieces for the Path B branch: a pure helper that checks `shutil.which("codex")`, plus a new auth-coupled announcement-family member (flag + constant + public helper). No call sites yet — those land in US-002. Lands in `_providers/_auth.py` and `_providers/__init__.py` only.
+
+**Traces to:** DEC-003, DEC-004, DEC-009.
+
+**Files:**
+- `src/clauditor/_providers/_auth.py` — add `_codex_cli_is_available() -> bool` (parallel to `_claude_cli_is_available` at lines 200-211). Add module-level `_announced_codex_cli_on_path: bool = False` (parallel to `_announced_auto_codex_harness` at line 399). Add `_CODEX_CLI_ON_PATH_ANNOUNCEMENT: Final[str]` (parallel to `_AUTO_CODEX_ANNOUNCEMENT` at line 409). Add public `announce_codex_cli_on_path() -> None` print-and-flip helper (parallel to `announce_auto_codex_harness` at line 418).
+- `src/clauditor/_providers/__init__.py` — re-export `announce_codex_cli_on_path` and `_CODEX_CLI_ON_PATH_ANNOUNCEMENT` alongside the existing announcement-helper re-exports.
+
+**TDD (write tests first):**
+- `tests/test_providers_auth.py::TestCodexCliIsAvailable` (NEW class, 2 tests):
+  - `test_returns_true_when_shutil_which_returns_path` — patches `_providers_mod.shutil.which` to return `"/usr/bin/codex"` for `"codex"`, asserts True.
+  - `test_returns_false_when_shutil_which_returns_none` — patches to return None, asserts False (this is also the autouse default).
+- `tests/test_providers_auth.py::TestAnnounceCodexCliOnPath` (NEW class, 7 tests; mirrors `TestAnnounceAutoCodexHarness` shape):
+  - Autouse fixture resets `_announced_codex_cli_on_path` to False.
+  - `test_first_call_emits_announcement` — asserts `_CODEX_CLI_ON_PATH_ANNOUNCEMENT` in stderr.
+  - `test_second_call_silent` — drain first, second call's stderr empty.
+  - `test_constant_names_codex` — `"codex"` substring.
+  - `test_constant_names_path` — `"PATH"` substring.
+  - `test_constant_names_auth_json` — `"~/.codex/auth.json"` substring.
+  - `test_constant_does_not_interpolate_values` — no `"{value"`, no `"sk-"`.
+  - `test_autouse_resets_between_tests` (split into two paired tests).
+
+**Acceptance:**
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest tests/test_providers_auth.py::TestCodexCliIsAvailable tests/test_providers_auth.py::TestAnnounceCodexCliOnPath -v` all pass.
+- `_announced_codex_cli_on_path` is NOT re-exported through any back-compat shim per `.claude/rules/back-compat-shim-discipline.md` Pattern 1 (mutable globals).
+- Public helper `announce_codex_cli_on_path` IS re-exported from `_providers/__init__.py` (functions are safe to re-export per Pattern 1).
+
+**Done when:** Both new test classes pass; the new helpers exist at the canonical seam in `_providers/_auth.py`; the announcement helper is re-exported. No callers wired yet — that's US-002.
+
+**Depends on:** none.
+
+---
+
+### US-002 — Extend `check_codex_auth` acceptance set + update error template
+
+**Description:** Wire the helper + announcement from US-001 into `check_codex_auth`. Three-branch strict-OR per DEC-001 (env-codex OR env-openai OR codex-on-PATH). Update `_CODEX_AUTH_MISSING_TEMPLATE` to mention the third acceptance path while preserving the three existing durable substrings. The four CLI seams (`validate`, `grade`, `capture`, `run`) and the two pytest fixtures (`clauditor_runner`, `clauditor_spec`) inherit the change for free — no edits at their call sites.
+
+**Traces to:** DEC-001, DEC-002, DEC-004, DEC-009, DEC-010.
+
+**Files:**
+- `src/clauditor/_providers/_auth.py` — modify `check_codex_auth` body (lines 483-532) per DEC-009/DEC-010 order. Update `_CODEX_AUTH_MISSING_TEMPLATE` (lines 459-466) to add a third bullet mentioning the codex CLI installation path. Preserve `CODEX_API_KEY`, `OPENAI_API_KEY`, `platform.openai.com` substrings.
+
+**TDD (write tests first):**
+- `tests/test_providers_auth.py::TestCheckCodexAuth` — add new tests, preserve all existing:
+  - `test_codex_on_path_no_env_vars_passes` — both env vars deleted, `shutil.which("codex")` returns path → passes, announcement fires.
+  - `test_codex_on_path_with_codex_env_silent` — `CODEX_API_KEY` set AND `which` returns path → passes, NO announcement (env branch short-circuits per DEC-010).
+  - `test_codex_on_path_with_openai_env_silent` — same as above with `OPENAI_API_KEY`.
+  - `test_codex_whitespace_env_on_path_passes_with_announcement` — both env vars whitespace-only, `which` returns path → passes, announcement fires (whitespace treated as unset per existing `_codex_api_key_is_set` / `_openai_api_key_is_set` shape).
+  - `test_neither_env_nor_path_raises` — both env vars unset, `which` returns None → raises `CodexAuthMissingError`. Pin all three existing durable substrings.
+  - `test_template_mentions_codex_cli_path` — single substring assertion on the new copy in `_CODEX_AUTH_MISSING_TEMPLATE` (NEW durable substring TBD; e.g. `"codex"` CLI mention).
+- `tests/test_providers_auth.py::TestCheckCodexAuth::test_neither_key_set_raises_with_hint` (existing) — verify it still passes byte-identically for the three pre-existing substrings.
+
+**Acceptance:**
+- `uv run ruff check src/ tests/` clean.
+- `uv run pytest tests/test_providers_auth.py::TestCheckCodexAuth -v` all pass (existing + new).
+- `uv run pytest --cov=clauditor.\_providers.\_auth --cov-report=term-missing tests/test_providers_auth.py -v` shows the new branches covered.
+- The four CLI seams (`cli/validate.py:191`, `cli/capture.py:159`, `cli/grade.py:421`, `cli/run.py:98`) are NOT edited — they inherit the change.
+- Announcement fires ONLY when PATH branch is load-bearing (DEC-009). Verified by `test_codex_on_path_with_codex_env_silent` / `test_codex_on_path_with_openai_env_silent`.
+
+**Done when:** All new and existing `TestCheckCodexAuth` tests pass; manual smoke test from this machine (`CODEX_API_KEY` unset, `OPENAI_API_KEY` unset, `~/.codex/auth.json` present with `auth_mode=chatgpt`, `codex` on PATH) — running `clauditor run <skill>` with `harness=codex` passes pre-flight (this reproduces the live failure case).
+
+**Depends on:** US-001.
+
+---
+
+### US-003 — CLI end-to-end test for `cached` source-label production wiring (DEC-017 of `#149`)
+
+**Description:** Add one CLI-end-to-end integration test that proves the forward-declared `cached` value finally fires in production after `#175`'s acceptance-set widening. Sets up a mock `~/.codex/auth.json`, no env vars, `shutil.which("codex")` returning a path, and a mocked codex subprocess that returns a clean stream. Asserts pre-flight passes, stderr emits `clauditor.runner: codex auth=cached`, exit code 0. This pins the previously-unreachable production code path against future regressions.
+
+**Traces to:** DEC-005.
+
+**Files:**
+- `tests/test_codex_harness.py` OR `tests/test_cli_codex_e2e.py` (NEW file if it doesn't exist; see below) — add the integration test. The reviewer noted that `tests/test_codex_harness.py:1208-1222` already has `test_auth_source_cached_when_auth_json_exists` which exercises the harness-only chain. This new test exercises the CLI-seam-to-stderr chain.
+
+**TDD (write test first):**
+- `test_cli_run_with_codex_chatgpt_login_emits_cached_source_label` — full integration:
+  1. `tmp_path` setup: skill file with valid SKILL.md + eval.json declaring `harness: codex`.
+  2. `CODEX_HOME=tmp_path/.codex/` with `auth.json` (single-key JSON `{"auth_mode": "chatgpt"}` — content not parsed, only existence matters).
+  3. `monkeypatch.delenv("CODEX_API_KEY")`, `monkeypatch.delenv("OPENAI_API_KEY")`.
+  4. `monkeypatch.setattr(_providers_mod.shutil, "which", lambda name: "/usr/bin/codex" if name == "codex" else None)` — override the autouse `which → None`.
+  5. Mock `subprocess.Popen` for the codex harness with a fake stream returning a successful agent message.
+  6. Invoke `cli/run.py::cmd_run` (or simplest CLI seam).
+  7. Assert: exit code 0, `clauditor.runner: codex auth=cached` in `capsys.readouterr().err`, no `CodexAuthMissingError` raised.
+
+**Acceptance:**
+- `uv run ruff check tests/` clean.
+- `uv run pytest tests/test_codex_harness.py::test_cli_run_with_codex_chatgpt_login_emits_cached_source_label -v` (or the new test path) passes.
+- The test exercises the live failure case from the ticket repro steps — running it BEFORE US-001/US-002 land would fail with exit 2 + `CodexAuthMissingError`; running it AFTER passes with `auth=cached` on stderr.
+
+**Done when:** New integration test passes; the chain `CLI seam → check_codex_auth → harness.invoke → _detect_auth_source → stderr emit` is regression-pinned.
+
+**Depends on:** US-002.
+
+---
+
+### US-004 — Quality Gate (code review × 4 + CodeRabbit + project validation)
+
+**Description:** Run the code-reviewer subagent four times across the full `#175` changeset, fixing every real bug each pass. Run CodeRabbit review if available. After all reviews, the project validation (`uv run ruff check src/ tests/` + `uv run pytest --cov=clauditor --cov-report=term-missing` with 80% coverage gate) must pass cleanly.
+
+**Files:** Any file in the `#175` changeset; pass-specific.
+
+**Acceptance:**
+- Four code-reviewer passes complete; every real bug found in each pass is fixed before the next pass starts.
+- CodeRabbit review (if available) addressed.
+- `uv run ruff check src/ tests/` exits 0.
+- `uv run pytest --cov=clauditor --cov-report=term-missing` passes with ≥ 80% coverage on touched modules.
+- `uv run pytest tests/test_providers_auth.py tests/test_codex_harness.py tests/test_cli.py -v` all pass.
+- No new test pollution (autouse fixtures intact, no leaked module-level state).
+
+**Done when:** Validation suite passes cleanly after all review passes.
+
+**Depends on:** US-001, US-002, US-003.
+
+---
+
+### US-005 — Patterns & Memory: update rules and docs for the new family member
+
+**Description:** Update the canonical implementation list in `.claude/rules/centralized-sdk-call.md` "Implicit-coupling announcements — an emerging family" subsection to add the 4th `_auth.py`-resident member (`_announced_codex_cli_on_path` + `_CODEX_CLI_ON_PATH_ANNOUNCEMENT` + `announce_codex_cli_on_path`). Document the DEC-017-fires-in-production transition. Optionally annotate `.claude/rules/precall-env-validation.md` if the relaxed-guard-on-codex shape adds a teaching not already covered.
+
+**Traces to:** DEC-003, DEC-005.
+
+**Files:**
+- `.claude/rules/centralized-sdk-call.md` — add the new family member to the bulleted enumeration; cite `#175`'s US-001 as the canonical anchor; preserve byte-stable references to the three existing members.
+- `.claude/rules/precall-env-validation.md` — small update if needed (likely just a citation that codex now has a CLI-on-PATH branch parallel to Anthropic's).
+- Plan document (`plans/super/175-codex-chatgpt-login-auth.md`) — fill in the Beads Manifest section with epic + task IDs once devolved.
+- README / docs — no changes (the CLI surface is unchanged; the announcement is the user-visible signal).
+
+**Acceptance:**
+- `.claude/rules/centralized-sdk-call.md` enumeration now lists 5 members of the announcement family (was 4, since the previous count includes 3 `_auth.py` + 1 `_anthropic.py` member; the new addition makes the `_auth.py` count 4 and total 5). Cross-references to test classes intact.
+- `git grep '_announced_codex_cli_on_path'` finds the rule's canonical-implementation citation alongside the source-of-truth file.
+- No memory pollution: no new memory files unless the user explicitly asks (per the project's CLAUDE.md / auto-memory guidance — most of what `#175` teaches is already in rules).
+
+**Done when:** Rules updated; `git diff` shows only the additive rule citation; no orphaned references.
+
+**Depends on:** US-004.
+
+---
+
+## Beads Manifest
+
+_Pending devolve phase. Will be filled in after the user approves the plan and says "devolve" or "ready for Ralph"._
+
+---
+
+## Session Notes
+
+### Session 1 — 2026-05-11
+
+- Created worktree at `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth` (plain `git worktree`; bark hit its 9-worktree cap from stale registrations).
+- Ran four parallel research subagents (ticket analyst, codebase scout, convention checker, domain expert).
+- Verified live failure on this machine: `/home/wesd/.codex/auth.json` has `auth_mode=chatgpt`, `OPENAI_API_KEY: null`, populated `tokens`.
+- Discovery → user picked all four recommended scope answers: Path B + announcement + verify-cached-wiring + reuse `CodexAuthMissingError`.
+- Ran focused architecture review (security + observability + testing). Security PASS. Observability flagged a perceived blocker on `InvokeResult.api_key_source` hardcoded `None` for codex — resolved via DEC-007 as intentional channel-separation (codex uses `harness_metadata["auth_source"]` not the typed field). Testing PASS.
+- Refinement → 10 decisions captured (DEC-001 through DEC-010). All operator-intent choices confirmed; mechanical decisions baked.
+- Detailing → 3 implementation stories (US-001/US-002/US-003) + Quality Gate (US-004) + Patterns & Memory (US-005). All right-sized for one context window each.
+- Phase advance: discovery → architecture → refinement → detailing. Next: publish PR.
+
+---
+
+## Session Notes
+
+### Session 1 — 2026-05-11
+
+- Created worktree at `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth` (plain `git worktree`; bark hit its 9-worktree cap from stale registrations).
+- Ran four parallel research subagents: ticket analyst, codebase scout, convention checker, domain expert (codex `auth.json` schema).
+- Verified live failure mode on this machine: `/home/wesd/.codex/auth.json` has `auth_mode=chatgpt`, `OPENAI_API_KEY: null`, populated `tokens`. Codex itself works; clauditor pre-flight rejects.
+- Key precedent: `CodexHarness._detect_auth_source` already detects file existence for observability/logging (DEC-017 of `#149`). The forward-declared `"cached"` source-name has never fired because the pre-flight blocks first — `#175` is what makes it reachable.
+- Strong precedent for Path B (trust `codex` on PATH): `check_any_auth_available` (#95) did exactly this for the Anthropic side and the symmetry is structurally clean.
+- Phase advance: discovery complete → awaiting scoping answers before architecture.

--- a/plans/super/175-codex-chatgpt-login-auth.md
+++ b/plans/super/175-codex-chatgpt-login-auth.md
@@ -56,7 +56,7 @@ A new ChatGPT-login announcement would be the fourth family member, same shape: 
 
 Canonical schema from `codex-rs/login/src/auth/storage.rs::AuthDotJson`:
 
-```
+```json
 {
   "auth_mode":      "chatgpt" | "apikey" | "chatgptAuthTokens" | "agentIdentity" | null,
   "OPENAI_API_KEY": str | null,
@@ -410,19 +410,6 @@ Same as DEC-009's resolution order. Beyond the announcement-suppression rational
 - Refinement → 10 decisions captured (DEC-001 through DEC-010). All operator-intent choices confirmed; mechanical decisions baked.
 - Detailing → 3 implementation stories (US-001/US-002/US-003) + Quality Gate (US-004) + Patterns & Memory (US-005). All right-sized for one context window each.
 - Phase advance: discovery → architecture → refinement → detailing. Next: publish PR.
-
----
-
-## Session Notes
-
-### Session 1 — 2026-05-11
-
-- Created worktree at `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth` (plain `git worktree`; bark hit its 9-worktree cap from stale registrations).
-- Ran four parallel research subagents: ticket analyst, codebase scout, convention checker, domain expert (codex `auth.json` schema).
-- Verified live failure mode on this machine: `/home/wesd/.codex/auth.json` has `auth_mode=chatgpt`, `OPENAI_API_KEY: null`, populated `tokens`. Codex itself works; clauditor pre-flight rejects.
-- Key precedent: `CodexHarness._detect_auth_source` already detects file existence for observability/logging (DEC-017 of `#149`). The forward-declared `"cached"` source-name has never fired because the pre-flight blocks first — `#175` is what makes it reachable.
-- Strong precedent for Path B (trust `codex` on PATH): `check_any_auth_available` (#95) did exactly this for the Anthropic side and the symmetry is structurally clean.
-- Phase advance: discovery complete → awaiting scoping answers before architecture.
 
 ### Session 2 — 2026-05-11
 

--- a/plans/super/175-codex-chatgpt-login-auth.md
+++ b/plans/super/175-codex-chatgpt-login-auth.md
@@ -6,7 +6,7 @@
 - **Branch:** `feature/175-codex-chatgpt-login-auth`
 - **Worktree:** `/home/wesd/dev/worktrees/clauditor/feature/175-codex-chatgpt-login-auth`
 - **PR:** https://github.com/wjduenow/clauditor/pull/179
-- **Phase:** devolved
+- **Phase:** completed
 - **Epic:** clauditor-lacb
 - **Sessions:** 1 (2026-05-11)
 - **Total decisions:** 10 (DEC-001 through DEC-010)
@@ -423,3 +423,12 @@ Same as DEC-009's resolution order. Beyond the announcement-suppression rational
 - Key precedent: `CodexHarness._detect_auth_source` already detects file existence for observability/logging (DEC-017 of `#149`). The forward-declared `"cached"` source-name has never fired because the pre-flight blocks first — `#175` is what makes it reachable.
 - Strong precedent for Path B (trust `codex` on PATH): `check_any_auth_available` (#95) did exactly this for the Anthropic side and the symmetry is structurally clean.
 - Phase advance: discovery complete → awaiting scoping answers before architecture.
+
+### Session 2 — 2026-05-11
+
+- /ralph-run executed the full devolve chain.
+- US-001 → US-002 → US-003 → Quality Gate → US-005 (this story).
+- Quality Gate: 0 bugs across 4 review passes (plan compliance, adversarial edge cases, test quality, production readiness).
+- All 3744 tests pass; coverage 86.20% (above 80% gate).
+- The forward-declared `apiKeySource=cached` value from DEC-017 of #149 finally reaches production users.
+- Phase advance: devolved → completed.

--- a/src/clauditor/_providers/__init__.py
+++ b/src/clauditor/_providers/__init__.py
@@ -158,28 +158,36 @@ class CodexAuthMissingError(Exception):
 # trumps style here — DO NOT rearrange these two ``from clauditor.
 # _providers.*`` blocks.
 #
-# The mutable one-shot announcement flag ``_announced_implicit_no_api_key``
-# is intentionally NOT re-exported. ``from X import Y`` creates a fresh
-# binding in this module, and ``announce_implicit_no_api_key()`` rebinds
-# the flag on its source module via ``global`` — a re-exported alias here
-# would frozen-copy the initial ``False`` and silently diverge after the
-# first call. Tests and any future consumer that needs to read or reset
-# the flag must target its canonical location:
-# ``clauditor._providers._auth._announced_implicit_no_api_key``.
+# The mutable one-shot announcement flags
+# (``_announced_implicit_no_api_key``,
+# ``_announced_call_anthropic_deprecation``,
+# ``_announced_auto_codex_harness``,
+# ``_announced_codex_cli_on_path``) are intentionally NOT re-exported
+# here. ``from X import Y`` creates a fresh binding in this module,
+# and each ``announce_*()`` helper rebinds its flag on the defining
+# module via ``global`` — a re-exported alias here would frozen-copy
+# the initial ``False`` and silently diverge after the first call
+# (``.claude/rules/back-compat-shim-discipline.md`` Pattern 1). Tests
+# and any future consumer that needs to read or reset a flag must
+# target its canonical location at
+# ``clauditor._providers._auth._announced_<name>``.
 from clauditor._providers._auth import (  # noqa: E402, I001
     _AUTH_MISSING_TEMPLATE,
     _AUTH_MISSING_TEMPLATE_KEY_ONLY,
     _AUTO_CODEX_ANNOUNCEMENT,
     _CALL_ANTHROPIC_DEPRECATION_NOTICE,
     _CODEX_AUTH_MISSING_TEMPLATE,
+    _CODEX_CLI_ON_PATH_ANNOUNCEMENT,
     _IMPLICIT_NO_API_KEY_ANNOUNCEMENT,
     _OPENAI_AUTH_MISSING_TEMPLATE,
     _api_key_is_set,
     _claude_cli_is_available,
     _codex_api_key_is_set,
+    _codex_cli_is_available,
     _openai_api_key_is_set,
     announce_auto_codex_harness,
     announce_call_anthropic_deprecation,
+    announce_codex_cli_on_path,
     announce_implicit_no_api_key,
     check_any_auth_available,
     check_api_key_only,
@@ -672,6 +680,7 @@ __all__ = [
     "OpenAIHelperError",
     "announce_auto_codex_harness",
     "announce_call_anthropic_deprecation",
+    "announce_codex_cli_on_path",
     "announce_implicit_no_api_key",
     "call_anthropic",
     "call_model",
@@ -694,10 +703,12 @@ __all__ = [
     "_AUTO_CODEX_ANNOUNCEMENT",
     "_CALL_ANTHROPIC_DEPRECATION_NOTICE",
     "_CODEX_AUTH_MISSING_TEMPLATE",
+    "_CODEX_CLI_ON_PATH_ANNOUNCEMENT",
     "_IMPLICIT_NO_API_KEY_ANNOUNCEMENT",
     "_OPENAI_AUTH_MISSING_TEMPLATE",
     "_api_key_is_set",
     "_claude_cli_is_available",
     "_codex_api_key_is_set",
+    "_codex_cli_is_available",
     "_openai_api_key_is_set",
 ]

--- a/src/clauditor/_providers/_auth.py
+++ b/src/clauditor/_providers/_auth.py
@@ -545,16 +545,22 @@ def announce_codex_cli_on_path() -> None:
 # users must export, and listing the commands that don't require auth
 # so users see the escape hatch.
 #
-# Three durable substrings tests pin: ``CODEX_API_KEY`` and
-# ``OPENAI_API_KEY`` (the two env-var names Codex accepts), plus
+# Four durable substrings tests pin: ``CODEX_API_KEY`` and
+# ``OPENAI_API_KEY`` (the two env-var names Codex accepts) and
 # ``platform.openai.com`` (the canonical place to obtain a key —
-# Codex's underlying transport routes to OpenAI).
+# Codex's underlying transport routes to OpenAI). The fourth anchor
+# (DEC-004 of ``plans/super/175-codex-chatgpt-login-auth.md``) is
+# the literal ``"codex CLI"`` — naming the third acceptance route so
+# users who prefer ChatGPT-login authentication learn from the error
+# message that installing the codex CLI on PATH is a supported path.
 _CODEX_AUTH_MISSING_TEMPLATE = (
-    "ERROR: Neither CODEX_API_KEY nor OPENAI_API_KEY is set.\n"
-    "clauditor {cmd_name} runs the codex harness, which needs an API\n"
-    "key. Get a key at https://platform.openai.com/api-keys, then\n"
-    "export CODEX_API_KEY=... (preferred) or OPENAI_API_KEY=... and\n"
-    "re-run.\n"
+    "ERROR: No usable Codex authentication found.\n"
+    "clauditor {cmd_name} runs the codex harness, which needs one of:\n"
+    "  1. CODEX_API_KEY exported (preferred), OR\n"
+    "  2. OPENAI_API_KEY exported (get a key at "
+    "https://platform.openai.com/api-keys), OR\n"
+    "  3. codex CLI installed on PATH and authenticated via\n"
+    "     ChatGPT login (credentials persisted at ~/.codex/auth.json)\n"
     "Commands that don't need a key: lint, init, badge, audit, trend."
 )
 
@@ -574,28 +580,51 @@ def _codex_api_key_is_set() -> bool:
 
 
 def check_codex_auth(cmd_name: str) -> None:
-    """Pre-flight guard: raise if neither Codex env var is set.
+    """Pre-flight guard: raise if no Codex auth path is available.
 
-    DEC-003 / DEC-010 of ``plans/super/151-harness-precedence.md``.
-    Pure helper raising :class:`CodexAuthMissingError` when
-    ``CODEX_API_KEY`` AND ``OPENAI_API_KEY`` are both absent, empty,
-    or whitespace-only. Strict-OR semantics: at least one of the two
-    env vars must be set (non-empty after whitespace trimming). There
-    is no CLI-fallback branch — Codex has no documented "subscription
-    only" auth analog like Claude Pro/Max.
+    DEC-001 / DEC-002 / DEC-009 / DEC-010 of
+    ``plans/super/175-codex-chatgpt-login-auth.md`` (extending
+    DEC-003 / DEC-010 of ``plans/super/151-harness-precedence.md``).
+    Three-branch strict-OR: accepts when ANY of
 
-    Codex is a HARNESS axis, not a PROVIDER axis (DEC-010): the
-    :func:`check_provider_auth` dispatcher is unchanged; the CLI seam
-    directly calls :func:`check_codex_auth` when the resolved harness
-    is ``"codex"``.
+    1. ``CODEX_API_KEY`` is set (whitespace-trimmed non-empty), OR
+    2. ``OPENAI_API_KEY`` is set (whitespace-trimmed non-empty), OR
+    3. The ``codex`` binary is on PATH (i.e. the user is logged in
+       via ChatGPT and credentials are persisted at
+       ``~/.codex/auth.json``; the codex CLI itself resolves them
+       downstream).
 
-    Pure function per ``.claude/rules/pure-compute-vs-io-split.md``:
-    reads ``os.environ`` only; does NOT print to stderr, does NOT call
-    ``sys.exit``, does NOT log. The CLI wrapper catches
-    :class:`CodexAuthMissingError` (a direct subclass of
-    :class:`Exception`, NOT :class:`AnthropicAuthMissingError`,
-    :class:`OpenAIAuthMissingError`, or any helper-error class) and
-    maps it to ``return 2`` per
+    Raises :class:`CodexAuthMissingError` only when all three branches
+    fail.
+
+    Per DEC-010 the env-var branches are checked FIRST and
+    short-circuit before the PATH probe — a CI run with
+    ``CODEX_API_KEY`` set never triggers the codex-CLI-on-PATH
+    announcement even when the CLI happens to be installed.
+
+    Per DEC-009 :func:`announce_codex_cli_on_path` fires ONLY when
+    the PATH branch is the load-bearing acceptance signal (no env
+    vars set, but codex on PATH). The announcement is one-shot per
+    Python process, same shape as the other implicit-coupling
+    announcements (see ``.claude/rules/centralized-sdk-call.md``
+    "Implicit-coupling announcements — an emerging family").
+
+    Codex is a HARNESS axis, not a PROVIDER axis (DEC-010 of #151):
+    the :func:`check_provider_auth` dispatcher is unchanged; the CLI
+    seam directly calls :func:`check_codex_auth` when the resolved
+    harness is ``"codex"``.
+
+    Pure function per ``.claude/rules/pure-compute-vs-io-split.md``
+    in the return-value sense: reads ``os.environ`` and probes PATH
+    via ``shutil.which`` only; raises on missing auth. The one
+    documented side-effect is the announcement family member
+    :func:`announce_codex_cli_on_path` (gated by a module-level
+    one-shot flag; resets only via test monkeypatch). The CLI
+    wrapper catches :class:`CodexAuthMissingError` (a direct
+    subclass of :class:`Exception`, NOT
+    :class:`AnthropicAuthMissingError`,
+    :class:`OpenAIAuthMissingError`, or any helper-error class)
+    and maps it to ``return 2`` per
     ``.claude/rules/llm-cli-exit-code-taxonomy.md``.
 
     Args:
@@ -607,12 +636,21 @@ def check_codex_auth(cmd_name: str) -> None:
     Raises:
         CodexAuthMissingError: when neither ``CODEX_API_KEY`` nor
             ``OPENAI_API_KEY`` is set (both checked via whitespace-
-            trimmed non-empty). Message contains the three durable
-            substrings (``CODEX_API_KEY``, ``OPENAI_API_KEY``,
-            ``platform.openai.com``) and the interpolated command
-            name.
+            trimmed non-empty) AND the ``codex`` binary is not on
+            PATH. Message contains the four durable substrings
+            (``CODEX_API_KEY``, ``OPENAI_API_KEY``,
+            ``platform.openai.com``, ``codex CLI``) and the
+            interpolated command name.
     """
+    # DEC-010: env-var branches short-circuit BEFORE the PATH probe so
+    # env-driven acceptance stays silent (no codex-CLI-on-PATH notice).
     if _codex_api_key_is_set() or _openai_api_key_is_set():
+        return None
+    # DEC-001 / DEC-002: third acceptance branch — codex on PATH.
+    # DEC-009: announce only here, where PATH is the load-bearing
+    # acceptance signal. The helper is one-shot per process.
+    if _codex_cli_is_available():
+        announce_codex_cli_on_path()
         return None
     # Local import to avoid a module-load circular hazard analogous to
     # ``AnthropicAuthMissingError`` (defined in ``_providers/__init__``

--- a/src/clauditor/_providers/_auth.py
+++ b/src/clauditor/_providers/_auth.py
@@ -211,6 +211,29 @@ def _claude_cli_is_available() -> bool:
     return shutil.which("claude") is not None
 
 
+def _codex_cli_is_available() -> bool:
+    """Return True when the ``codex`` binary is on PATH.
+
+    DEC-001 / DEC-002 of ``plans/super/175-codex-chatgpt-login-auth.md``.
+    Presence check only — we do NOT verify the CLI is authenticated or
+    functional. That's deliberate: the goal of the pre-flight guard is
+    to bail out cheaply when *neither* env-var auth path nor the CLI
+    binary is even theoretically available. If the CLI is on PATH but
+    its ``~/.codex/auth.json`` is stale or absent, ``codex exec``
+    itself produces a crisp ``"Please log out and sign in again"``
+    error downstream — pre-flight does NOT try to parse the JSON to
+    second-guess codex (DEC-008: explicit decision to skip
+    ``auth.json`` parsing in favor of trusting the CLI binary).
+
+    Parallel shape to :func:`_claude_cli_is_available`: both helpers
+    pin ``shutil.which`` against their respective harness binary names
+    and return a bool. Tests override the autouse
+    ``shutil.which → None`` pin from ``tests/conftest.py`` via
+    ``monkeypatch.setattr`` targeting this module's ``shutil``.
+    """
+    return shutil.which("codex") is not None
+
+
 def check_any_auth_available(cmd_name: str) -> None:
     """Pre-flight guard: raise only when no auth path is available at all.
 
@@ -443,6 +466,76 @@ def announce_auto_codex_harness() -> None:
         return
     print(_AUTO_CODEX_ANNOUNCEMENT, file=sys.stderr)
     _announced_auto_codex_harness = True
+
+
+# DEC-003 / DEC-009 (#175 US-001): one-shot stderr announcement when
+# :func:`check_codex_auth` accepts the pre-flight via the codex-CLI-on-
+# PATH branch (i.e. neither ``CODEX_API_KEY`` nor ``OPENAI_API_KEY``
+# is set; ``codex`` binary is on PATH; user is authenticated via
+# ChatGPT login persisted in ``~/.codex/auth.json``). Flipped to
+# ``True`` after the first emission per Python process. Fourth member
+# of the implicit-coupling announcement family (co-located with
+# :data:`_announced_implicit_no_api_key`,
+# :data:`_announced_call_anthropic_deprecation`, and
+# :data:`_announced_auto_codex_harness`) per
+# ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+# announcements — an emerging family". Per DEC-009 the announcement
+# fires ONLY when the PATH branch is the load-bearing acceptance
+# signal — env-var-driven acceptance stays silent to keep CI noise
+# down. Tests reset via the standard
+# ``monkeypatch.setattr(..., False)`` autouse fixture pattern,
+# targeting the canonical flag location at
+# ``clauditor._providers._auth._announced_codex_cli_on_path``.
+_announced_codex_cli_on_path: bool = False
+
+
+# DEC-003 / DEC-004 (#175 US-001): the codex-CLI-on-PATH announcement
+# emitted on the first PATH-load-bearing :func:`check_codex_auth`
+# acceptance per Python process. Names env-var names and file paths
+# only (NEVER interpolates values) per the Auth review #7 precedent
+# from #151. Three durable substrings tests pin: ``codex`` (the CLI
+# name), ``PATH`` (the discovery mechanism), and
+# ``~/.codex/auth.json`` (where codex itself looks for credentials,
+# so a user who has codex on PATH but never logged in knows what to
+# do next). The remainder of the message is stylistic copy and may be
+# edited without churning tests.
+_CODEX_CLI_ON_PATH_ANNOUNCEMENT: Final[str] = (
+    "clauditor: accepted codex pre-flight via codex CLI on PATH "
+    "(neither CODEX_API_KEY nor OPENAI_API_KEY is set; codex itself "
+    "will resolve credentials from ~/.codex/auth.json — typically "
+    "the ChatGPT-login flow). If you intended to use an API key, "
+    "export CODEX_API_KEY or OPENAI_API_KEY."
+)
+
+
+def announce_codex_cli_on_path() -> None:
+    """Emit the codex-CLI-on-PATH notice to stderr once per process.
+
+    DEC-003 / DEC-009 (#175 US-001). Called from :func:`check_codex_auth`
+    immediately before returning ``None`` via the PATH-on-disk branch
+    (i.e. neither ``CODEX_API_KEY`` nor ``OPENAI_API_KEY`` was set, but
+    ``shutil.which("codex")`` returned a path). The one-shot module
+    flag :data:`_announced_codex_cli_on_path` ensures a single
+    announcement per Python process regardless of how many subsequent
+    CLI commands resolve under the same conditions.
+
+    Same shape as :func:`announce_implicit_no_api_key` (#95 US-002),
+    :func:`announce_call_anthropic_deprecation` (#144 US-007), and
+    :func:`announce_auto_codex_harness` (#151 US-003): public helper,
+    print-and-flip, one-shot per process. Tests reset via
+    ``monkeypatch.setattr`` on the canonical flag location.
+
+    Per ``.claude/rules/centralized-sdk-call.md`` "Implicit-coupling
+    announcements — an emerging family", the helper lives in
+    ``_providers/_auth.py`` because the notice is auth-coupled (it
+    names ``CODEX_API_KEY`` / ``OPENAI_API_KEY`` and
+    ``~/.codex/auth.json``).
+    """
+    global _announced_codex_cli_on_path
+    if _announced_codex_cli_on_path:
+        return
+    print(_CODEX_CLI_ON_PATH_ANNOUNCEMENT, file=sys.stderr)
+    _announced_codex_cli_on_path = True
 
 
 # DEC-003 / DEC-010 (#151 US-003): message template for

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -1315,6 +1315,114 @@ class TestInvokeCodexExec:
         assert result.error_category is None
 
 
+class TestCliRunCodexCachedSourceLabel:
+    """#175 US-003 — end-to-end CLI integration test for the ``cached``
+    source-label production wiring (DEC-005 / DEC-017 of #149).
+
+    Proves the full chain after US-001 (helper) and US-002
+    (acceptance-set widening) landed:
+
+      CLI (``cmd_run`` with ``--harness codex``) →
+      :func:`_resolve_harness` returns ``"codex"`` →
+      :func:`check_codex_auth` accepts via the new PATH branch
+      (no env keys, codex on PATH) →
+      :class:`CodexHarness.invoke` runs →
+      :meth:`CodexHarness._detect_auth_source` returns ``"cached"``
+      (because ``$CODEX_HOME/auth.json`` exists) →
+      stderr emits ``clauditor.runner: codex auth=cached``.
+
+    Pre-#175 the ``"cached"`` value was UNREACHABLE in CLI flow
+    because :func:`check_codex_auth` raised first with no env vars
+    set. This test regression-pins the previously-unreachable
+    label being surfaced.
+    """
+
+    def _patch_popen(self, monkeypatch, fake):
+        """Patch ``subprocess.Popen`` inside the codex harness module."""
+        import clauditor._harnesses._codex as _codex_mod
+
+        def _fake_popen(*args, **kwargs):
+            return fake
+
+        monkeypatch.setattr(_codex_mod.subprocess, "Popen", _fake_popen)
+
+    def test_cli_run_codex_chatgpt_login_emits_cached_source(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """End-to-end CLI run with the ChatGPT-login flow: no env-var
+        keys, ``codex`` on PATH (accepted via the new US-002 branch),
+        and ``$CODEX_HOME/auth.json`` present produces an
+        ``auth=cached`` stderr line. Durable substring:
+        ``"clauditor.runner: codex auth=cached"``.
+        """
+        import argparse
+
+        from clauditor._providers import _auth as _auth_mod
+        from clauditor.cli.run import cmd_run
+
+        # 1. Build the ChatGPT-login env state: CODEX_HOME pointed at a
+        #    tmp dir containing an empty ``auth.json`` (only file
+        #    existence is checked — content is opaque to clauditor).
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text("{}")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        # 2. Clear env-var auth so the harness's auth-source detector
+        #    falls through to the cached-file branch AND so
+        #    ``check_codex_auth`` exercises its third (PATH) branch.
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # 3. Override the autouse ``shutil.which → None`` pin from
+        #    tests/conftest.py so :func:`_codex_cli_is_available`
+        #    sees codex on PATH (per
+        #    ``.claude/rules/test-infra-shutil-which-coupling.md``).
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        # 4. Reset the one-shot ``codex CLI on PATH`` announcement
+        #    flag (per the announcement-family reset pattern from
+        #    ``.claude/rules/centralized-sdk-call.md``) so the
+        #    accept-via-PATH path runs cleanly even if a prior test
+        #    in the same process flipped it.
+        monkeypatch.setattr(
+            "clauditor._providers._auth._announced_codex_cli_on_path",
+            False,
+        )
+        # 5. Patch ``subprocess.Popen`` for the codex harness body so
+        #    ``CodexHarness.invoke`` does not spawn a real codex
+        #    binary. The fake stream returns a clean ``agent_message``
+        #    so the call returns exit_code=0.
+        fake = make_fake_codex_stream("hello-from-fake-codex")
+        self._patch_popen(monkeypatch, fake)
+
+        # 6. Build the argparse Namespace ``cmd_run`` expects. Pin
+        #    ``--harness codex`` so the four-layer resolver picks
+        #    codex deterministically (without consulting env / auto).
+        ns = argparse.Namespace(
+            skill="some-skill",
+            args=None,
+            project_dir=str(tmp_path),
+            timeout=None,
+            no_api_key=False,
+            sync_tasks=False,
+            harness="codex",
+        )
+
+        exit_code = cmd_run(ns)
+
+        captured = capsys.readouterr()
+        # The full chain produced an ``auth=cached`` stderr line —
+        # the previously-unreachable label is now reachable per
+        # DEC-005 of #175 / DEC-017 of #149.
+        assert "clauditor.runner: codex auth=cached" in captured.err, (
+            f"expected 'auth=cached' in stderr, got: {captured.err!r}"
+        )
+        # The run succeeded end-to-end.
+        assert exit_code == 0
+
+
 class TestInvokeCodexExecErrorPaths:
     """Error-path tests for :meth:`CodexHarness.invoke` (US-004).
 

--- a/tests/test_providers_auth.py
+++ b/tests/test_providers_auth.py
@@ -1178,3 +1178,156 @@ class TestAnnounceAutoCodexHarness:
         announce_auto_codex_harness()
         captured = capsys.readouterr()
         assert captured.err != ""
+
+
+class TestCodexCliIsAvailable:
+    """Direct unit coverage for ``_codex_cli_is_available()`` (#175 US-001).
+
+    Parallel to :class:`TestClaudeCliIsAvailable`. The helper is the
+    presence-only PATH probe that #175 uses as the load-bearing third
+    branch of :func:`check_codex_auth` (DEC-001 / DEC-002), accepting
+    pre-flight when neither ``CODEX_API_KEY`` nor ``OPENAI_API_KEY`` is
+    set but the ``codex`` binary itself is on PATH (i.e. the user is
+    authenticated via ChatGPT login persisted in
+    ``~/.codex/auth.json``).
+
+    Presence-only contract: the helper does NOT verify the CLI is
+    authenticated or functional. Codex itself produces crisp
+    "Please log out and sign in again" downstream when a stale
+    ``auth.json`` is present.
+    """
+
+    def test_returns_true_when_on_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Override the autouse ``shutil.which → None`` pin from
+        ``conftest.py`` so the helper sees codex on PATH."""
+        from clauditor._providers import _auth as _auth_mod
+        from clauditor._providers._auth import _codex_cli_is_available
+
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        assert _codex_cli_is_available() is True
+
+    def test_returns_false_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The autouse ``shutil.which → None`` pin already returns
+        ``None`` for every name; this test confirms the helper honors
+        it."""
+        from clauditor._providers import _auth as _auth_mod
+        from clauditor._providers._auth import _codex_cli_is_available
+
+        monkeypatch.setattr(
+            _auth_mod.shutil, "which", lambda name: None
+        )
+        assert _codex_cli_is_available() is False
+
+
+class TestAnnounceCodexCliOnPath:
+    """DEC-003 / DEC-004 / DEC-009 (#175 US-001): one-shot stderr notice
+    emitted on the first ``check_codex_auth`` call where the codex CLI
+    on PATH is the load-bearing acceptance signal (no env vars set).
+
+    Parallel to :class:`TestAnnounceAutoCodexHarness`,
+    :class:`TestAnnounceImplicitNoApiKey`, and
+    :class:`TestCallAnthropicDeprecationAnnouncement` — same autouse-
+    reset pattern; same one-shot-per-process contract. Tests pin three
+    durable substrings (``codex``, ``PATH``, ``~/.codex/auth.json``)
+    per ``.claude/rules/precall-env-validation.md``'s durable-substring
+    discipline so stylistic copy edits don't churn tests.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_announcement_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every test starts with the one-shot flag set to False."""
+        monkeypatch.setattr(
+            "clauditor._providers._auth._announced_codex_cli_on_path",
+            False,
+        )
+
+    def test_first_call_emits_announcement(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from clauditor._providers import announce_codex_cli_on_path
+
+        announce_codex_cli_on_path()
+        captured = capsys.readouterr()
+        from clauditor._providers import _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+        assert _CODEX_CLI_ON_PATH_ANNOUNCEMENT in captured.err
+
+    def test_second_call_silent(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from clauditor._providers import announce_codex_cli_on_path
+
+        announce_codex_cli_on_path()
+        # Drain the first emission.
+        capsys.readouterr()
+        announce_codex_cli_on_path()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_constant_names_codex(self) -> None:
+        """First durable substring — users must see ``codex`` so they
+        know which CLI was detected on PATH."""
+        from clauditor._providers import _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+        assert "codex" in _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+    def test_constant_names_path(self) -> None:
+        """Second durable substring — users must see ``PATH`` so they
+        know the helper is doing PATH discovery (not env-var check)."""
+        from clauditor._providers import _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+        assert "PATH" in _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+    def test_constant_names_auth_json(self) -> None:
+        """Third durable substring — users must see
+        ``~/.codex/auth.json`` so they know where codex looks for
+        credentials when neither env var is set."""
+        from clauditor._providers import _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+        assert "~/.codex/auth.json" in _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+    def test_constant_does_not_interpolate_values(self) -> None:
+        """Auth review #7 (#151 precedent): the announcement names
+        env-var names / paths only; it MUST NOT interpolate values. A
+        leaked secret in the constant would surface in the test text —
+        fail closed."""
+        from clauditor._providers import _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+        # No format placeholders for values.
+        assert "{value" not in _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+        # No literal "sk-" prefixed tokens (canonical OpenAI/Codex key
+        # shape).
+        assert "sk-" not in _CODEX_CLI_ON_PATH_ANNOUNCEMENT
+
+    def test_autouse_resets_between_tests_pair_1(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """First test of a pair — proves first-call emission works."""
+        from clauditor._providers import announce_codex_cli_on_path
+
+        announce_codex_cli_on_path()
+        captured = capsys.readouterr()
+        assert captured.err != ""
+
+    def test_autouse_resets_between_tests_pair_2(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Second test of the pair — if the autouse fixture did not
+        reset the flag, this test would see silence (the flag would
+        still be ``True`` from the first test). Seeing an emission
+        here proves the fixture reset works."""
+        from clauditor._providers import announce_codex_cli_on_path
+
+        announce_codex_cli_on_path()
+        captured = capsys.readouterr()
+        assert captured.err != ""

--- a/tests/test_providers_auth.py
+++ b/tests/test_providers_auth.py
@@ -1331,3 +1331,221 @@ class TestAnnounceCodexCliOnPath:
         announce_codex_cli_on_path()
         captured = capsys.readouterr()
         assert captured.err != ""
+
+
+class TestCheckCodexAuthPathBranch:
+    """Three-branch strict-OR for :func:`check_codex_auth` (#175 US-002).
+
+    DEC-001 / DEC-002 / DEC-004 / DEC-009 / DEC-010 of
+    ``plans/super/175-codex-chatgpt-login-auth.md``. The pre-flight guard
+    now accepts on any of:
+
+    1. ``CODEX_API_KEY`` set (whitespace-trimmed non-empty) — pass silently.
+    2. ``OPENAI_API_KEY`` set (whitespace-trimmed non-empty) — pass silently.
+    3. ``codex`` binary on PATH (the new branch) — pass + fire the
+       :func:`announce_codex_cli_on_path` one-shot stderr notice.
+
+    Per DEC-009 the announcement fires only when the PATH branch is the
+    load-bearing acceptance signal. Per DEC-010 the env-var branches
+    short-circuit BEFORE the PATH probe so a CI run with ``CODEX_API_KEY``
+    set never sees a noisy "codex CLI on PATH" notice even when the CLI
+    happens to be installed.
+
+    Tests use ``monkeypatch.setattr`` to override the autouse
+    ``shutil.which → None`` pin from ``tests/conftest.py`` per
+    ``.claude/rules/test-infra-shutil-which-coupling.md``. Each test
+    that exercises the PATH branch also resets the
+    :data:`_announced_codex_cli_on_path` flag.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_announcement_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every test starts with the one-shot flag set to False so
+        announcement assertions are deterministic."""
+        monkeypatch.setattr(
+            "clauditor._providers._auth._announced_codex_cli_on_path",
+            False,
+        )
+
+    def test_codex_on_path_no_env_vars_passes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """DEC-001 / DEC-002: PATH-only acceptance succeeds AND fires
+        the announcement (DEC-009 — PATH is the load-bearing signal)."""
+        from clauditor._providers import (
+            _CODEX_CLI_ON_PATH_ANNOUNCEMENT,
+            check_codex_auth,
+        )
+        from clauditor._providers import _auth as _auth_mod
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        assert check_codex_auth("grade") is None
+        captured = capsys.readouterr()
+        assert _CODEX_CLI_ON_PATH_ANNOUNCEMENT in captured.err
+
+    def test_codex_on_path_with_codex_env_silent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """DEC-010: env-var branch short-circuits BEFORE the PATH probe.
+        ``CODEX_API_KEY`` set + codex on PATH must pass silently — no
+        announcement, since the env-var branch is the load-bearing
+        accept signal, not PATH."""
+        from clauditor._providers import _auth as _auth_mod
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.setenv("CODEX_API_KEY", "sk-codex-test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        assert check_codex_auth("grade") is None
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_codex_on_path_with_openai_env_silent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """DEC-010 sibling: ``OPENAI_API_KEY`` set + codex on PATH must
+        also pass silently. The env-var short-circuit applies to either
+        env-var branch."""
+        from clauditor._providers import _auth as _auth_mod
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        assert check_codex_auth("grade") is None
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_codex_whitespace_env_on_path_passes_with_announcement(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Whitespace-only env vars count as absent (existing helper
+        contract); the PATH branch should fire and announce since it's
+        the load-bearing signal."""
+        from clauditor._providers import (
+            _CODEX_CLI_ON_PATH_ANNOUNCEMENT,
+            check_codex_auth,
+        )
+        from clauditor._providers import _auth as _auth_mod
+
+        monkeypatch.setenv("CODEX_API_KEY", "   \t\n")
+        monkeypatch.setenv("OPENAI_API_KEY", "  ")
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        assert check_codex_auth("grade") is None
+        captured = capsys.readouterr()
+        assert _CODEX_CLI_ON_PATH_ANNOUNCEMENT in captured.err
+
+    def test_neither_env_nor_path_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All three branches fail → raise. Verify the four durable
+        substrings: the three pre-#175 anchors (``CODEX_API_KEY``,
+        ``OPENAI_API_KEY``, ``platform.openai.com``) plus the NEW
+        substring naming the codex CLI install path so users learn
+        about the third acceptance path from the error message."""
+        from clauditor._providers import (
+            CodexAuthMissingError,
+            check_codex_auth,
+        )
+        from clauditor._providers import _auth as _auth_mod
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # Override autouse pin defensively; this test asserts the
+        # raise path AND the new substring naming the codex CLI route.
+        monkeypatch.setattr(_auth_mod.shutil, "which", lambda name: None)
+        with pytest.raises(CodexAuthMissingError) as exc_info:
+            check_codex_auth("grade")
+        message = str(exc_info.value)
+        # Three pre-#175 durable substrings — must still hold per DEC-004.
+        assert "CODEX_API_KEY" in message
+        assert "OPENAI_API_KEY" in message
+        assert "platform.openai.com" in message
+        # NEW DEC-004 durable substring: a mention of the codex CLI as
+        # a third acceptance path. The literal ``"codex CLI"`` is the
+        # pin; stylistic copy around it may change.
+        assert "codex CLI" in message
+        # Command-name interpolation still works.
+        assert "clauditor grade" in message
+
+    def test_announcement_one_shot_across_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Repeat PATH-branch acceptance in the same process fires the
+        announcement exactly once (one-shot contract — same shape as
+        :func:`announce_auto_codex_harness`)."""
+        from clauditor._providers import _auth as _auth_mod
+        from clauditor._providers import check_codex_auth
+
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            _auth_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/codex" if name == "codex" else None,
+        )
+        check_codex_auth("grade")
+        # Drain first emission.
+        first = capsys.readouterr().err
+        assert first != ""
+        check_codex_auth("validate")
+        # Second call must be silent.
+        second = capsys.readouterr().err
+        assert second == ""
+
+
+class TestCodexAuthMissingTemplateAcceptsPathBranch:
+    """The :data:`_CODEX_AUTH_MISSING_TEMPLATE` must mention the codex
+    CLI install path as a third acceptance route (DEC-004 of
+    ``plans/super/175-codex-chatgpt-login-auth.md``) while preserving
+    the three pre-#175 durable substrings."""
+
+    def test_template_mentions_codex_cli(self) -> None:
+        """New durable substring: ``codex CLI`` — users learn the
+        third acceptance path from the missing-auth error message."""
+        from clauditor._providers import _CODEX_AUTH_MISSING_TEMPLATE
+
+        assert "codex CLI" in _CODEX_AUTH_MISSING_TEMPLATE
+
+    def test_template_preserves_pre_175_substrings(self) -> None:
+        """Three pre-#175 anchors (``CODEX_API_KEY``, ``OPENAI_API_KEY``,
+        ``platform.openai.com``) must still hold so existing CI parsers
+        and the substring-based test in :class:`TestCheckCodexAuth` keep
+        matching."""
+        from clauditor._providers import _CODEX_AUTH_MISSING_TEMPLATE
+
+        assert "CODEX_API_KEY" in _CODEX_AUTH_MISSING_TEMPLATE
+        assert "OPENAI_API_KEY" in _CODEX_AUTH_MISSING_TEMPLATE
+        assert "platform.openai.com" in _CODEX_AUTH_MISSING_TEMPLATE
+        # Command-name interpolation preserved.
+        assert "{cmd_name}" in _CODEX_AUTH_MISSING_TEMPLATE


### PR DESCRIPTION
## Summary

Super plan for #175 — `check_codex_auth` does not recognize ChatGPT-login auth (`~/.codex/auth.json` with `auth_mode=chatgpt`, no env vars set) even though `codex exec` works fine in that state.

**Phase:** detailing (awaiting approval)
**Stories:** 3 implementation stories + Quality Gate + Patterns & Memory
**Decisions:** 10 (DEC-001 through DEC-010)

## Scope

- **Path B** — extend `check_codex_auth` to a three-branch strict-OR: env-codex OR env-openai OR `shutil.which("codex") is not None`. Mirrors `check_any_auth_available`'s Anthropic shape from #95.
- **No `auth.json` parse** — trust the codex CLI on PATH; defer auth verification to codex itself (it produces crisp `"Please log out and sign in again"` errors on stale tokens downstream).
- **4th announcement-family member** — `_announced_codex_cli_on_path` + `_CODEX_CLI_ON_PATH_ANNOUNCEMENT` + `announce_codex_cli_on_path()` in `_providers/_auth.py`. Fires once per process when PATH branch is the load-bearing acceptance signal.
- **DEC-017 of #149 finally fires** — the forward-declared `apiKeySource=cached` stderr emission is already wired in `_detect_auth_source` but unreachable today because pre-flight blocks first. Add one CLI end-to-end test to pin the now-reachable production path.
- **Reuse `CodexAuthMissingError`** — extend the message template; preserve the three existing durable substrings.

## Out of scope (DEC-007/DEC-008)

- Typed-field symmetry on `InvokeResult.api_key_source` for codex (uses `harness_metadata["auth_source"]` channel intentionally).
- Parsing `~/.codex/auth.json` (avoids binding to codex's serde schema).

## Blast radius

Two source files (`_providers/_auth.py`, `_providers/__init__.py`). Three test files. One rules file. The four CLI commands and two pytest fixtures inherit the fix without edits.

## Plan document

See `plans/super/175-codex-chatgpt-login-auth.md`.

## Next steps

- Review this PR.
- Approve in Claude Code to proceed to devolve (beads creation + Ralph-ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended Codex authentication to accept credentials from the Codex CLI if available on system PATH, in addition to environment variable keys.
  * Added a one-time notification when authentication succeeds via the PATH-based method.

* **Documentation**
  * Updated authentication rules and implementation plan to document the new Codex CLI on PATH acceptance route.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/179)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->