### PR TITLE
#183: wrap grading criteria in <criterion> tags

### DIFF
--- a/.claude/rules/positional-id-zip-validation.md
+++ b/.claude/rules/positional-id-zip-validation.md
@@ -77,12 +77,68 @@ def parse_grading_response(text: str, criteria: list[dict]) -> list[Result]:
   If the judge misbehaves, the right answer is to regenerate, not to
   guess.
 
+## Prompt-side companion: don't render items in a shape that tempts the model to echo a prefix
+
+The strict text-match validator on the parser side is only half of
+the contract. The prompt-side rendering of the same items must NOT
+present them in a shape that some well-behaved model will faithfully
+reproduce a positional prefix from. The canonical foot-gun is a
+markdown numbered list:
+
+```python
+# WRONG — `1. `, `2. `, … tempt the model to echo the prefix.
+for i, criterion in enumerate(criteria, 1):
+    lines.append(f"{i}. {criterion_text(criterion)}")
+```
+
+Anthropic Claude models tend to strip the leading `N. ` when echoing
+the item into a structured response field; OpenAI gpt-5.4 (and
+likely gpt-5.4-mini) preserves it verbatim. The result: every
+positional-zip text match fails with
+`"Expected 'Output contains ...', got '1. Output contains ...'"`
+across every criterion, and the user sees `parse_response: 0/N`
+even when the model graded correctly.
+
+The fix is structural at the prompt boundary, not the parser:
+
+```python
+# RIGHT — XML-tagged items, explicit verbatim-echo instruction.
+for i, criterion in enumerate(criteria, 1):
+    lines.append(
+        f'<criterion id="{i}">{criterion_text(criterion)}</criterion>'
+    )
+# ... plus prompt body adds:
+# "In each result object, the `criterion` field MUST contain the
+#  verbatim text inside the corresponding <criterion> tag — no
+#  leading number, no tag, no prefix, no rewording. Return one
+#  result per criterion, in the same order as listed."
+```
+
+The XML tag is visually distinct so the model has no "obvious"
+prefix to copy. The explicit `id` attribute is intentionally
+adjacent on the line (not on the next line) so it does NOT bleed
+into the inner text, and the instruction sentence enumerates every
+plausible thing the model might echo (number, tag, prefix,
+rewording) so the prohibition is exhaustive.
+
+This rule applies wherever a positional-zip-validated structured
+list lives at the LLM boundary: grading criteria, trigger-test
+slots, future per-section field lists. Anything else risks the
+same silent cross-provider divergence.
+
+Traces to #183.
+
 ## Canonical implementation
 
 `src/clauditor/quality_grader.py::parse_grading_response` — length check,
 per-index text check, then positional id assignment. `grade_quality`
 catches the `ValueError` and produces a failed-parse `GradingReport` so the
 hard-fail surfaces as a graceful report rather than a traceback.
+
+`src/clauditor/quality_grader.py::build_grading_prompt` — renders
+the criteria block as `<criterion id="N">...</criterion>` tags
+plus the explicit verbatim-echo instruction per the prompt-side
+companion above (#183).
 
 ## When this rule applies
 

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -946,7 +946,9 @@ def build_grading_prompt(
     """
     criteria_lines = []
     for i, criterion in enumerate(eval_spec.grading_criteria, 1):
-        criteria_lines.append(f"{i}. {criterion_text(criterion)}")
+        criteria_lines.append(
+            f'<criterion id="{i}">{criterion_text(criterion)}</criterion>'
+        )
     criteria_block = "\n".join(criteria_lines)
 
     header = (
@@ -966,6 +968,12 @@ def build_grading_prompt(
         f"- evidence: quote specific text from the output supporting your"
         f" judgment\n"
         f"- reasoning: explain in 1-2 sentences\n"
+        f"\n"
+        f"Criteria are listed below, each wrapped in a <criterion> tag."
+        f" In each result object, the `criterion` field MUST contain the"
+        f" verbatim text inside the corresponding <criterion> tag — no"
+        f" leading number, no tag, no prefix, no rewording. Return one"
+        f" result per criterion, in the same order as listed.\n"
         f"\n"
         f"Criteria:\n"
         f"{criteria_block}\n"

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1043,12 +1043,35 @@ class TestBuildGradingPrompt:
         assert "professional and clear" in prompt
         assert "requested topics are covered" in prompt
 
-    def test_criteria_are_numbered(self):
+    def test_criteria_are_wrapped_in_tags(self):
+        """Criteria are rendered as ``<criterion id="N">text</criterion>``
+        (NOT a leading-``N.`` numbered list). gpt-5.4 echoed the ``"N. "``
+        prefix into the ``criterion`` field of each result object, which
+        broke the strict positional-zip parser per
+        ``.claude/rules/positional-id-zip-validation.md``. The tag wrapper
+        plus the explicit verbatim instruction below removes the prefix
+        the model would otherwise reproduce. See issue #183.
+        """
         spec = _make_spec()
         prompt = build_grading_prompt(spec)
-        assert "1. Output contains actionable" in prompt
-        assert "2. Tone is professional" in prompt
-        assert "3. All requested topics" in prompt
+        assert (
+            '<criterion id="1">Output contains actionable'
+            in prompt
+        )
+        assert '<criterion id="2">Tone is professional' in prompt
+        assert '<criterion id="3">All requested topics' in prompt
+        # The pre-#183 leading-``N.`` shape must not reappear.
+        assert "1. Output contains actionable" not in prompt
+        assert "2. Tone is professional" not in prompt
+
+    def test_instructs_verbatim_echo_without_prefix(self):
+        """Issue #183: the prompt must tell the model not to echo any
+        leading number or tag prefix into the ``criterion`` field.
+        """
+        spec = _make_spec()
+        prompt = build_grading_prompt(spec)
+        assert "verbatim text inside the corresponding <criterion>" in prompt
+        assert "no leading number" in prompt
 
     def test_asks_for_json_response(self):
         spec = _make_spec()

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1066,12 +1066,18 @@ class TestBuildGradingPrompt:
 
     def test_instructs_verbatim_echo_without_prefix(self):
         """Issue #183: the prompt must tell the model not to echo any
-        leading number or tag prefix into the ``criterion`` field.
+        leading number, tag, prefix, or rewording into the ``criterion``
+        field. The full prohibition set is pinned so a future prompt
+        edit that drops any clause trips this test (CodeRabbit nit on
+        PR #184).
         """
         spec = _make_spec()
         prompt = build_grading_prompt(spec)
         assert "verbatim text inside the corresponding <criterion>" in prompt
         assert "no leading number" in prompt
+        assert "no tag" in prompt
+        assert "no prefix" in prompt
+        assert "no rewording" in prompt
 
     def test_asks_for_json_response(self):
         spec = _make_spec()


### PR DESCRIPTION
## Summary

- Issue #183: `gpt-5.4` echoed `"N. "` numeric prefixes (from `build_grading_prompt`'s numbered criteria list) into the `criterion` field of each JSON result object, breaking `parse_grading_response`'s strict positional zip per `.claude/rules/positional-id-zip-validation.md`.
- Switch the L3 grading-prompt criteria block from a numbered markdown list to `<criterion id="N">...</criterion>` tags and add an explicit instruction that the `criterion` field MUST contain the verbatim tag-inner text — no leading number, no tag, no prefix, no rewording.
- Fix is **prompt-side only**; the positional-zip parser stays unchanged per the rule's discipline.

## Audit

- L2 `build_extraction_prompt` (`grader.py`) — **not affected**. Its response is keyed by section/tier/field names, not a positional list, so there's no analogous "model echoes prefix" failure mode.

## Test plan

- [x] `uv run pytest tests/test_quality_grader.py` — 218 passed (includes 2 new regression tests in `TestBuildGradingPrompt`: `test_criteria_are_wrapped_in_tags`, `test_instructs_verbatim_echo_without_prefix`).
- [x] `uv run pytest` — full suite, 3801 passed, 1 skipped.
- [x] `uv run ruff check src/clauditor/quality_grader.py tests/test_quality_grader.py` — clean.
- [ ] Manual cross-provider validation against the issue's reproduction case (`clauditor grade .claude/skills/find-restaurants/SKILL.md --grading-provider openai --model gpt-5.4 …`) to confirm gpt-5.4 produces real per-criterion verdicts. Anthropic regression (`claude-sonnet-4-6`) should still parse cleanly against the new tag-wrapped shape.

Closes #183.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced criterion text processing in the grading system to ensure accurate extraction without formatting artifacts and consistent ordering of rubric criteria.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/184)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->