### PR TITLE
docs: cover multi-harness, cost tracking, and audit-trend workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Documentation: three new deep-dive docs.** Filled doc gaps that
+  accumulated as the multi-provider / multi-harness / cost-tracking
+  surface landed:
+  - [`docs/codex-harness.md`](docs/codex-harness.md) — user-facing
+    narrative for running skills under the OpenAI Codex CLI (auth,
+    four-layer precedence, sandbox modes, troubleshooting, useful
+    harness × grader pairings).
+  - [`docs/cost-tracking.md`](docs/cost-tracking.md) — the `context.json`
+    sidecar shape, `cost_usd` estimation rules, the pricing table,
+    reasoning-token semantics, and the always-v1 contract.
+  - [`docs/audit-trend-workflow.md`](docs/audit-trend-workflow.md) —
+    end-to-end story for the iteration-history surface: how `grade`
+    builds history, how `audit` / `trend` / `compare` / `badge`
+    consume it, and how cross-axis comparability refusal protects
+    against silent averaging across stacks.
+  
+  README updated to mention the harness axis and cost tracking in
+  prose, and the Reference docs list now links all three new docs
+  plus the previously-orphaned `codex-stream-schema.md`.
+
 - **Pytest fixtures: `harness` × `provider` parametrization (#155).** The
   pytest plugin gained two new CLI options and four new factory kwargs so
   a single test can sweep across `{claude-code, codex} × {anthropic, openai}`

--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ clauditor also supports multi-provider grading: pass `--grading-provider {anthro
 
 Running `clauditor grade <skill> --transport cli` is the one-liner for subscription auth end-to-end: it implicitly strips `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from the skill subprocess env, so both the grader and the skill use subscription auth. Pass `--transport api` to keep the keys.
 
+**Running skills under a non-Claude harness.** Clauditor can also drive your skill through the OpenAI Codex CLI instead of Claude Code: pass `--harness codex` (or set `CLAUDITOR_HARNESS` / `EvalSpec.harness`) to `validate`, `grade`, `capture`, or `run`. Codex needs `CODEX_API_KEY` or `OPENAI_API_KEY` in the subprocess env; the default `auto` harness picks Claude when `claude` is on PATH, else Codex. The harness axis is independent of the grader provider — an eval can run under Codex while the L3 grader still calls Claude (or vice versa). Full reference: [docs/codex-harness.md](docs/codex-harness.md).
+
+## Cost and observability
+
+Every `clauditor grade` iteration writes a `context.json` sidecar capturing the harness, provider, model, sandbox mode, reasoning-token count, and an estimated `cost_usd` for the grader calls. `clauditor trend` and `clauditor audit` aggregate across iterations and refuse to silently average across mismatched harness or provider axes — pass `--cross-harness` / `--cross-provider` to opt in. Full reference: [docs/cost-tracking.md](docs/cost-tracking.md) and [docs/audit-trend-workflow.md](docs/audit-trend-workflow.md).
+
 ## Reference docs
 
 - [`docs/architecture.md`](docs/architecture.md) — how clauditor works under the hood (mermaid diagrams of the grade flow)
@@ -273,7 +279,11 @@ Running `clauditor grade <skill> --transport cli` is the one-liner for subscript
 - [`docs/skills.md`](docs/skills.md) — catalog of skills shipped with this repo, with live badge status
 - [`docs/badges.md`](docs/badges.md) — shields.io badges from iteration sidecars (`clauditor badge`)
 - [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — `claude` stream-json parser contract
+- [`docs/codex-stream-schema.md`](docs/codex-stream-schema.md) — `codex` NDJSON parser contract (sibling of stream-json-schema)
 - [`docs/transport-architecture.md`](docs/transport-architecture.md) — CLI vs SDK transport, auth-state matrix, precedence, migration
+- [`docs/codex-harness.md`](docs/codex-harness.md) — running skills under the OpenAI Codex CLI
+- [`docs/cost-tracking.md`](docs/cost-tracking.md) — `cost_usd`, reasoning tokens, the pricing table, and per-iteration `context.json`
+- [`docs/audit-trend-workflow.md`](docs/audit-trend-workflow.md) — measuring regressions over iterations with `audit` / `trend` / `compare` / `badge`
 - [`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood) — maintainer pre-release dogfood gate + contribution workflow
 
 ## License

--- a/docs/audit-trend-workflow.md
+++ b/docs/audit-trend-workflow.md
@@ -1,0 +1,167 @@
+# Audit, trend, and the regression-catching workflow
+
+This doc walks the "did my SKILL.md edit improve or regress the skill?" workflow end-to-end: how `clauditor grade` builds up history over time, how `audit` and `trend` aggregate it, how `compare` deltas two snapshots, and how `badge` surfaces the latest result in CI. The individual command flags are in [docs/cli-reference.md](cli-reference.md); this doc tells the story of how they fit together.
+
+> Returning from the [root README](../README.md). This doc is the full reference for the iteration-history workflow.
+
+## The data flow
+
+```
+clauditor grade  →  .clauditor/iteration-N/<skill>/{assertions,extraction,grading,context}.json
+                    .clauditor/history.jsonl  (append)
+                                          │
+                ┌─────────────────────────┼────────────────────────┐
+                ▼                         ▼                        ▼
+        clauditor audit          clauditor trend          clauditor badge
+        (per-assertion           (one metric              (latest iteration
+         pass-rate across         over time, TSV)          → shields.io JSON)
+         last N iterations)
+```
+
+Every `grade` invocation:
+
+1. Allocates a fresh `iteration-N-tmp/` staging dir.
+2. Runs the skill subprocess + L1 assertions + (optional) L2 extraction + L3 grading.
+3. Writes per-iteration JSON sidecars **into the staging dir** (`schema_version` first key in each).
+4. Atomically renames `iteration-N-tmp/` → `iteration-N/`. Either every sidecar is visible or none are.
+5. Appends one line to `history.jsonl` (`schema_version: 3` today) with the run's primary metrics, harness, and provider.
+
+This is the data substrate the other three commands consume. There is no separate database; the iteration directory is the source of truth.
+
+## `clauditor audit` — per-assertion pass-rate
+
+Use audit when you want to find **which assertions are flaky** across recent iterations.
+
+```bash
+clauditor audit my-skill --last 20
+clauditor audit my-skill --last 20 --min-fail-rate 0.1 --min-discrimination 0.2
+clauditor audit my-skill --json > audit.json
+```
+
+Audit reads every iteration's sidecars (`assertions.json` for L1, `extraction.json` for L2, `grading.json` for L3), groups by the 4-tuple `(harness, provider, layer, id)`, and prints a pass-rate per group. The 4-tuple grouping means a run of the same skill under `(claude-code, anthropic)` and another under `(codex, openai)` produce two distinct rows rather than averaging across stacks.
+
+Threshold flagging (`--min-fail-rate`, `--min-discrimination`) is the way you surface the "this assertion fires too often / doesn't discriminate" pattern in CI.
+
+The `--verbose` flag includes the per-iteration `context.json` fields (model_grader, cost_usd, reasoning_tokens) in the rendered table — useful when you want to see "did this regression coincide with a model swap?"
+
+## `clauditor trend` — one metric over time
+
+Use trend when you want a **single metric over many iterations** for one skill — pass-rate, mean-score, total cost, token counts, grader duration.
+
+```bash
+clauditor trend my-skill --metric pass_rate --last 30
+clauditor trend my-skill --metric grader.input_tokens --last 30
+clauditor trend my-skill --list-metrics    # discover what's available
+```
+
+Output is TSV (iteration, timestamp, value). Pipe to `gnuplot`, `vega-lite`, your spreadsheet of choice, or just `awk '{print $3}'` for a quick eyeball.
+
+### Cross-axis comparability refusal
+
+**This is the most important behavior to understand.** Trend refuses by default to average across mismatched harness or provider axes:
+
+```bash
+$ clauditor trend my-skill --metric pass_rate
+ERROR: Mixed providers detected in history for skill 'my-skill'
+  (anthropic, openai). Pass --provider anthropic (or --provider openai)
+  to filter, or --cross-provider to allow averaging.
+```
+
+You have three responses per axis:
+
+1. **Filter**: `--provider anthropic` keeps only that stack's records.
+2. **Opt in**: `--cross-provider` allows averaging, with a stderr WARNING that results may not be comparable.
+3. **Fix the data**: re-run the missing stack so the history is uniform.
+
+The same applies to `--harness` / `--cross-harness`. The two axes are independent — `--harness claude-code --cross-provider` is valid (filter harness, allow mixed provider).
+
+Why the refusal exists: a user who ran the same eval under Claude+Sonnet one week and Codex+gpt-5.4 the next deserves a refusal, not a smooth pass-rate line that silently averages two non-comparable execution stacks. See [`.claude/rules/cross-axis-comparability-refusal.md`](../.claude/rules/cross-axis-comparability-refusal.md) for the full design rationale.
+
+The refusal fires AFTER the full filtered set is loaded but BEFORE the `--last` slice, so a narrow window can't silently bypass it.
+
+## `clauditor compare` — two-snapshot delta
+
+Compare two specific grading reports (a "before" and "after") to measure the delta of a single change:
+
+```bash
+# Positional grade.json paths
+clauditor compare \
+  .clauditor/iteration-7/my-skill/grading.json \
+  .clauditor/iteration-8/my-skill/grading.json
+
+# Or by iteration number
+clauditor compare --skill my-skill --from 7 --to 8
+
+# A/B blind compare (different mode — judges two captured outputs)
+clauditor compare --blind --skill my-skill capture-a.txt capture-b.txt
+```
+
+Delta mode honors the same cross-axis refusal as `trend`: if the two grading reports came from mismatched stacks, you get an exit-2 refusal naming both axes and the opt-in flags. `.txt` capture pairs silent-skip the check (they carry no metadata).
+
+`--blind` mode is **untouched** by the cross-axis block — blind A/B is a per-call LLM judgment between two outputs and is *expected* to span stacks (that's the comparison).
+
+## `clauditor badge` — surface the latest result
+
+Generate a shields.io endpoint JSON from the latest iteration's sidecars:
+
+```bash
+clauditor badge .claude/skills/my-skill/SKILL.md --output .clauditor/badges/my-skill.json
+clauditor badge .claude/skills/my-skill/SKILL.md --url-only
+```
+
+Produces a **pair** of files: the shields.io-strict JSON the badge service consumes, and a sibling `<name>.clauditor.json` carrying the full per-iteration context (layers, model, cost, reasoning tokens) for downstream tooling. See [docs/badges.md](badges.md) for the dual-file pattern and shields.io embedding recipes.
+
+The badge reflects the **latest** iteration — it is a current-state indicator, not an aggregate. Pair it with `trend` for history visibility.
+
+## A typical workflow
+
+```bash
+# 1. Grade the skill in its current state.
+clauditor grade .claude/skills/my-skill/SKILL.md
+
+# 2. Look at the per-assertion pass rate.
+clauditor audit my-skill --last 5
+
+# 3. Edit SKILL.md based on the failing criteria.
+clauditor suggest .claude/skills/my-skill/SKILL.md
+$EDITOR .claude/skills/my-skill/SKILL.md
+
+# 4. Re-grade to get a new iteration.
+clauditor grade .claude/skills/my-skill/SKILL.md
+
+# 5. Delta the two iterations.
+clauditor compare --skill my-skill --from N-1 --to N
+
+# 6. Once happy, trend over time.
+clauditor trend my-skill --metric pass_rate --last 20
+
+# 7. Surface in README.
+clauditor badge .claude/skills/my-skill/SKILL.md \
+  --output .clauditor/badges/my-skill.json
+git add .clauditor/badges/my-skill.json .clauditor/badges/my-skill.clauditor.json
+```
+
+If your history is mixed across harness/provider, step 6 will refuse with a clear error and tell you exactly which `--<axis>` filter or `--cross-<axis>` opt-in to add. That's the design intent — silent averaging across stacks is the failure mode it exists to prevent.
+
+## Schema versions on disk
+
+Useful when you're reading sidecars programmatically or migrating history. Loaders accept all listed versions; new versions are additive.
+
+| File | Current `schema_version` | Notes |
+| --- | --- | --- |
+| `assertions.json` | 2 | Bumped at #152 (`harness` field). |
+| `extraction.json` | 5 | Bumped through #86, #147, #152, #170 (transport, provider, harness, reasoning_tokens). |
+| `grading.json` | 5 | Same lifecycle as extraction. |
+| `context.json` | 1 | **Always-v1 by design** — nullable fields pre-declared so new metadata adds without bumping. |
+| `history.jsonl` | 3 | Per-record; legacy v1/v2 lines default `provider="anthropic"`, `harness="claude-code"`. |
+| `audit --json` output | 4 | Per-#154; adds `iteration_contexts` array. |
+| `badge.json` | 1 (shields.io camelCase) + `badge.clauditor.json` v1 (sibling extension) | Two files, two lifecycles. |
+
+For the full schema-bump rationale, see [`.claude/rules/json-schema-version.md`](../.claude/rules/json-schema-version.md).
+
+## See also
+
+- [docs/cli-reference.md](cli-reference.md) — every flag on every command in this workflow.
+- [docs/cost-tracking.md](cost-tracking.md) — `context.json` fields and what `cost_usd` / `reasoning_tokens` mean.
+- [docs/badges.md](badges.md) — the dual-file badge pattern and CI integration.
+- [docs/codex-harness.md](codex-harness.md) — running skills under Codex, the harness axis the refusal protects.

--- a/docs/codex-harness.md
+++ b/docs/codex-harness.md
@@ -1,0 +1,101 @@
+# Codex harness
+
+This doc covers running your skill under the OpenAI **Codex** CLI instead of Claude Code. If you just want to grade Anthropic-authored skills with Claude as the runtime, you can skip this — the default `--harness auto` resolves to `claude-code` whenever the `claude` binary is on PATH.
+
+> Returning from the [root README](../README.md). This doc is the full reference for the harness axis; the README has a one-paragraph summary.
+
+The harness axis is **independent** of the grader provider axis. A common shape: skill runs under Codex (`--harness codex`), and the L3 grader still calls Claude Sonnet (`--grading-provider anthropic`). The two CLIs are evaluating each other.
+
+## When to use it
+
+- You don't have a Claude Code subscription and don't want one — Codex bills against `OPENAI_API_KEY` directly.
+- You want to compare how the same skill behaves under different runtimes (e.g. baseline A/B between Claude and Codex).
+- You're auditing a skill author's claim that their SKILL.md is harness-agnostic.
+
+## Quick start
+
+```bash
+# 1. Install the Codex CLI separately (npm install -g @openai/codex or similar).
+$ which codex
+/usr/local/bin/codex
+
+# 2. Export an auth env var. Either works; CODEX_API_KEY wins if both are set.
+$ export CODEX_API_KEY=sk-...
+
+# 3. Run a skill under Codex.
+$ clauditor validate path/to/SKILL.md --harness codex
+$ clauditor grade    path/to/SKILL.md --harness codex
+$ clauditor capture  path/to/SKILL.md --harness codex --output codex-run.txt
+```
+
+## Four-layer harness resolution
+
+Same precedence shape as `--transport` and `--grading-provider`:
+
+| Layer | Value | Notes |
+| --- | --- | --- |
+| CLI flag | `--harness {claude-code,codex,auto}` | On `validate`, `grade`, `capture`, `run` only. LLM-mediated commands (`extract`, `triggers`, `compare --blind`, `propose-eval`, `suggest`) have no harness axis — they call `call_model` directly without running a skill subprocess. |
+| Env var | `CLAUDITOR_HARNESS={claude-code,codex,auto}` | Whitespace-only values are normalized to "unset". |
+| Spec field | `EvalSpec.harness: str = "auto"` | Per-skill author preference. Validated at load time. |
+| Default | `"auto"` | `shutil.which("claude")` first; then `shutil.which("codex")`; hard-fail with a three-escape-hatch error if neither is on PATH. |
+
+When the `auto` branch lands on `codex` because `claude` is not on PATH, clauditor emits a one-time stderr notice per process pointing at the env vars and explicit-pin escape hatches — see "Implicit-coupling announcements" in `.claude/rules/centralized-sdk-call.md`. An explicit `--harness codex` (or any non-auto value) stays silent.
+
+## Auth precedence inside the Codex subprocess
+
+The harness exports auth into the skill subprocess in this order:
+
+1. `CODEX_API_KEY` — Codex-specific key. Wins if set.
+2. `OPENAI_API_KEY` — fallback. Codex CLI accepts this directly.
+3. Cached `~/.codex/auth.json` — only honored when `auth_mode == "apikey"`. Clauditor **refuses** ChatGPT-mode credentials at pre-flight per [#177](https://github.com/wjduenow/clauditor/issues/177) because the codex subprocess would route via ChatGPT and reject every model.
+
+If none of the three is available, the pre-flight `check_codex_auth` guard raises `CodexAuthMissingError` and the CLI exits 2 with an actionable message naming the required env vars.
+
+## Sandbox modes
+
+Codex supports three sandbox levels: `read-only`, `workspace-write`, `danger-full-access`. Clauditor pins `workspace-write` today — enough for skills that need to write under the workspace but not enough for skills that need network or arbitrary filesystem access. The pinned value is stamped on `IterationContext.sandbox_mode` for audit visibility. Making it user-configurable is a future ticket; if your skill needs a different mode, file an issue.
+
+## Stream parser
+
+Codex emits NDJSON on stdout (different from Claude's stream-json). The parser is in `src/clauditor/_harnesses/_codex.py`; the on-disk contract — event types, failure surface, `harness_metadata` keys, advisory warnings — is documented at [docs/codex-stream-schema.md](codex-stream-schema.md). You shouldn't need to read it unless you're contributing to the harness itself or debugging a parse-level failure.
+
+## What lands on disk
+
+Every Codex run produces the same sidecar shape as Claude Code runs, with one observability difference:
+
+- `assertions.json` — `harness: "codex"`.
+- `grading.json` / `extraction.json` — `harness: "codex"`, plus the grader's provider/model untouched.
+- `context.json` — `harness: "codex"`, `sandbox_mode: "workspace-write"`, plus `harness_metadata` carrying Codex-specific keys (auth source, dropped-events count when applicable).
+- `history.jsonl` — each appended record carries `harness: "codex"` so `clauditor trend` can refuse to average across harnesses unless `--cross-harness` is passed.
+
+## Limitations
+
+- **No subscription path.** Anthropic users with a Claude Pro/Max subscription can grade for free via `--transport cli`; Codex has no equivalent — every call bills against an API key.
+- **Hardcoded sandbox.** `workspace-write` only. Future ticket.
+- **No allow-hang heuristic.** The Claude Code harness has a `allow_hang_heuristic` knob that classifies "model returned a question" as a failure; Codex doesn't expose the parse hooks needed for it. The flag is silently a no-op when the resolved harness is Codex.
+- **Pytest fixtures.** `clauditor_runner` and `clauditor_spec` both honor the harness axis; the eager `check_codex_auth` guard fires at fixture-setup time so a missing-key surfaces as a test-setup error rather than a deep subprocess failure mid-run.
+
+## Pairing harness with grader
+
+The four useful combinations:
+
+| Harness | Grader | When to use |
+| --- | --- | --- |
+| `claude-code` | `anthropic` | Default. Subscription-friendly if you have Claude Pro/Max. |
+| `claude-code` | `openai` | Audit Claude-authored skills with a non-Claude grader to reduce same-vendor bias. |
+| `codex` | `anthropic` | Anthropic-graded evaluation of Codex behavior. Common when comparing runtimes. |
+| `codex` | `openai` | All-OpenAI stack. |
+
+Resolve provider per [docs/transport-architecture.md](transport-architecture.md) and pair via independent flags — clauditor will refuse to silently average across mismatched harness OR provider axes during `clauditor trend` / `clauditor compare`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Exit 2 — `CodexAuthMissingError` | Neither `CODEX_API_KEY` nor `OPENAI_API_KEY` set; no usable cached auth | Export one of the two env vars. |
+| Exit 2 — "ChatGPT-mode credentials refused" | `~/.codex/auth.json` has `auth_mode == "chatgpt"` | Re-authenticate Codex with an API key flow, OR export `CODEX_API_KEY` to override the cached creds. |
+| Auto resolved to codex unexpectedly | `claude` not on PATH | Install Claude Code, or pin `--harness=claude-code` / `CLAUDITOR_HARNESS=claude-code`. |
+| "stderr line about auto→codex" | First time the auto branch picked Codex this process | One-shot notice. Pin explicitly to silence. |
+| Skills that worked under Claude fail under Codex | Different sandbox / runtime semantics | Expected — that's what cross-harness evaluation reveals. The skill is harness-coupled. |
+
+See also `clauditor doctor` for environment-level diagnostics (which binaries are on PATH, which env vars are set, which auth paths resolve).

--- a/docs/cost-tracking.md
+++ b/docs/cost-tracking.md
@@ -1,0 +1,98 @@
+# Cost tracking and per-iteration context
+
+This doc covers how clauditor measures and persists the cost of an LLM grading run — both dollars (`cost_usd`) and reasoning-token effort — plus the broader `context.json` sidecar that captures comparability metadata so `audit` and `trend` can compare like-with-like across iterations.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a one-paragraph summary.
+
+## What gets recorded
+
+Every `clauditor grade` (or `validate`) iteration writes a sibling sidecar at `.clauditor/iteration-N/<skill>/context.json` with these fields (schema_version: 1, designed to stay at v1 — see [Always-v1 contract](#always-v1-contract) below):
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schema_version` | `int = 1` | Always first key on disk. |
+| `harness` | `str` | `"claude-code"` or `"codex"`. Materialized by the four-layer harness resolver. |
+| `provider` | `str \| None` | `"anthropic"` or `"openai"`, or `null` when no LLM grading happened (e.g. `validate`-only). |
+| `model_runner` | `str \| None` | The model the harness actually used to run the skill. Null when the harness can't expose it (Claude Code's stream-json `result` carries no model field unless pinned). |
+| `model_grader` | `str \| None` | The model the grader called. Null iff `provider` is null. |
+| `system_prompt_source` | `str` | `"explicit"` / `"agents_md"` / `"skill_md"` — where the system prompt came from for this run. |
+| `sandbox_mode` | `str \| None` | Codex-only: `"read-only"` / `"workspace-write"` / `"danger-full-access"`. Null when `harness != "codex"`. |
+| `reasoning_tokens` | `int \| None` | Separately-billed thinking/reasoning tokens summed across the grader chain. See [Reasoning tokens](#reasoning-tokens). |
+| `cost_usd` | `float \| None` | Estimated grader-call cost in USD. See [Cost estimation](#cost-estimation). |
+
+## Cost estimation
+
+The pure helper `clauditor._providers._pricing.estimate_cost(provider, model, input_tokens, output_tokens, reasoning_tokens=None)` returns a USD float (or `None` on lookup miss). The composition helper `compute_iteration_cost_usd` sums Layer 2 + Layer 3 grader-call cost from the already-populated `GradingReport` / `ExtractionReport` dataclasses.
+
+The pricing table is hardcoded into clauditor at release time — it lives at `src/clauditor/_providers/_pricing.py::_PRICING_TABLE`. Today's coverage:
+
+| Provider | Model | Input $/MTok | Output $/MTok |
+| --- | --- | --- | --- |
+| anthropic | claude-sonnet-4-6 | 3.00 | 15.00 |
+| anthropic | claude-opus-4-7 | 15.00 | 75.00 |
+| anthropic | claude-haiku-4-5 | 0.80 | 4.00 |
+| openai | gpt-5.4 | 2.50 | 10.00 |
+| openai | gpt-5.4-mini | 0.15 | 0.60 |
+| openai | o4-mini | 1.10 | 4.40 |
+
+Reasoning tokens roll into the output rate (model bills them at output prices). The cost is **all-or-nothing across the grader chain**: if any Layer 2 or Layer 3 call can't be priced (unknown model, missing usage data), `cost_usd` is `null` rather than a partial sum — a "roughly right" estimate is silently wrong for budgeting per the design decision in [#169](https://github.com/wjduenow/clauditor/issues/169).
+
+### Stale-table warnings
+
+Clauditor emits a one-time stderr warning per process when the pricing table is older than 90 days. Today's verification date is pinned at `_LAST_VERIFIED` in the same module. The warning names the canonical price sources (platform.claude.com, openai.com/api/pricing) so a maintainer can update the table. The warning is loud-but-safe: a typo in the date constant still fires the warning (treats the table as stale) rather than crashing the grading run.
+
+### Unknown-model warnings
+
+Calling `estimate_cost("anthropic", "claude-future-9", ...)` returns `None` AND emits a one-time-per-`(provider, model)` warning to stderr — distinct unknown models each get their own first-call warning rather than the first miss muting all subsequent ones. An unknown **provider** stays silent (different code path) so a typo'd provider doesn't flood stderr.
+
+## Reasoning tokens
+
+The `reasoning_tokens` field is the count of separately-billed thinking tokens the grader chain consumed. Sourced asymmetrically per provider:
+
+- **Anthropic**: always `None`. The SDK's `Usage` object has no separately-billed thinking-token field; for extended-thinking models the thinking tokens are already included in `output_tokens`. Clauditor records `None` rather than fabricating a value.
+- **OpenAI**: extracted from `usage.output_tokens_details.reasoning_tokens` via a defensive helper (`isinstance` guards, `bool`-vs-`int` discipline). `0` is preserved as a real signal ("model didn't reason on this call"); `None` means "couldn't read."
+
+The grader chain may make multiple calls (variance reps, parse-retry attempts, blind-compare's two parallel calls). The chain-level aggregator `_sum_optional_reasoning_tokens` distinguishes "no source surfaced a count" (all-`None` → `None`) from "sources surfaced zero" (mixed or all-int → real sum), so a single `None` component doesn't poison a sum that has at least one real value.
+
+## Always-v1 contract
+
+`context.json` is engineered so anticipated follow-ups can populate new fields **without bumping the schema version**. The trick: nullable fields are pre-declared in v1. When [#169](https://github.com/wjduenow/clauditor/issues/169) wired up `cost_usd` and [#170](https://github.com/wjduenow/clauditor/issues/170) wired up `reasoning_tokens`, the on-disk shape stayed v1 and every existing reader kept working unchanged. This is the inverse of `grading.json` / `extraction.json`, which bumped at every additive change (v1→v5 today) because their fields weren't pre-declared.
+
+Bumps cost integration churn (default-on-read defaults, loader branches, regression tests). Pre-declaring nullable fields when the follow-ups are known up-front avoids the churn.
+
+## How to read it
+
+### From the CLI
+
+`clauditor audit` reads every iteration's `context.json` and surfaces the metadata in its grouped output (group key: `(harness, provider, layer, id)`). `clauditor trend` reads `history.jsonl` (which carries the harness + provider stamps but not the per-iteration context) and refuses to silently average across mismatched harness or provider axes unless `--cross-harness` / `--cross-provider` is passed.
+
+`clauditor badge` reads the latest iteration's sidecars and emits both a shields.io endpoint JSON AND a sibling `<name>.clauditor.json` extension carrying the per-iteration context — see [docs/badges.md](badges.md) for the dual-file pattern.
+
+### Programmatically
+
+```python
+from clauditor.context import IterationContext
+import json
+
+with open(".clauditor/iteration-7/my-skill/context.json") as f:
+    ctx = IterationContext(**json.load(f))
+
+print(f"Grader: {ctx.provider}/{ctx.model_grader}")
+print(f"Cost: ${ctx.cost_usd:.4f}" if ctx.cost_usd else "Cost: unknown")
+print(f"Reasoning: {ctx.reasoning_tokens or 0} tokens")
+```
+
+## When cost is `None`
+
+| `cost_usd` is null because… | Fix |
+| --- | --- |
+| `validate`-only run (no grader call) | Expected. Cost only meaningful for `grade` / `extract`. |
+| Grader call used an unknown model | Look for the stderr unknown-model warning. Add the model to `_PRICING_TABLE` and bump `_LAST_VERIFIED`. |
+| One of Layer 2 / Layer 3 was priced but the other wasn't | All-or-nothing per [#169](https://github.com/wjduenow/clauditor/issues/169) DEC-002. Add the missing model. |
+| Pricing table older than 90 days | Stale warning fires but cost is still computed. Update the table. |
+
+## See also
+
+- [docs/audit-trend-workflow.md](audit-trend-workflow.md) — how `audit` / `trend` consume the data.
+- [docs/transport-architecture.md](transport-architecture.md) — provider / transport / harness axes.
+- [docs/badges.md](badges.md) — the sibling `.clauditor.json` extension that surfaces context in the badge pair.


### PR DESCRIPTION
## Summary

Three new deep-dive docs + small README polish, addressing gaps surfaced by the doc audit against the codebase. The Anthropic-only, Claude-Code-only story shipped well in the original docs; ~6 months of axis-extension work (multi-provider OpenAI, multi-harness Codex, cost tracking, cross-axis refusal) has been under-documented.

- **\`docs/codex-harness.md\`** — user-facing narrative for running skills under the OpenAI Codex CLI. Covers auth precedence (CODEX_API_KEY → OPENAI_API_KEY → cached auth), four-layer harness resolution, sandbox modes, troubleshooting table, and the four useful harness × grader pairings.
- **\`docs/cost-tracking.md\`** — \`context.json\` sidecar shape, \`cost_usd\` estimation rules (all-or-nothing across grader chain), pricing table contents, reasoning-token semantics (asymmetric per provider per #170), and the always-v1 contract that pre-declares nullable fields so additive changes don't bump the schema.
- **\`docs/audit-trend-workflow.md\`** — the missing end-to-end story for the iteration-history workflow. Walks data flow (\`grade\` → iteration sidecars + history.jsonl → \`audit\`/\`trend\`/\`compare\`/\`badge\`), cross-axis comparability refusal (with filter/opt-in/fix responses), the typical edit-grade-suggest-compare loop, and a schema-version table.

README gains a **Cost and observability** section and a paragraph in **Authentication** mentioning \`--harness codex\`. Reference docs list now links all three new docs plus the previously-orphaned \`codex-stream-schema.md\`.

## What's NOT in this PR

The doc audit identified additional polish opportunities deferred for now:
- \`docs/pytest-plugin.md\` expansion to cover #155's factory-fixture parametrize overhaul (currently 131 lines, thinnest doc relative to feature surface).
- \`docs/quick-start.md\` refresh (last touched 2026-04-22, pre-dates Codex/OpenAI work).
- Troubleshooting / FAQ doc.

Happy to follow up if there's appetite.

## Test plan

- [ ] Verify all new internal doc links resolve (relative paths within \`docs/\`).
- [ ] Verify README links to the three new docs resolve from GitHub blob view.
- [ ] Spot-check CLI examples in the new docs against actual flag spellings (\`--harness codex\`, \`--grading-provider openai\`, \`--from-iteration N\`, \`badge <SKILL.md path>\`, \`compare --skill X --from N --to M\`).
- [ ] No code changes — no automated tests to run.