### PR TITLE
chore: merge dev into main for v0.1.2 release

### DIFF
--- a/.claude/rules/numeric-judge-field-anchors.md
+++ b/.claude/rules/numeric-judge-field-anchors.md
@@ -59,8 +59,8 @@ return (
     f' "the output completely fails this criterion" and 1.0 means'
     f' "the output completely satisfies this criterion". This MUST'
     f" be monotonically aligned with `passed`: any score >= 0.5"
-    f" implies passed=true, and any score < 0.5 implies"
-    f" passed=false.\n"
+    f' implies "passed": true, and any score < 0.5 implies'
+    f' "passed": false.\n'
     f"- evidence: ...\n"
     f"- reasoning: ...\n"
 )

--- a/.claude/rules/numeric-judge-field-anchors.md
+++ b/.claude/rules/numeric-judge-field-anchors.md
@@ -1,0 +1,247 @@
+# Rule: Numeric judge fields define 0.0/1.0 anchors and alignment with boolean siblings
+
+When an LLM judge prompt asks the model to emit a **numeric** field
+in a per-criterion result object — `score`, `confidence`, `severity`,
+a future `quality` rating — the prompt MUST (a) define what the
+endpoints of the numeric range mean concretely, and (b) if the numeric
+field has a boolean sibling in the same object (`passed`, `valid`,
+`triggered`), declare the monotonic-alignment invariant tying them
+together at a specific threshold. A bare `"score: 0.0 to 1.0"` or
+`"confidence level from 0.0 to 1.0"` is the foot-gun this rule
+exists to prevent: Anthropic Claude reads such phrasing as graded
+fulfillment ("how passing is this"), gpt-5.4 reads it literally as
+verdict confidence ("how sure am I about my passed value"), and the
+two readings produce non-commensurable values for the same on-disk
+field within a single grader run.
+
+The cross-provider divergence is **silent** — both responses parse
+cleanly, both look plausible field-by-field, and the divergence only
+surfaces when an aggregator averages across the two (mean_score
+divergence) or a downstream consumer reads the numeric field as an
+ordering signal.
+
+## The trap
+
+```python
+# WRONG — "confidence" is provider-ambiguous; no threshold tying
+# score to passed.
+return (
+    f"For each criterion, determine:\n"
+    f"- passed: whether the output satisfies the criterion (true/false)\n"
+    f"- score: confidence level from 0.0 to 1.0\n"
+    f"- evidence: ...\n"
+    f"- reasoning: ...\n"
+)
+```
+
+Observed failure shape on the same captured output, same eval spec
+(`find-restaurants` fixture, 13 criteria):
+
+| Provider                | Pass rate | Mean score | `passed=false, score>=0.5` rows |
+| ----------------------- | --------- | ---------- | ------------------------------- |
+| claude-sonnet-4-6       | 10/13     | 0.785      | 0/13 (failing scores 0.0–0.4)   |
+| gpt-5.4 (pre-rule)      | 8/13      | **0.965**  | **5/13** (failing scores 0.93–1.0) |
+
+gpt-5.4 emitted `passed=false, score=1.0` rows, treating `score` as
+"how confident am I in this failure verdict" — orthogonal to
+`passed`. `mean_score` aggregation across the two providers became
+meaningless: gpt-5.4 reports 0.965 while passing fewer criteria,
+which a naive trend consumer would read as "better quality".
+
+## The pattern
+
+```python
+# RIGHT — anchored endpoints + monotonic-alignment invariant.
+return (
+    f"For each criterion, determine:\n"
+    f"- passed: whether the output satisfies the criterion (true/false)\n"
+    f'- score: fulfillment level from 0.0 to 1.0, where 0.0 means'
+    f' "the output completely fails this criterion" and 1.0 means'
+    f' "the output completely satisfies this criterion". This MUST'
+    f" be monotonically aligned with `passed`: any score >= 0.5"
+    f" implies passed=true, and any score < 0.5 implies"
+    f" passed=false.\n"
+    f"- evidence: ...\n"
+    f"- reasoning: ...\n"
+)
+```
+
+Three load-bearing clauses, all required:
+
+1. **A semantic name for what the numeric field measures.**
+   `"fulfillment level"` (or `"severity"`, `"completeness"`,
+   `"alignment"`) — NOT the word `"confidence"`, which is the
+   verdict-confidence trap. Pick a noun that describes the
+   property being measured, not the model's certainty about its
+   answer.
+2. **Concrete sentences anchoring the endpoints.** What does 0.0
+   *mean*? What does 1.0 *mean*? `"completely fails this
+   criterion"` / `"completely satisfies this criterion"` are
+   unambiguous; `"low confidence"` / `"high confidence"` are not.
+3. **The monotonic-alignment invariant** at an explicit threshold,
+   in MUST language, naming both directions. `"any score >= 0.5
+   implies passed=true, and any score < 0.5 implies passed=false"`
+   — both implications, the threshold pinned. This is the clause
+   that tells the model "do not decouple the numeric field from
+   the boolean field, regardless of how you interpret the
+   numeric scale."
+
+## Why each piece matters
+
+- **Word choice (`"confidence"` is the trap)**: the word
+  `"confidence"` has a separate technical meaning in ML / decision
+  theory that gpt-5.4 honors literally (verdict confidence,
+  orthogonal to verdict correctness). Anthropic Claude has been
+  observed treating `"confidence"` more idiomatically in this
+  context — closer to "graded fulfillment" — but the prompt
+  cannot rely on idiomatic reading. The remedy is to NOT use
+  `"confidence"` for the fulfillment-axis field at all. If
+  verdict-confidence is genuinely the property you want to
+  measure, name a SECOND field `confidence` and keep `score`
+  separate.
+- **Anchored endpoints, not range alone**: `"0.0 to 1.0"` says
+  nothing about what the endpoints mean. A model facing an
+  ambiguous range will fall back to whatever its training
+  distribution suggests, which differs across providers. Spelling
+  out `"0.0 means X, 1.0 means Y"` removes the ambiguity at the
+  prompt boundary, where it costs nothing, instead of trying to
+  recover it at the parser boundary, where there is no signal to
+  recover from.
+- **MUST + threshold + both directions**: the monotonic-alignment
+  clause is the load-bearing piece. Without it, even an anchored
+  range can produce decoupled values (a model could rate
+  `passed=false` and `score=0.6` claiming "this output mostly
+  fulfills the criterion but tips below the bar"). The 0.5
+  threshold matches the natural pass/fail boundary the aggregator
+  already implicitly assumes (`mean_score >= 0.5` ↔ "passing
+  quality"). Naming both implications (`>=0.5 → true`, `<0.5 →
+  false`) prevents a one-sided reading.
+- **Prompt-side fix, not parser-side reconciliation**: tempting
+  alternative is to have the parser detect violation and rewrite
+  `score` to match `passed` (e.g. `if not passed and score >= 0.5:
+  score = 1 - score`). DO NOT do this. The model's score is its
+  judgment; rewriting it after the fact loses information about
+  how the model actually graded. The right answer is to fix the
+  prompt so the model emits commensurable values in the first
+  place. The parser stays strict on shape: validates types,
+  alignment with criteria, but never rewrites field values.
+- **Cross-provider validation is the only real test**: unit tests
+  that pin substrings catch regression of the prompt language,
+  but the only way to verify the language actually produces
+  commensurable values is to grade the same captured output
+  against both providers and compare. A `tests/` test cannot do
+  this without spending real tokens; the validation belongs in
+  PR-review-time manual or smoke-test territory, not CI.
+
+## What NOT to do
+
+- Do NOT use the word `"confidence"` for a fulfillment-axis
+  numeric field. It is the provider-ambiguity trap this rule
+  exists to prevent. If the field genuinely measures
+  verdict-confidence, use a different field name and ALSO declare
+  its anchors and (if applicable) its relationship to the
+  fulfillment field.
+- Do NOT use range-only definitions (`"score: 0.0 to 1.0"`).
+  Anchor the endpoints with concrete sentences.
+- Do NOT omit the monotonic-alignment clause when the numeric
+  field has a boolean sibling. The two will silently decouple on
+  some provider, some prompt, some run.
+- Do NOT enforce monotonic alignment in the parser by rewriting
+  the numeric field. Rewriting loses signal. Fix at the prompt.
+- Do NOT skip the cross-provider validation step on a real
+  captured fixture before merging a new numeric judge prompt.
+  Unit tests pin the prompt language but cannot verify the
+  language produces commensurable values across providers.
+- Do NOT pick a non-0.5 threshold without a reason. The 0.5
+  midpoint is the natural pass/fail boundary the aggregator
+  already implicitly uses (`mean_score >= 0.5` reads as "passing
+  quality"). A different threshold would create a second source
+  of truth for "what counts as passing".
+
+## Canonical implementation
+
+`src/clauditor/quality_grader.py::build_grading_prompt` (post-#186)
+— the `score` clause defines fulfillment level with concrete
+endpoints and the MUST monotonic-alignment invariant tying it to
+`passed` at 0.5. The pre-#186 phrase `"confidence level from 0.0
+to 1.0"` is the documented foot-gun.
+
+Tests:
+
+- `tests/test_quality_grader.py::TestBuildGradingPrompt::test_score_defined_as_fulfillment_not_confidence`
+  — pins `"fulfillment level from 0.0 to 1.0"` plus the
+  completeness clauses; asserts the pre-#186 `"confidence level
+  from 0.0 to 1.0"` phrase is gone.
+- `tests/test_quality_grader.py::TestBuildGradingPrompt::test_score_monotonically_aligned_with_passed`
+  — pins the MUST clause and both threshold implications.
+- `tests/test_quality_grader.py::TestBuildGradingPrompt::test_prompt_language_would_have_prevented_gpt5_shape`
+  — documents the two response shapes (Claude-style fulfillment
+  vs gpt-5.4 verdict-confidence) and pins the load-bearing
+  clauses that rule out the gpt-5.4 shape.
+
+Cross-provider validation evidence: PR #187 comment on the
+`find-restaurants` fixture, 13 criteria, grading the same
+captured output. Pre-fix gpt-5.4 showed 5/13 monotonic-alignment
+violations; post-fix gpt-5.4 showed 0/13, with failing-criterion
+scores moving from 0.93–1.0 down to 0.0–0.4.
+
+## Companion rules
+
+- `.claude/rules/positional-id-zip-validation.md` — sibling rule
+  for the same class of cross-provider prompt divergence on a
+  different shape (textual `criterion` echo field). The
+  "Prompt-side companion" section there documents the same
+  Anthropic-vs-gpt-5.4 divergence pattern for `1. ` prefix
+  echoing. Both rules trace to real-world validation against the
+  same `find-restaurants` fixture, both fix prompt-side, both
+  pin substring assertions to catch prompt regressions.
+- `.claude/rules/llm-judge-prompt-injection.md` — the prompt
+  hardening rule for untrusted content. This rule extends the
+  prompt-builder discipline from "treat tagged content as data"
+  to "anchor numeric fields to concrete semantics".
+- `.claude/rules/pre-llm-contract-hard-validate.md` — the broader
+  "fail loudly at the earliest safe moment" principle. This rule
+  applies that principle at the prompt boundary: the cheapest
+  place to prevent non-commensurable judge output is in the
+  prompt-builder, not in the parser or aggregator.
+- `.claude/rules/cross-axis-comparability-refusal.md` — the
+  downstream refusal mechanism that would catch averaging
+  across non-commensurable history records. This rule prevents
+  the non-commensurability from arising in the first place,
+  within a single run.
+
+## When this rule applies
+
+Any future LLM judge prompt that asks the model to emit a numeric
+field per result. Plausible callers:
+
+- A rubric critic that emits a `severity` field on each criticism.
+- A trigger-precision judge with a `confidence` field tied to a
+  `should_trigger` boolean.
+- A blind-compare judge with a `margin` field measuring how
+  decisively one output won.
+- A regression-detection judge with a `quality_delta` field
+  tied to a `regressed` boolean.
+
+The rule also applies retroactively: any existing judge prompt with
+a bare `"0.0 to 1.0"` definition is a latent foot-gun. Add anchored
+endpoints + monotonic-alignment (if applicable) the next time the
+prompt is touched. Run the cross-provider validation step before
+merging.
+
+## When this rule does NOT apply
+
+- Non-numeric judge fields. Categorical fields (`"verdict": "a" |
+  "b" | "tie"`), enumerated fields, free-text fields — those have
+  their own discipline. The verdict-vs-fulfillment ambiguity is
+  specific to ranged numeric fields.
+- Single-provider prompts that genuinely never run against more
+  than one model. Rare in clauditor today (most LLM-mediated
+  CLIs accept `--grading-provider`), but possible for a future
+  internal-only judge.
+- Numeric fields with no boolean sibling. The anchored-endpoints
+  half of the rule still applies; the monotonic-alignment half
+  does not.
+- Diagnostic / debug prompts that print a free-form analysis
+  rather than a structured per-criterion result object. There is
+  no parser-side commensurability invariant to defend.

--- a/.claude/rules/positional-id-zip-validation.md
+++ b/.claude/rules/positional-id-zip-validation.md
@@ -126,7 +126,11 @@ list lives at the LLM boundary: grading criteria, trigger-test
 slots, future per-section field lists. Anything else risks the
 same silent cross-provider divergence.
 
-Traces to #183.
+Traces to #183. Sibling rule for the same cross-provider prompt-
+semantics class of bug on a numeric field (per-criterion `score`
+read as fulfillment by Anthropic and as verdict-confidence by
+gpt-5.4) lives in `.claude/rules/numeric-judge-field-anchors.md`
+— traces to #186.
 
 ## Canonical implementation
 

--- a/.claude/rules/pytest-fixture-precedence-mirror.md
+++ b/.claude/rules/pytest-fixture-precedence-mirror.md
@@ -1,0 +1,243 @@
+# Rule: Pytest fixtures mirror the CLI's operator > author > default precedence
+
+When clauditor exposes a multi-axis precedence resolver at the CLI
+seam (`harness`, `grading_provider`, `grading_model`, …) via the
+shape codified in `.claude/rules/spec-cli-precedence.md`, the
+matching pytest fixtures **MUST** mirror the same precedence
+direction in fixture-land. The fixture seam is a **factory-fixture
+mirror**: each fixture exposes a `_factory(...)` callable whose
+kwargs are the operator-intent layer at the call site, and the
+factory closes over the pytest CLI options + env vars + spec fields
+to compose the same operator > author > default direction the CLI
+honors. A fixture that resolves axes differently from the CLI
+silently produces test results that do not reflect what
+`clauditor <cmd>` would do for the same operator under the same
+spec.
+
+The mirror is intentionally **asymmetric** across fixtures — three
+distinct precedence shapes ship today, each tuned to the seam's
+available context. The asymmetry is load-bearing, not an oversight.
+
+## The three shapes
+
+### Shape A — operator-only (no spec available)
+
+`clauditor_runner` does not load an `EvalSpec`, so only the
+operator-intent and default layers apply. Four layers:
+
+1. Factory `harness=` kwarg — operator intent at call site (wins).
+2. `--clauditor-harness` pytest option — operator intent at session start.
+3. `CLAUDITOR_HARNESS` env var — operator intent in the shell.
+4. Default `"auto"` — `resolve_harness(..., spec_value=None)` falls
+   through to PATH lookup.
+
+The author layer (`EvalSpec.harness`) is **structurally absent**, NOT
+silently skipped. A test that wants spec-author intent honored uses
+`clauditor_spec` (Shape B) instead. The fixture has no spec to read;
+faking one would require a sentinel and a defensive code path with
+no production analog.
+
+### Shape B — author-only (spec-load seam)
+
+`clauditor_spec` honors `EvalSpec.harness` (when set to a concrete
+value, not `"auto"`) and threads it as `harness_name_override` to
+`SkillSpec.run`. The fixture itself takes no operator-intent
+kwargs, no pytest option, no env var — but **per-call operator
+intent IS supported via `spec.run(harness_name_override="codex")`**
+on the wrapped run method (DEC-005: per-call kwarg wins over the
+spec field, mirroring the four-layer CLI precedence at the
+call-site granularity). Session-level operator intent
+(`--clauditor-harness`, `CLAUDITOR_HARNESS`) lives on
+`clauditor_runner`'s factory instead; consulting it here would let
+a session flag silently override a skill author's explicit
+`EvalSpec.harness` even for tests that deliberately probe author
+intent.
+
+### Shape C — full five-layer mirror (spec-load + grader call)
+
+`clauditor_grader` / `clauditor_blind_compare` / `clauditor_triggers`
+wrap both a spec-load AND a grader call, so they compose author intent
+(in the loaded spec) AND operator intent (factory kwargs + pytest
+options + env). Per axis:
+
+1. Factory `provider=` / `model=` kwarg — operator intent at call site (wins).
+2. `--clauditor-grading-provider` / `--clauditor-model` pytest option.
+3. `CLAUDITOR_GRADING_PROVIDER` env var (provider only — no
+   `CLAUDITOR_MODEL` env var per DEC-010).
+4. `EvalSpec.grading_provider` / `EvalSpec.grading_model` — author intent.
+5. Default — `"auto"` with auto-inference, or per-provider model default.
+
+Both axes flow through the same pure resolver chain
+(`resolve_grading_provider` + `resolve_grading_model`) the CLI uses,
+so a fixture caller and an operator running `clauditor grade` get
+the same provider+model resolution from the same `EvalSpec`.
+
+## Why each piece matters
+
+- **Factory > pytest option > env > spec > default direction is the
+  same shape the CLI honors.** A test that pins `provider="openai"`
+  at the factory kwarg is expressing the same operator-at-call-site
+  intent as `clauditor grade --grading-provider openai`. Reversing
+  the direction in fixture-land would mean tests grade with one
+  provider while documented user behavior grades with another —
+  silently false positives in CI.
+- **Shape A's missing author layer is structural, not a bug.** The
+  runner-factory fixture has no spec to read; pretending otherwise
+  by routing through `EvalSpec` would require a fake spec object
+  and would invite the "factory secretly knows about author intent"
+  hazard. The fixture's audience opted out of the spec layer by
+  picking the runner factory.
+- **Shape B's missing session-level operator layer is structural,
+  not a bug.** Reading `--clauditor-harness` at `clauditor_spec`
+  would let a session-level flag silently mask spec-author tests.
+  A test that asserts "this skill author's harness preference is
+  honored" must NOT be overridable by the test runner's session
+  flags. Per-call operator intent on `spec.run()` is fine — it is
+  scoped to one test's one run, not the whole session, and DEC-005
+  pins it as the winning layer over the spec field.
+- **Auth dispatch fires per-provider via
+  `_dispatch_fixture_auth_guard`.** Mirrors the CLI's
+  `check_provider_auth` ladder with distinct exception classes
+  (`AnthropicAuthMissingError` / `OpenAIAuthMissingError`) so
+  fixture callers route on a structural `except` ladder per
+  `.claude/rules/multi-provider-dispatch.md`. The Anthropic branch
+  retains the `CLAUDITOR_FIXTURE_ALLOW_CLI` opt-in toggle (relaxed
+  `check_any_auth_available` vs strict `check_api_key_only`) per
+  #86 DEC-009; the OpenAI branch is always strict per #145 DEC-002.
+- **Eager `check_codex_auth` at TWO seams, not one (DEC-005).**
+  Both `clauditor_runner` (resolved harness `"codex"`) AND
+  `clauditor_spec` (`eval_spec.harness == "codex"`) fire the codex
+  auth guard eagerly. The two seams are independent: each fires its
+  own guard on its own resolved value. A test using both fixtures
+  sees both guards fire when applicable; a test using only one sees
+  only that seam's guard. Mirrors the CLI's
+  `cli/grade.py::cmd_grade` shape (`_resolve_harness` resolves;
+  `check_codex_auth` dispatches).
+- **Hard break, not back-compat shim.** Per DEC-002 / DEC-009 of
+  #155, the pre-#155 value-fixture form
+  (`clauditor_runner.run("foo")`) is a hard break — callers must
+  now invoke `clauditor_runner()` to get the runner. The
+  value-fixture shape conflicts structurally with the per-call
+  `harness=` kwarg the factory needs; a back-compat shim would
+  defeat the conversion. Companion discipline:
+  `.claude/rules/back-compat-shim-discipline.md` — break loudly
+  rather than degrade silently.
+
+## What NOT to do
+
+- Do NOT route `clauditor_runner` through a fake `EvalSpec` to
+  "preserve symmetry" with `clauditor_spec`. The missing author
+  layer is intentional; faking it removes the cross-axis isolation
+  Shape A buys.
+- Do NOT consult `--clauditor-harness` inside `clauditor_spec`.
+  Operator-intent layers live on Shape A's factory only; mixing
+  them at the spec-load seam defeats the author-intent isolation
+  Shape B buys.
+- Do NOT pre-compute `env_without_api_key()` outside the per-call
+  closure inside `clauditor_spec`'s factory. The session-scoped
+  `--clauditor-no-api-key` option tempts this, but pre-computing
+  defaults the scrub to claude-code semantics (strips
+  `OPENAI_API_KEY`), which silently breaks codex callers when the
+  resolved harness is codex. **Defer the
+  `env_without_api_key(harness_name=...)` call until inside the
+  per-call wrapper**, after the effective harness is resolved (per
+  DEC-006 / US-007 of #155). This is the inverse failure mode of
+  `.claude/rules/test-infra-shutil-which-coupling.md` —
+  pre-computed scrub couples unrelated harness backends.
+- Do NOT swallow `ValueError` in `_resolve_fixture_provider` (or
+  any future pure resolver helper). Fail-fast on misconfigured
+  spec / CLI override at test setup — a swallowed exception
+  silently degrades to "fixture returned None" and downstream tests
+  pass spuriously. CodeRabbit finding on PR #164.
+
+## Canonical implementation
+
+Factory fixtures (one per shape):
+
+- **Shape A**:
+  `src/clauditor/pytest_plugin.py::clauditor_runner` — closes over
+  `--clauditor-harness`, `CLAUDITOR_HARNESS` env, and the factory
+  `harness=` kwarg. Calls `resolve_harness(cli, env, None)` then
+  `check_codex_auth("runner")` when name == `"codex"`. Materializes
+  a fresh `SkillRunner` via `construct_harness(name)` for
+  non-default harnesses; preserves `--clauditor-claude-bin`
+  plumbing for the default `"claude-code"` path.
+- **Shape B**:
+  `src/clauditor/pytest_plugin.py::clauditor_spec` — reads
+  `spec.eval_spec.harness` (concrete values only) and threads as
+  `harness_name_override=` to `SkillSpec.run`. Eager
+  `check_codex_auth("spec")` fires when spec author declared
+  `harness="codex"`. Same-harness skip layer avoids reconstructing
+  a runner with the same harness class but losing the fixture's
+  `--clauditor-claude-bin` configuration.
+- **Shape C**:
+  `src/clauditor/pytest_plugin.py::clauditor_grader`,
+  `clauditor_blind_compare`, `clauditor_triggers` — each closes
+  over `--clauditor-grading-provider` / `--clauditor-model`,
+  accepts `provider=` / `model=` factory kwargs (kwarg wins at call
+  site), loads the spec, dispatches `_dispatch_fixture_auth_guard`
+  and `_resolve_fixture_provider`, invokes the grader orchestrator.
+
+Pure helpers (mirror the CLI seam):
+
+- `src/clauditor/pytest_plugin.py::_resolve_fixture_provider` —
+  threads `provider_override` as `cli_override` to
+  `clauditor._providers.resolve_grading_provider`, honoring the
+  same env > spec > auto chain. Does NOT swallow `ValueError`.
+- `src/clauditor/pytest_plugin.py::_dispatch_fixture_auth_guard` —
+  routes by resolved provider (anthropic strict/relaxed via
+  `CLAUDITOR_FIXTURE_ALLOW_CLI`; openai always strict). Distinct
+  exception classes preserve structural routing per
+  `.claude/rules/multi-provider-dispatch.md`.
+
+Test-infra coupling: the autouse
+`_force_api_transport_in_tests` fixture in `tests/conftest.py`
+pairs its `shutil.which → None` patch with
+`monkeypatch.setenv("CLAUDITOR_HARNESS", "claude-code")` so the
+harness resolver short-circuits at the env layer rather than
+landing on the `which → None` path. Full pattern + rationale in
+`.claude/rules/test-infra-shutil-which-coupling.md`; #155 DEC-011
+inherits the recipe.
+
+Traces to DEC-001 through DEC-012 of
+`plans/super/155-pytest-fixtures-parametrize.md`. Companion rules:
+`.claude/rules/spec-cli-precedence.md` (the CLI-side precedence
+shape this rule mirrors),
+`.claude/rules/multi-provider-dispatch.md` (the structural-routing
+invariant the distinct fixture-side exception classes preserve),
+`.claude/rules/precall-env-validation.md` (the eager auth-guard
+pattern at the fixture seam),
+`.claude/rules/back-compat-shim-discipline.md` (the value→factory
+hard break),
+`.claude/rules/test-infra-shutil-which-coupling.md` (the
+autouse-PATH-pin coupling at fixture collection).
+
+## When this rule applies
+
+Any future multi-axis precedence resolver added to the CLI per
+`.claude/rules/spec-cli-precedence.md` — the matching pytest
+fixtures need to mirror the new axis in whichever of the three
+shapes fits the fixture's available context. The mechanical recipe
+when adding a new axis to an existing fixture:
+
+1. Identify which shape the fixture belongs to (A / B / C).
+2. For Shape A, expose the new axis as a factory kwarg, a pytest
+   option, and an env var. Skip the spec layer.
+3. For Shape B, read the new axis from `EvalSpec.<field>` only.
+   Skip operator-intent layers.
+4. For Shape C, expose the new axis at all four operator-intent
+   layers + the spec field + the default.
+5. Route the resolved value through the same pure resolver the CLI
+   uses (do NOT re-implement precedence in `pytest_plugin.py`).
+6. Mirror any per-axis eager auth-guard the CLI fires.
+
+## When this rule does NOT apply
+
+- Knobs that have no fixture-facing surface (library-internal
+  constants, construction-time config). Fixtures don't need to
+  mirror what users can't set anyway.
+- Diagnostic / one-off scripts in `scripts/` that hit clauditor
+  directly. They are not fixtures; they can resolve axes inline.
+- Tests that mock the resolver entirely (`patch("clauditor._providers.resolve_*")`).
+  The mock substitutes for the real resolver; no fixture-side
+  mirroring is needed.

--- a/.claude/show-maintainer-skills.sh
+++ b/.claude/show-maintainer-skills.sh
@@ -5,9 +5,44 @@
 SKILLS_DIR=".claude/skills"
 LOGO="docs/assets/clauditor-social-preview.png"
 
-# Write directly to the terminal so the banner is visible to the user.
-# Hook stdout is captured for Claude's context injection; /dev/tty bypasses that.
-exec > /dev/tty
+# Write directly to the user's terminal so the banner is visible.
+#
+# Hook stdout is captured by Claude Code for context injection — anything we
+# print there is hidden from the user (and counted against context budget). We
+# need a sidechannel to the real terminal.
+#
+# /dev/tty doesn't work: Claude Code spawns hook children without a
+# controlling terminal, so `exec > /dev/tty` fails with ENXIO.
+#
+# Strategy: walk up the parent process chain and find the first ancestor whose
+# stdout (/proc/PID/fd/1) is a /dev/pts/N device. That's the terminal that
+# launched Claude (works whether or not tmux is in the chain). Write the
+# banner there directly. If no PTY ancestor is found (Claude launched from a
+# non-terminal context — IDE plugin, CI, etc.), exit silently.
+
+find_user_tty() {
+    local pid=$PPID
+    local depth=0
+    while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ $depth -lt 20 ]; do
+        local target
+        target=$(readlink "/proc/$pid/fd/1" 2>/dev/null)
+        case "$target" in
+            /dev/pts/*|/dev/tty[0-9]*)
+                if [ -w "$target" ]; then
+                    echo "$target"
+                    return 0
+                fi
+                ;;
+        esac
+        pid=$(awk '{print $4}' "/proc/$pid/stat" 2>/dev/null)
+        depth=$((depth + 1))
+    done
+    return 1
+}
+
+USER_TTY=$(find_user_tty)
+[ -z "$USER_TTY" ] && exit 0
+exec > "$USER_TTY"
 
 BOLD=$'\033[1m'
 CYAN=$'\033[36m'
@@ -15,12 +50,14 @@ YELLOW=$'\033[33m'
 GRAY=$'\033[90m'
 RESET=$'\033[0m'
 
-# Logo. Leading newline so chafa's first row starts at column 0 — without
-# it, chafa emits on the same line where the cursor already sits (after
-# Claude Code's prompt marker), indenting only the first row of the image.
+# Render order: small thumbnail logo FIRST, then skills list. Claude Code
+# repaints its TUI over the bottom of the banner output, so the bottom
+# portion gets clipped. Logo is sized small (24x12 cells) so the total
+# banner height stays compact and the skills list lands in the survival zone.
+
 if command -v chafa &>/dev/null && [[ -f "$LOGO" ]]; then
     echo ""
-    chafa --size 60x30 -f symbols "$LOGO"
+    chafa --size 24x12 -f symbols "$LOGO"
 fi
 
 skills=()

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/temp/
 site/
 .envrc
 docs/medium-article-draft.md
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Documentation: three new deep-dive docs.** Filled doc gaps that
+  accumulated as the multi-provider / multi-harness / cost-tracking
+  surface landed:
+  - [`docs/codex-harness.md`](docs/codex-harness.md) — user-facing
+    narrative for running skills under the OpenAI Codex CLI (auth,
+    four-layer precedence, sandbox modes, troubleshooting, useful
+    harness × grader pairings).
+  - [`docs/cost-tracking.md`](docs/cost-tracking.md) — the `context.json`
+    sidecar shape, `cost_usd` estimation rules, the pricing table,
+    reasoning-token semantics, and the always-v1 contract.
+  - [`docs/audit-trend-workflow.md`](docs/audit-trend-workflow.md) —
+    end-to-end story for the iteration-history surface: how `grade`
+    builds history, how `audit` / `trend` / `compare` / `badge`
+    consume it, and how cross-axis comparability refusal protects
+    against silent averaging across stacks.
+  
+  README updated to mention the harness axis and cost tracking in
+  prose, and the Reference docs list now links all three new docs
+  plus the previously-orphaned `codex-stream-schema.md`.
+
 - **Pytest fixtures: `harness` × `provider` parametrization (#155).** The
   pytest plugin gained two new CLI options and four new factory kwargs so
   a single test can sweep across `{claude-code, codex} × {anthropic, openai}`

--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ clauditor also supports multi-provider grading: pass `--grading-provider {anthro
 
 Running `clauditor grade <skill> --transport cli` is the one-liner for subscription auth end-to-end: it implicitly strips `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from the skill subprocess env, so both the grader and the skill use subscription auth. Pass `--transport api` to keep the keys.
 
+**Running skills under a non-Claude harness.** Clauditor can also drive your skill through the OpenAI Codex CLI instead of Claude Code: pass `--harness codex` (or set `CLAUDITOR_HARNESS` / `EvalSpec.harness`) to `validate`, `grade`, `capture`, or `run`. Codex needs `CODEX_API_KEY` or `OPENAI_API_KEY` in the subprocess env; the default `auto` harness picks Claude when `claude` is on PATH, else Codex. The harness axis is independent of the grader provider — an eval can run under Codex while the L3 grader still calls Claude (or vice versa). Full reference: [docs/codex-harness.md](docs/codex-harness.md).
+
+## Cost and observability
+
+Every `clauditor grade` iteration writes a `context.json` sidecar capturing the harness, provider, model, sandbox mode, reasoning-token count, and an estimated `cost_usd` for the grader calls. `clauditor trend` and `clauditor audit` aggregate across iterations and refuse to silently average across mismatched harness or provider axes — pass `--cross-harness` / `--cross-provider` to opt in. Full reference: [docs/cost-tracking.md](docs/cost-tracking.md) and [docs/audit-trend-workflow.md](docs/audit-trend-workflow.md).
+
 ## Reference docs
 
 - [`docs/architecture.md`](docs/architecture.md) — how clauditor works under the hood (mermaid diagrams of the grade flow)
@@ -273,7 +279,11 @@ Running `clauditor grade <skill> --transport cli` is the one-liner for subscript
 - [`docs/skills.md`](docs/skills.md) — catalog of skills shipped with this repo, with live badge status
 - [`docs/badges.md`](docs/badges.md) — shields.io badges from iteration sidecars (`clauditor badge`)
 - [`docs/stream-json-schema.md`](docs/stream-json-schema.md) — `claude` stream-json parser contract
+- [`docs/codex-stream-schema.md`](docs/codex-stream-schema.md) — `codex` NDJSON parser contract (sibling of stream-json-schema)
 - [`docs/transport-architecture.md`](docs/transport-architecture.md) — CLI vs SDK transport, auth-state matrix, precedence, migration
+- [`docs/codex-harness.md`](docs/codex-harness.md) — running skills under the OpenAI Codex CLI
+- [`docs/cost-tracking.md`](docs/cost-tracking.md) — `cost_usd`, reasoning tokens, the pricing table, and per-iteration `context.json`
+- [`docs/audit-trend-workflow.md`](docs/audit-trend-workflow.md) — measuring regressions over iterations with `audit` / `trend` / `compare` / `badge`
 - [`CONTRIBUTING.md`](CONTRIBUTING.md#pre-release-dogfood) — maintainer pre-release dogfood gate + contribution workflow
 
 ## License

--- a/docs/audit-trend-workflow.md
+++ b/docs/audit-trend-workflow.md
@@ -1,0 +1,167 @@
+# Audit, trend, and the regression-catching workflow
+
+This doc walks the "did my SKILL.md edit improve or regress the skill?" workflow end-to-end: how `clauditor grade` builds up history over time, how `audit` and `trend` aggregate it, how `compare` deltas two snapshots, and how `badge` surfaces the latest result in CI. The individual command flags are in [docs/cli-reference.md](cli-reference.md); this doc tells the story of how they fit together.
+
+> Returning from the [root README](../README.md). This doc is the full reference for the iteration-history workflow.
+
+## The data flow
+
+```
+clauditor grade  →  .clauditor/iteration-N/<skill>/{assertions,extraction,grading,context}.json
+                    .clauditor/history.jsonl  (append)
+                                          │
+                ┌─────────────────────────┼────────────────────────┐
+                ▼                         ▼                        ▼
+        clauditor audit          clauditor trend          clauditor badge
+        (per-assertion           (one metric              (latest iteration
+         pass-rate across         over time, TSV)          → shields.io JSON)
+         last N iterations)
+```
+
+Every `grade` invocation:
+
+1. Allocates a fresh `iteration-N-tmp/` staging dir.
+2. Runs the skill subprocess + L1 assertions + (optional) L2 extraction + L3 grading.
+3. Writes per-iteration JSON sidecars **into the staging dir** (`schema_version` first key in each).
+4. Atomically renames `iteration-N-tmp/` → `iteration-N/`. Either every sidecar is visible or none are.
+5. Appends one line to `history.jsonl` (`schema_version: 3` today) with the run's primary metrics, harness, and provider.
+
+This is the data substrate the other three commands consume. There is no separate database; the iteration directory is the source of truth.
+
+## `clauditor audit` — per-assertion pass-rate
+
+Use audit when you want to find **which assertions are flaky** across recent iterations.
+
+```bash
+clauditor audit my-skill --last 20
+clauditor audit my-skill --last 20 --min-fail-rate 0.1 --min-discrimination 0.2
+clauditor audit my-skill --json > audit.json
+```
+
+Audit reads every iteration's sidecars (`assertions.json` for L1, `extraction.json` for L2, `grading.json` for L3), groups by the 4-tuple `(harness, provider, layer, id)`, and prints a pass-rate per group. The 4-tuple grouping means a run of the same skill under `(claude-code, anthropic)` and another under `(codex, openai)` produce two distinct rows rather than averaging across stacks.
+
+Threshold flagging (`--min-fail-rate`, `--min-discrimination`) is the way you surface the "this assertion fires too often / doesn't discriminate" pattern in CI.
+
+The `--verbose` flag includes the per-iteration `context.json` fields (model_grader, cost_usd, reasoning_tokens) in the rendered table — useful when you want to see "did this regression coincide with a model swap?"
+
+## `clauditor trend` — one metric over time
+
+Use trend when you want a **single metric over many iterations** for one skill — pass-rate, mean-score, total cost, token counts, grader duration.
+
+```bash
+clauditor trend my-skill --metric pass_rate --last 30
+clauditor trend my-skill --metric grader.input_tokens --last 30
+clauditor trend my-skill --list-metrics    # discover what's available
+```
+
+Output is TSV (iteration, timestamp, value). Pipe to `gnuplot`, `vega-lite`, your spreadsheet of choice, or just `awk '{print $3}'` for a quick eyeball.
+
+### Cross-axis comparability refusal
+
+**This is the most important behavior to understand.** Trend refuses by default to average across mismatched harness or provider axes:
+
+```bash
+$ clauditor trend my-skill --metric pass_rate
+ERROR: Mixed providers detected in history for skill 'my-skill'
+  (anthropic, openai). Pass --provider anthropic (or --provider openai)
+  to filter, or --cross-provider to allow averaging.
+```
+
+You have three responses per axis:
+
+1. **Filter**: `--provider anthropic` keeps only that stack's records.
+2. **Opt in**: `--cross-provider` allows averaging, with a stderr WARNING that results may not be comparable.
+3. **Fix the data**: re-run the missing stack so the history is uniform.
+
+The same applies to `--harness` / `--cross-harness`. The two axes are independent — `--harness claude-code --cross-provider` is valid (filter harness, allow mixed provider).
+
+Why the refusal exists: a user who ran the same eval under Claude+Sonnet one week and Codex+gpt-5.4 the next deserves a refusal, not a smooth pass-rate line that silently averages two non-comparable execution stacks. See [`.claude/rules/cross-axis-comparability-refusal.md`](../.claude/rules/cross-axis-comparability-refusal.md) for the full design rationale.
+
+The refusal fires AFTER the full filtered set is loaded but BEFORE the `--last` slice, so a narrow window can't silently bypass it.
+
+## `clauditor compare` — two-snapshot delta
+
+Compare two specific grading reports (a "before" and "after") to measure the delta of a single change:
+
+```bash
+# Positional grade.json paths
+clauditor compare \
+  .clauditor/iteration-7/my-skill/grading.json \
+  .clauditor/iteration-8/my-skill/grading.json
+
+# Or by iteration number
+clauditor compare --skill my-skill --from 7 --to 8
+
+# A/B blind compare (different mode — judges two captured outputs)
+clauditor compare --blind --skill my-skill capture-a.txt capture-b.txt
+```
+
+Delta mode honors the same cross-axis refusal as `trend`: if the two grading reports came from mismatched stacks, you get an exit-2 refusal naming both axes and the opt-in flags. `.txt` capture pairs silent-skip the check (they carry no metadata).
+
+`--blind` mode is **untouched** by the cross-axis block — blind A/B is a per-call LLM judgment between two outputs and is *expected* to span stacks (that's the comparison).
+
+## `clauditor badge` — surface the latest result
+
+Generate a shields.io endpoint JSON from the latest iteration's sidecars:
+
+```bash
+clauditor badge .claude/skills/my-skill/SKILL.md --output .clauditor/badges/my-skill.json
+clauditor badge .claude/skills/my-skill/SKILL.md --url-only
+```
+
+Produces a **pair** of files: the shields.io-strict JSON the badge service consumes, and a sibling `<name>.clauditor.json` carrying the full per-iteration context (layers, model, cost, reasoning tokens) for downstream tooling. See [docs/badges.md](badges.md) for the dual-file pattern and shields.io embedding recipes.
+
+The badge reflects the **latest** iteration — it is a current-state indicator, not an aggregate. Pair it with `trend` for history visibility.
+
+## A typical workflow
+
+```bash
+# 1. Grade the skill in its current state.
+clauditor grade .claude/skills/my-skill/SKILL.md
+
+# 2. Look at the per-assertion pass rate.
+clauditor audit my-skill --last 5
+
+# 3. Edit SKILL.md based on the failing criteria.
+clauditor suggest .claude/skills/my-skill/SKILL.md
+$EDITOR .claude/skills/my-skill/SKILL.md
+
+# 4. Re-grade to get a new iteration.
+clauditor grade .claude/skills/my-skill/SKILL.md
+
+# 5. Delta the two iterations.
+clauditor compare --skill my-skill --from N-1 --to N
+
+# 6. Once happy, trend over time.
+clauditor trend my-skill --metric pass_rate --last 20
+
+# 7. Surface in README.
+clauditor badge .claude/skills/my-skill/SKILL.md \
+  --output .clauditor/badges/my-skill.json
+git add .clauditor/badges/my-skill.json .clauditor/badges/my-skill.clauditor.json
+```
+
+If your history is mixed across harness/provider, step 6 will refuse with a clear error and tell you exactly which `--<axis>` filter or `--cross-<axis>` opt-in to add. That's the design intent — silent averaging across stacks is the failure mode it exists to prevent.
+
+## Schema versions on disk
+
+Useful when you're reading sidecars programmatically or migrating history. Loaders accept all listed versions; new versions are additive.
+
+| File | Current `schema_version` | Notes |
+| --- | --- | --- |
+| `assertions.json` | 2 | Bumped at #152 (`harness` field). |
+| `extraction.json` | 5 | Bumped through #86, #147, #152, #170 (transport, provider, harness, reasoning_tokens). |
+| `grading.json` | 5 | Same lifecycle as extraction. |
+| `context.json` | 1 | **Always-v1 by design** — nullable fields pre-declared so new metadata adds without bumping. |
+| `history.jsonl` | 3 | Per-record; legacy v1/v2 lines default `provider="anthropic"`, `harness="claude-code"`. |
+| `audit --json` output | 4 | Per-#154; adds `iteration_contexts` array. |
+| `badge.json` | 1 (shields.io camelCase) + `badge.clauditor.json` v1 (sibling extension) | Two files, two lifecycles. |
+
+For the full schema-bump rationale, see [`.claude/rules/json-schema-version.md`](../.claude/rules/json-schema-version.md).
+
+## See also
+
+- [docs/cli-reference.md](cli-reference.md) — every flag on every command in this workflow.
+- [docs/cost-tracking.md](cost-tracking.md) — `context.json` fields and what `cost_usd` / `reasoning_tokens` mean.
+- [docs/badges.md](badges.md) — the dual-file badge pattern and CI integration.
+- [docs/codex-harness.md](codex-harness.md) — running skills under Codex, the harness axis the refusal protects.

--- a/docs/codex-harness.md
+++ b/docs/codex-harness.md
@@ -1,0 +1,101 @@
+# Codex harness
+
+This doc covers running your skill under the OpenAI **Codex** CLI instead of Claude Code. If you just want to grade Anthropic-authored skills with Claude as the runtime, you can skip this — the default `--harness auto` resolves to `claude-code` whenever the `claude` binary is on PATH.
+
+> Returning from the [root README](../README.md). This doc is the full reference for the harness axis; the README has a one-paragraph summary.
+
+The harness axis is **independent** of the grader provider axis. A common shape: skill runs under Codex (`--harness codex`), and the L3 grader still calls Claude Sonnet (`--grading-provider anthropic`). The two CLIs are evaluating each other.
+
+## When to use it
+
+- You don't have a Claude Code subscription and don't want one — Codex bills against `OPENAI_API_KEY` directly.
+- You want to compare how the same skill behaves under different runtimes (e.g. baseline A/B between Claude and Codex).
+- You're auditing a skill author's claim that their SKILL.md is harness-agnostic.
+
+## Quick start
+
+```bash
+# 1. Install the Codex CLI separately (npm install -g @openai/codex or similar).
+$ which codex
+/usr/local/bin/codex
+
+# 2. Export an auth env var. Either works; CODEX_API_KEY wins if both are set.
+$ export CODEX_API_KEY=sk-...
+
+# 3. Run a skill under Codex.
+$ clauditor validate path/to/SKILL.md --harness codex
+$ clauditor grade    path/to/SKILL.md --harness codex
+$ clauditor capture  path/to/SKILL.md --harness codex --output codex-run.txt
+```
+
+## Four-layer harness resolution
+
+Same precedence shape as `--transport` and `--grading-provider`:
+
+| Layer | Value | Notes |
+| --- | --- | --- |
+| CLI flag | `--harness {claude-code,codex,auto}` | On `validate`, `grade`, `capture`, `run` only. LLM-mediated commands (`extract`, `triggers`, `compare --blind`, `propose-eval`, `suggest`) have no harness axis — they call `call_model` directly without running a skill subprocess. |
+| Env var | `CLAUDITOR_HARNESS={claude-code,codex,auto}` | Whitespace-only values are normalized to "unset". |
+| Spec field | `EvalSpec.harness: str = "auto"` | Per-skill author preference. Validated at load time. |
+| Default | `"auto"` | `shutil.which("claude")` first; then `shutil.which("codex")`; hard-fail with a three-escape-hatch error if neither is on PATH. |
+
+When the `auto` branch lands on `codex` because `claude` is not on PATH, clauditor emits a one-time stderr notice per process pointing at the env vars and explicit-pin escape hatches — see "Implicit-coupling announcements" in `.claude/rules/centralized-sdk-call.md`. An explicit `--harness codex` (or any non-auto value) stays silent.
+
+## Auth precedence inside the Codex subprocess
+
+The harness exports auth into the skill subprocess in this order:
+
+1. `CODEX_API_KEY` — Codex-specific key. Wins if set.
+2. `OPENAI_API_KEY` — fallback. Codex CLI accepts this directly.
+3. Cached `~/.codex/auth.json` — only honored when `auth_mode == "apikey"`. Clauditor **refuses** ChatGPT-mode credentials at pre-flight per [#177](https://github.com/wjduenow/clauditor/issues/177) because the codex subprocess would route via ChatGPT and reject every model.
+
+If none of the three is available, the pre-flight `check_codex_auth` guard raises `CodexAuthMissingError` and the CLI exits 2 with an actionable message naming the required env vars.
+
+## Sandbox modes
+
+Codex supports three sandbox levels: `read-only`, `workspace-write`, `danger-full-access`. Clauditor pins `workspace-write` today — enough for skills that need to write under the workspace but not enough for skills that need network or arbitrary filesystem access. The pinned value is stamped on `IterationContext.sandbox_mode` for audit visibility. Making it user-configurable is a future ticket; if your skill needs a different mode, file an issue.
+
+## Stream parser
+
+Codex emits NDJSON on stdout (different from Claude's stream-json). The parser is in `src/clauditor/_harnesses/_codex.py`; the on-disk contract — event types, failure surface, `harness_metadata` keys, advisory warnings — is documented at [docs/codex-stream-schema.md](codex-stream-schema.md). You shouldn't need to read it unless you're contributing to the harness itself or debugging a parse-level failure.
+
+## What lands on disk
+
+Every Codex run produces the same sidecar shape as Claude Code runs, with one observability difference:
+
+- `assertions.json` — `harness: "codex"`.
+- `grading.json` / `extraction.json` — `harness: "codex"`, plus the grader's provider/model untouched.
+- `context.json` — `harness: "codex"`, `sandbox_mode: "workspace-write"`, plus `harness_metadata` carrying Codex-specific keys (auth source, dropped-events count when applicable).
+- `history.jsonl` — each appended record carries `harness: "codex"` so `clauditor trend` can refuse to average across harnesses unless `--cross-harness` is passed.
+
+## Limitations
+
+- **No subscription path.** Anthropic users with a Claude Pro/Max subscription can grade for free via `--transport cli`; Codex has no equivalent — every call bills against an API key.
+- **Hardcoded sandbox.** `workspace-write` only. Future ticket.
+- **No allow-hang heuristic.** The Claude Code harness has a `allow_hang_heuristic` knob that classifies "model returned a question" as a failure; Codex doesn't expose the parse hooks needed for it. The flag is silently a no-op when the resolved harness is Codex.
+- **Pytest fixtures.** `clauditor_runner` and `clauditor_spec` both honor the harness axis; the eager `check_codex_auth` guard fires at fixture-setup time so a missing-key surfaces as a test-setup error rather than a deep subprocess failure mid-run.
+
+## Pairing harness with grader
+
+The four useful combinations:
+
+| Harness | Grader | When to use |
+| --- | --- | --- |
+| `claude-code` | `anthropic` | Default. Subscription-friendly if you have Claude Pro/Max. |
+| `claude-code` | `openai` | Audit Claude-authored skills with a non-Claude grader to reduce same-vendor bias. |
+| `codex` | `anthropic` | Anthropic-graded evaluation of Codex behavior. Common when comparing runtimes. |
+| `codex` | `openai` | All-OpenAI stack. |
+
+Resolve provider per [docs/transport-architecture.md](transport-architecture.md) and pair via independent flags — clauditor will refuse to silently average across mismatched harness OR provider axes during `clauditor trend` / `clauditor compare`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Exit 2 — `CodexAuthMissingError` | Neither `CODEX_API_KEY` nor `OPENAI_API_KEY` set; no usable cached auth | Export one of the two env vars. |
+| Exit 2 — "ChatGPT-mode credentials refused" | `~/.codex/auth.json` has `auth_mode == "chatgpt"` | Re-authenticate Codex with an API key flow, OR export `CODEX_API_KEY` to override the cached creds. |
+| Auto resolved to codex unexpectedly | `claude` not on PATH | Install Claude Code, or pin `--harness=claude-code` / `CLAUDITOR_HARNESS=claude-code`. |
+| "stderr line about auto→codex" | First time the auto branch picked Codex this process | One-shot notice. Pin explicitly to silence. |
+| Skills that worked under Claude fail under Codex | Different sandbox / runtime semantics | Expected — that's what cross-harness evaluation reveals. The skill is harness-coupled. |
+
+See also `clauditor doctor` for environment-level diagnostics (which binaries are on PATH, which env vars are set, which auth paths resolve).

--- a/docs/cost-tracking.md
+++ b/docs/cost-tracking.md
@@ -1,0 +1,98 @@
+# Cost tracking and per-iteration context
+
+This doc covers how clauditor measures and persists the cost of an LLM grading run — both dollars (`cost_usd`) and reasoning-token effort — plus the broader `context.json` sidecar that captures comparability metadata so `audit` and `trend` can compare like-with-like across iterations.
+
+> Returning from the [root README](../README.md). This doc is the full reference; the README has a one-paragraph summary.
+
+## What gets recorded
+
+Every `clauditor grade` (or `validate`) iteration writes a sibling sidecar at `.clauditor/iteration-N/<skill>/context.json` with these fields (schema_version: 1, designed to stay at v1 — see [Always-v1 contract](#always-v1-contract) below):
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schema_version` | `int = 1` | Always first key on disk. |
+| `harness` | `str` | `"claude-code"` or `"codex"`. Materialized by the four-layer harness resolver. |
+| `provider` | `str \| None` | `"anthropic"` or `"openai"`, or `null` when no LLM grading happened (e.g. `validate`-only). |
+| `model_runner` | `str \| None` | The model the harness actually used to run the skill. Null when the harness can't expose it (Claude Code's stream-json `result` carries no model field unless pinned). |
+| `model_grader` | `str \| None` | The model the grader called. Null iff `provider` is null. |
+| `system_prompt_source` | `str` | `"explicit"` / `"agents_md"` / `"skill_md"` — where the system prompt came from for this run. |
+| `sandbox_mode` | `str \| None` | Codex-only: `"read-only"` / `"workspace-write"` / `"danger-full-access"`. Null when `harness != "codex"`. |
+| `reasoning_tokens` | `int \| None` | Separately-billed thinking/reasoning tokens summed across the grader chain. See [Reasoning tokens](#reasoning-tokens). |
+| `cost_usd` | `float \| None` | Estimated grader-call cost in USD. See [Cost estimation](#cost-estimation). |
+
+## Cost estimation
+
+The pure helper `clauditor._providers._pricing.estimate_cost(provider, model, input_tokens, output_tokens, reasoning_tokens=None)` returns a USD float (or `None` on lookup miss). The composition helper `compute_iteration_cost_usd` sums Layer 2 + Layer 3 grader-call cost from the already-populated `GradingReport` / `ExtractionReport` dataclasses.
+
+The pricing table is hardcoded into clauditor at release time — it lives at `src/clauditor/_providers/_pricing.py::_PRICING_TABLE`. Today's coverage:
+
+| Provider | Model | Input $/MTok | Output $/MTok |
+| --- | --- | --- | --- |
+| anthropic | claude-sonnet-4-6 | 3.00 | 15.00 |
+| anthropic | claude-opus-4-7 | 15.00 | 75.00 |
+| anthropic | claude-haiku-4-5 | 0.80 | 4.00 |
+| openai | gpt-5.4 | 2.50 | 10.00 |
+| openai | gpt-5.4-mini | 0.15 | 0.60 |
+| openai | o4-mini | 1.10 | 4.40 |
+
+Reasoning tokens roll into the output rate (model bills them at output prices). The cost is **all-or-nothing across the grader chain**: if any Layer 2 or Layer 3 call can't be priced (unknown model, missing usage data), `cost_usd` is `null` rather than a partial sum — a "roughly right" estimate is silently wrong for budgeting per the design decision in [#169](https://github.com/wjduenow/clauditor/issues/169).
+
+### Stale-table warnings
+
+Clauditor emits a one-time stderr warning per process when the pricing table is older than 90 days. Today's verification date is pinned at `_LAST_VERIFIED` in the same module. The warning names the canonical price sources (platform.claude.com, openai.com/api/pricing) so a maintainer can update the table. The warning is loud-but-safe: a typo in the date constant still fires the warning (treats the table as stale) rather than crashing the grading run.
+
+### Unknown-model warnings
+
+Calling `estimate_cost("anthropic", "claude-future-9", ...)` returns `None` AND emits a one-time-per-`(provider, model)` warning to stderr — distinct unknown models each get their own first-call warning rather than the first miss muting all subsequent ones. An unknown **provider** stays silent (different code path) so a typo'd provider doesn't flood stderr.
+
+## Reasoning tokens
+
+The `reasoning_tokens` field is the count of separately-billed thinking tokens the grader chain consumed. Sourced asymmetrically per provider:
+
+- **Anthropic**: always `None`. The SDK's `Usage` object has no separately-billed thinking-token field; for extended-thinking models the thinking tokens are already included in `output_tokens`. Clauditor records `None` rather than fabricating a value.
+- **OpenAI**: extracted from `usage.output_tokens_details.reasoning_tokens` via a defensive helper (`isinstance` guards, `bool`-vs-`int` discipline). `0` is preserved as a real signal ("model didn't reason on this call"); `None` means "couldn't read."
+
+The grader chain may make multiple calls (variance reps, parse-retry attempts, blind-compare's two parallel calls). The chain-level aggregator `_sum_optional_reasoning_tokens` distinguishes "no source surfaced a count" (all-`None` → `None`) from "sources surfaced zero" (mixed or all-int → real sum), so a single `None` component doesn't poison a sum that has at least one real value.
+
+## Always-v1 contract
+
+`context.json` is engineered so anticipated follow-ups can populate new fields **without bumping the schema version**. The trick: nullable fields are pre-declared in v1. When [#169](https://github.com/wjduenow/clauditor/issues/169) wired up `cost_usd` and [#170](https://github.com/wjduenow/clauditor/issues/170) wired up `reasoning_tokens`, the on-disk shape stayed v1 and every existing reader kept working unchanged. This is the inverse of `grading.json` / `extraction.json`, which bumped at every additive change (v1→v5 today) because their fields weren't pre-declared.
+
+Bumps cost integration churn (default-on-read defaults, loader branches, regression tests). Pre-declaring nullable fields when the follow-ups are known up-front avoids the churn.
+
+## How to read it
+
+### From the CLI
+
+`clauditor audit` reads every iteration's `context.json` and surfaces the metadata in its grouped output (group key: `(harness, provider, layer, id)`). `clauditor trend` reads `history.jsonl` (which carries the harness + provider stamps but not the per-iteration context) and refuses to silently average across mismatched harness or provider axes unless `--cross-harness` / `--cross-provider` is passed.
+
+`clauditor badge` reads the latest iteration's sidecars and emits both a shields.io endpoint JSON AND a sibling `<name>.clauditor.json` extension carrying the per-iteration context — see [docs/badges.md](badges.md) for the dual-file pattern.
+
+### Programmatically
+
+```python
+from clauditor.context import IterationContext
+import json
+
+with open(".clauditor/iteration-7/my-skill/context.json") as f:
+    ctx = IterationContext(**json.load(f))
+
+print(f"Grader: {ctx.provider}/{ctx.model_grader}")
+print(f"Cost: ${ctx.cost_usd:.4f}" if ctx.cost_usd else "Cost: unknown")
+print(f"Reasoning: {ctx.reasoning_tokens or 0} tokens")
+```
+
+## When cost is `None`
+
+| `cost_usd` is null because… | Fix |
+| --- | --- |
+| `validate`-only run (no grader call) | Expected. Cost only meaningful for `grade` / `extract`. |
+| Grader call used an unknown model | Look for the stderr unknown-model warning. Add the model to `_PRICING_TABLE` and bump `_LAST_VERIFIED`. |
+| One of Layer 2 / Layer 3 was priced but the other wasn't | All-or-nothing per [#169](https://github.com/wjduenow/clauditor/issues/169) DEC-002. Add the missing model. |
+| Pricing table older than 90 days | Stale warning fires but cost is still computed. Update the table. |
+
+## See also
+
+- [docs/audit-trend-workflow.md](audit-trend-workflow.md) — how `audit` / `trend` consume the data.
+- [docs/transport-architecture.md](transport-architecture.md) — provider / transport / harness axes.
+- [docs/badges.md](badges.md) — the sibling `.clauditor.json` extension that surfaces context in the badge pair.

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -964,7 +964,12 @@ def build_grading_prompt(
         f" determine:\n"
         f"- passed: whether the output satisfies the criterion"
         f" (true/false)\n"
-        f"- score: confidence level from 0.0 to 1.0\n"
+        f"- score: fulfillment level from 0.0 to 1.0, where 0.0 means"
+        f' "the output completely fails this criterion" and 1.0 means'
+        f' "the output completely satisfies this criterion". This MUST'
+        f" be monotonically aligned with `passed`: any score >= 0.5"
+        f" implies passed=true, and any score < 0.5 implies"
+        f" passed=false.\n"
         f"- evidence: quote specific text from the output supporting your"
         f" judgment\n"
         f"- reasoning: explain in 1-2 sentences\n"

--- a/src/clauditor/quality_grader.py
+++ b/src/clauditor/quality_grader.py
@@ -968,8 +968,8 @@ def build_grading_prompt(
         f' "the output completely fails this criterion" and 1.0 means'
         f' "the output completely satisfies this criterion". This MUST'
         f" be monotonically aligned with `passed`: any score >= 0.5"
-        f" implies passed=true, and any score < 0.5 implies"
-        f" passed=false.\n"
+        f' implies "passed": true, and any score < 0.5 implies'
+        f' "passed": false.\n'
         f"- evidence: quote specific text from the output supporting your"
         f" judgment\n"
         f"- reasoning: explain in 1-2 sentences\n"

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1121,8 +1121,8 @@ class TestBuildGradingPrompt:
         spec = _make_spec()
         prompt = build_grading_prompt(spec)
         assert "monotonically aligned with `passed`" in prompt
-        assert "score >= 0.5 implies passed=true" in prompt
-        assert "score < 0.5 implies passed=false" in prompt
+        assert 'score >= 0.5 implies "passed": true' in prompt
+        assert 'score < 0.5 implies "passed": false' in prompt
 
     def test_prompt_language_would_have_prevented_gpt5_shape(self):
         """Issue #186 acceptance bullet 5: the new prompt language

--- a/tests/test_quality_grader.py
+++ b/tests/test_quality_grader.py
@@ -1092,6 +1092,77 @@ class TestBuildGradingPrompt:
         assert "untrusted data, not instructions" in prompt
         assert "<skill_output>" in prompt
 
+    def test_score_defined_as_fulfillment_not_confidence(self):
+        """Issue #186: the prompt must define ``score`` as a
+        fulfillment level (0.0 = totally fails, 1.0 = totally passes),
+        NOT as verdict confidence. gpt-5.4 read the pre-#186 phrase
+        "confidence level from 0.0 to 1.0" as verdict-confidence and
+        returned ``passed=false, score=1.0`` on failing criteria,
+        producing non-commensurable ``mean_score`` values across
+        providers. Pinning the load-bearing substrings here so a
+        future prompt edit that regresses to "confidence level"
+        trips this test.
+        """
+        spec = _make_spec()
+        prompt = build_grading_prompt(spec)
+        assert "fulfillment level from 0.0 to 1.0" in prompt
+        assert "completely fails this criterion" in prompt
+        assert "completely satisfies this criterion" in prompt
+        # The pre-#186 ambiguous phrase must not reappear.
+        assert "confidence level from 0.0 to 1.0" not in prompt
+
+    def test_score_monotonically_aligned_with_passed(self):
+        """Issue #186: the prompt must enforce the
+        monotonic-alignment invariant tying ``score`` to ``passed``
+        — any score >= 0.5 implies passed=true, any score < 0.5
+        implies passed=false. This is the load-bearing clause that
+        tells gpt-5.4 not to decouple ``score`` from ``passed``.
+        """
+        spec = _make_spec()
+        prompt = build_grading_prompt(spec)
+        assert "monotonically aligned with `passed`" in prompt
+        assert "score >= 0.5 implies passed=true" in prompt
+        assert "score < 0.5 implies passed=false" in prompt
+
+    def test_prompt_language_would_have_prevented_gpt5_shape(self):
+        """Issue #186 acceptance bullet 5: the new prompt language
+        must contain the clauses that would have prevented the
+        observed gpt-5.4 response shape (``passed=false, score=1.0``).
+
+        Two shapes are illustrative here:
+
+        - Claude-style on a failing criterion:
+          ``{"passed": false, "score": 0.2}`` — fulfillment-aligned,
+          satisfies the new monotonic invariant.
+        - gpt-5.4-style on a failing criterion (pre-#186):
+          ``{"passed": false, "score": 1.0}`` — verdict-confidence,
+          violates the new monotonic invariant.
+
+        The fix is prompt-side: the parser stays strict on shape
+        (no score-rewriting). This test pins the two clauses that
+        together rule out the gpt-5.4 shape — "fulfillment level"
+        defines what ``score`` measures, "monotonically aligned"
+        ties it to ``passed`` with a 0.5 threshold.
+        """
+        claude_style = {"passed": False, "score": 0.2}
+        gpt5_style_pre_186 = {"passed": False, "score": 1.0}
+
+        # Sanity-check the fixture shapes: only the gpt-5.4 pre-#186
+        # shape violates the monotonic-alignment invariant the new
+        # prompt declares.
+        def violates_monotonic(r: dict) -> bool:
+            return (r["score"] >= 0.5) != r["passed"]
+
+        assert not violates_monotonic(claude_style)
+        assert violates_monotonic(gpt5_style_pre_186)
+
+        spec = _make_spec()
+        prompt = build_grading_prompt(spec)
+        # The two load-bearing clauses that together prevent the
+        # gpt-5.4 shape from being a valid model response.
+        assert "fulfillment level" in prompt
+        assert "monotonically aligned with `passed`" in prompt
+
 
 class TestParseGradingResponseAlignment:
     """FIX-10: parse_grading_response must hard-fail on misalignment."""


### PR DESCRIPTION
Brings 9 commits from dev to main ahead of the v0.1.2 full release.

Includes:
- #189 Fix maintainer-skills SessionStart hook on Linux/WSL
- #188 docs: multi-harness, cost tracking, audit-trend workflow
- #187 / #186 grader score prompt monotonic alignment + numeric-judge-field-anchors rule
- docs: pytest-fixture-precedence-mirror rule; ignore package-lock.json

Pre-flight for the full release will run from main once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex harness support for running skills with OpenAI CLI as an alternative to Claude Code.
  * Introduced cost tracking with per-iteration context files recording grading costs and reasoning effort.
  * Added cross-harness and cross-provider filtering options for audit and trend aggregation.

* **Documentation**
  * New guides for audit/trend workflows, Codex harness setup, and cost tracking.
  * Enhanced README with harness selection and observability sections.

* **Chores**
  * Updated `.gitignore` and maintainer script improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->