### PR TITLE
chore: release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-21
+
 ### Breaking changes
 
 - **Codex auth pre-flight refuses ChatGPT-mode credentials (#177, PR #181).**
@@ -439,6 +441,7 @@ First stable release on PyPI: <https://pypi.org/project/clauditor-eval/0.1.0/>.
 - Bundled `/clauditor` Claude Code slash command installable via
   `clauditor setup`.
 
-[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.2
 [0.1.1]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.1
 [0.1.0]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.2.dev0"
+version = "0.1.2"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "clauditor-eval"
-version = "0.1.2.dev0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Cuts v0.1.2 to PyPI. Pre-flight tests pass (3807 passed, 86.10% cov); `uv build` + `uvx twine check` PASSED on both wheel and sdist. CHANGELOG promoted from `[Unreleased]` to `[0.1.2] - 2026-05-21`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.1.2 has been released.
  * Updated changelog with the latest release information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->