### PR TITLE
chore: begin 0.1.3.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.2"
+version = "0.1.3.dev0"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/clauditor/__init__.py
+++ b/src/clauditor/__init__.py
@@ -36,7 +36,13 @@ __all__ = [
     "VarianceReport",
 ]
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("clauditor-eval")
+except PackageNotFoundError:  # pragma: no cover - editable/uninstalled tree
+    __version__ = "0.0.0+unknown"
 
 
 def __getattr__(name: str):

--- a/src/clauditor/__init__.py
+++ b/src/clauditor/__init__.py
@@ -1,5 +1,8 @@
 """Clauditor — Auditor for Claude Code skills and slash commands."""
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from clauditor.asserters import SkillAsserter, assert_from
 from clauditor.assertions import AssertionResult, AssertionSet
 from clauditor.context import IterationContext
@@ -35,9 +38,6 @@ __all__ = [
     "VarianceConfig",
     "VarianceReport",
 ]
-
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 
 try:
     __version__ = _pkg_version("clauditor-eval")

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "clauditor-eval"
-version = "0.1.2"
+version = "0.1.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps version to 0.1.3.dev0 after the v0.1.2 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library now reports its installed package version at runtime, with a safe fallback when the version metadata is unavailable.

* **Chores**
  * Package version bumped to 0.1.3.dev0 for ongoing development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->