### PR TITLE
docs: surface Codex harness across discovery docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Surface the Codex harness across the discovery docs.** The Codex
+  runtime shipped in 0.1.2 but was only mentioned in a buried
+  paragraph of the README's auth section. Added a dedicated
+  "Running skills under Codex" README section (with a tagline clause
+  and Contents-nav entry), documented the `--harness {claude-code,codex,auto}`
+  flag on the four skill-running commands in the CLI reference's
+  shared-runner-flags table, added a `harness` field entry to the
+  eval-spec reference, and a "Running under Codex" subsection to the
+  quick-start. All link to the existing [`docs/codex-harness.md`](docs/codex-harness.md)
+  as the single source of truth. Also fixed the README and quick-start
+  pytest examples to use the post-#155 `clauditor_runner()` factory
+  form (they still showed the pre-#155 value-fixture call).
+
 ## [0.1.2] - 2026-05-21
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 [![License](https://img.shields.io/github/license/wjduenow/clauditor)](https://github.com/wjduenow/clauditor/blob/dev/LICENSE)
 [![codecov](https://codecov.io/gh/wjduenow/clauditor/branch/dev/graph/badge.svg)](https://codecov.io/gh/wjduenow/clauditor)
 
-Automated quality checks for [Agent Skills](https://agentskills.io). A skill is a reusable instruction file (`SKILL.md`) that tells Claude how to do a task. clauditor answers three questions about every run: **Did it run?** **Did it return the right structure?** **Was the answer actually good?** First two checks cost pennies and run in CI; the third is for release gates.
+Automated quality checks for [Agent Skills](https://agentskills.io). A skill is a reusable instruction file (`SKILL.md`) that tells Claude how to do a task. clauditor answers three questions about every run: **Did it run?** **Did it return the right structure?** **Was the answer actually good?** First two checks cost pennies and run in CI; the third is for release gates. Skills run under [Claude Code or the OpenAI Codex CLI](#running-skills-under-codex) — pick the runtime per command.
 
 <details markdown="1">
 <summary>Contents</summary>
 
-[Why clauditor?](#why-clauditor) · [Install](#install) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [Suggest](#llm-assisted-skill-improvement-clauditor-suggest) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Skill compatibility](#skill-compatibility) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
+[Why clauditor?](#why-clauditor) · [Install](#install) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [Suggest](#llm-assisted-skill-improvement-clauditor-suggest) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Skill compatibility](#skill-compatibility) · [Running under Codex](#running-skills-under-codex) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
 
 </details>
 
@@ -165,7 +165,8 @@ clauditor badge <skill.md>            # Shields.io endpoint JSON for README embe
 
 ```python
 def test_my_skill(clauditor_runner, clauditor_asserter):
-    result = clauditor_runner.run("my-skill", '"San Jose, CA"')
+    runner = clauditor_runner()  # factory fixture; clauditor_runner(harness="codex") runs under Codex
+    result = runner.run("my-skill", '"San Jose, CA"')
     clauditor_asserter(result).assert_contains("Results")
 ```
 
@@ -247,6 +248,20 @@ Full matrix and refactoring recipes: [`docs/skill-usage.md#skill-compatibility`]
 
 </details>
 
+## Running skills under Codex
+
+clauditor can drive your skill through the **OpenAI Codex CLI** instead of Claude Code. Pass `--harness codex` (or set `CLAUDITOR_HARNESS` / the `harness` field in `eval.json`) to `validate`, `grade`, `capture`, or `run`:
+
+```bash
+export CODEX_API_KEY=sk-...                          # or OPENAI_API_KEY
+clauditor validate .claude/skills/my-skill/SKILL.md --harness codex
+clauditor grade    .claude/skills/my-skill/SKILL.md --harness codex
+```
+
+The default `auto` harness picks Claude Code when `claude` is on PATH, else Codex. The **runtime axis is independent of the grader**: an eval can run under Codex while the L3 quality grader still calls Claude Sonnet (or vice versa), so you can A/B the same skill across runtimes. `clauditor audit` / `trend` / `compare` group results by harness and refuse to silently average across them.
+
+**Covered in the full reference:** four-layer harness precedence, Codex auth modes (`CODEX_API_KEY` / `OPENAI_API_KEY` / `~/.codex/auth.json`), sandbox modes, the NDJSON stream contract, and useful harness × grader pairings. Full reference: [docs/codex-harness.md](docs/codex-harness.md).
+
 ## Authentication and API Keys
 
 **Do I need an Anthropic API key?**
@@ -261,7 +276,7 @@ clauditor also supports multi-provider grading: pass `--grading-provider {anthro
 
 Running `clauditor grade <skill> --transport cli` is the one-liner for subscription auth end-to-end: it implicitly strips `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from the skill subprocess env, so both the grader and the skill use subscription auth. Pass `--transport api` to keep the keys.
 
-**Running skills under a non-Claude harness.** Clauditor can also drive your skill through the OpenAI Codex CLI instead of Claude Code: pass `--harness codex` (or set `CLAUDITOR_HARNESS` / `EvalSpec.harness`) to `validate`, `grade`, `capture`, or `run`. Codex needs `CODEX_API_KEY` or `OPENAI_API_KEY` in the subprocess env; the default `auto` harness picks Claude when `claude` is on PATH, else Codex. The harness axis is independent of the grader provider — an eval can run under Codex while the L3 grader still calls Claude (or vice versa). Full reference: [docs/codex-harness.md](docs/codex-harness.md).
+**Running the skill subprocess under Codex** needs `CODEX_API_KEY` or `OPENAI_API_KEY` in the subprocess env rather than Anthropic credentials — this is the runtime axis, separate from the grader auth above. See [Running skills under Codex](#running-skills-under-codex).
 
 ## Cost and observability
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -109,6 +109,7 @@ clauditor capture <skill> --no-api-key --timeout 600  # subscription auth, 10-mi
 | `-- <args>` | Arguments passed to the skill command as initial context, appended to the `-p` prompt: `claude -p "/<skill> <args>"`. The only injection point before the skill runs — see [Interactive skills](#interactive-skills) below. |
 | `--out PATH` | Write captured output to a custom path instead of the default `tests/eval/captured/<skill>.txt`. |
 | `--versioned` | Append `-YYYY-MM-DD` to the output file stem (e.g. `my-skill-2026-04-22.txt`). Useful when keeping a dated history of captures. |
+| `--harness {claude-code,codex,auto}` | Select which CLI runs the skill (shared runner flag). `codex` captures a run under the OpenAI Codex CLI instead of `claude -p`; needs `CODEX_API_KEY` or `OPENAI_API_KEY`. Precedence: this flag > `CLAUDITOR_HARNESS` env > `EvalSpec.harness` > default `auto`. See [`docs/codex-harness.md`](codex-harness.md). |
 | `--no-api-key` | Strip `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the subprocess environment. Falls back to subscription auth cached in `~/.claude/`. Useful for skills that exhaust the API-tier rate limit. |
 | `--timeout SECONDS` | Override the default 300-second watchdog. Long-running skills (deep research, multi-step workflows) may still need 600 s or more. |
 | `--claude-bin PATH` | Path to the `claude` CLI (default: `claude` on PATH). |
@@ -366,7 +367,7 @@ Generate a starter `eval.json` next to a `SKILL.md`. Reads the skill's frontmatt
 
 ### `validate`
 
-Run Layer 1 deterministic assertions against a skill's output. Spawns the skill via `claude -p`, captures stdout, then evaluates each assertion in `eval.json`. No LLM call on the clauditor side.
+Run Layer 1 deterministic assertions against a skill's output. Spawns the skill via the resolved harness (`claude -p` by default; the OpenAI Codex CLI under `--harness codex`), captures stdout, then evaluates each assertion in `eval.json`. No LLM call on the clauditor side.
 
 | Flag | Purpose |
 | ---- | ------- |
@@ -376,7 +377,7 @@ Run Layer 1 deterministic assertions against a skill's output. Spawns the skill 
 | `--no-transcript` | Skip writing per-run stream-json transcripts to disk. |
 | `-v / --verbose` | On assertion failure, print the last 5 assistant text blocks to stderr. |
 
-Also accepts the [shared runner flags](#shared-runner-flags-validate-grade-capture-run): `--no-api-key`, `--sync-tasks`, `--timeout`.
+Also accepts the [shared runner flags](#shared-runner-flags-validate-grade-capture-run): `--harness`, `--no-api-key`, `--sync-tasks`, `--timeout`.
 
 ### `grade`
 
@@ -399,17 +400,17 @@ Run Layer 3 LLM-graded quality scoring. Auto-increments the iteration slot (`.cl
 | `--transport {api,cli,auto}` | Override the Anthropic call backend. See [transport architecture](#transport-architecture). |
 | `--grading-provider {anthropic,openai,auto}` | Select which provider's SDK handles the LLM-grader call. Precedence: this flag > `CLAUDITOR_GRADING_PROVIDER` env > `EvalSpec.grading_provider` > default `auto`. Under `auto`, infers from the model prefix (`claude-*` → anthropic, `gpt-*` / `o[0-9]+*` → openai). |
 
-Also accepts the shared runner flags: `--no-api-key`, `--sync-tasks`, `--timeout`, `-v`, `--no-transcript`.
+Also accepts the shared runner flags: `--harness`, `--no-api-key`, `--sync-tasks`, `--timeout`, `-v`, `--no-transcript`.
 
 ### `run`
 
-Run a skill via `claude -p` and print its output to stdout. The thinnest of the skill-invoking commands — no eval, no assertions, no grading.
+Run a skill via the resolved harness (`claude -p` by default, or the OpenAI Codex CLI under `--harness codex`) and print its output to stdout. The thinnest of the skill-invoking commands — no eval, no assertions, no grading.
 
 | Flag | Purpose |
 | ---- | ------- |
 | `--args STRING` | Arguments to pass to the skill command. |
 | `--project-dir PATH` | Override project-root detection (default: cwd). |
-| `--timeout SECONDS`, `--no-api-key`, `--sync-tasks` | Shared runner flags. |
+| `--harness {claude-code,codex,auto}`, `--timeout SECONDS`, `--no-api-key`, `--sync-tasks` | Shared runner flags. |
 
 ### `extract`
 
@@ -507,10 +508,11 @@ Print environment diagnostics: clauditor version, `claude` CLI presence and vers
 
 ## Shared runner flags (`validate`, `grade`, `capture`, `run`)
 
-Four skill-invoking commands share three flags that control the `claude -p` subprocess the runner spawns. All default to "not set" so today's behavior is unchanged when none are passed.
+Four skill-invoking commands share these flags that control the skill subprocess the runner spawns (Claude Code's `claude -p` by default, or the OpenAI Codex CLI under `--harness codex`). All default to "not set" so today's behavior is unchanged when none are passed.
 
 | Flag | Purpose |
 | ---- | ------- |
+| `--harness {claude-code,codex,auto}` | Select which CLI runs the skill subprocess. `claude-code` spawns `claude -p`; `codex` spawns the OpenAI Codex CLI (needs `CODEX_API_KEY` or `OPENAI_API_KEY` in the subprocess env); `auto` (default) prefers `claude` when it is on PATH, else falls back to `codex`. Precedence: this flag > `CLAUDITOR_HARNESS` env var > `EvalSpec.harness` > default `auto`. The harness (runtime) axis is independent of the grader-side `--transport` / `--grading-provider` axes — a skill can run under Codex while the L3 grader still calls Claude Sonnet. Full reference: [`docs/codex-harness.md`](codex-harness.md). |
 | `--no-api-key` | Strip both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the subprocess environment before invoking `claude -p`. The child then falls back to whatever auth is cached in `~/.claude/` — typically a Pro/Max subscription, which carries a much higher throughput ceiling than the API-key tier. Useful for research-heavy skills (multi-agent, deep-research) that exhaust the free API tier in a single run. Non-auth Anthropic env vars such as `ANTHROPIC_BASE_URL` are preserved. Also implied by `--transport cli` on `grade` (see `--transport`). |
 | `--timeout SECONDS` | Override the runner's 300-second watchdog for a single invocation. Must be a positive integer; `--timeout 0`, `--timeout -5`, and `--timeout foo` exit `2` at argparse time. Precedence: the CLI flag wins when passed explicitly; otherwise the `EvalSpec.timeout` field wins when set; otherwise the built-in 300s default applies. See [`docs/eval-spec-reference.md#optional-top-level-fields`](eval-spec-reference.md#optional-top-level-fields) for the spec-field side of the contract. |
 | `--sync-tasks` | Set `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in the subprocess env, forcing `Task(run_in_background=true)` spawns to run synchronously. Resolves the output-truncation failure mode for skills that use background sub-agents for parallel fanout. Also suppresses the `background-task:` warning from the [#97](https://github.com/wjduenow/clauditor/issues/97) detector under that env. Precedence: CLI flag > `EvalSpec.sync_tasks` > default `False`. On `grade --baseline`, applies to both primary and baseline arms so the delta compares like-for-like. Synchronous Tasks roughly double wall time vs the parallel default — non-trivial skills routinely land in the 300-400s range and exhaust the built-in 300s watchdog; pair `--sync-tasks` with `--timeout 600` (or higher) to avoid first-run timeouts. **Read the fidelity caveats in [`docs/skill-usage.md#--sync-tasks-force-task-mode-synchronous-at-eval-time`](skill-usage.md#--sync-tasks-force-task-mode-synchronous-at-eval-time) before relying on `--sync-tasks` — you are evaluating a different execution model than what ships.** Full decision record: [`docs/adr/transport-research-103.md`](adr/transport-research-103.md). |

--- a/docs/eval-spec-reference.md
+++ b/docs/eval-spec-reference.md
@@ -286,6 +286,19 @@ A few `EvalSpec` fields tune specific code paths and are safe to omit:
   default. Load-time validation rejects values outside the three-
   choice set. See [`docs/transport-architecture.md`](transport-architecture.md)
   for the full backend matrix.
+- **`harness`** (string, default `"auto"`) — selects which CLI runs the
+  skill subprocess: `"claude-code"` (Claude Code via `claude -p`),
+  `"codex"` (the OpenAI Codex CLI), or `"auto"` (prefers `claude` when
+  on PATH, falls back to `codex`). This is the *runtime* axis and is
+  independent of `transport` / `grading_provider`, which govern the
+  *grader* call — a skill can run under Codex while the L3 grader still
+  calls Claude Sonnet. Precedence: `--harness` on the CLI wins (on
+  `validate`, `grade`, `capture`, `run`), then the `CLAUDITOR_HARNESS`
+  env var, then this field, then the `auto` default. Load-time
+  validation rejects values outside the three-choice set. Running under
+  Codex requires `CODEX_API_KEY` or `OPENAI_API_KEY` in the subprocess
+  env. See [`docs/codex-harness.md`](codex-harness.md) for the full
+  harness reference.
 - **`sync_tasks`** (bool, default `false`) — when `true`, clauditor
   sets `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in the `claude -p`
   subprocess env, forcing `Task(run_in_background=true)` spawns to
@@ -304,8 +317,8 @@ A few `EvalSpec` fields tune specific code paths and are safe to omit:
 `EvalSpec.system_prompt` (string, default `null`) is the prompt body
 sent to harnesses that consume a separate system-prompt channel. The
 shipping `ClaudeCodeHarness` ignores it (the `claude -p` CLI has no
-analogue — slash-command identity carries the skill body), but the
-forthcoming `CodexHarness` (#149) will prepend it before the user
+analogue — slash-command identity carries the skill body), while the
+`CodexHarness` (#149) prepends it before the user
 message. It is part of the cross-harness `Harness.build_prompt`
 contract introduced in #150 so a single `EvalSpec` shape feeds every
 harness identically.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -92,11 +92,23 @@ clauditor validate .claude/commands/my-skill.md
 clauditor validate .claude/commands/my-skill.md --json
 ```
 
+### Running under Codex instead of Claude Code
+
+Every skill-running command (`validate`, `grade`, `capture`, `run`) accepts `--harness codex` to drive the skill through the OpenAI Codex CLI instead of `claude -p`. Export `CODEX_API_KEY` (or `OPENAI_API_KEY`) first:
+
+```bash
+export CODEX_API_KEY=sk-...
+clauditor validate .claude/commands/my-skill.md --harness codex
+```
+
+The default `--harness auto` picks Claude Code when `claude` is on PATH, else Codex. The runtime axis is independent of the grader — a skill can run under Codex while L3 still grades with Claude Sonnet. Full reference: [Codex harness](codex-harness.md).
+
 ## 5. Use in pytest
 
 ```python
 def test_my_skill(clauditor_runner, clauditor_asserter):
-    result = clauditor_runner.run("my-skill", '"San Jose, CA" --depth quick')
+    runner = clauditor_runner()  # factory fixture; pass harness="codex" to run under Codex
+    result = runner.run("my-skill", '"San Jose, CA" --depth quick')
     asserter = clauditor_asserter(result)
     asserter.assert_contains("Results")
     asserter.assert_has_entries(minimum=3)


### PR DESCRIPTION
## Why

The Codex harness shipped in 0.1.2, but the discovery docs barely covered it — the README only mentioned it in a buried paragraph of the auth section, and `docs/cli-reference.md` omitted `--harness` from the shared-runner-flags table entirely (it only documented `--harness`/`--cross-harness` for `audit`/`trend`/`compare`). A user landing on the README or CLI reference would not learn they can run/eval skills under Codex.

`docs/codex-harness.md` (the deep reference) is already thorough — this PR fixes **discovery**, routing every new mention to that doc as the single source of truth.

## Changes

**README**
- Tagline clause + Contents-nav entry pointing at a new `## Running skills under Codex` section (lean teaser per the readme-promotion recipe).
- Slimmed the duplicate Codex paragraph in the auth section to a focused pointer.

**docs/cli-reference.md**
- Added `--harness {claude-code,codex,auto}` to the shared-runner-flags table; reworded the section intro and the `validate`/`run` descriptions away from hardcoded `claude -p`; added `--harness` to the `validate`/`grade`/`run`/`capture` flag lists.

**docs/eval-spec-reference.md**
- Added a first-class `harness` entry to the optional-top-level-fields section (mirrors `transport`); fixed stale "forthcoming CodexHarness" wording.

**docs/quick-start.md**
- Added a "Running under Codex" subsection.

**Drive-by fix:** README + quick-start pytest examples used the pre-#155 `clauditor_runner.run(...)` value-fixture form, which is now broken — updated to the `clauditor_runner()` factory form (and show the `harness=` kwarg).

## Validation
- `tests/test_docs_examples.py` + `tests/test_init.py`: 55 passed.
- New README anchor `#running-skills-under-codex` resolves from both the tagline and the nav.