### PR TITLE
#4: npm Node.js wrapper

### DIFF
--- a/.claude/rules/json-stdout-purity.md
+++ b/.claude/rules/json-stdout-purity.md
@@ -83,7 +83,7 @@ The external consumer treats the producer's stdout as a tolerated
 contract (parse defensively, surface a crisp error on non-JSON) and
 mirrors the producer's exit-code taxonomy structurally — NOT by
 substring-matching messages. See
-`src/clauditor/lib/exec.js::mapExit` (npm bridge): exit 0/1 → parsed
+`npm/lib/exec.js::mapExit` (npm bridge): exit 0/1 → parsed
 JSON data, 2 → `ClauditorInputError`, 3 → `ClauditorApiError`, other →
 `ClauditorError`; non-JSON stdout → `ClauditorError` with a bounded
 snippet.

--- a/.claude/rules/json-stdout-purity.md
+++ b/.claude/rules/json-stdout-purity.md
@@ -1,0 +1,175 @@
+# Rule: `--json` stdout is PURE JSON — every other line goes to stderr
+
+When a CLI command has a `--json` mode whose stdout is consumed by an
+external wrapper that does `JSON.parse(entire stdout)` (today: the npm
+`clauditor-eval` subprocess bridge; tomorrow plausibly a CI step, a
+GitHub Action, or any tool that pipes `clauditor … --json` into a
+parser), **stdout under `--json` must contain ONLY the single JSON
+document and nothing else**. Every progress breadcrumb, warning,
+"Running …", "Staged N input files", "Skill completed in …" line, and
+error render MUST go to **stderr** (or be suppressed) when `--json` is
+set. A single stray stdout line turns the consumer's `JSON.parse` into
+a hard failure with an opaque "non-JSON output" error.
+
+This is a *cross-cutting* contract: the polluting line is frequently
+emitted by a **callee** several layers below the CLI command (e.g.
+`SkillSpec.run` printing "Staged …" from inside `cli/validate.py`'s
+`--json` path), so it cannot be audited by reading the command
+function alone. It bit the #4 npm-wrapper work three times (validate's
+two progress lines, then `spec.py`'s staging breadcrumb).
+
+## The pattern
+
+### Command-level: route progress by mode
+
+```python
+# cli/validate.py
+print(
+    f"Running /{spec.skill_name} {spec.eval_spec.test_args}...",
+    file=sys.stderr if args.json else sys.stdout,
+)
+# ... later, the ONLY stdout write under --json:
+if args.json:
+    print(json.dumps(payload, indent=2))   # pure JSON, nothing before/after
+else:
+    print(results.summary())
+```
+
+### Callee-level: progress breadcrumbs ALWAYS go to stderr
+
+A shared helper like `SkillSpec.run` has no `args.json` visibility and
+may be called from both human-facing and `--json` paths. Its
+progress/diagnostic output is **unconditionally** stderr — stdout is
+reserved for the caller's data:
+
+```python
+# spec.py — progress breadcrumb, never stdout.
+print(
+    f"Staged {len(sources)} input file(s) into {effective_cwd}",
+    file=sys.stderr,
+)
+```
+
+The convention is simply: **stdout = data, stderr = everything else.**
+Every `print(...)` in a module reachable from a `--json` code path
+either targets `file=sys.stderr`, or is the one intended JSON payload,
+or is guarded behind `else:` (the non-`--json` branch).
+
+### Exit-code semantics: `--json` payload carries the result, process returns 0
+
+When the JSON payload itself carries the operation's outcome (an
+`exit_code` / `error` / `passed` field), the **process** should return
+0 in `--json` mode so the wrapper receives the parsed object as DATA
+rather than mapping an arbitrary exit code to a thrown error. The
+skill's own exit code lives inside the JSON:
+
+```python
+# cli/run.py — run --json
+if args.json:
+    print(json.dumps(_result_to_json(result), indent=2))
+    return 0  # skill's real exit code is in payload["exit_code"]
+```
+
+This is distinct from commands where the exit code IS the contract
+(`validate --json` returns 0/1 for pass/fail because the wrapper treats
+exit 1 as "failing eval is data" per the exit-code taxonomy). The rule:
+if the wrapper reads the verdict from the JSON body, don't also encode a
+*non-taxonomy* exit code (like a subprocess's -1/124) the wrapper would
+misinterpret.
+
+### Wrapper-side: parse stdout defensively, mirror the exit taxonomy
+
+The external consumer treats the producer's stdout as a tolerated
+contract (parse defensively, surface a crisp error on non-JSON) and
+mirrors the producer's exit-code taxonomy structurally — NOT by
+substring-matching messages. See
+`src/clauditor/lib/exec.js::mapExit` (npm bridge): exit 0/1 → parsed
+JSON data, 2 → `ClauditorInputError`, 3 → `ClauditorApiError`, other →
+`ClauditorError`; non-JSON stdout → `ClauditorError` with a bounded
+snippet.
+
+## Why this shape
+
+- **`JSON.parse(entire stdout)` is all-or-nothing.** The npm bridge
+  (and most `--json` consumers) parse the whole stdout buffer in one
+  call. There is no "skip the first line" affordance; one breadcrumb
+  breaks the parse for every invocation that hits that code path.
+- **The leak is usually in a callee, not the command.** Auditing the
+  CLI command function is insufficient — `SkillSpec.run`, the workspace
+  stager, the history appender, and the transcript writer are all
+  reachable from a `--json` path and each has its own `print`s. The
+  cheap defense is the blanket convention "progress → stderr always."
+- **stdout/stderr separation is the POSIX contract anyway.** Data on
+  stdout, diagnostics on stderr is how every composable Unix tool
+  behaves. `--json` just makes the cost of violating it visible.
+- **Exit-code-as-data vs exit-code-as-verdict is a real fork.** `run`
+  produces a result object (exit code is data → return 0); `validate`
+  produces a verdict (exit 0/1 is the verdict → return it). Conflating
+  them either hides failures or makes the wrapper throw on valid data.
+
+## What NOT to do
+
+- Do NOT emit ANY non-JSON line to stdout under `--json` — not a
+  progress line, not a warning, not a deprecation notice, not a blank
+  line. Route them to stderr.
+- Do NOT assume the command function is the only stdout writer. Grep
+  every module on the `--json` call path for `print(` without
+  `file=sys.stderr` (and for multi-line prints, check the `file=`
+  kwarg on a later line).
+- Do NOT return a subprocess's raw exit code (-1, 124, 137) as the
+  process exit code in `--json` mode when the payload already carries
+  it — the wrapper's exit-taxonomy mapper will turn valid data into a
+  thrown error.
+- Do NOT have the wrapper substring-match stderr/stdout to classify
+  outcomes; mirror the producer's exit-code taxonomy structurally.
+
+## Canonical implementation
+
+- `src/clauditor/cli/run.py::cmd_run` — `--json` prints one JSON
+  object and `return 0` (skill exit code in `payload["exit_code"]`);
+  error render goes to stderr.
+- `src/clauditor/cli/validate.py::cmd_validate` — "Running …" /
+  "Skill completed …" route to stderr under `--json`; the
+  skill-failed-to-run branch emits a `{passed:false, results:[],
+  error, error_category}` JSON object on stdout (so exit 1 is still
+  parseable data); the final happy-path JSON is the only other stdout
+  write.
+- `src/clauditor/spec.py::SkillSpec.run` — the "Staged N input
+  file(s)" breadcrumb is unconditionally `file=sys.stderr`.
+- `npm/lib/exec.js::execJson` / `mapExit` — the consumer side: parses
+  all of stdout as JSON, mirrors the 0/1/2/3 exit taxonomy, throws
+  `ClauditorError` (with a bounded snippet) on non-JSON stdout.
+
+Regression tests: `tests/test_cli.py::TestCmdRun::test_run_json_returns_zero_even_on_nonzero_skill_exit`,
+`tests/test_cli.py::TestCmdValidate::test_validate_json_emits_json_when_skill_fails_to_run`,
+`tests/test_spec.py` (asserts "Staged …" is on stderr, not stdout).
+
+Traces to the #4 npm-wrapper Quality Gate (epic `clauditor-ovml`,
+DEC-004/DEC-008/DEC-009 of `plans/super/4-npm-wrapper.md`).
+
+## Companion rules
+
+- `.claude/rules/llm-cli-exit-code-taxonomy.md` — the 0/1/2/3 exit
+  taxonomy the wrapper mirrors and the exit-code-as-verdict shape.
+- `.claude/rules/stream-json-schema.md` — the defensive-parse posture
+  for an external streaming format, applied here to the wrapper's
+  stdout-JSON parse.
+- `.claude/rules/pure-compute-vs-io-split.md` — `_result_to_json` /
+  `mapExit` are the pure projections; the I/O layer owns stream choice.
+
+## When this rule applies
+
+Any CLI command that gains a `--json` (or other machine-readable)
+output mode intended for a programmatic consumer. The moment a wrapper,
+CI step, or pipe does `parse(stdout)`, every module on that command's
+call path is bound by the stdout-purity contract.
+
+## When this rule does NOT apply
+
+- Human-facing output modes (no `--json`), where interleaving progress
+  and results on stdout is fine.
+- Commands whose `--json` output is a JSONL stream (one object per
+  line) AND the consumer reads line-by-line — there the per-line
+  contract differs (still no non-JSON lines, but the consumer tolerates
+  multiple documents). See `.claude/rules/stream-json-schema.md`.
+- Debug/diagnostic dumps with no programmatic consumer.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,30 @@
+name: Publish to npm
+
+# Dedicated tag pattern so this is independent of the PyPI publish.yml
+# workflow (which triggers on GitHub release). The npm package versions
+# independently of the Python engine, so it gets its own ``npm-v*`` tag.
+on:
+  push:
+    tags:
+      - 'npm-v*'
+
+defaults:
+  run:
+    working-directory: npm
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm test
+      - run: npm run test:vitest
+      - run: npm run lint
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,8 @@ jobs:
       - run: npm test
       - run: npm run test:vitest
       - run: npm run lint
-      - run: npm publish --access public
+      # Unscoped packages publish public by default; no --access flag needed
+      # (and passing one is only meaningful for scoped packages).
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Publish workflow never pushes to git; don't leave the token
+          # configured in git config for later steps.
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Automated quality checks for [Agent Skills](https://agentskills.io). A skill is 
 <details markdown="1">
 <summary>Contents</summary>
 
-[Why clauditor?](#why-clauditor) · [Install](#install) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [Suggest](#llm-assisted-skill-improvement-clauditor-suggest) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Eval Spec Format](#eval-spec-format) · [Skill compatibility](#skill-compatibility) · [Running under Codex](#running-skills-under-codex) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
+[Why clauditor?](#why-clauditor) · [Install](#install) · [One-minute example](#one-minute-example) · [Installing /clauditor](#installing-the-clauditor-slash-command) · [Using /clauditor](#using-clauditor-in-claude-code) · [Quick Start](#quick-start) · [Three Layers](#three-layers-of-validation) · [Suggest](#llm-assisted-skill-improvement-clauditor-suggest) · [CLI Reference](#cli-reference) · [Pytest Integration](#pytest-integration) · [Node.js](#nodejs-jest--vitest) · [Eval Spec Format](#eval-spec-format) · [Skill compatibility](#skill-compatibility) · [Running under Codex](#running-skills-under-codex) · [Authentication](#authentication-and-api-keys) · [Reference docs](#reference-docs)
 
 </details>
 
@@ -171,6 +171,19 @@ def test_my_skill(clauditor_runner, clauditor_asserter):
 ```
 
 Full reference: [docs/pytest-plugin.md](https://github.com/wjduenow/clauditor/blob/dev/docs/pytest-plugin.md).
+
+## Node.js (Jest / Vitest)
+
+The `clauditor-eval` npm package is a subprocess bridge to the Python engine (install it separately), exposing `runSkill` / `validate` / `loadSpec` plus a `toPassClauditor` matcher.
+
+```js
+const { validate } = require("clauditor-eval");
+const { toPassClauditor } = require("clauditor-eval/jest-helper");
+expect.extend({ toPassClauditor });
+await expect(await validate(".claude/skills/my-skill/SKILL.md")).toPassClauditor();
+```
+
+Full reference: [npm/README.md](https://github.com/wjduenow/clauditor/blob/dev/npm/README.md).
 
 ## Eval Spec Format
 

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+*.log
+.DS_Store
+# Note: package-lock.json is ignored repo-wide via the root .gitignore
+# (this is a library package; the CI workflow runs a fresh `npm install`).

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,0 +1,22 @@
+# Tests
+__tests__/
+test/
+*.test.js
+*.spec.js
+
+# Tooling configs
+jest.config.js
+vitest.config.js
+eslint.config.js
+.eslintrc.json
+
+# Dependencies / build artifacts
+node_modules/
+coverage/
+
+# Lockfiles (the published package does not need the dev lockfile)
+package-lock.json
+
+# Misc
+.DS_Store
+*.log

--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,45 @@
+# clauditor-eval
+
+Node.js wrapper for [clauditor](https://github.com/wjduenow/clauditor) — an
+auditor for Claude Code skills and slash commands.
+
+> **Status: skeleton (US-002).** The public JS API (`runSkill`, `validate`,
+> `loadSpec`), the Jest/Vitest matcher, and the CLI launcher land in later
+> stories. Full documentation arrives in US-007.
+
+## What this is
+
+`clauditor-eval` is a **subprocess bridge**: it shells out to the Python
+`clauditor` engine (`pip install clauditor-eval`) rather than
+reimplementing the evaluation layers in JavaScript. v1 ships **no
+PyInstaller binary and no platform packages** — the Python engine must be
+installed separately.
+
+## Requirements
+
+- Node.js `>=18`
+- The Python `clauditor` engine on `PATH` (or reachable via
+  `python -m clauditor`).
+
+## Naming and versioning
+
+- **Package name `clauditor-eval`.** The unscoped npm name `clauditor` is
+  already taken by an unrelated owner, so this package uses
+  `clauditor-eval`, matching the PyPI package name (DEC-001).
+- **npm version `0.1.0`.** The Python engine's version
+  (`pyproject.toml [project].version`, currently `0.1.3.dev0`) is not a
+  valid npm semver. Rather than mechanically transliterate it, the initial
+  npm release uses the clean semver `0.1.0`. Future npm releases track the
+  npm package's own changes; they are not pinned 1:1 to the PyPI version.
+
+## Reserved scope
+
+The npm scope `@clauditor-eval/*` is **RESERVED** for a future
+PyInstaller binary-distribution epic (DEC-013). It is intentionally unused
+in v1 — there are no `optionalDependencies` and no per-platform packages.
+The scope is documented here so the binary follow-up can claim it without
+renaming this package.
+
+## License
+
+Apache-2.0. See [LICENSE](./LICENSE).

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,44 +1,234 @@
 # clauditor-eval
 
 Node.js wrapper for [clauditor](https://github.com/wjduenow/clauditor) — an
-auditor for Claude Code skills and slash commands.
+auditor for Claude Code skills and slash commands. Run skills, validate them
+against an eval spec, and assert the result from Jest or Vitest.
 
-> **Status: skeleton (US-002).** The public JS API (`runSkill`, `validate`,
-> `loadSpec`), the Jest/Vitest matcher, and the CLI launcher land in later
-> stories. Full documentation arrives in US-007.
+## How it works: a subprocess bridge
 
-## What this is
+`clauditor-eval` is a **subprocess bridge**. It does NOT reimplement
+clauditor's evaluation layers in JavaScript and it does NOT bundle Python —
+it shells out to the Python `clauditor` engine and parses its `--json`
+output. The Python engine **must be installed separately**.
 
-`clauditor-eval` is a **subprocess bridge**: it shells out to the Python
-`clauditor` engine (`pip install clauditor-eval`) rather than
-reimplementing the evaluation layers in JavaScript. v1 ships **no
-PyInstaller binary and no platform packages** — the Python engine must be
-installed separately.
+### Prerequisite: install the Python engine
 
-## Requirements
+Install the engine with any of:
 
-- Node.js `>=18`
-- The Python `clauditor` engine on `PATH` (or reachable via
-  `python -m clauditor`).
+```sh
+pipx install clauditor-eval        # recommended — isolated, on PATH
+uv tool install clauditor-eval     # if you use uv
+pip install clauditor-eval         # into the active environment
+```
 
-## Naming and versioning
+`clauditor-eval` resolves the engine in this order:
 
-- **Package name `clauditor-eval`.** The unscoped npm name `clauditor` is
-  already taken by an unrelated owner, so this package uses
-  `clauditor-eval`, matching the PyPI package name (DEC-001).
-- **npm version `0.1.0`.** The Python engine's version
-  (`pyproject.toml [project].version`, currently `0.1.3.dev0`) is not a
-  valid npm semver. Rather than mechanically transliterate it, the initial
-  npm release uses the clean semver `0.1.0`. Future npm releases track the
-  npm package's own changes; they are not pinned 1:1 to the PyPI version.
+1. `CLAUDITOR_BIN` — an explicit path to the engine binary (wins).
+2. `clauditor` on `PATH`.
+3. `python3 -m clauditor` — best-effort fallback when `python3` is on `PATH`.
 
-## Reserved scope
+If none resolve, calls throw `ClauditorNotFoundError` with an install hint.
 
-The npm scope `@clauditor-eval/*` is **RESERVED** for a future
-PyInstaller binary-distribution epic (DEC-013). It is intentionally unused
-in v1 — there are no `optionalDependencies` and no per-platform packages.
-The scope is documented here so the binary follow-up can claim it without
-renaming this package.
+## Install
+
+```sh
+npm install --save-dev clauditor-eval
+```
+
+Requires Node.js `>=18`.
+
+## API
+
+```js
+const { runSkill, validate, loadSpec } = require("clauditor-eval");
+```
+
+### `runSkill(skill, opts)`
+
+Runs `clauditor run <skill> --json` and resolves to the parsed SkillResult:
+
+```js
+const result = await runSkill("my-skill", {
+  args: '"San Jose, CA"',
+  projectDir: ".",
+  timeout: 120, // SECONDS
+});
+// result === {
+//   output, exit_code, duration_seconds, error, error_category,
+//   warnings, input_tokens, output_tokens, harness, skill, args
+// }
+```
+
+Options:
+
+- `args` — forwarded as `--args <value>`.
+- `projectDir` — forwarded as `--project-dir <value>`.
+- `timeout` — engine timeout in **seconds** (also bounds the subprocess).
+
+**v1 limitation:** `runSkill` does NOT return an `entries` field. Per-field
+Layer 2 `entries` require an eval spec and the L2 extraction pass — use
+`validate()` for per-criterion assertion results (DEC-004).
+
+### `validate(skillPath, opts)`
+
+Runs `clauditor validate <skillPath> --json` and resolves to the eval report:
+
+```js
+const report = await validate(".claude/skills/my-skill/SKILL.md", {
+  eval: "my-skill.eval.json",
+  timeout: 180,
+});
+// report === {
+//   passed, pass_rate,
+//   results: [{ name, passed, message, ... }, ...]
+// }
+```
+
+Options:
+
+- `eval` — forwarded as `--eval <path>`.
+- `timeout` — engine timeout in **seconds**.
+
+**A failing eval resolves, it does not throw.** A failing eval is the Python
+engine's exit code 1, which `clauditor-eval` treats as DATA: `validate()`
+resolves with `{ passed: false, ... }`. Only exit 2 (input validation) and
+exit 3 (provider API failure) throw (see Errors below).
+
+### `loadSpec(target)`
+
+Reads and parses an eval spec from disk and resolves to the parsed object:
+
+```js
+const spec = await loadSpec(".claude/skills/my-skill/SKILL.md");
+const explicit = await loadSpec("my-skill.eval.json");
+```
+
+Discovery rules:
+
+- A `target` ending in `.json` is read directly as the eval file.
+- `X.md` → looks for sibling `X.eval.json`.
+- `.../SKILL.md` → looks for `eval.json`, then `<dirname>.eval.json`, in the
+  skill's directory.
+
+**v1 limitation:** `loadSpec` only reads and `JSON.parse`s the file. It does
+NOT re-validate the spec through the Python engine's loader (DEC-012).
+
+## Errors
+
+All errors extend `ClauditorError`, so one `catch` can cover the family:
+
+- `ClauditorNotFoundError` — the Python engine could not be resolved.
+- `ClauditorInputError` — Python exit code 2 (input validation failure).
+- `ClauditorApiError` — Python exit code 3 (provider API failure).
+
+```js
+const {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("clauditor-eval");
+
+try {
+  await validate(".claude/skills/my-skill/SKILL.md");
+} catch (err) {
+  if (err instanceof ClauditorNotFoundError) {
+    console.error("Install the engine: pipx install clauditor-eval");
+  } else if (err instanceof ClauditorInputError) {
+    console.error("Bad input:", err.message);
+  } else if (err instanceof ClauditorApiError) {
+    console.error("Provider API failure — retry later:", err.message);
+  } else if (err instanceof ClauditorError) {
+    console.error("clauditor failed:", err.message);
+  } else {
+    throw err;
+  }
+}
+```
+
+## Jest / Vitest matcher
+
+`clauditor-eval/jest-helper` exports a custom `toPassClauditor` matcher that
+works under both Jest and Vitest (both await async matchers).
+
+Register it once and assert against a `validate()` result:
+
+```js
+const { validate } = require("clauditor-eval");
+const { toPassClauditor } = require("clauditor-eval/jest-helper");
+expect.extend({ toPassClauditor });
+
+test("skill passes eval", async () => {
+  await expect(
+    await validate(".claude/skills/my-skill/SKILL.md")
+  ).toPassClauditor();
+});
+```
+
+You can also pass a `runSkill()` result plus the eval path — the matcher
+calls `validate(evalPath)` to obtain the verdict:
+
+```js
+const { runSkill } = require("clauditor-eval");
+
+test("run then judge", async () => {
+  const result = await runSkill("my-skill", { args: '"San Jose, CA"' });
+  await expect(result).toPassClauditor(".claude/skills/my-skill/SKILL.md");
+});
+```
+
+Negate with `.not.toPassClauditor()`. On failure the matcher message lists
+the names of the criteria that did not pass.
+
+### Vitest
+
+The matcher is the same; import `expect` from `vitest`:
+
+```js
+import { expect, test } from "vitest";
+import { validate } from "clauditor-eval";
+import { toPassClauditor } from "clauditor-eval/jest-helper";
+
+expect.extend({ toPassClauditor });
+
+test("skill passes eval", async () => {
+  await expect(
+    await validate(".claude/skills/my-skill/SKILL.md")
+  ).toPassClauditor();
+});
+```
+
+## `CLAUDITOR_BIN`
+
+Set `CLAUDITOR_BIN` to point at a specific engine binary, bypassing PATH
+resolution entirely:
+
+```sh
+export CLAUDITOR_BIN=/opt/pipx/venvs/clauditor-eval/bin/clauditor
+```
+
+This wins over `clauditor` on `PATH` and the `python3 -m clauditor` fallback.
+
+## v1 limitations and roadmap
+
+- **Subprocess bridge today.** The Python engine is a hard prerequisite;
+  this package does not bundle Python.
+- **Standalone binaries are planned.** Zero-Python-install distribution via
+  PyInstaller binaries is a planned follow-up (DEC-013). The npm scope
+  `@clauditor-eval/*` is reserved for that per-platform binary epic and is
+  intentionally unused in v1 — no `optionalDependencies`, no platform
+  packages (DEC-002 / DEC-003 / DEC-013).
+- **No `entries` from `runSkill`.** See the `runSkill` note above (DEC-004).
+- **`loadSpec` does not re-validate.** See the `loadSpec` note above
+  (DEC-012).
+
+## Versioning
+
+The npm package version is **`0.1.0`** — a clean semver chosen for the
+initial npm release. The Python engine versions independently
+(`pyproject.toml [project].version`); the two are not pinned 1:1. The
+unscoped npm name `clauditor` was already taken by an unrelated owner, so
+this package uses `clauditor-eval`, matching the PyPI package name (DEC-001).
 
 ## License
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -21,13 +21,21 @@ uv tool install clauditor-eval     # if you use uv
 pip install clauditor-eval         # into the active environment
 ```
 
-`clauditor-eval` resolves the engine in this order:
+`clauditor-eval` resolves the **Python engine** in this order:
 
 1. `CLAUDITOR_BIN` — an explicit path to the engine binary (wins).
-2. `clauditor` on `PATH`.
-3. `python3 -m clauditor` — best-effort fallback when `python3` is on `PATH`.
+2. `clauditor` on `PATH` — this is the **Python engine's** console script
+   (installed by `pipx install clauditor-eval`), NOT this npm wrapper. The
+   wrapper installs its own command as `clauditor-eval`, so the scan can
+   never resolve to itself.
+3. `python -m clauditor` — best-effort fallback, probing `python3`, then
+   `python`, then (on Windows) the `py` launcher.
 
 If none resolve, calls throw `ClauditorNotFoundError` with an install hint.
+
+Note: on Windows the PATH scan only accepts a spawnable `clauditor.exe`;
+`.cmd`/`.bat` shims are skipped (they can't be launched without a shell), so
+point `CLAUDITOR_BIN` at the real interpreter for those installs.
 
 ## Install
 

--- a/npm/__tests__/api.test.js
+++ b/npm/__tests__/api.test.js
@@ -98,6 +98,18 @@ describe("runSkill", () => {
     ]);
   });
 
+  test.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["string", "30"],
+  ])("rejects an invalid timeout (%s)", async (_label, bad) => {
+    await expect(runSkill("my-skill", { timeout: bad })).rejects.toThrow(
+      ClauditorError,
+    );
+  });
+
   test("returns the parsed run --json shape", async () => {
     const payload = {
       output: "hello",

--- a/npm/__tests__/api.test.js
+++ b/npm/__tests__/api.test.js
@@ -240,6 +240,22 @@ describe("loadSpec", () => {
     expect(spec).toEqual({ skill_name: "greeter" });
   });
 
+  test("prefers SKILL.eval.json (engine-canonical) for a SKILL.md skill", async () => {
+    // The Python engine loads skill_path.with_suffix(".eval.json") ->
+    // SKILL.eval.json; loadSpec must agree, even when eval.json also exists.
+    fs.writeFileSync(path.join(specDir, "SKILL.md"), "# skill");
+    fs.writeFileSync(
+      path.join(specDir, "SKILL.eval.json"),
+      JSON.stringify({ via: "SKILL.eval.json" })
+    );
+    fs.writeFileSync(
+      path.join(specDir, "eval.json"),
+      JSON.stringify({ via: "eval.json" })
+    );
+    const spec = await loadSpec(path.join(specDir, "SKILL.md"));
+    expect(spec).toEqual({ via: "SKILL.eval.json" });
+  });
+
   test("discovers eval.json for a SKILL.md skill", async () => {
     fs.writeFileSync(path.join(specDir, "SKILL.md"), "# skill");
     fs.writeFileSync(

--- a/npm/__tests__/api.test.js
+++ b/npm/__tests__/api.test.js
@@ -1,0 +1,281 @@
+// Public JS API tests (jest). Drives runSkill/validate through a FAKE
+// clauditor stub via CLAUDITOR_BIN — a node script that dumps the argv it
+// received and echoes a canned JSON payload + exit code — so we can assert
+// both the option->flag mapping and the parsed return shape. loadSpec is
+// tested against real tmp-dir fixtures (no subprocess).
+const { runSkill, validate, loadSpec } = require("../index");
+const {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("../index");
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+let tmpDir;
+let argvDumpPath;
+
+function writeStub() {
+  const script = `
+const fs = require("fs");
+const argv = process.argv.slice(2);
+if (process.env.ARGV_DUMP) {
+  fs.writeFileSync(process.env.ARGV_DUMP, JSON.stringify(argv));
+}
+if (process.env.CANNED_JSON) {
+  process.stdout.write(process.env.CANNED_JSON);
+}
+if (process.env.CANNED_STDERR) {
+  process.stderr.write(process.env.CANNED_STDERR);
+}
+process.exit(Number(process.env.EXIT_CODE || "0"));
+`;
+  const exeStub = path.join(tmpDir, "clauditor-stub");
+  fs.writeFileSync(exeStub, `#!${process.execPath}\n${script}`);
+  fs.chmodSync(exeStub, 0o755);
+  return exeStub;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-api-"));
+  argvDumpPath = path.join(tmpDir, "argv.json");
+  process.env.CLAUDITOR_BIN = writeStub();
+  process.env.ARGV_DUMP = argvDumpPath;
+});
+
+afterEach(() => {
+  delete process.env.CLAUDITOR_BIN;
+  delete process.env.ARGV_DUMP;
+  delete process.env.CANNED_JSON;
+  delete process.env.CANNED_STDERR;
+  delete process.env.EXIT_CODE;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function receivedArgv() {
+  return JSON.parse(fs.readFileSync(argvDumpPath, "utf8"));
+}
+
+describe("re-exported error classes", () => {
+  test("are the same classes lib/errors exports", () => {
+    const libErrors = require("../lib/errors");
+    expect(ClauditorError).toBe(libErrors.ClauditorError);
+    expect(ClauditorNotFoundError).toBe(libErrors.ClauditorNotFoundError);
+    expect(ClauditorInputError).toBe(libErrors.ClauditorInputError);
+    expect(ClauditorApiError).toBe(libErrors.ClauditorApiError);
+  });
+});
+
+describe("runSkill", () => {
+  test("maps to `run <skill> --json` with no options", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    await runSkill("my-skill");
+    expect(receivedArgv()).toEqual(["run", "my-skill", "--json"]);
+  });
+
+  test("maps args / projectDir / timeout to flags", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    await runSkill("my-skill", {
+      args: "find me thai food",
+      projectDir: "/tmp/proj",
+      timeout: 45,
+    });
+    expect(receivedArgv()).toEqual([
+      "run",
+      "my-skill",
+      "--json",
+      "--args",
+      "find me thai food",
+      "--project-dir",
+      "/tmp/proj",
+      "--timeout",
+      "45",
+    ]);
+  });
+
+  test("returns the parsed run --json shape", async () => {
+    const payload = {
+      output: "hello",
+      exit_code: 0,
+      duration_seconds: 1.5,
+      error: null,
+      error_category: null,
+      warnings: [],
+      input_tokens: 10,
+      output_tokens: 20,
+      harness: "claude-code",
+      skill: "my-skill",
+      args: "",
+    };
+    process.env.CANNED_JSON = JSON.stringify(payload);
+    process.env.EXIT_CODE = "0";
+    const result = await runSkill("my-skill");
+    expect(result).toEqual(payload);
+  });
+
+  test("does not push --args when args is omitted", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    await runSkill("my-skill", { projectDir: "/x" });
+    const argv = receivedArgv();
+    expect(argv).not.toContain("--args");
+    expect(argv).toContain("--project-dir");
+  });
+
+  test("exit 2 throws ClauditorInputError", async () => {
+    process.env.EXIT_CODE = "2";
+    process.env.CANNED_STDERR = "ERROR: bad skill";
+    await expect(runSkill("nope")).rejects.toThrow(ClauditorInputError);
+  });
+
+  test("exit 3 throws ClauditorApiError", async () => {
+    process.env.EXIT_CODE = "3";
+    process.env.CANNED_STDERR = "ERROR: rate limited";
+    await expect(runSkill("my-skill")).rejects.toThrow(ClauditorApiError);
+  });
+});
+
+describe("validate", () => {
+  test("maps to `validate <skillPath> --json`", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    await validate("skills/my-skill/SKILL.md");
+    expect(receivedArgv()).toEqual([
+      "validate",
+      "skills/my-skill/SKILL.md",
+      "--json",
+    ]);
+  });
+
+  test("maps eval / timeout options to flags", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    await validate("SKILL.md", { eval: "my.eval.json", timeout: 30 });
+    expect(receivedArgv()).toEqual([
+      "validate",
+      "SKILL.md",
+      "--json",
+      "--eval",
+      "my.eval.json",
+      "--timeout",
+      "30",
+    ]);
+  });
+
+  test("resolves {passed: true} on exit 0", async () => {
+    process.env.CANNED_JSON = JSON.stringify({
+      skill: "s",
+      pass_rate: 1.0,
+      passed: true,
+      results: [{ name: "a", passed: true }],
+    });
+    process.env.EXIT_CODE = "0";
+    const result = await validate("SKILL.md");
+    expect(result.passed).toBe(true);
+    expect(result.pass_rate).toBe(1.0);
+  });
+
+  test("resolves {passed: false} on exit 1 (failing eval is data, not thrown)", async () => {
+    process.env.CANNED_JSON = JSON.stringify({
+      skill: "s",
+      pass_rate: 0.5,
+      passed: false,
+      results: [{ name: "a", passed: false }],
+    });
+    process.env.EXIT_CODE = "1";
+    const result = await validate("SKILL.md");
+    expect(result.passed).toBe(false);
+    expect(result.pass_rate).toBe(0.5);
+  });
+
+  test("exit 2 throws ClauditorInputError", async () => {
+    process.env.EXIT_CODE = "2";
+    process.env.CANNED_STDERR = "ERROR: malformed spec";
+    await expect(validate("SKILL.md")).rejects.toThrow(ClauditorInputError);
+  });
+
+  test("exit 3 throws ClauditorApiError", async () => {
+    process.env.EXIT_CODE = "3";
+    process.env.CANNED_STDERR = "ERROR: api down";
+    await expect(validate("SKILL.md")).rejects.toThrow(ClauditorApiError);
+  });
+});
+
+describe("loadSpec", () => {
+  let specDir;
+
+  beforeEach(() => {
+    specDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-spec-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(specDir, { recursive: true, force: true });
+  });
+
+  test("reads an explicit .eval.json path", async () => {
+    const evalPath = path.join(specDir, "my.eval.json");
+    fs.writeFileSync(evalPath, JSON.stringify({ skill_name: "my", assertions: [] }));
+    const spec = await loadSpec(evalPath);
+    expect(spec).toEqual({ skill_name: "my", assertions: [] });
+  });
+
+  test("reads an explicit plain .json path", async () => {
+    const evalPath = path.join(specDir, "config.json");
+    fs.writeFileSync(evalPath, JSON.stringify({ k: 1 }));
+    expect(await loadSpec(evalPath)).toEqual({ k: 1 });
+  });
+
+  test("discovers sibling <stem>.eval.json for an X.md skill", async () => {
+    fs.writeFileSync(path.join(specDir, "greeter.md"), "# skill");
+    fs.writeFileSync(
+      path.join(specDir, "greeter.eval.json"),
+      JSON.stringify({ skill_name: "greeter" })
+    );
+    const spec = await loadSpec(path.join(specDir, "greeter.md"));
+    expect(spec).toEqual({ skill_name: "greeter" });
+  });
+
+  test("discovers eval.json for a SKILL.md skill", async () => {
+    fs.writeFileSync(path.join(specDir, "SKILL.md"), "# skill");
+    fs.writeFileSync(
+      path.join(specDir, "eval.json"),
+      JSON.stringify({ via: "eval.json" })
+    );
+    const spec = await loadSpec(path.join(specDir, "SKILL.md"));
+    expect(spec).toEqual({ via: "eval.json" });
+  });
+
+  test("falls back to <dir>.eval.json for a SKILL.md skill", async () => {
+    const skillDir = path.join(specDir, "my-skill");
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "# skill");
+    fs.writeFileSync(
+      path.join(skillDir, "my-skill.eval.json"),
+      JSON.stringify({ via: "dir.eval.json" })
+    );
+    const spec = await loadSpec(path.join(skillDir, "SKILL.md"));
+    expect(spec).toEqual({ via: "dir.eval.json" });
+  });
+
+  test("throws when no sibling eval file is found", async () => {
+    fs.writeFileSync(path.join(specDir, "lonely.md"), "# skill");
+    await expect(loadSpec(path.join(specDir, "lonely.md"))).rejects.toThrow(
+      /no eval spec found/
+    );
+  });
+
+  test("throws on a non-string / empty target", async () => {
+    await expect(loadSpec("")).rejects.toThrow(/non-empty string/);
+  });
+
+  test("throws on invalid JSON in the eval file", async () => {
+    const evalPath = path.join(specDir, "broken.eval.json");
+    fs.writeFileSync(evalPath, "{not json");
+    await expect(loadSpec(evalPath)).rejects.toThrow(/invalid JSON/);
+  });
+});

--- a/npm/__tests__/bin.test.js
+++ b/npm/__tests__/bin.test.js
@@ -1,0 +1,132 @@
+// bin/clauditor.js launcher tests (jest runner). Drives ``run`` with
+// injectable fake spawn / resolve / stderr / exit so no real process is
+// launched. The pure arg-assembly helper is also mirrored under
+// test/bin.test.js for vitest.
+const { EventEmitter } = require("events");
+
+const { run, buildChildArgs } = require("../bin/clauditor");
+const { ClauditorNotFoundError } = require("../lib/errors");
+
+// A fake child the test can drive by emitting ``exit`` / ``error``.
+function makeFakeChild() {
+  return new EventEmitter();
+}
+
+// Build a deps bundle capturing spawn args + exit code + stderr writes.
+function makeDeps(resolution, { throwNotFound = false } = {}) {
+  const captured = { spawnArgs: null, exitCode: undefined, stderr: "" };
+  const child = makeFakeChild();
+  const deps = {
+    spawn: (command, args, opts) => {
+      captured.spawnArgs = { command, args, opts };
+      return child;
+    },
+    resolve: () => {
+      if (throwNotFound) {
+        throw new ClauditorNotFoundError("install hint: pipx install clauditor-eval");
+      }
+      return resolution;
+    },
+    stderr: { write: (s) => { captured.stderr += s; } },
+    exit: (code) => { captured.exitCode = code; },
+  };
+  return { deps, child, captured };
+}
+
+describe("buildChildArgs", () => {
+  test("prepends empty prefix verbatim", () => {
+    expect(buildChildArgs({ command: "clauditor", argsPrefix: [] }, ["validate", "foo.md"]))
+      .toEqual(["validate", "foo.md"]);
+  });
+
+  test("prepends python module fallback prefix", () => {
+    expect(
+      buildChildArgs(
+        { command: "python3", argsPrefix: ["-m", "clauditor"] },
+        ["run", "foo.md", "--json"],
+      ),
+    ).toEqual(["-m", "clauditor", "run", "foo.md", "--json"]);
+  });
+
+  test("preserves args with spaces verbatim", () => {
+    expect(buildChildArgs({ command: "clauditor", argsPrefix: [] }, ["run", "a b c"]))
+      .toEqual(["run", "a b c"]);
+  });
+});
+
+describe("run argv forwarding", () => {
+  test("forwards argv to resolved binary as an array, no shell", () => {
+    const { deps, captured } = makeDeps({ command: "clauditor", argsPrefix: [] });
+    run(["validate", "foo.md", "--json"], deps);
+
+    expect(captured.spawnArgs.command).toBe("clauditor");
+    expect(captured.spawnArgs.args).toEqual(["validate", "foo.md", "--json"]);
+    // No shell: true — argument array only (DEC-007).
+    expect(captured.spawnArgs.opts.shell).toBeUndefined();
+    expect(captured.spawnArgs.opts.stdio).toBe("inherit");
+    expect(captured.spawnArgs.opts.env).toBe(process.env);
+  });
+
+  test("prepends argsPrefix for the python -m fallback", () => {
+    const { deps, captured } = makeDeps({
+      command: "python3",
+      argsPrefix: ["-m", "clauditor"],
+    });
+    run(["run", "foo.md", "--json"], deps);
+
+    expect(captured.spawnArgs.command).toBe("python3");
+    expect(captured.spawnArgs.args).toEqual(["-m", "clauditor", "run", "foo.md", "--json"]);
+  });
+
+  test("preserves an arg containing spaces", () => {
+    const { deps, captured } = makeDeps({ command: "clauditor", argsPrefix: [] });
+    run(["run", "skill with spaces.md"], deps);
+    expect(captured.spawnArgs.args).toEqual(["run", "skill with spaces.md"]);
+  });
+});
+
+describe("run exit-code propagation", () => {
+  test.each([0, 1, 2, 3])("child exit %i → process exit %i", (code) => {
+    const { deps, child, captured } = makeDeps({ command: "clauditor", argsPrefix: [] });
+    run([], deps);
+    child.emit("exit", code, null);
+    expect(captured.exitCode).toBe(code);
+  });
+
+  test("signal-kill (code null) → nonzero exit + stderr note", () => {
+    const { deps, child, captured } = makeDeps({ command: "clauditor", argsPrefix: [] });
+    run([], deps);
+    child.emit("exit", null, "SIGKILL");
+    expect(captured.exitCode).toBe(1);
+    expect(captured.stderr).toContain("SIGKILL");
+  });
+
+  test("spawn error → exit 1 + stderr note", () => {
+    const { deps, child, captured } = makeDeps({ command: "clauditor", argsPrefix: [] });
+    run([], deps);
+    child.emit("error", new Error("ENOENT"));
+    expect(captured.exitCode).toBe(1);
+    expect(captured.stderr).toContain("ENOENT");
+  });
+});
+
+describe("run missing-engine handling", () => {
+  test("ClauditorNotFoundError → install hint to stderr + exit 2", () => {
+    const { deps, captured } = makeDeps(null, { throwNotFound: true });
+    run(["validate", "foo.md"], deps);
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toContain("install hint");
+    // Did NOT spawn.
+    expect(captured.spawnArgs).toBeNull();
+  });
+
+  test("non-NotFound resolve error propagates", () => {
+    const deps = {
+      resolve: () => { throw new TypeError("boom"); },
+      spawn: () => { throw new Error("should not spawn"); },
+      stderr: { write: () => {} },
+      exit: () => {},
+    };
+    expect(() => run([], deps)).toThrow(TypeError);
+  });
+});

--- a/npm/__tests__/exec-json.test.js
+++ b/npm/__tests__/exec-json.test.js
@@ -1,0 +1,115 @@
+// execJson integration test (jest only — avoids duplicating temp-file
+// fixtures across runners). Drives a FAKE clauditor stub via CLAUDITOR_BIN:
+// a tiny node script that echoes canned JSON + a chosen exit code, and
+// records the argv it received so we can prove no shell was used.
+const { execJson } = require("../lib/exec");
+const {
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("../lib/errors");
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+let tmpDir;
+let argvDumpPath;
+
+// Write a stub script that:
+//   - dumps its argv (everything after `node stub.js`) to ARGV_DUMP as JSON,
+//   - prints CANNED_JSON to stdout,
+//   - prints CANNED_STDERR to stderr,
+//   - exits with EXIT_CODE.
+// All three are read from env so each test configures behavior without
+// rewriting the file.
+function writeStub() {
+  const script = `
+const fs = require("fs");
+const argv = process.argv.slice(2);
+if (process.env.ARGV_DUMP) {
+  fs.writeFileSync(process.env.ARGV_DUMP, JSON.stringify(argv));
+}
+if (process.env.CANNED_JSON) {
+  process.stdout.write(process.env.CANNED_JSON);
+}
+if (process.env.CANNED_STDERR) {
+  process.stderr.write(process.env.CANNED_STDERR);
+}
+process.exit(Number(process.env.EXIT_CODE || "0"));
+`;
+  // CLAUDITOR_BIN must be a single executable command, and resolveBinary
+  // returns argsPrefix=[] for the override path — so the stub must BE the
+  // command. Make it self-executing with a node shebang + chmod so execFile
+  // can run it directly.
+  const exeStub = path.join(tmpDir, "clauditor-stub");
+  fs.writeFileSync(exeStub, `#!${process.execPath}\n${script}`);
+  fs.chmodSync(exeStub, 0o755);
+  return exeStub;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-exec-"));
+  argvDumpPath = path.join(tmpDir, "argv.json");
+  process.env.CLAUDITOR_BIN = writeStub();
+  process.env.ARGV_DUMP = argvDumpPath;
+});
+
+afterEach(() => {
+  delete process.env.CLAUDITOR_BIN;
+  delete process.env.ARGV_DUMP;
+  delete process.env.CANNED_JSON;
+  delete process.env.CANNED_STDERR;
+  delete process.env.EXIT_CODE;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("execJson", () => {
+  test("exit 0 resolves with parsed JSON", async () => {
+    process.env.CANNED_JSON = '{"passed": true, "pass_rate": 1.0}';
+    process.env.EXIT_CODE = "0";
+    const result = await execJson(["run", "--json", "my-skill"]);
+    expect(result).toEqual({ passed: true, pass_rate: 1.0 });
+  });
+
+  test("exit 1 resolves with parsed JSON (failing eval is data)", async () => {
+    process.env.CANNED_JSON = '{"passed": false, "pass_rate": 0.0}';
+    process.env.EXIT_CODE = "1";
+    const result = await execJson(["run", "--json", "my-skill"]);
+    expect(result).toEqual({ passed: false, pass_rate: 0.0 });
+  });
+
+  test("exit 2 throws ClauditorInputError", async () => {
+    process.env.EXIT_CODE = "2";
+    process.env.CANNED_STDERR = "ERROR: missing skill file";
+    await expect(execJson(["run", "missing"])).rejects.toThrow(
+      ClauditorInputError
+    );
+  });
+
+  test("exit 3 throws ClauditorApiError", async () => {
+    process.env.EXIT_CODE = "3";
+    process.env.CANNED_STDERR = "ERROR: rate limited";
+    await expect(execJson(["grade", "my-skill"])).rejects.toThrow(
+      ClauditorApiError
+    );
+  });
+
+  test("args with spaces/special chars pass literally (no shell)", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    const args = ["run", "--user-prompt", "hello $(rm -rf /); world", "a b c"];
+    await execJson(args);
+    const received = JSON.parse(fs.readFileSync(argvDumpPath, "utf8"));
+    // The stub receives EXACTLY the args we passed — no shell expansion,
+    // no word-splitting on the spaces, no $() evaluation.
+    expect(received).toEqual(args);
+  });
+
+  test("timeout option is forwarded (no crash on small timeout)", async () => {
+    process.env.CANNED_JSON = "{}";
+    process.env.EXIT_CODE = "0";
+    // A generous timeout that the fast stub finishes well within.
+    const result = await execJson(["run"], { timeout: 30000 });
+    expect(result).toEqual({});
+  });
+});

--- a/npm/__tests__/exec-json.test.js
+++ b/npm/__tests__/exec-json.test.js
@@ -47,7 +47,23 @@ process.exit(Number(process.env.EXIT_CODE || "0"));
   return exeStub;
 }
 
+// Env keys these tests mutate. Save originals in beforeEach and restore in
+// afterEach (rather than blanket-delete) so a pre-existing value in the
+// developer's shell — notably CLAUDITOR_BIN — survives the test run.
+const _MUTATED_ENV = [
+  "CLAUDITOR_BIN",
+  "ARGV_DUMP",
+  "CANNED_JSON",
+  "CANNED_STDERR",
+  "EXIT_CODE",
+];
+let _savedEnv;
+
 beforeEach(() => {
+  _savedEnv = {};
+  for (const key of _MUTATED_ENV) {
+    _savedEnv[key] = process.env[key];
+  }
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-exec-"));
   argvDumpPath = path.join(tmpDir, "argv.json");
   process.env.CLAUDITOR_BIN = writeStub();
@@ -55,11 +71,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete process.env.CLAUDITOR_BIN;
-  delete process.env.ARGV_DUMP;
-  delete process.env.CANNED_JSON;
-  delete process.env.CANNED_STDERR;
-  delete process.env.EXIT_CODE;
+  for (const key of _MUTATED_ENV) {
+    if (_savedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = _savedEnv[key];
+    }
+  }
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 

--- a/npm/__tests__/exec-maxbuffer.test.js
+++ b/npm/__tests__/exec-maxbuffer.test.js
@@ -1,0 +1,48 @@
+// execJson maxBuffer-overflow branch (jest only). This case is NOT
+// mirrored under vitest: it relies on mocking the CommonJS
+// `require("child_process")` that exec.js loads, which `vi.mock` does not
+// intercept when the module is pulled in via `createRequire`. jest's
+// `jest.mock` patches the CJS require cache and covers the branch here.
+//
+// On stdout/stderr overflow, Node's execFile rejects with a STRING
+// err.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" (not a numeric exit
+// code). exec.js must surface that as a clear ClauditorError naming the
+// buffer size, not the misleading "killed (timeout?)" message.
+
+// Mock child_process BEFORE requiring exec.js so promisify(execFile) wraps
+// our fake. The fake invokes the callback with the maxBuffer error.
+jest.mock("child_process", () => ({
+  execFile: (_file, _args, _options, callback) => {
+    const err = new Error("stdout maxBuffer length exceeded");
+    err.code = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+    callback(err);
+  },
+}));
+
+const { execJson } = require("../lib/exec");
+const { ClauditorError } = require("../lib/errors");
+
+describe("execJson maxBuffer overflow", () => {
+  const ORIG_BIN = process.env.CLAUDITOR_BIN;
+
+  beforeEach(() => {
+    // Pin CLAUDITOR_BIN so resolveBinary() short-circuits without a PATH scan.
+    process.env.CLAUDITOR_BIN = "/usr/bin/clauditor";
+  });
+
+  afterEach(() => {
+    if (ORIG_BIN === undefined) {
+      delete process.env.CLAUDITOR_BIN;
+    } else {
+      process.env.CLAUDITOR_BIN = ORIG_BIN;
+    }
+  });
+
+  test("maps ERR_CHILD_PROCESS_STDIO_MAXBUFFER to a clear ClauditorError", async () => {
+    await expect(execJson(["run", "x", "--json"])).rejects.toThrow(
+      ClauditorError,
+    );
+    await expect(execJson(["run", "x", "--json"])).rejects.toThrow(/exceeded/);
+    await expect(execJson(["run", "x", "--json"])).rejects.toThrow(/64 MB/);
+  });
+});

--- a/npm/__tests__/jest-helper.test.js
+++ b/npm/__tests__/jest-helper.test.js
@@ -1,0 +1,138 @@
+// toPassClauditor matcher tests (jest). Mirrored under test/jest-helper.test.js
+// for vitest so the SAME matcher proves identical behavior under both runners.
+//
+// validate-result branches feed the matcher a plain eval-shaped object so no
+// subprocess is needed. The runSkill-result branch drives a FAKE clauditor
+// stub via CLAUDITOR_BIN so `validate(evalPath)` returns a canned payload.
+const { toPassClauditor } = require("../jest-helper");
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+expect.extend({ toPassClauditor });
+
+function passingValidateResult() {
+  return {
+    skill: "greeter",
+    pass_rate: 1.0,
+    passed: true,
+    results: [
+      { name: "contains-hi", passed: true },
+      { name: "min-length", passed: true },
+    ],
+  };
+}
+
+function failingValidateResult() {
+  return {
+    skill: "greeter",
+    pass_rate: 0.5,
+    passed: false,
+    results: [
+      { name: "contains-hi", passed: true },
+      { name: "min-length", passed: false },
+      { name: "no-todo", passed: false },
+    ],
+  };
+}
+
+describe("toPassClauditor with a validate() result", () => {
+  test("passes when passed:true", async () => {
+    await expect(passingValidateResult()).toPassClauditor();
+  });
+
+  test("fails when passed:false and message names failing criteria", async () => {
+    const result = await toPassClauditor.call(
+      { isNot: false },
+      failingValidateResult()
+    );
+    expect(result.pass).toBe(false);
+    const msg = result.message();
+    expect(msg).toContain("min-length");
+    expect(msg).toContain("no-todo");
+    // A passing criterion must NOT be listed.
+    expect(msg).not.toContain("contains-hi");
+  });
+
+  test(".not passes for a failing result", async () => {
+    await expect(failingValidateResult()).not.toPassClauditor();
+  });
+
+  test(".not fails (with a message) for a passing result", async () => {
+    const result = await toPassClauditor.call(
+      { isNot: true },
+      passingValidateResult()
+    );
+    expect(result.pass).toBe(true); // isNot inverts the outcome
+    expect(result.message()).toContain("NOT to pass");
+  });
+});
+
+describe("toPassClauditor with a runSkill() result", () => {
+  let tmpDir;
+  let argvDumpPath;
+
+  function writeStub() {
+    const script = `
+const fs = require("fs");
+const argv = process.argv.slice(2);
+if (process.env.ARGV_DUMP) {
+  fs.writeFileSync(process.env.ARGV_DUMP, JSON.stringify(argv));
+}
+if (process.env.CANNED_JSON) {
+  process.stdout.write(process.env.CANNED_JSON);
+}
+process.exit(Number(process.env.EXIT_CODE || "0"));
+`;
+    const exeStub = path.join(tmpDir, "clauditor-stub");
+    fs.writeFileSync(exeStub, `#!${process.execPath}\n${script}`);
+    fs.chmodSync(exeStub, 0o755);
+    return exeStub;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-jh-"));
+    argvDumpPath = path.join(tmpDir, "argv.json");
+    process.env.CLAUDITOR_BIN = writeStub();
+    process.env.ARGV_DUMP = argvDumpPath;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDITOR_BIN;
+    delete process.env.ARGV_DUMP;
+    delete process.env.CANNED_JSON;
+    delete process.env.EXIT_CODE;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("requires an eval path argument", async () => {
+    const runResult = { output: "hi", exit_code: 0, skill: "greeter" };
+    const result = await toPassClauditor.call({ isNot: false }, runResult);
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain("eval path argument is REQUIRED");
+  });
+
+  test("calls validate(evalPath) and passes on a passing payload", async () => {
+    process.env.CANNED_JSON = JSON.stringify(passingValidateResult());
+    process.env.EXIT_CODE = "0";
+    const runResult = { output: "hi", exit_code: 0, skill: "greeter" };
+    await expect(runResult).toPassClauditor("SKILL.md");
+    // Confirm validate routed `validate <path> --json`.
+    const argv = JSON.parse(fs.readFileSync(argvDumpPath, "utf8"));
+    expect(argv).toEqual(["validate", "SKILL.md", "--json"]);
+  });
+
+  test("calls validate(evalPath) and fails (naming criteria) on a failing payload", async () => {
+    process.env.CANNED_JSON = JSON.stringify(failingValidateResult());
+    process.env.EXIT_CODE = "1"; // failing eval is data, not an error
+    const runResult = { output: "hi", exit_code: 0, skill: "greeter" };
+    const result = await toPassClauditor.call(
+      { isNot: false },
+      runResult,
+      "SKILL.md"
+    );
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain("min-length");
+  });
+});

--- a/npm/__tests__/lib-core.test.js
+++ b/npm/__tests__/lib-core.test.js
@@ -1,5 +1,8 @@
 // Pure-helper + resolveBinary tests (jest runner). Mirrored under
 // test/lib-core.test.js for vitest. No subprocess spawned here.
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const { mapExit } = require("../lib/exec");
 const { resolveBinary } = require("../lib/resolve-binary");
 const {
@@ -109,6 +112,42 @@ describe("resolveBinary", () => {
     } catch (e) {
       expect(e.message).toContain("pipx install clauditor-eval");
       expect(e.message).toContain("CLAUDITOR_BIN");
+    }
+  });
+
+  // H2: a `clauditor` on PATH resolves to the FULL path (incl. extension),
+  // not the bare name — Windows execFile/spawn must target the exact file.
+  test("PATH resolution returns the full resolved path, not the bare name", () => {
+    delete process.env.CLAUDITOR_BIN;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-path-"));
+    const name = process.platform === "win32" ? "clauditor.exe" : "clauditor";
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, "#!/bin/sh\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    try {
+      const res = resolveBinary();
+      expect(res.command).toBe(full);
+      expect(res.argsPrefix).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // H3: the python fallback fires for `python` (not only `python3`), and
+  // returns the full interpreter path + the `-m clauditor` prefix.
+  test("python fallback resolves `python` with the -m clauditor prefix", () => {
+    delete process.env.CLAUDITOR_BIN;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-py-"));
+    const name = process.platform === "win32" ? "python.exe" : "python";
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, "#!/bin/sh\n", { mode: 0o755 });
+    process.env.PATH = dir; // no `clauditor` here — forces the fallback
+    try {
+      const res = resolveBinary();
+      expect(res.command).toBe(full);
+      expect(res.argsPrefix).toEqual(["-m", "clauditor"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/npm/__tests__/lib-core.test.js
+++ b/npm/__tests__/lib-core.test.js
@@ -150,4 +150,40 @@ describe("resolveBinary", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // POSIX: a non-executable file named `clauditor` on PATH must NOT be
+  // selected (it would fail at spawn). Skipped on Windows (no exec bit).
+  const itPosix = process.platform === "win32" ? test.skip : test;
+  itPosix("skips a non-executable PATH match (POSIX)", () => {
+    delete process.env.CLAUDITOR_BIN;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-noexec-"));
+    fs.writeFileSync(path.join(dir, "clauditor"), "not a binary\n", {
+      mode: 0o644,
+    });
+    process.env.PATH = dir;
+    try {
+      // No executable `clauditor` and no python here → nothing resolves.
+      expect(() => resolveBinary()).toThrow(ClauditorNotFoundError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Recursion guard: a PATH `clauditor` that is really this wrapper's own
+  // launcher (npm/bin/clauditor.js) must be skipped, not spawned as the
+  // engine. Simulated via a symlink whose realpath is the wrapper bin.
+  itPosix("skips a PATH match that resolves to the wrapper's own bin", () => {
+    delete process.env.CLAUDITOR_BIN;
+    const selfBin = path.join(__dirname, "..", "bin", "clauditor.js");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-self-"));
+    fs.symlinkSync(selfBin, path.join(dir, "clauditor"));
+    process.env.PATH = dir;
+    try {
+      // The only `clauditor` on PATH is the wrapper itself → must NOT
+      // resolve to it (would infinite-loop); nothing else here resolves.
+      expect(() => resolveBinary()).toThrow(ClauditorNotFoundError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/npm/__tests__/lib-core.test.js
+++ b/npm/__tests__/lib-core.test.js
@@ -1,0 +1,114 @@
+// Pure-helper + resolveBinary tests (jest runner). Mirrored under
+// test/lib-core.test.js for vitest. No subprocess spawned here.
+const { mapExit } = require("../lib/exec");
+const { resolveBinary } = require("../lib/resolve-binary");
+const {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("../lib/errors");
+
+describe("error class hierarchy", () => {
+  test("every error extends ClauditorError and sets .name", () => {
+    for (const Cls of [
+      ClauditorNotFoundError,
+      ClauditorInputError,
+      ClauditorApiError,
+    ]) {
+      const e = new Cls("boom");
+      expect(e).toBeInstanceOf(ClauditorError);
+      expect(e).toBeInstanceOf(Error);
+      expect(e.name).toBe(Cls.name);
+      expect(e.message).toBe("boom");
+    }
+    expect(new ClauditorError("x").name).toBe("ClauditorError");
+  });
+});
+
+describe("mapExit (pure exit-code mapper)", () => {
+  test("exit 0 returns parsed JSON", () => {
+    const out = mapExit(0, '{"passed": true, "pass_rate": 1.0}', "");
+    expect(out).toEqual({ passed: true, pass_rate: 1.0 });
+  });
+
+  test("exit 1 returns parsed JSON (failing eval is data, not error)", () => {
+    const out = mapExit(1, '{"passed": false, "pass_rate": 0.5}', "");
+    expect(out).toEqual({ passed: false, pass_rate: 0.5 });
+  });
+
+  test("exit 2 throws ClauditorInputError with stderr text", () => {
+    expect(() => mapExit(2, "", "bad spec: missing id")).toThrow(
+      ClauditorInputError
+    );
+    try {
+      mapExit(2, "", "bad spec: missing id");
+    } catch (e) {
+      expect(e.message).toContain("bad spec: missing id");
+    }
+  });
+
+  test("exit 3 throws ClauditorApiError with stderr text", () => {
+    expect(() => mapExit(3, "", "rate limited")).toThrow(ClauditorApiError);
+    try {
+      mapExit(3, "", "rate limited");
+    } catch (e) {
+      expect(e.message).toContain("rate limited");
+    }
+  });
+
+  test("exit 7 (unexpected) throws ClauditorError", () => {
+    expect(() => mapExit(7, "", "weird")).toThrow(ClauditorError);
+    try {
+      mapExit(7, "", "weird");
+    } catch (e) {
+      expect(e).not.toBeInstanceOf(ClauditorInputError);
+      expect(e).not.toBeInstanceOf(ClauditorApiError);
+      expect(e.message).toContain("7");
+    }
+  });
+
+  test("non-JSON stdout on exit 0 throws ClauditorError with snippet", () => {
+    expect(() => mapExit(0, "not json at all", "")).toThrow(ClauditorError);
+    try {
+      mapExit(0, "not json at all", "");
+    } catch (e) {
+      expect(e.message).toContain("non-JSON");
+      expect(e.message).toContain("not json at all");
+    }
+  });
+});
+
+describe("resolveBinary", () => {
+  const ORIG_BIN = process.env.CLAUDITOR_BIN;
+  const ORIG_PATH = process.env.PATH;
+
+  afterEach(() => {
+    if (ORIG_BIN === undefined) {
+      delete process.env.CLAUDITOR_BIN;
+    } else {
+      process.env.CLAUDITOR_BIN = ORIG_BIN;
+    }
+    process.env.PATH = ORIG_PATH;
+  });
+
+  test("honors CLAUDITOR_BIN override", () => {
+    process.env.CLAUDITOR_BIN = "/opt/custom/clauditor";
+    expect(resolveBinary()).toEqual({
+      command: "/opt/custom/clauditor",
+      argsPrefix: [],
+    });
+  });
+
+  test("throws ClauditorNotFoundError with install hint when nothing resolves", () => {
+    delete process.env.CLAUDITOR_BIN;
+    process.env.PATH = "";
+    expect(() => resolveBinary()).toThrow(ClauditorNotFoundError);
+    try {
+      resolveBinary();
+    } catch (e) {
+      expect(e.message).toContain("pipx install clauditor-eval");
+      expect(e.message).toContain("CLAUDITOR_BIN");
+    }
+  });
+});

--- a/npm/__tests__/skeleton.test.js
+++ b/npm/__tests__/skeleton.test.js
@@ -1,0 +1,9 @@
+// Jest skeleton test (US-002): assert the package requires cleanly.
+const pkg = require("../index.js");
+
+describe("clauditor-eval skeleton (jest)", () => {
+  test("index.js requires cleanly and exports an object", () => {
+    expect(typeof pkg).toBe("object");
+    expect(pkg).not.toBeNull();
+  });
+});

--- a/npm/bin/clauditor.js
+++ b/npm/bin/clauditor.js
@@ -62,19 +62,31 @@ function run(argv, deps = {}) {
     env: process.env,
   });
 
-  child.on("error", (err) => {
-    stderr.write(`clauditor-eval: failed to launch engine: ${err.message}\n`);
-    return exit(1);
-  });
-
-  child.on("exit", (code, signal) => {
-    if (code != null) {
-      return exit(code);
+  // Guard against double-dispatch: a spawn failure can emit both "error"
+  // and "exit"; only the first should drive the process exit code.
+  let settled = false;
+  const settle = (codeOrNull, signal) => {
+    if (settled) {
+      return undefined;
+    }
+    settled = true;
+    if (codeOrNull != null) {
+      return exit(codeOrNull);
     }
     // Signal-killed (code === null): propagate as a nonzero exit.
     stderr.write(`clauditor-eval: engine terminated by signal ${signal}\n`);
     return exit(1);
+  };
+
+  child.on("error", (err) => {
+    if (settled) {
+      return undefined;
+    }
+    stderr.write(`clauditor-eval: failed to launch engine: ${err.message}\n`);
+    return settle(1);
   });
+
+  child.on("exit", (code, signal) => settle(code, signal));
 
   return child;
 }

--- a/npm/bin/clauditor.js
+++ b/npm/bin/clauditor.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+// clauditor-eval CLI launcher (npx clauditor / clauditor-eval bin).
+//
+// v1 is a SUBPROCESS BRIDGE: US-005 fills this stub to forward argv to the
+// Python `clauditor` CLI (via the binary resolver from US-003) and proxy
+// its exit code.
+//
+// Skeleton story (US-002): keep it parseable and a no-op success so the
+// package installs and the bin entry is wired. Not yet implemented.
+"use strict";
+
+process.stderr.write(
+  "clauditor-eval: CLI launcher not yet implemented (skeleton). " +
+    "See https://github.com/wjduenow/clauditor\n",
+);
+process.exit(0);

--- a/npm/bin/clauditor.js
+++ b/npm/bin/clauditor.js
@@ -1,16 +1,86 @@
 #!/usr/bin/env node
-// clauditor-eval CLI launcher (npx clauditor / clauditor-eval bin).
+// clauditor-eval CLI launcher (npx clauditor-eval / `clauditor` bin).
 //
-// v1 is a SUBPROCESS BRIDGE: US-005 fills this stub to forward argv to the
-// Python `clauditor` CLI (via the binary resolver from US-003) and proxy
-// its exit code.
+// v1 is a SUBPROCESS BRIDGE (US-005): resolve the Python `clauditor`
+// engine via lib/resolve-binary.js, forward every CLI arg through to it
+// with inherited stdio, and propagate the child's exit code.
 //
-// Skeleton story (US-002): keep it parseable and a no-op success so the
-// package installs and the bin entry is wired. Not yet implemented.
+// The core logic lives in a testable ``run(argv, deps)`` function with
+// injectable dependencies (spawn / resolve / stderr / exit) so tests can
+// drive it with a fake child without launching a real process. The
+// ``require.main === module`` guard at the bottom wires it to the real
+// dependencies when executed as a script (per pure-compute-vs-io-split.md:
+// arg-assembly is separated from the spawn I/O).
 "use strict";
 
-process.stderr.write(
-  "clauditor-eval: CLI launcher not yet implemented (skeleton). " +
-    "See https://github.com/wjduenow/clauditor\n",
-);
-process.exit(0);
+const childProcess = require("child_process");
+
+const { resolveBinary } = require("../lib/resolve-binary");
+const { ClauditorNotFoundError } = require("../lib/errors");
+
+// Exit code for engine-missing / input-category failures, mirroring the
+// Python exit-code taxonomy (DEC-008): 2 == input/pre-call category.
+const ENGINE_MISSING_EXIT = 2;
+
+// Pure: assemble the argv array the child engine should receive.
+// ``resolution.argsPrefix`` makes the ``python3 -m clauditor`` fallback
+// work — the user's args are appended verbatim after the prefix.
+function buildChildArgs(resolution, userArgs) {
+  return [...resolution.argsPrefix, ...userArgs];
+}
+
+// Core launcher logic with injectable deps for testability.
+//
+//   deps.spawn   — child_process.spawn-compatible (command, args, opts)
+//   deps.resolve — resolveBinary-compatible (() => {command, argsPrefix})
+//   deps.stderr  — writable stream for the install hint
+//   deps.exit    — process.exit-compatible (code) => never returns
+function run(argv, deps = {}) {
+  const spawn = deps.spawn || childProcess.spawn;
+  const resolve = deps.resolve || resolveBinary;
+  const stderr = deps.stderr || process.stderr;
+  const exit = deps.exit || process.exit;
+
+  let resolution;
+  try {
+    resolution = resolve();
+  } catch (err) {
+    if (err instanceof ClauditorNotFoundError) {
+      // Surface the actionable install hint to stderr, exit 2.
+      stderr.write(`${err.message}\n`);
+      return exit(ENGINE_MISSING_EXIT);
+    }
+    throw err;
+  }
+
+  const args = buildChildArgs(resolution, argv);
+  // INHERIT stdio for interactive passthrough; inherit env so API keys
+  // flow through. Argument ARRAY only (no shell: true) to prevent
+  // command injection (DEC-007).
+  const child = spawn(resolution.command, args, {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  child.on("error", (err) => {
+    stderr.write(`clauditor-eval: failed to launch engine: ${err.message}\n`);
+    return exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (code != null) {
+      return exit(code);
+    }
+    // Signal-killed (code === null): propagate as a nonzero exit.
+    stderr.write(`clauditor-eval: engine terminated by signal ${signal}\n`);
+    return exit(1);
+  });
+
+  return child;
+}
+
+module.exports = { run, buildChildArgs, ENGINE_MISSING_EXIT };
+
+if (require.main === module) {
+  run(process.argv.slice(2));
+}

--- a/npm/eslint.config.js
+++ b/npm/eslint.config.js
@@ -1,0 +1,45 @@
+// ESLint flat config for clauditor-eval. Minimal, Node env, sane defaults.
+const js = require("@eslint/js");
+const globals = require("globals");
+
+module.exports = [
+  {
+    ignores: ["node_modules/**", "coverage/**"],
+  },
+  // CommonJS sources: index.js, bin/, lib/, jest config, jest tests.
+  {
+    files: [
+      "index.js",
+      "bin/**/*.js",
+      "lib/**/*.js",
+      "jest-helper.js",
+      "jest.config.js",
+      "__tests__/**/*.js",
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "commonjs",
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+    },
+  },
+  // ESM sources: vitest config + vitest tests.
+  {
+    files: ["vitest.config.js", "test/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+    },
+  },
+];

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -1,0 +1,116 @@
+// TypeScript declarations for clauditor-eval's public JS API (US-004).
+//
+// v1 is a subprocess bridge to the Python clauditor engine. The shapes
+// below mirror the engine's `run --json` / `validate --json` stdout
+// payloads (DEC-004 / DEC-008).
+
+/**
+ * Parsed `clauditor run <skill> --json` payload.
+ *
+ * NOTE: v1 does NOT include `entries` — per-field L2 extraction requires
+ * an eval spec and is exposed via `validate()` / the `extract` command.
+ */
+export interface RunSkillResult {
+  output: string;
+  exit_code: number;
+  duration_seconds: number;
+  error: string | null;
+  error_category: string | null;
+  warnings: string[];
+  input_tokens: number;
+  output_tokens: number;
+  harness: string;
+  skill: string;
+  args: string;
+  // The `run --json` stdout is unversioned (DEC-009); additional engine
+  // fields are surfaced as-is.
+  [key: string]: unknown;
+}
+
+/** One per-assertion result inside a `validate --json` payload. */
+export interface ValidateResultEntry {
+  name: string;
+  passed: boolean;
+  [key: string]: unknown;
+}
+
+/** Parsed `clauditor validate <skillPath> --json` payload. */
+export interface ValidateResult {
+  skill: string;
+  pass_rate: number;
+  passed: boolean;
+  results: ValidateResultEntry[];
+  [key: string]: unknown;
+}
+
+export interface RunSkillOptions {
+  /** Forwarded as `--args <value>`. */
+  args?: string;
+  /** Forwarded as `--project-dir <value>`. */
+  projectDir?: string;
+  /** Engine timeout in SECONDS (also used as the exec timeout in ms). */
+  timeout?: number;
+}
+
+export interface ValidateOptions {
+  /** Forwarded as `--eval <path>`. */
+  eval?: string;
+  /** Engine timeout in SECONDS (also used as the exec timeout in ms). */
+  timeout?: number;
+}
+
+/**
+ * Run a skill via `clauditor run <skill> --json`.
+ *
+ * Resolves with the parsed SkillResult shape. Throws `ClauditorInputError`
+ * (exit 2), `ClauditorApiError` (exit 3), or `ClauditorError` on other
+ * failures / non-JSON output.
+ */
+export function runSkill(
+  skill: string,
+  opts?: RunSkillOptions
+): Promise<RunSkillResult>;
+
+/**
+ * Validate a skill against its eval spec via
+ * `clauditor validate <skillPath> --json`.
+ *
+ * A failing eval (exit 1) resolves with `{passed: false, ...}` — it is data,
+ * not an error. Exit 2 throws `ClauditorInputError`; exit 3 throws
+ * `ClauditorApiError`.
+ */
+export function validate(
+  skillPath: string,
+  opts?: ValidateOptions
+): Promise<ValidateResult>;
+
+/**
+ * Discover and read a clauditor eval spec from disk (DEC-012).
+ *
+ * If `target` ends in `.json`, it is read directly. Otherwise `target` is a
+ * skill file path and the sibling eval is discovered (`X.md` -> `X.eval.json`;
+ * `.../SKILL.md` -> `eval.json` or `<dir>.eval.json`). Throws if no eval file
+ * is found. Does NOT shell out to the Python engine and does NOT re-validate
+ * the spec (a documented v1 limitation).
+ */
+export function loadSpec(target: string): Promise<Record<string, unknown>>;
+
+/** Base error class for the clauditor-eval subprocess bridge. */
+export class ClauditorError extends Error {
+  constructor(message: string);
+}
+
+/** Engine binary could not be resolved (no exit code). */
+export class ClauditorNotFoundError extends ClauditorError {
+  constructor(message: string);
+}
+
+/** Python exit code 2 — input validation failure. */
+export class ClauditorInputError extends ClauditorError {
+  constructor(message: string);
+}
+
+/** Python exit code 3 — provider API failure. */
+export class ClauditorApiError extends ClauditorError {
+  constructor(message: string);
+}

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -40,6 +40,13 @@ export interface ValidateResult {
   pass_rate: number;
   passed: boolean;
   results: ValidateResultEntry[];
+  /**
+   * Present on the skill-failed-to-run path (exit 1 is data): a rendered
+   * error string and the engine's error category. Absent on the normal
+   * pass/fail path.
+   */
+  error?: string;
+  error_category?: string | null;
   [key: string]: unknown;
 }
 

--- a/npm/index.js
+++ b/npm/index.js
@@ -2,14 +2,192 @@
 //
 // This is the public JS API entry point. v1 is a SUBPROCESS BRIDGE: it
 // shells out to the `clauditor` Python CLI rather than reimplementing the
-// engine in JS.
+// engine in JS. All three async functions build a CLI arg array and route
+// it through `lib/exec.execJson`, which resolves the engine binary, spawns
+// it with NO shell (DEC-007), and maps the exit code to outcome/error per
+// the Python exit-code taxonomy (DEC-008).
 //
-// US-004 fills this stub with the public async API:
-//   - runSkill(skill, opts)        -> run --json, parsed SkillResult
-//   - validate(skillPath, opts)    -> validate --json {passed, pass_rate, results}
-//   - loadSpec(path | skillPath)   -> discover + read sibling <skill>.eval.json
-// plus re-exported error classes (from lib/, landed in US-003).
-//
-// Skeleton story (US-002): export an empty object so the package requires
-// cleanly and `npm test` is green.
-module.exports = {};
+// Public surface (US-004):
+//   - runSkill(skill, opts)     -> `clauditor run <skill> --json` (DEC-004)
+//   - validate(skillPath, opts) -> `clauditor validate <skillPath> --json`
+//   - loadSpec(target)          -> discover + read sibling eval (DEC-012)
+// plus re-exported error classes from lib/errors.
+
+const fs = require("fs");
+const path = require("path");
+
+const { execJson } = require("./lib/exec");
+const {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("./lib/errors");
+
+/**
+ * Run a skill via `clauditor run <skill> --json` and return the parsed
+ * SkillResult-shaped object (DEC-004).
+ *
+ * NOTE: v1 does NOT return `entries`. The `run --json` payload is the raw
+ * skill execution result; per-field L2 `entries` require an eval spec and
+ * the L2 extraction pass, which is the `validate()` / `extract` path.
+ *
+ * @param {string} skill - Skill name or path passed to `clauditor run`.
+ * @param {object} [opts]
+ * @param {string} [opts.args]       - Forwarded as `--args <value>`.
+ * @param {string} [opts.projectDir] - Forwarded as `--project-dir <value>`.
+ * @param {number} [opts.timeout]    - Engine timeout in SECONDS. Forwarded as
+ *   `--timeout <value>` AND used as the execJson exec timeout (timeout * 1000 ms).
+ * @returns {Promise<object>} Parsed `run --json` object:
+ *   `{output, exit_code, duration_seconds, error, error_category, warnings,
+ *     input_tokens, output_tokens, harness, skill, args}`.
+ */
+async function runSkill(skill, opts = {}) {
+  const options = opts || {};
+  const cliArgs = ["run", skill, "--json"];
+
+  if (options.args !== undefined) {
+    cliArgs.push("--args", String(options.args));
+  }
+  if (options.projectDir !== undefined) {
+    cliArgs.push("--project-dir", String(options.projectDir));
+  }
+
+  const execOpts = {};
+  if (typeof options.timeout === "number") {
+    // The engine's --timeout is in SECONDS; the execJson timeout is in ms.
+    cliArgs.push("--timeout", String(options.timeout));
+    execOpts.timeout = options.timeout * 1000;
+  }
+
+  return execJson(cliArgs, execOpts);
+}
+
+/**
+ * Validate a skill against its eval spec via
+ * `clauditor validate <skillPath> --json`.
+ *
+ * Per DEC-008, a failing eval (Python exit 1) is DATA, not an error:
+ * `execJson` returns the parsed object on exit 1, so this resolves with
+ * `{passed: false, ...}` rather than throwing. Exit 2 (input validation)
+ * and exit 3 (provider API failure) throw via execJson.
+ *
+ * @param {string} skillPath - Skill path passed to `clauditor validate`.
+ * @param {object} [opts]
+ * @param {string} [opts.eval]    - Forwarded as `--eval <path>`.
+ * @param {number} [opts.timeout] - Engine timeout in SECONDS (also ms exec timeout).
+ * @returns {Promise<object>} Parsed `validate --json` object:
+ *   `{skill, pass_rate, passed, results: [...]}`.
+ */
+async function validate(skillPath, opts = {}) {
+  const options = opts || {};
+  const cliArgs = ["validate", skillPath, "--json"];
+
+  if (options.eval !== undefined) {
+    cliArgs.push("--eval", String(options.eval));
+  }
+
+  const execOpts = {};
+  if (typeof options.timeout === "number") {
+    cliArgs.push("--timeout", String(options.timeout));
+    execOpts.timeout = options.timeout * 1000;
+  }
+
+  return execJson(cliArgs, execOpts);
+}
+
+/**
+ * Discover and read a clauditor eval spec from disk (DEC-012).
+ *
+ * This is a pure-ish file read: it does NOT shell out to the Python engine
+ * and does NOT re-validate the spec through the engine's loader (a
+ * documented v1 limitation). It only resolves a path and `JSON.parse`s it.
+ *
+ * Discovery rules:
+ *   - If `target` ends in `.json` (e.g. `foo.eval.json` or any `.json`),
+ *     it is treated as an explicit eval file: read + parse it directly.
+ *   - Otherwise `target` is treated as a skill file path and the sibling
+ *     eval is discovered:
+ *       - `X.md`        -> look for `X.eval.json` in the same directory.
+ *       - `.../SKILL.md` -> look for, in order:
+ *           1. `eval.json` in the same directory, then
+ *           2. `<dirname>.eval.json` in the same directory (where
+ *              `<dirname>` is the name of the skill's parent directory).
+ *
+ * @param {string} target - Explicit `.json` eval path OR a skill file path.
+ * @returns {Promise<object>} The parsed eval-spec object.
+ * @throws {Error} If no eval file is found, or if reading/parsing fails.
+ */
+async function loadSpec(target) {
+  if (typeof target !== "string" || target === "") {
+    throw new Error("loadSpec: target must be a non-empty string");
+  }
+
+  // Explicit .json path: read it directly.
+  if (target.endsWith(".json")) {
+    return _readJson(target);
+  }
+
+  // Skill file path: discover the sibling eval.
+  const dir = path.dirname(target);
+  const base = path.basename(target);
+
+  const candidates = [];
+  if (base === "SKILL.md") {
+    // Modern layout: <skill-dir>/SKILL.md
+    candidates.push(path.join(dir, "eval.json"));
+    candidates.push(path.join(dir, `${path.basename(dir)}.eval.json`));
+  } else {
+    // Legacy / flat layout: X.md -> X.eval.json
+    const stem = base.replace(/\.md$/, "");
+    candidates.push(path.join(dir, `${stem}.eval.json`));
+  }
+
+  for (const candidate of candidates) {
+    if (_existsFile(candidate)) {
+      return _readJson(candidate);
+    }
+  }
+
+  throw new Error(
+    `loadSpec: no eval spec found for ${r(target)} — looked for: ` +
+      candidates.join(", ")
+  );
+}
+
+// Format a value for an error message.
+function r(value) {
+  return JSON.stringify(value);
+}
+
+function _existsFile(p) {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function _readJson(p) {
+  let text;
+  try {
+    text = fs.readFileSync(p, "utf8");
+  } catch (err) {
+    throw new Error(`loadSpec: could not read ${r(p)}: ${err.message}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`loadSpec: invalid JSON in ${r(p)}: ${err.message}`);
+  }
+}
+
+module.exports = {
+  runSkill,
+  validate,
+  loadSpec,
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+};

--- a/npm/index.js
+++ b/npm/index.js
@@ -34,6 +34,26 @@ const {
 // a genuinely hung engine.
 const _EXEC_TIMEOUT_GRACE_MS = 5000;
 
+// Validate an optional `timeout` (seconds). Returns the number when present
+// and valid, undefined when omitted. Throws on a non-positive / non-finite /
+// non-number value (NaN, Infinity, 0, negative, "30") so a typo'd timeout
+// fails loudly instead of producing a bad `--timeout` CLI arg.
+function _validateTimeoutSeconds(timeout) {
+  if (timeout === undefined) {
+    return undefined;
+  }
+  if (
+    typeof timeout !== "number" ||
+    !Number.isFinite(timeout) ||
+    timeout <= 0
+  ) {
+    throw new ClauditorError(
+      `timeout must be a positive finite number of seconds, got: ${timeout}`,
+    );
+  }
+  return timeout;
+}
+
 /**
  * Run a skill via `clauditor run <skill> --json` and return the parsed
  * SkillResult-shaped object (DEC-004).
@@ -64,11 +84,12 @@ async function runSkill(skill, opts = {}) {
   }
 
   const execOpts = {};
-  if (typeof options.timeout === "number") {
+  const timeoutSec = _validateTimeoutSeconds(options.timeout);
+  if (timeoutSec !== undefined) {
     // The engine's --timeout is in SECONDS; the execJson timeout is in ms,
     // with a grace margin so the engine's own watchdog wins (see constant).
-    cliArgs.push("--timeout", String(options.timeout));
-    execOpts.timeout = options.timeout * 1000 + _EXEC_TIMEOUT_GRACE_MS;
+    cliArgs.push("--timeout", String(timeoutSec));
+    execOpts.timeout = timeoutSec * 1000 + _EXEC_TIMEOUT_GRACE_MS;
   }
 
   return execJson(cliArgs, execOpts);
@@ -99,9 +120,10 @@ async function validate(skillPath, opts = {}) {
   }
 
   const execOpts = {};
-  if (typeof options.timeout === "number") {
-    cliArgs.push("--timeout", String(options.timeout));
-    execOpts.timeout = options.timeout * 1000 + _EXEC_TIMEOUT_GRACE_MS;
+  const timeoutSec = _validateTimeoutSeconds(options.timeout);
+  if (timeoutSec !== undefined) {
+    cliArgs.push("--timeout", String(timeoutSec));
+    execOpts.timeout = timeoutSec * 1000 + _EXEC_TIMEOUT_GRACE_MS;
   }
 
   return execJson(cliArgs, execOpts);

--- a/npm/index.js
+++ b/npm/index.js
@@ -24,6 +24,16 @@ const {
   ClauditorApiError,
 } = require("./lib/errors");
 
+// Grace added to the JS-side exec timeout over the engine's own --timeout
+// (both in the same wall-clock window otherwise). The engine catches its
+// OWN timeout and reports it as structured data (run --json exit 0 with
+// error_category="timeout"; validate --json exit 1 with passed:false). If
+// the JS execFile kill fired at the same instant it would instead surface
+// as a thrown ClauditorError ("killed (timeout?)"). The grace lets the
+// engine's watchdog always win; the JS timeout is only a hard backstop for
+// a genuinely hung engine.
+const _EXEC_TIMEOUT_GRACE_MS = 5000;
+
 /**
  * Run a skill via `clauditor run <skill> --json` and return the parsed
  * SkillResult-shaped object (DEC-004).
@@ -55,9 +65,10 @@ async function runSkill(skill, opts = {}) {
 
   const execOpts = {};
   if (typeof options.timeout === "number") {
-    // The engine's --timeout is in SECONDS; the execJson timeout is in ms.
+    // The engine's --timeout is in SECONDS; the execJson timeout is in ms,
+    // with a grace margin so the engine's own watchdog wins (see constant).
     cliArgs.push("--timeout", String(options.timeout));
-    execOpts.timeout = options.timeout * 1000;
+    execOpts.timeout = options.timeout * 1000 + _EXEC_TIMEOUT_GRACE_MS;
   }
 
   return execJson(cliArgs, execOpts);
@@ -90,7 +101,7 @@ async function validate(skillPath, opts = {}) {
   const execOpts = {};
   if (typeof options.timeout === "number") {
     cliArgs.push("--timeout", String(options.timeout));
-    execOpts.timeout = options.timeout * 1000;
+    execOpts.timeout = options.timeout * 1000 + _EXEC_TIMEOUT_GRACE_MS;
   }
 
   return execJson(cliArgs, execOpts);
@@ -110,8 +121,10 @@ async function validate(skillPath, opts = {}) {
  *     eval is discovered:
  *       - `X.md`        -> look for `X.eval.json` in the same directory.
  *       - `.../SKILL.md` -> look for, in order:
- *           1. `eval.json` in the same directory, then
- *           2. `<dirname>.eval.json` in the same directory (where
+ *           1. `SKILL.eval.json` (engine-canonical sibling, matches
+ *              spec.py's skill_path.with_suffix(".eval.json")), then
+ *           2. `eval.json` in the same directory, then
+ *           3. `<dirname>.eval.json` in the same directory (where
  *              `<dirname>` is the name of the skill's parent directory).
  *
  * @param {string} target - Explicit `.json` eval path OR a skill file path.
@@ -134,7 +147,11 @@ async function loadSpec(target) {
 
   const candidates = [];
   if (base === "SKILL.md") {
-    // Modern layout: <skill-dir>/SKILL.md
+    // Modern layout: <skill-dir>/SKILL.md. Lead with the engine-canonical
+    // sibling name (spec.py uses skill_path.with_suffix(".eval.json") ->
+    // SKILL.eval.json) so loadSpec agrees with what `validate()` loads;
+    // keep eval.json / <dir>.eval.json as convenience fallbacks.
+    candidates.push(path.join(dir, "SKILL.eval.json"));
     candidates.push(path.join(dir, "eval.json"));
     candidates.push(path.join(dir, `${path.basename(dir)}.eval.json`));
   } else {

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,0 +1,15 @@
+// clauditor-eval — Node.js wrapper for the Python clauditor engine.
+//
+// This is the public JS API entry point. v1 is a SUBPROCESS BRIDGE: it
+// shells out to the `clauditor` Python CLI rather than reimplementing the
+// engine in JS.
+//
+// US-004 fills this stub with the public async API:
+//   - runSkill(skill, opts)        -> run --json, parsed SkillResult
+//   - validate(skillPath, opts)    -> validate --json {passed, pass_rate, results}
+//   - loadSpec(path | skillPath)   -> discover + read sibling <skill>.eval.json
+// plus re-exported error classes (from lib/, landed in US-003).
+//
+// Skeleton story (US-002): export an empty object so the package requires
+// cleanly and `npm test` is green.
+module.exports = {};

--- a/npm/jest-helper.d.ts
+++ b/npm/jest-helper.d.ts
@@ -1,0 +1,54 @@
+// TypeScript declarations for clauditor-eval's `toPassClauditor` matcher.
+//
+//   import { toPassClauditor } from "clauditor-eval/jest-helper";
+//   expect.extend({ toPassClauditor });
+//   await expect(result).toPassClauditor(evalPath);
+//
+// Works under both Jest and Vitest. The matcher is async — always `await`
+// the assertion.
+
+/**
+ * The raw matcher function passed to `expect.extend({ toPassClauditor })`.
+ *
+ * `received` is either a `validate()` result (used directly) or a
+ * `runSkill()` result (in which case `evalPath` is required). Returns a
+ * Promise resolving to the standard matcher result.
+ */
+export function toPassClauditor(
+  this: { isNot?: boolean } | void,
+  received: unknown,
+  evalPath?: string
+): Promise<{ pass: boolean; message: () => string }>;
+
+// Best-effort matcher-type augmentation for both Jest and Vitest. These
+// module augmentations are guarded by `declare global` so they only take
+// effect when the host project already pulls in the runner's type
+// definitions; if a runner's namespace is absent, its block is inert.
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      /**
+       * Assert a clauditor eval passed. Pass an `evalPath` when the
+       * received value is a `runSkill()` result. Async — `await` it.
+       */
+      toPassClauditor(evalPath?: string): Promise<R>;
+    }
+  }
+}
+
+declare module "vitest" {
+  interface Assertion<T = unknown> {
+    /**
+     * Assert a clauditor eval passed. Pass an `evalPath` when the
+     * received value is a `runSkill()` result. Async — `await` it.
+     */
+    toPassClauditor(evalPath?: string): Promise<T>;
+  }
+  interface AsymmetricMatchersContaining {
+    toPassClauditor(evalPath?: string): unknown;
+  }
+}
+
+export {};

--- a/npm/jest-helper.js
+++ b/npm/jest-helper.js
@@ -1,0 +1,105 @@
+// clauditor-eval — custom matcher `toPassClauditor` for Jest and Vitest.
+//
+// Register it with either runner's `expect.extend`:
+//
+//   const { toPassClauditor } = require("clauditor-eval/jest-helper");
+//   expect.extend({ toPassClauditor });
+//
+// Then assert (async — always `await`):
+//
+//   await expect(validateResult).toPassClauditor();
+//   await expect(runSkillResult).toPassClauditor("path/to/SKILL.md");
+//   await expect(failingResult).not.toPassClauditor();
+//
+// Both Jest and Vitest support async matchers (a matcher returning a
+// Promise is awaited), so a single implementation works under both via
+// `expect.extend({ toPassClauditor })`. CommonJS to match the package's
+// `main`/`bin`/`lib` style.
+
+const { validate } = require("./index");
+
+/**
+ * Detect whether `received` is already a `validate()` eval result.
+ *
+ * Detection rule: an eval result is a non-null object that carries the
+ * `results` array (the per-criterion list) OR the `pass_rate` field —
+ * both are produced by `validate --json` and absent from a `runSkill`
+ * (`run --json`) payload, which instead carries `output` / `exit_code`.
+ * If neither eval field is present we treat `received` as a runSkill
+ * result and require an eval path to derive the verdict.
+ */
+function isValidateResult(received) {
+  return (
+    received !== null &&
+    typeof received === "object" &&
+    (Array.isArray(received.results) || typeof received.pass_rate === "number")
+  );
+}
+
+/**
+ * Custom matcher: assert a clauditor eval passed.
+ *
+ * `received` is EITHER a `validate()` result (used directly) OR a
+ * `runSkill()` result (in which case `evalPath` is REQUIRED and the
+ * matcher calls `validate(evalPath)` to obtain the eval verdict).
+ *
+ * Returns a Promise (async matcher) resolving to the standard
+ * `{ pass, message }` matcher result. On failure, `message()` enumerates
+ * the names of the criteria that did not pass so the developer sees
+ * exactly what failed. `.not` is honored via `this.isNot`.
+ *
+ * @param {object} received - validate() result OR runSkill() result.
+ * @param {string} [evalPath] - skill/eval path; REQUIRED when `received`
+ *   is a runSkill() result.
+ * @returns {Promise<{pass: boolean, message: () => string}>}
+ */
+async function toPassClauditor(received, evalPath) {
+  const isNot = this && this.isNot;
+
+  let evalResult;
+  if (isValidateResult(received)) {
+    // Already an eval result — judge it directly.
+    evalResult = received;
+  } else {
+    // A runSkill() result (or anything without eval fields): we need a
+    // path to validate against.
+    if (typeof evalPath !== "string" || evalPath === "") {
+      return {
+        pass: false,
+        message: () =>
+          "toPassClauditor: received a value without `results`/`pass_rate` " +
+          "(looks like a runSkill() result), so an eval path argument is " +
+          "REQUIRED — call `expect(result).toPassClauditor(evalPath)`.",
+      };
+    }
+    evalResult = await validate(evalPath);
+  }
+
+  const pass = evalResult.passed === true;
+
+  // Names of failing criteria for the failure message.
+  const failingNames = Array.isArray(evalResult.results)
+    ? evalResult.results
+        .filter((r) => r && typeof r === "object" && r.passed === false)
+        .map((r) => (typeof r.name === "string" ? r.name : "(unnamed)"))
+    : [];
+
+  const message = () => {
+    if (isNot) {
+      // `.not.toPassClauditor()` — this message shows only when the
+      // negated assertion fails (i.e. the eval DID pass).
+      return "Expected clauditor eval NOT to pass, but it passed.";
+    }
+    if (failingNames.length > 0) {
+      return (
+        "Expected clauditor eval to pass, but it failed. " +
+        `Failing criteria: ${failingNames.join(", ")}.`
+      );
+    }
+    return "Expected clauditor eval to pass, but it failed.";
+  };
+
+  return { pass, message };
+}
+
+module.exports = { toPassClauditor };

--- a/npm/jest.config.js
+++ b/npm/jest.config.js
@@ -1,0 +1,8 @@
+// Jest config for clauditor-eval.
+// Jest owns tests under __tests__/; vitest owns tests under test/ (see
+// vitest.config.js). The two test runners are scoped to disjoint
+// directories so running both does not double-collect the same files.
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/__tests__/**/*.test.js"],
+};

--- a/npm/lib/errors.js
+++ b/npm/lib/errors.js
@@ -1,0 +1,48 @@
+// Error classes for the clauditor-eval subprocess bridge.
+//
+// All errors extend a single base (`ClauditorError`) so callers can catch
+// the whole family with one `catch (err) { if (err instanceof ClauditorError) }`
+// check. Each subclass maps to a distinct failure category, mirroring the
+// Python engine's exit-code taxonomy (.claude/rules/llm-cli-exit-code-taxonomy.md):
+//
+//   - ClauditorNotFoundError  — engine binary could not be resolved (no exit code).
+//   - ClauditorInputError     — Python exit code 2 (input validation failure).
+//   - ClauditorApiError       — Python exit code 3 (provider API failure).
+//
+// A failing eval (Python exit code 1) is DATA, not an exception: execJson
+// returns the parsed JSON so the caller inspects `passed` itself.
+
+class ClauditorError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ClauditorError";
+  }
+}
+
+class ClauditorNotFoundError extends ClauditorError {
+  constructor(message) {
+    super(message);
+    this.name = "ClauditorNotFoundError";
+  }
+}
+
+class ClauditorInputError extends ClauditorError {
+  constructor(message) {
+    super(message);
+    this.name = "ClauditorInputError";
+  }
+}
+
+class ClauditorApiError extends ClauditorError {
+  constructor(message) {
+    super(message);
+    this.name = "ClauditorApiError";
+  }
+}
+
+module.exports = {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+};

--- a/npm/lib/exec.js
+++ b/npm/lib/exec.js
@@ -1,0 +1,130 @@
+// Run the Python clauditor engine and map its result for JS callers.
+//
+// `execJson(args, opts)` resolves the engine binary, spawns it with an
+// ARGUMENT ARRAY (never a shell string), collects stdout/stderr, and routes
+// the exit code through the pure `mapExit` helper per DEC-008 of
+// plans/super/4-npm-wrapper.md (mirroring the Python exit-code taxonomy in
+// .claude/rules/llm-cli-exit-code-taxonomy.md):
+//
+//   exit 0 → resolve with parsed JSON (success).
+//   exit 1 → resolve with parsed JSON (a failing eval is DATA, not an error;
+//            the caller inspects `passed`).
+//   exit 2 → throw ClauditorInputError  (input validation failure).
+//   exit 3 → throw ClauditorApiError    (provider API failure).
+//   other  → throw ClauditorError.
+//
+// Security (DEC-007): the child is spawned via `execFile` with an arg array
+// and NO shell, so skill names / args cannot inject shell metacharacters.
+// `process.env` is inherited so ANTHROPIC_API_KEY / OPENAI_API_KEY flow to
+// the child — secrets travel via env, never argv, and argv is never logged.
+
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+
+const { resolveBinary } = require("./resolve-binary");
+const {
+  ClauditorError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("./errors");
+
+const _execFileAsync = promisify(execFile);
+
+// Defensively parse `stdout` as JSON. Throws ClauditorError with a clear
+// message (including a bounded snippet) when stdout is not valid JSON.
+function _parseJson(stdout) {
+  try {
+    return JSON.parse(stdout);
+  } catch (err) {
+    const snippet = String(stdout).slice(0, 500);
+    throw new ClauditorError(
+      "clauditor engine returned non-JSON output on stdout: " +
+        `${err.message}; output snippet: ${JSON.stringify(snippet)}`
+    );
+  }
+}
+
+// Pure exit-code → outcome/error mapper (DEC-008). Separated from the I/O
+// spawn per .claude/rules/pure-compute-vs-io-split.md so it is unit-testable
+// without spawning a subprocess.
+//
+//   - code 0 / 1: parse stdout as JSON and RETURN the parsed object. Exit 1
+//     is a failing eval (data), not an exception; the caller reads `passed`.
+//   - code 2: throw ClauditorInputError (stderr text included).
+//   - code 3: throw ClauditorApiError (stderr text included).
+//   - any other code: throw ClauditorError.
+//
+// A non-JSON stdout on exit 0/1 surfaces as ClauditorError via _parseJson.
+function mapExit(code, stdout, stderr) {
+  if (code === 0 || code === 1) {
+    return _parseJson(stdout);
+  }
+  const detail = String(stderr || "").trim();
+  if (code === 2) {
+    throw new ClauditorInputError(
+      detail !== "" ? detail : "clauditor input validation failed (exit 2)"
+    );
+  }
+  if (code === 3) {
+    throw new ClauditorApiError(
+      detail !== "" ? detail : "clauditor provider API call failed (exit 3)"
+    );
+  }
+  throw new ClauditorError(
+    `clauditor exited with unexpected code ${code}` +
+      (detail !== "" ? `: ${detail}` : "")
+  );
+}
+
+// Run the engine with `args` (an array) and return the parsed JSON result.
+//
+// opts:
+//   - timeout: milliseconds; forwarded to execFile's `timeout`.
+//
+// Resolves with the parsed JSON object on exit 0/1; rejects with a
+// Clauditor* error on exit 2/3/other or on a non-JSON exit-0/1 payload.
+async function execJson(args, opts) {
+  const options = opts || {};
+  const { command, argsPrefix } = resolveBinary();
+  const fullArgs = [...argsPrefix, ...args];
+
+  // execFile options: inherit env (so API keys flow to the child), large
+  // buffer for transcript-heavy JSON, optional timeout. NO `shell` — the
+  // arg array is passed literally so special characters cannot inject.
+  const execOptions = {
+    env: process.env,
+    maxBuffer: 64 * 1024 * 1024,
+  };
+  if (typeof options.timeout === "number") {
+    execOptions.timeout = options.timeout;
+  }
+
+  let stdout;
+  let stderr;
+  let code = 0;
+  try {
+    const result = await _execFileAsync(command, fullArgs, execOptions);
+    stdout = result.stdout;
+    stderr = result.stderr;
+  } catch (err) {
+    // A non-zero exit rejects with an Error carrying `code`, `stdout`,
+    // `stderr`. A killed-by-timeout / spawn failure carries `killed` /
+    // `code === null`. Route the exit code through mapExit; surface
+    // spawn/timeout failures as ClauditorError.
+    if (typeof err.code === "number") {
+      code = err.code;
+      stdout = err.stdout != null ? err.stdout : "";
+      stderr = err.stderr != null ? err.stderr : "";
+    } else {
+      // No numeric exit code: spawn failure (ENOENT), timeout kill, etc.
+      const detail = err.killed
+        ? `clauditor process was killed (timeout?): ${err.message}`
+        : `failed to run clauditor engine: ${err.message}`;
+      throw new ClauditorError(detail);
+    }
+  }
+
+  return mapExit(code, stdout, stderr);
+}
+
+module.exports = { execJson, mapExit };

--- a/npm/lib/exec.js
+++ b/npm/lib/exec.js
@@ -115,6 +115,14 @@ async function execJson(args, opts) {
       code = err.code;
       stdout = err.stdout != null ? err.stdout : "";
       stderr = err.stderr != null ? err.stderr : "";
+    } else if (err.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+      // Output exceeded maxBuffer — distinct from a timeout. Surface a
+      // clear message so a huge transcript isn't misread as a hang.
+      throw new ClauditorError(
+        `clauditor engine output exceeded the ${
+          execOptions.maxBuffer / (1024 * 1024)
+        } MB buffer: ${err.message}`,
+      );
     } else {
       // No numeric exit code: spawn failure (ENOENT), timeout kill, etc.
       const detail = err.killed

--- a/npm/lib/resolve-binary.js
+++ b/npm/lib/resolve-binary.js
@@ -1,0 +1,90 @@
+// Resolve the Python `clauditor` engine binary for the subprocess bridge.
+//
+// Per DEC-005 of plans/super/4-npm-wrapper.md, resolution order is:
+//   1. process.env.CLAUDITOR_BIN — explicit operator override (wins).
+//   2. `clauditor` on PATH — a pure fs scan of each PATH entry (no spawn).
+//   3. `python3 -m clauditor` — best-effort fallback when python3 is on PATH.
+//   4. throw ClauditorNotFoundError with an actionable install hint.
+//
+// The return shape is normalized so callers can uniformly prepend a prefix
+// to the engine's CLI args:
+//
+//   { command: string, argsPrefix: string[] }
+//
+// Callers spawn `command` with `[...argsPrefix, ...cliArgs]`. For the binary
+// path (cases 1 and 2) argsPrefix is empty; for the python module fallback
+// (case 3) argsPrefix is `["-m", "clauditor"]`.
+
+const fs = require("fs");
+const path = require("path");
+
+const { ClauditorNotFoundError } = require("./errors");
+
+const _NOT_FOUND_HINT =
+  "clauditor engine not found. Install it with: " +
+  "pipx install clauditor-eval  (or: uv tool install clauditor-eval), " +
+  "or set CLAUDITOR_BIN to the binary path.";
+
+// On Windows, PATHEXT-style executables need the extension. We keep this
+// minimal: try the bare name and `.exe`. (Cross-platform without spawning.)
+function _candidateNames(base) {
+  if (process.platform === "win32") {
+    return [base + ".exe", base + ".cmd", base + ".bat", base];
+  }
+  return [base];
+}
+
+// Pure fs PATH scan: return true if `name` is found as a file on PATH.
+// Avoids spawning `which`/`where` (which would be a subprocess per resolve).
+function _isOnPath(name) {
+  const pathEnv = process.env.PATH || "";
+  if (pathEnv === "") {
+    return false;
+  }
+  const entries = pathEnv.split(path.delimiter);
+  for (const dir of entries) {
+    if (dir === "") {
+      continue;
+    }
+    for (const candidate of _candidateNames(name)) {
+      const full = path.join(dir, candidate);
+      try {
+        const stat = fs.statSync(full);
+        if (stat.isFile()) {
+          return true;
+        }
+      } catch {
+        // Not present / not readable in this dir — keep scanning.
+        continue;
+      }
+    }
+  }
+  return false;
+}
+
+// Resolve the engine binary per the DEC-005 precedence order.
+//
+// Returns { command, argsPrefix }. Throws ClauditorNotFoundError when no
+// resolution path succeeds.
+function resolveBinary() {
+  // 1. Explicit override.
+  const override = process.env.CLAUDITOR_BIN;
+  if (typeof override === "string" && override.trim() !== "") {
+    return { command: override, argsPrefix: [] };
+  }
+
+  // 2. `clauditor` on PATH.
+  if (_isOnPath("clauditor")) {
+    return { command: "clauditor", argsPrefix: [] };
+  }
+
+  // 3. `python3 -m clauditor` best-effort fallback.
+  if (_isOnPath("python3")) {
+    return { command: "python3", argsPrefix: ["-m", "clauditor"] };
+  }
+
+  // 4. Nothing resolved.
+  throw new ClauditorNotFoundError(_NOT_FOUND_HINT);
+}
+
+module.exports = { resolveBinary };

--- a/npm/lib/resolve-binary.js
+++ b/npm/lib/resolve-binary.js
@@ -34,12 +34,18 @@ function _candidateNames(base) {
   return [base];
 }
 
-// Pure fs PATH scan: return true if `name` is found as a file on PATH.
-// Avoids spawning `which`/`where` (which would be a subprocess per resolve).
-function _isOnPath(name) {
+// Pure fs PATH scan: return the FULL resolved path (including any platform
+// extension) of `name` on PATH, or null if not found. Avoids spawning
+// `which`/`where`. Returning the full path — rather than the bare name —
+// matters on Windows: `child_process.execFile`/`spawn` targets the exact
+// file, and the `.exe` candidate is tried before `.cmd`/`.bat` so the
+// spawnable executable wins. (Node refuses to spawn `.cmd`/`.bat` without
+// `shell: true` since CVE-2024-27980; for those rare shim-only installs the
+// operator should point CLAUDITOR_BIN at the real interpreter.)
+function _findOnPath(name) {
   const pathEnv = process.env.PATH || "";
   if (pathEnv === "") {
-    return false;
+    return null;
   }
   const entries = pathEnv.split(path.delimiter);
   for (const dir of entries) {
@@ -51,7 +57,7 @@ function _isOnPath(name) {
       try {
         const stat = fs.statSync(full);
         if (stat.isFile()) {
-          return true;
+          return full;
         }
       } catch {
         // Not present / not readable in this dir — keep scanning.
@@ -59,7 +65,17 @@ function _isOnPath(name) {
       }
     }
   }
-  return false;
+  return null;
+}
+
+// Interpreter names to probe for the `python -m clauditor` fallback, in
+// order. Windows installs almost always expose `python` (not `python3`),
+// and the `py` launcher as a last resort.
+function _pythonCandidates() {
+  if (process.platform === "win32") {
+    return ["python", "python3", "py"];
+  }
+  return ["python3", "python"];
 }
 
 // Resolve the engine binary per the DEC-005 precedence order.
@@ -73,14 +89,18 @@ function resolveBinary() {
     return { command: override, argsPrefix: [] };
   }
 
-  // 2. `clauditor` on PATH.
-  if (_isOnPath("clauditor")) {
-    return { command: "clauditor", argsPrefix: [] };
+  // 2. `clauditor` on PATH — return the full resolved path.
+  const clauditorPath = _findOnPath("clauditor");
+  if (clauditorPath !== null) {
+    return { command: clauditorPath, argsPrefix: [] };
   }
 
-  // 3. `python3 -m clauditor` best-effort fallback.
-  if (_isOnPath("python3")) {
-    return { command: "python3", argsPrefix: ["-m", "clauditor"] };
+  // 3. `python -m clauditor` best-effort fallback (probe python3/python/py).
+  for (const interpreter of _pythonCandidates()) {
+    const interpreterPath = _findOnPath(interpreter);
+    if (interpreterPath !== null) {
+      return { command: interpreterPath, argsPrefix: ["-m", "clauditor"] };
+    }
   }
 
   // 4. Nothing resolved.

--- a/npm/lib/resolve-binary.js
+++ b/npm/lib/resolve-binary.js
@@ -25,23 +25,55 @@ const _NOT_FOUND_HINT =
   "pipx install clauditor-eval  (or: uv tool install clauditor-eval), " +
   "or set CLAUDITOR_BIN to the binary path.";
 
-// On Windows, PATHEXT-style executables need the extension. We keep this
-// minimal: try the bare name and `.exe`. (Cross-platform without spawning.)
+// Windows: only consider extensions we can actually spawn WITHOUT a shell.
+// `.exe` is spawnable via execFile; `.cmd`/`.bat` are NOT (Node refuses them
+// without `shell: true` since CVE-2024-27980), so we deliberately do NOT
+// return them — a `.cmd`/`.bat`-only install must point CLAUDITOR_BIN at the
+// real interpreter. The bare name is kept as a last resort.
 function _candidateNames(base) {
   if (process.platform === "win32") {
-    return [base + ".exe", base + ".cmd", base + ".bat", base];
+    return [base + ".exe", base];
   }
   return [base];
+}
+
+// Realpath of this wrapper's OWN launcher (npm/bin/clauditor.js). Used to
+// skip self-matches during the PATH scan: belt-and-suspenders against the
+// infinite-recursion trap where the wrapper resolves its own installed bin
+// shim instead of the Python engine. (The primary defense is naming the
+// installed command `clauditor-eval` in package.json, so a scan for the
+// engine's `clauditor` cannot match it; this guard covers symlink/rename
+// edge cases too.) Computed once; null if it can't be resolved.
+const _SELF_BIN = (() => {
+  try {
+    return fs.realpathSync(path.join(__dirname, "..", "bin", "clauditor.js"));
+  } catch {
+    return null;
+  }
+})();
+
+// True when `full` is executable. On POSIX we require the execute bit so a
+// non-exec data file named `clauditor` earlier on PATH doesn't shadow the
+// real binary and then fail at spawn. On Windows, file presence is the
+// signal (the exec bit has no POSIX meaning there).
+function _isExecutable(full) {
+  if (process.platform === "win32") {
+    return true;
+  }
+  try {
+    fs.accessSync(full, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // Pure fs PATH scan: return the FULL resolved path (including any platform
 // extension) of `name` on PATH, or null if not found. Avoids spawning
 // `which`/`where`. Returning the full path — rather than the bare name —
-// matters on Windows: `child_process.execFile`/`spawn` targets the exact
-// file, and the `.exe` candidate is tried before `.cmd`/`.bat` so the
-// spawnable executable wins. (Node refuses to spawn `.cmd`/`.bat` without
-// `shell: true` since CVE-2024-27980; for those rare shim-only installs the
-// operator should point CLAUDITOR_BIN at the real interpreter.)
+// matters on Windows: `execFile`/`spawn` targets the exact file. Skips
+// non-executable files (POSIX) and any path that resolves to this wrapper's
+// own launcher (recursion guard).
 function _findOnPath(name) {
   const pathEnv = process.env.PATH || "";
   if (pathEnv === "") {
@@ -56,9 +88,22 @@ function _findOnPath(name) {
       const full = path.join(dir, candidate);
       try {
         const stat = fs.statSync(full);
-        if (stat.isFile()) {
-          return full;
+        if (!stat.isFile() || !_isExecutable(full)) {
+          continue;
         }
+        // Skip a match that is really this wrapper's own launcher.
+        if (_SELF_BIN !== null) {
+          let real;
+          try {
+            real = fs.realpathSync(full);
+          } catch {
+            real = full;
+          }
+          if (real === _SELF_BIN) {
+            continue;
+          }
+        }
+        return full;
       } catch {
         // Not present / not readable in this dir — keep scanning.
         continue;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "clauditor-eval",
+  "version": "0.1.0",
+  "description": "Node.js wrapper for clauditor — auditor for Claude Code skills and slash commands. Subprocess bridge to the Python clauditor-eval engine.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Wes Duenow",
+    "email": "wes@wjduenow.com"
+  },
+  "homepage": "https://github.com/wjduenow/clauditor#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wjduenow/clauditor.git",
+    "directory": "npm"
+  },
+  "bugs": {
+    "url": "https://github.com/wjduenow/clauditor/issues"
+  },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "testing",
+    "eval",
+    "skills",
+    "llm",
+    "jest",
+    "vitest"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "index.js",
+  "bin": {
+    "clauditor": "bin/clauditor.js"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "bin/",
+    "lib/",
+    "jest-helper.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "jest",
+    "test:vitest": "vitest run",
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0",
+    "jest": "^29.7.0",
+    "vitest": "^2.0.0"
+  },
+  "//note-scope-reserved": "The npm scope @clauditor-eval/* is RESERVED for a future PyInstaller binary-distribution epic (DEC-013). v1 is a subprocess bridge to the Python engine; there are intentionally NO optionalDependencies and NO platform packages. See README.md for details.",
+  "//note-version": "npm version 0.1.0 is a clean semver chosen for the initial npm release. The Python engine version (pyproject.toml [project].version = 0.1.3.dev0) is not a valid npm semver; see README.md for the version-mapping rationale (DEC-001)."
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -31,7 +31,7 @@
   },
   "main": "index.js",
   "bin": {
-    "clauditor": "bin/clauditor.js"
+    "clauditor-eval": "bin/clauditor.js"
   },
   "files": [
     "index.js",

--- a/npm/package.json
+++ b/npm/package.json
@@ -39,6 +39,7 @@
     "bin/",
     "lib/",
     "jest-helper.js",
+    "jest-helper.d.ts",
     "README.md",
     "LICENSE"
   ],

--- a/npm/test/api.test.js
+++ b/npm/test/api.test.js
@@ -1,0 +1,166 @@
+// Public JS API tests (vitest). Mirrors __tests__/api.test.js so the same
+// contract runs under both runners. Uses a FAKE clauditor stub via
+// CLAUDITOR_BIN for runSkill/validate and real tmp-dir fixtures for loadSpec.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const { runSkill, validate, loadSpec } = require("../index");
+const {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("../index");
+
+let tmpDir;
+let argvDumpPath;
+
+function writeStub() {
+  const script = `
+const fs = require("fs");
+const argv = process.argv.slice(2);
+if (process.env.ARGV_DUMP) {
+  fs.writeFileSync(process.env.ARGV_DUMP, JSON.stringify(argv));
+}
+if (process.env.CANNED_JSON) {
+  process.stdout.write(process.env.CANNED_JSON);
+}
+if (process.env.CANNED_STDERR) {
+  process.stderr.write(process.env.CANNED_STDERR);
+}
+process.exit(Number(process.env.EXIT_CODE || "0"));
+`;
+  const exeStub = path.join(tmpDir, "clauditor-stub");
+  fs.writeFileSync(exeStub, `#!${process.execPath}\n${script}`);
+  fs.chmodSync(exeStub, 0o755);
+  return exeStub;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-api-v-"));
+  argvDumpPath = path.join(tmpDir, "argv.json");
+  process.env.CLAUDITOR_BIN = writeStub();
+  process.env.ARGV_DUMP = argvDumpPath;
+});
+
+afterEach(() => {
+  delete process.env.CLAUDITOR_BIN;
+  delete process.env.ARGV_DUMP;
+  delete process.env.CANNED_JSON;
+  delete process.env.CANNED_STDERR;
+  delete process.env.EXIT_CODE;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function receivedArgv() {
+  return JSON.parse(fs.readFileSync(argvDumpPath, "utf8"));
+}
+
+describe("re-exported error classes (vitest)", () => {
+  it("are the same classes lib/errors exports", () => {
+    const libErrors = require("../lib/errors");
+    expect(ClauditorError).toBe(libErrors.ClauditorError);
+    expect(ClauditorNotFoundError).toBe(libErrors.ClauditorNotFoundError);
+    expect(ClauditorInputError).toBe(libErrors.ClauditorInputError);
+    expect(ClauditorApiError).toBe(libErrors.ClauditorApiError);
+  });
+});
+
+describe("runSkill (vitest)", () => {
+  it("maps args / projectDir / timeout to flags and returns parsed shape", async () => {
+    process.env.CANNED_JSON = JSON.stringify({ output: "ok", exit_code: 0 });
+    process.env.EXIT_CODE = "0";
+    const result = await runSkill("my-skill", {
+      args: "a b",
+      projectDir: "/p",
+      timeout: 12,
+    });
+    expect(receivedArgv()).toEqual([
+      "run",
+      "my-skill",
+      "--json",
+      "--args",
+      "a b",
+      "--project-dir",
+      "/p",
+      "--timeout",
+      "12",
+    ]);
+    expect(result).toEqual({ output: "ok", exit_code: 0 });
+  });
+
+  it("exit 2 throws ClauditorInputError", async () => {
+    process.env.EXIT_CODE = "2";
+    process.env.CANNED_STDERR = "bad";
+    await expect(runSkill("nope")).rejects.toThrow(ClauditorInputError);
+  });
+});
+
+describe("validate (vitest)", () => {
+  it("maps to validate --json and resolves {passed:false} on exit 1", async () => {
+    process.env.CANNED_JSON = JSON.stringify({
+      skill: "s",
+      pass_rate: 0.0,
+      passed: false,
+      results: [],
+    });
+    process.env.EXIT_CODE = "1";
+    const result = await validate("SKILL.md");
+    expect(receivedArgv()).toEqual(["validate", "SKILL.md", "--json"]);
+    expect(result.passed).toBe(false);
+  });
+
+  it("exit 3 throws ClauditorApiError", async () => {
+    process.env.EXIT_CODE = "3";
+    process.env.CANNED_STDERR = "api down";
+    await expect(validate("SKILL.md")).rejects.toThrow(ClauditorApiError);
+  });
+});
+
+describe("loadSpec (vitest)", () => {
+  let specDir;
+
+  beforeEach(() => {
+    specDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-spec-v-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(specDir, { recursive: true, force: true });
+  });
+
+  it("reads an explicit .eval.json path", async () => {
+    const evalPath = path.join(specDir, "my.eval.json");
+    fs.writeFileSync(evalPath, JSON.stringify({ skill_name: "my" }));
+    expect(await loadSpec(evalPath)).toEqual({ skill_name: "my" });
+  });
+
+  it("discovers sibling <stem>.eval.json for an X.md skill", async () => {
+    fs.writeFileSync(path.join(specDir, "greeter.md"), "# skill");
+    fs.writeFileSync(
+      path.join(specDir, "greeter.eval.json"),
+      JSON.stringify({ skill_name: "greeter" })
+    );
+    expect(await loadSpec(path.join(specDir, "greeter.md"))).toEqual({
+      skill_name: "greeter",
+    });
+  });
+
+  it("discovers eval.json for a SKILL.md skill", async () => {
+    fs.writeFileSync(path.join(specDir, "SKILL.md"), "# skill");
+    fs.writeFileSync(path.join(specDir, "eval.json"), JSON.stringify({ via: "eval.json" }));
+    expect(await loadSpec(path.join(specDir, "SKILL.md"))).toEqual({
+      via: "eval.json",
+    });
+  });
+
+  it("throws when no sibling eval file is found", async () => {
+    fs.writeFileSync(path.join(specDir, "lonely.md"), "# skill");
+    await expect(loadSpec(path.join(specDir, "lonely.md"))).rejects.toThrow(
+      /no eval spec found/
+    );
+  });
+});

--- a/npm/test/bin.test.js
+++ b/npm/test/bin.test.js
@@ -1,0 +1,32 @@
+// bin/clauditor.js pure-helper mirror (vitest runner). Only the
+// arg-assembly helper is exercised here — the spawn/exit propagation
+// tests live jest-only in __tests__/bin.test.js to avoid duplicating
+// fake-child event plumbing across runners.
+import { describe, test, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { buildChildArgs } = require("../bin/clauditor.js");
+
+describe("buildChildArgs (vitest mirror)", () => {
+  test("prepends empty prefix verbatim", () => {
+    expect(
+      buildChildArgs({ command: "clauditor", argsPrefix: [] }, ["validate", "foo.md", "--json"]),
+    ).toEqual(["validate", "foo.md", "--json"]);
+  });
+
+  test("prepends python module fallback prefix", () => {
+    expect(
+      buildChildArgs(
+        { command: "python3", argsPrefix: ["-m", "clauditor"] },
+        ["run", "foo.md"],
+      ),
+    ).toEqual(["-m", "clauditor", "run", "foo.md"]);
+  });
+
+  test("preserves args with spaces verbatim", () => {
+    expect(
+      buildChildArgs({ command: "clauditor", argsPrefix: [] }, ["run", "a b c"]),
+    ).toEqual(["run", "a b c"]);
+  });
+});

--- a/npm/test/jest-helper.test.js
+++ b/npm/test/jest-helper.test.js
@@ -1,0 +1,136 @@
+// toPassClauditor matcher tests (vitest). Mirrors __tests__/jest-helper.test.js
+// so the SAME matcher registers and behaves identically under both runners via
+// each runner's `expect.extend({ toPassClauditor })`.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const { toPassClauditor } = require("../jest-helper");
+
+expect.extend({ toPassClauditor });
+
+function passingValidateResult() {
+  return {
+    skill: "greeter",
+    pass_rate: 1.0,
+    passed: true,
+    results: [
+      { name: "contains-hi", passed: true },
+      { name: "min-length", passed: true },
+    ],
+  };
+}
+
+function failingValidateResult() {
+  return {
+    skill: "greeter",
+    pass_rate: 0.5,
+    passed: false,
+    results: [
+      { name: "contains-hi", passed: true },
+      { name: "min-length", passed: false },
+      { name: "no-todo", passed: false },
+    ],
+  };
+}
+
+describe("toPassClauditor with a validate() result (vitest)", () => {
+  it("passes when passed:true", async () => {
+    await expect(passingValidateResult()).toPassClauditor();
+  });
+
+  it("fails when passed:false and message names failing criteria", async () => {
+    const result = await toPassClauditor.call(
+      { isNot: false },
+      failingValidateResult()
+    );
+    expect(result.pass).toBe(false);
+    const msg = result.message();
+    expect(msg).toContain("min-length");
+    expect(msg).toContain("no-todo");
+    expect(msg).not.toContain("contains-hi");
+  });
+
+  it(".not passes for a failing result", async () => {
+    await expect(failingValidateResult()).not.toPassClauditor();
+  });
+
+  it(".not fails (with a message) for a passing result", async () => {
+    const result = await toPassClauditor.call(
+      { isNot: true },
+      passingValidateResult()
+    );
+    expect(result.pass).toBe(true);
+    expect(result.message()).toContain("NOT to pass");
+  });
+});
+
+describe("toPassClauditor with a runSkill() result (vitest)", () => {
+  let tmpDir;
+  let argvDumpPath;
+
+  function writeStub() {
+    const script = `
+const fs = require("fs");
+const argv = process.argv.slice(2);
+if (process.env.ARGV_DUMP) {
+  fs.writeFileSync(process.env.ARGV_DUMP, JSON.stringify(argv));
+}
+if (process.env.CANNED_JSON) {
+  process.stdout.write(process.env.CANNED_JSON);
+}
+process.exit(Number(process.env.EXIT_CODE || "0"));
+`;
+    const exeStub = path.join(tmpDir, "clauditor-stub");
+    fs.writeFileSync(exeStub, `#!${process.execPath}\n${script}`);
+    fs.chmodSync(exeStub, 0o755);
+    return exeStub;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-jh-v-"));
+    argvDumpPath = path.join(tmpDir, "argv.json");
+    process.env.CLAUDITOR_BIN = writeStub();
+    process.env.ARGV_DUMP = argvDumpPath;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDITOR_BIN;
+    delete process.env.ARGV_DUMP;
+    delete process.env.CANNED_JSON;
+    delete process.env.EXIT_CODE;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("requires an eval path argument", async () => {
+    const runResult = { output: "hi", exit_code: 0, skill: "greeter" };
+    const result = await toPassClauditor.call({ isNot: false }, runResult);
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain("eval path argument is REQUIRED");
+  });
+
+  it("calls validate(evalPath) and passes on a passing payload", async () => {
+    process.env.CANNED_JSON = JSON.stringify(passingValidateResult());
+    process.env.EXIT_CODE = "0";
+    const runResult = { output: "hi", exit_code: 0, skill: "greeter" };
+    await expect(runResult).toPassClauditor("SKILL.md");
+    const argv = JSON.parse(fs.readFileSync(argvDumpPath, "utf8"));
+    expect(argv).toEqual(["validate", "SKILL.md", "--json"]);
+  });
+
+  it("calls validate(evalPath) and fails (naming criteria) on a failing payload", async () => {
+    process.env.CANNED_JSON = JSON.stringify(failingValidateResult());
+    process.env.EXIT_CODE = "1";
+    const runResult = { output: "hi", exit_code: 0, skill: "greeter" };
+    const result = await toPassClauditor.call(
+      { isNot: false },
+      runResult,
+      "SKILL.md"
+    );
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain("min-length");
+  });
+});

--- a/npm/test/lib-core.test.js
+++ b/npm/test/lib-core.test.js
@@ -1,0 +1,84 @@
+// Pure-helper + resolveBinary tests (vitest runner). Mirrors
+// __tests__/lib-core.test.js so the same contract runs under both runners.
+import { describe, it, expect, afterEach } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { mapExit } = require("../lib/exec");
+const { resolveBinary } = require("../lib/resolve-binary");
+const {
+  ClauditorError,
+  ClauditorNotFoundError,
+  ClauditorInputError,
+  ClauditorApiError,
+} = require("../lib/errors");
+
+describe("error class hierarchy (vitest)", () => {
+  it("every error extends ClauditorError and sets .name", () => {
+    for (const Cls of [
+      ClauditorNotFoundError,
+      ClauditorInputError,
+      ClauditorApiError,
+    ]) {
+      const e = new Cls("boom");
+      expect(e).toBeInstanceOf(ClauditorError);
+      expect(e).toBeInstanceOf(Error);
+      expect(e.name).toBe(Cls.name);
+    }
+    expect(new ClauditorError("x").name).toBe("ClauditorError");
+  });
+});
+
+describe("mapExit (vitest)", () => {
+  it("exit 0 returns parsed JSON", () => {
+    expect(mapExit(0, '{"passed": true}', "")).toEqual({ passed: true });
+  });
+
+  it("exit 1 returns parsed JSON (failing eval is data)", () => {
+    expect(mapExit(1, '{"passed": false}', "")).toEqual({ passed: false });
+  });
+
+  it("exit 2 throws ClauditorInputError", () => {
+    expect(() => mapExit(2, "", "bad input")).toThrow(ClauditorInputError);
+  });
+
+  it("exit 3 throws ClauditorApiError", () => {
+    expect(() => mapExit(3, "", "api down")).toThrow(ClauditorApiError);
+  });
+
+  it("exit 7 throws ClauditorError", () => {
+    expect(() => mapExit(7, "", "weird")).toThrow(ClauditorError);
+  });
+
+  it("non-JSON stdout on exit 0 throws ClauditorError", () => {
+    expect(() => mapExit(0, "nope", "")).toThrow(ClauditorError);
+  });
+});
+
+describe("resolveBinary (vitest)", () => {
+  const ORIG_BIN = process.env.CLAUDITOR_BIN;
+  const ORIG_PATH = process.env.PATH;
+
+  afterEach(() => {
+    if (ORIG_BIN === undefined) {
+      delete process.env.CLAUDITOR_BIN;
+    } else {
+      process.env.CLAUDITOR_BIN = ORIG_BIN;
+    }
+    process.env.PATH = ORIG_PATH;
+  });
+
+  it("honors CLAUDITOR_BIN override", () => {
+    process.env.CLAUDITOR_BIN = "/opt/custom/clauditor";
+    expect(resolveBinary()).toEqual({
+      command: "/opt/custom/clauditor",
+      argsPrefix: [],
+    });
+  });
+
+  it("throws ClauditorNotFoundError with install hint when nothing resolves", () => {
+    delete process.env.CLAUDITOR_BIN;
+    process.env.PATH = "";
+    expect(() => resolveBinary()).toThrow(ClauditorNotFoundError);
+  });
+});

--- a/npm/test/lib-core.test.js
+++ b/npm/test/lib-core.test.js
@@ -2,6 +2,9 @@
 // __tests__/lib-core.test.js so the same contract runs under both runners.
 import { describe, it, expect, afterEach } from "vitest";
 import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 const require = createRequire(import.meta.url);
 const { mapExit } = require("../lib/exec");
@@ -80,5 +83,39 @@ describe("resolveBinary (vitest)", () => {
     delete process.env.CLAUDITOR_BIN;
     process.env.PATH = "";
     expect(() => resolveBinary()).toThrow(ClauditorNotFoundError);
+  });
+
+  // H2: PATH resolution returns the FULL resolved path, not the bare name.
+  it("PATH resolution returns the full resolved path, not the bare name", () => {
+    delete process.env.CLAUDITOR_BIN;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-path-"));
+    const name = process.platform === "win32" ? "clauditor.exe" : "clauditor";
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, "#!/bin/sh\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    try {
+      const res = resolveBinary();
+      expect(res.command).toBe(full);
+      expect(res.argsPrefix).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // H3: python fallback resolves `python` (not only python3) with -m prefix.
+  it("python fallback resolves `python` with the -m clauditor prefix", () => {
+    delete process.env.CLAUDITOR_BIN;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clauditor-py-"));
+    const name = process.platform === "win32" ? "python.exe" : "python";
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, "#!/bin/sh\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    try {
+      const res = resolveBinary();
+      expect(res.command).toBe(full);
+      expect(res.argsPrefix).toEqual(["-m", "clauditor"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/npm/test/skeleton.test.js
+++ b/npm/test/skeleton.test.js
@@ -1,0 +1,13 @@
+// Vitest skeleton test (US-002): assert the package requires cleanly.
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../index.js");
+
+describe("clauditor-eval skeleton (vitest)", () => {
+  it("index.js requires cleanly and exports an object", () => {
+    expect(typeof pkg).toBe("object");
+    expect(pkg).not.toBeNull();
+  });
+});

--- a/npm/vitest.config.js
+++ b/npm/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// Vitest config for clauditor-eval.
+// Vitest owns tests under test/; jest owns tests under __tests__/ (see
+// jest.config.js). The two test runners are scoped to disjoint
+// directories so running both does not double-collect the same files.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.js"],
+  },
+});

--- a/plans/super/4-npm-wrapper.md
+++ b/plans/super/4-npm-wrapper.md
@@ -1,0 +1,397 @@
+# Super Plan: #4 — npm package: Node.js wrapper with Jest/Vitest helpers
+
+## Meta
+- **Ticket:** https://github.com/wjduenow/clauditor/issues/4
+- **Branch:** `feature/4-npm-wrapper`
+- **Worktree:** in-place (`/home/wesd/Projects/clauditor`)
+- **Phase:** `detailing`
+- **PR:** _(filled at publish)_
+- **Beads epic:** _(filled at devolve)_
+- **Sessions:** 1
+- **Last session:** 2026-05-25
+
+> **Scope note:** This plan implements a **v1 subprocess-bridge** npm
+> wrapper (JS API + jest/vitest helpers) plus the one Python-side
+> change needed to back it (`run --json`). PyInstaller binary
+> distribution (the issue's "esbuild pattern") is **explicitly
+> deferred** to a sequenced follow-up epic — see DEC-002 / DEC-003.
+
+---
+
+## Discovery
+
+### Ticket Summary
+
+**What:** Ship an npm-installable wrapper so Node.js developers can
+use clauditor in their Jest/Vitest test suites — a JS API
+(`runSkill`, `validate`, `loadSpec`), a `toPassClauditor` custom
+matcher, and a CLI launcher (`npx`).
+
+**Why:** The clauditor engine is Python (`pip install
+clauditor-eval`). Node.js teams testing Claude Code skills today have
+no first-class entry point; they'd shell out by hand and parse output
+ad hoc.
+
+**Who benefits:** Node.js / TypeScript teams with Jest or Vitest
+suites that want to assert on skill output and eval-spec pass/fail.
+
+**Done when:** `npm install clauditor-eval` exposes a working JS API
+and jest matcher that drive the Python CLI via subprocess, with a
+clear actionable error when the Python engine is not installed; README
+documents Node usage; an npm-publish CI workflow exists.
+
+### Critical findings that correct the issue's assumptions
+
+The issue was written early and carries **stale assumptions** that
+this plan corrects:
+
+| Issue assumes | Reality (verified) | Consequence |
+|---------------|--------------------|-------------|
+| npm name `clauditor` | **Taken** — npm `clauditor@1.0.0`, unrelated owner | Must rename → `clauditor-eval` (DEC-001) |
+| PyPI `clauditor` @ `0.1.0` | PyPI is **`clauditor-eval`** @ `0.1.3.dev0` | Naming + version references updated |
+| All CLI commands support `--json` | `validate`, `extract`, `triggers`, `audit`, `lint`, `grade`, `suggest`, `propose_eval` do; **`run` and `capture` do NOT** | Add `run --json` (DEC-004) |
+| `runSkill()` returns `{output, entries}` | No single command returns both; `entries` need an eval spec + L2 extraction | `runSkill` returns SkillResult shape (no entries) in v1; entries documented via `validate`/`extract` (DEC-004) |
+| `python -m clauditor` fallback works | No `src/clauditor/__main__.py` exists | Resolver can't rely on `-m`; see DEC-005 |
+| Binary wrapper is the recommended approach | clauditor **requires** API keys + network for grading, so "no Python runtime needed" buys far less than for ruff/esbuild; bundling `anthropic`+`openai` yields large/fragile binaries | Subprocess bridge is v1 (DEC-002); binary deferred |
+
+### Codebase Findings
+
+**Engine entry points (Python):**
+- Console script: `clauditor = "clauditor.cli:main"` (`pyproject.toml`).
+  No `__main__.py`, so `python -m clauditor` is unavailable today.
+- Modular CLI under `src/clauditor/cli/*.py`. Commands: `validate`,
+  `run`, `capture`, `grade`, `extract`, `triggers`, `compare`,
+  `audit`, `trend`, `badge`, `lint`, `init`, `setup`, `suggest`,
+  `propose-eval`, `doctor`.
+- Exit-code taxonomy (`.claude/rules/llm-cli-exit-code-taxonomy.md`):
+  **0** success · **1** load/parse failure · **2** input-validation /
+  post-call invariant · **3** Anthropic/OpenAI API failure.
+
+**Existing `--json` shapes (the JS wrapper parses these verbatim):**
+- `validate --json` → `{skill, pass_rate, passed, results:[{name,
+  passed, message, evidence?, raw_data?}]}`. Returns exit 0 when
+  passed, 1 when failed. (`cli/validate.py:358`)
+- `extract --json` → `{skill, model, pass_rate, passed, results:[…]}`
+  (`cli/extract.py:247`).
+- These stdout payloads carry **no `schema_version`** — established
+  convention for stdout `--json` (distinct from persisted sidecars
+  which MUST carry it per `.claude/rules/json-schema-version.md`).
+  See DEC-009.
+
+**`run` today (`cli/run.py`):** resolves harness, runs the skill, and
+prints `result.output` (or a rendered error). No `--json`. The
+backing `SkillResult` (`runner.py:54`) carries: `output`, `exit_code`,
+`skill_name`, `args`, `duration_seconds`, `error`, `error_category`,
+`harness`, `input_tokens`, `output_tokens`, `warnings`,
+`api_key_source` — the field set for the new `run --json` contract.
+
+**npm / binary state:** greenfield. No `package.json`, no `npm/`
+subtree, no PyInstaller config. CI has `ci.yml` (lint + validate-skill
++ pytest matrix) and `publish.yml` (PyPI trusted-publish on GitHub
+release). The npm-publish workflow will be **new and separate** — it
+must not touch the PyPI path.
+
+**Name availability (verified 2026-05-25):**
+- npm `clauditor` → taken (1.0.0). npm `clauditor-eval` → **free**.
+  npm scope `@clauditor` / `@clauditor-eval` → **free**.
+
+### Applicable `.claude/rules/`
+
+Most rules are Python-engine-specific and don't bind the `npm/`
+subtree, but these shape the design:
+
+1. **`llm-cli-exit-code-taxonomy.md`** — the JS exec layer MUST mirror
+   the 0/1/2/3 mapping: 0=pass, 1=fail (returned as data, not thrown),
+   2=input error (throw `ClauditorInputError`), 3=API error (throw
+   `ClauditorApiError`). DEC-008.
+2. **`json-schema-version.md`** — stdout `--json` (run/validate/extract)
+   stays *unversioned* to match existing convention; only persisted
+   sidecars carry `schema_version`. `run --json` follows the stdout
+   convention. DEC-009.
+3. **`pure-compute-vs-io-split.md`** — `run --json` reuses the existing
+   `SkillResult`→dict composition; the CLI command stays a thin
+   serialize-and-print wrapper. The JS side keeps a pure
+   exit-code→error mapping helper separate from the I/O `execFile`.
+4. **`stream-json-schema.md`** (spirit) — the JS parser treats the
+   Python stdout JSON as a tolerated external contract: parse
+   defensively, surface a crisp error if stdout isn't valid JSON
+   rather than throwing a raw `SyntaxError`.
+5. **`precall-env-validation.md`** — when the Python engine exits 2/3
+   on missing `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`, the JS layer
+   surfaces that engine message verbatim (it's already actionable);
+   the JS layer does NOT re-implement the env check.
+
+---
+
+## Architecture Review
+
+| Area | Rating | Finding |
+|------|--------|---------|
+| Security | **concern** | Subprocess spawn must use `execFile`/`spawn` with an **argument array, never a shell string** — skill names/args could otherwise inject. Skill-name safety is already enforced Python-side (`SKILL_NAME_RE`). `CLAUDITOR_BIN` env override runs an arbitrary path: acceptable (user's own env) but documented. Secrets (API keys) flow via **inherited env**, never argv — don't log argv. |
+| Performance | **pass** | Skill runs are seconds-to-minutes; one subprocess spawn per call is negligible. API must be **async** (non-blocking) so a multi-minute run doesn't freeze the Node event loop. |
+| Data model | **concern** | The `run --json` stdout shape becomes a **cross-language contract**. Document it; JS parses defensively. No `schema_version` (stdout convention). |
+| API design | **concern** | JS API is **async** (promisified `execFile`), not `execFileSync` as the issue sketched. `runSkill`/`validate` return data; throw only on input(2)/API(3) errors. Honor a `timeout` option. |
+| Observability | **pass** | JS surfaces engine `stderr` + `warnings[]` on errors; no secret logging. |
+| Testing | **concern** | Node tests must NOT call the real API. Use a **fake `clauditor` stub** on PATH (a tiny script emitting canned JSON / exit codes) so jest/vitest exercise resolve+exec+mapping deterministically. Python `run --json` covered by `tests/test_cli.py`. |
+
+**Blockers:** none. The two largest forks (naming, distribution) were
+resolved in Discovery scoping questions.
+
+---
+
+## Refinement Log (Decisions)
+
+- **DEC-001 — npm name `clauditor-eval`.** Matches the PyPI name
+  exactly; `clauditor` is taken on npm. Platform-package scope
+  `@clauditor-eval/*` is reserved for the deferred binary epic
+  (DEC-013) but unused in v1.
+- **DEC-002 — Distribution = subprocess bridge.** The npm package
+  resolves and shells out to the Python `clauditor` engine. Chosen
+  over PyInstaller because clauditor requires API keys + network to do
+  anything useful, so the "no runtime needed" benefit that justifies
+  ruff/esbuild's binary pattern is largely absent here, while the
+  cross-compile CI + large fragile binaries are the bulk of the cost.
+- **DEC-003 — v1 scope = JS API + jest/vitest helpers.** No
+  PyInstaller, no platform packages, no `optionalDependencies` in v1.
+  The full binary-distribution path is a sequenced follow-up epic
+  (file at devolve).
+- **DEC-004 — Add `run --json`; `runSkill` returns SkillResult shape.**
+  `clauditor run --json` emits `{output, exit_code, duration_seconds,
+  error, error_category, warnings, input_tokens, output_tokens,
+  harness, skill, args}`. `runSkill()` is a thin parser over it and
+  does **not** return `entries` in v1 (entries need an eval spec +
+  L2). The issue's `result.entries` is documented as the
+  `validate()`/`extract` path. Benefits Python users too.
+- **DEC-005 — Binary resolution order.** `CLAUDITOR_BIN` env (explicit
+  override) → `clauditor` on `PATH` → (best-effort) `python3 -m
+  clauditor` *only if* a `__main__.py` is added → else throw
+  `ClauditorNotFoundError` with an actionable hint (`pipx install
+  clauditor-eval` / `uv tool install clauditor-eval`). A tiny
+  `src/clauditor/__main__.py` is added so `python -m clauditor` works
+  as a real fallback (cheap, also useful standalone).
+- **DEC-006 — Async JS API.** Uses `child_process.execFile` promisified
+  (or `spawn` with collected stdout) — never the `*Sync` variants, so
+  long runs don't block the event loop. Each call honors a `timeout`
+  option (ms), defaulting to the Python engine's own default.
+- **DEC-007 — `execFile` with arg array, no shell, no secrets in
+  argv.** Prevents command injection; API keys ride the inherited
+  env. argv is never logged.
+- **DEC-008 — JS exit-code mapping mirrors the Python taxonomy.** 0 →
+  resolve with `{passed:true,…}`; 1 → resolve with `{passed:false,…}`
+  (a *failing* eval is data, not an exception); 2 → throw
+  `ClauditorInputError`; 3 → throw `ClauditorApiError`; any other code
+  / non-JSON stdout → throw `ClauditorError`. Pure mapping helper
+  separated from the I/O exec per the pure/IO-split rule.
+- **DEC-009 — `run --json` stdout is unversioned.** Matches the
+  existing `validate`/`extract` stdout `--json` convention; persisted
+  sidecars (not produced by `run`) keep `schema_version` per the rule.
+- **DEC-010 — `npm/` subtree at repo root; separate publish workflow.**
+  All Node code lives under `npm/`. A new `.github/workflows/
+  npm-publish.yml` publishes on a dedicated tag/release and is fully
+  independent of `publish.yml` (PyPI).
+- **DEC-011 — Node engines `>=18`.** LTS baseline with stable
+  `fs/promises`, `util.promisify`, native `fetch` (unused here but
+  future-proof). `package.json` declares `"engines": {"node": ">=18"}`.
+- **DEC-012 — `loadSpec` = discover + read.** Resolves an explicit eval
+  path or the sibling `<skill>.eval.json`, reads + JSON-parses it, and
+  returns the object. v1 does **not** re-validate through the Python
+  loader (documented limitation); a future `--echo-spec` command could
+  add validation.
+- **DEC-013 — `@clauditor-eval/*` platform scope reserved.** No
+  platform packages ship in v1; the scope is documented as reserved so
+  the binary follow-up epic can claim it without renaming.
+
+---
+
+## Detailed Breakdown (Stories)
+
+> Validation command (Python stories): `uv run ruff check src/ tests/`
+> + `uv run pytest --cov=clauditor --cov-report=term-missing` (80%
+> gate). Validation command (Node stories): `cd npm && npm test` (jest)
+> + `npm run test:vitest` + `npm run lint`.
+
+### US-001 — Python: `run --json` structured output + `python -m clauditor`
+- **Description:** Add a `--json` flag to the `run` command that emits
+  the `SkillResult` as a stable JSON object, and add
+  `src/clauditor/__main__.py` so `python -m clauditor` dispatches to
+  `cli:main` (fallback path for the JS resolver).
+- **Traces to:** DEC-004, DEC-005, DEC-009.
+- **Files:**
+  - `src/clauditor/cli/run.py` — add `--json` arg; when set, print
+    `json.dumps({output, exit_code, duration_seconds, error,
+    error_category, warnings, input_tokens, output_tokens, harness,
+    skill, args}, indent=2)` instead of the rendered output. Preserve
+    the existing exit-code behavior.
+    - **Note:** harness key already populated on `SkillResult`. Do NOT
+      include secrets.
+  - `src/clauditor/__main__.py` — `from clauditor.cli import main;
+    raise SystemExit(main())`.
+- **TDD:**
+  - `tests/test_cli.py::TestCmdRun` — `run --json` emits valid JSON
+    with the documented keys; `output`/`exit_code` correct on a mocked
+    `SkillRunner.run`.
+  - `--json` payload omits/empties optional fields cleanly (no crash
+    when `error is None`, `warnings == []`).
+  - `python -m clauditor --help` exits 0 (smoke via `subprocess` or
+    `runpy`).
+- **Acceptance:** `clauditor run <skill> --json` prints parseable JSON
+  with all documented keys; `python -m clauditor` works; ruff + pytest
+  pass (80% gate).
+- **Done when:** new tests green; coverage gate holds.
+- **Depends on:** none.
+
+### US-002 — Node: `npm/` package skeleton + tooling
+- **Description:** Scaffold the `npm/` subtree: `package.json` (name
+  `clauditor-eval`, version mirroring PyPI, `engines.node >=18`, `bin`,
+  `main`, `files`), `.npmignore`, jest + vitest config, an ESLint/lint
+  script, and a placeholder `index.js`/`bin/clauditor.js` so the
+  package is installable and `npm test` runs (empty-green).
+- **Traces to:** DEC-001, DEC-003, DEC-010, DEC-011, DEC-013.
+- **Files:** `npm/package.json`, `npm/.npmignore`, `npm/jest.config.js`,
+  `npm/vitest.config.js`, `npm/.eslintrc.json` (or flat config),
+  `npm/index.js` (stub), `npm/bin/clauditor.js` (stub, executable),
+  `npm/README.md` (stub).
+- **Acceptance:** `cd npm && npm install && npm test && npm run lint`
+  succeed; `package.json` declares `clauditor-eval`, `engines`,
+  `bin.clauditor`, `main`, `files` (whitelist), and documents
+  `@clauditor-eval/*` as reserved.
+- **Done when:** package installs and the empty test suite passes.
+- **Depends on:** none.
+
+### US-003 — Node: lib core (resolve-binary + exec-json + errors)
+- **Description:** Implement the engine resolver and the exec/parse/map
+  core. `resolveBinary()` follows DEC-005 order and throws
+  `ClauditorNotFoundError` with an install hint when nothing is found.
+  `execJson(args, opts)` runs the engine via `execFile` (array args, no
+  shell, inherited env, honored `timeout`), parses stdout JSON
+  defensively, and maps the exit code to outcome/error per DEC-008.
+- **Traces to:** DEC-005, DEC-006, DEC-007, DEC-008.
+- **Files:** `npm/lib/resolve-binary.js`, `npm/lib/exec.js`,
+  `npm/lib/errors.js` (`ClauditorError`, `ClauditorNotFoundError`,
+  `ClauditorInputError`, `ClauditorApiError`).
+- **TDD:**
+  - `resolveBinary`: honors `CLAUDITOR_BIN`; falls back to PATH; throws
+    `ClauditorNotFoundError` with hint when absent (mock PATH lookup).
+  - exit-code map (pure helper): 0→pass, 1→fail-data, 2→InputError,
+    3→ApiError, 7→generic ClauditorError, non-JSON stdout→ClauditorError.
+  - `execJson` runs a **fake clauditor stub** script (fixture emitting
+    canned JSON + chosen exit code); asserts parsed result + error
+    classes; never invokes a shell (assert arg-array path).
+  - timeout option propagated to `execFile`.
+- **Acceptance:** all lib tests green under jest AND vitest; no shell
+  string used; secrets never appear in any logged output.
+- **Done when:** resolve/exec/error modules covered and green.
+- **Depends on:** US-002.
+
+### US-004 — Node: JS API (`index.js`) — runSkill / validate / loadSpec
+- **Description:** Public async API. `runSkill(skill, opts)` → `run
+  --json` parsed (DEC-004 shape). `validate(skillPath, opts)` →
+  `validate --json` (`{passed, pass_rate, results}`). `loadSpec(path |
+  skillPath)` → discover sibling `<skill>.eval.json`, read + parse
+  (DEC-012). Re-export error classes.
+- **Traces to:** DEC-004, DEC-006, DEC-008, DEC-012.
+- **Files:** `npm/index.js` (+ `npm/index.d.ts` TypeScript types).
+- **TDD:**
+  - `runSkill` maps options (`args`, `projectDir`, `timeout`) to the
+    correct CLI flags; returns the parsed SkillResult shape.
+  - `validate` returns `{passed:true}` on exit 0, `{passed:false}` on
+    exit 1, throws on 2/3 — driven by the fake stub.
+  - `loadSpec` discovers the sibling eval file and returns parsed JSON;
+    throws a clear error when missing.
+- **Acceptance:** API tests green (jest + vitest); `index.d.ts` types
+  compile (`tsc --noEmit` smoke).
+- **Done when:** all three functions covered and green.
+- **Depends on:** US-003, US-001 (needs `run --json`).
+
+### US-005 — Node: `bin/clauditor.js` CLI launcher
+- **Description:** `npx clauditor-eval <args…>` resolves the engine and
+  forwards argv with inherited stdio, propagating the child's exit
+  code. On `ClauditorNotFoundError`, print the install hint to stderr
+  and exit 2.
+- **Traces to:** DEC-005, DEC-007, DEC-008.
+- **Files:** `npm/bin/clauditor.js` (shebang, executable).
+- **TDD:**
+  - forwards argv verbatim to the resolved binary (assert via fake
+    stub that echoes argv); exit code propagated.
+  - missing engine → stderr hint + exit 2.
+- **Acceptance:** launcher tests green; `bin` wired in `package.json`;
+  stdio is inherited (interactive passthrough).
+- **Done when:** launcher covered and green.
+- **Depends on:** US-003.
+
+### US-006 — Node: `jest-helper.js` `toPassClauditor` + Vitest compat
+- **Description:** Custom matcher `toPassClauditor(received, evalPath?)`.
+  Accepts either a `runSkill` result (then runs `validate` on the
+  resolved eval) or a `validate` result directly; returns the
+  `{pass, message}` matcher shape. Verify it works under both Jest
+  `expect.extend` and Vitest `expect.extend` (same contract).
+- **Traces to:** DEC-004, DEC-008.
+- **Files:** `npm/jest-helper.js` (+ types), tests under
+  `npm/__tests__/` for jest and `npm/test/` (or shared) for vitest.
+- **TDD:**
+  - matcher passes when eval passes, fails with a readable message
+    listing failing assertion names when it doesn't (fake stub).
+  - identical behavior asserted under jest and vitest harnesses.
+- **Acceptance:** matcher green under both runners; failure message
+  enumerates failing `results[].name`.
+- **Done when:** jest + vitest matcher suites green.
+- **Depends on:** US-004.
+
+### US-007 — Node: README usage + npm-publish CI workflow
+- **Description:** Write `npm/README.md` (install incl. the Python
+  engine prerequisite, `runSkill`/`validate`/`loadSpec` examples,
+  jest + vitest matcher examples, `CLAUDITOR_BIN` override, error
+  classes, v1-limitations note re: entries + binary distribution). Add
+  `.github/workflows/npm-publish.yml` publishing `npm/` on a dedicated
+  tag (e.g. `npm-v*`) via `NODE_AUTH_TOKEN`; independent of the PyPI
+  workflow. Cross-link from the root `README.md` (a short teaser per
+  `.claude/rules/readme-promotion-recipe.md`).
+- **Traces to:** DEC-002, DEC-003, DEC-010, DEC-013.
+- **Files:** `npm/README.md`, `.github/workflows/npm-publish.yml`,
+  root `README.md` (teaser pointing to `npm/README.md`).
+- **Acceptance:** README renders the documented examples; workflow
+  lints (actionlint or manual review) and uses a separate tag trigger;
+  does not modify `publish.yml`.
+- **Done when:** docs + workflow committed; root README cross-links.
+- **Depends on:** US-005, US-006.
+
+### US-008 — Quality Gate — code review x4 + CodeRabbit
+- **Description:** Run the code reviewer 4× over the full changeset
+  (Python `run --json` + entire `npm/` subtree + CI workflow), fixing
+  every real bug each pass. Run CodeRabbit if available. Re-run both
+  validation commands (Python: ruff + pytest 80% gate; Node: `npm
+  test` + `npm run test:vitest` + `npm run lint`) until green.
+- **Traces to:** all DECs.
+- **Acceptance:** 4 review passes complete; all real findings fixed;
+  both validation suites pass.
+- **Done when:** clean review + green gates.
+- **Depends on:** US-001 … US-007.
+
+### US-009 — Patterns & Memory (priority 99)
+- **Description:** Capture new patterns: the cross-language stdout-JSON
+  contract + defensive JS parse, the JS exit-code mirror of the Python
+  taxonomy, the subprocess-bridge distribution decision, and a pointer
+  to the deferred binary epic. Update `.claude/rules/` and/or
+  `docs/`, and `MEMORY.md` as appropriate. File the **PyInstaller
+  binary-distribution follow-up epic** (deferred per DEC-003).
+- **Traces to:** DEC-002, DEC-003, DEC-008, DEC-009.
+- **Acceptance:** rules/docs updated; follow-up epic filed and linked
+  in this plan's Meta.
+- **Done when:** patterns recorded; follow-up issue created.
+- **Depends on:** US-008.
+
+---
+
+## Deferred to follow-up epic (NOT in this plan)
+- PyInstaller standalone-binary builds for linux-x64, darwin-arm64,
+  darwin-x64, win32-x64 (DEC-002 / DEC-003).
+- `@clauditor-eval/<platform>` scoped platform packages +
+  `optionalDependencies` wiring (DEC-013).
+- Binary-build CI matrix + per-platform npm publish.
+- Platform-detection swap-in inside `lib/resolve-binary.js` (the
+  resolver seam is designed v1 to accept this without an API change).
+
+---
+
+## Beads Manifest
+_(filled at devolve)_

--- a/plans/super/4-npm-wrapper.md
+++ b/plans/super/4-npm-wrapper.md
@@ -7,6 +7,7 @@
 - **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/199
 - **Beads epic:** `clauditor-ovml` (tasks `.1`–`.9`)
+- **Follow-up epic (deferred binary distribution):** https://github.com/wjduenow/clauditor/issues/200
 - **Sessions:** 1
 - **Last session:** 2026-05-25
 
@@ -383,6 +384,8 @@ resolved in Discovery scoping questions.
 ---
 
 ## Deferred to follow-up epic (NOT in this plan)
+> Filed as https://github.com/wjduenow/clauditor/issues/200.
+
 - PyInstaller standalone-binary builds for linux-x64, darwin-arm64,
   darwin-x64, win32-x64 (DEC-002 / DEC-003).
 - `@clauditor-eval/<platform>` scoped platform packages +

--- a/plans/super/4-npm-wrapper.md
+++ b/plans/super/4-npm-wrapper.md
@@ -4,8 +4,8 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/4
 - **Branch:** `feature/4-npm-wrapper`
 - **Worktree:** in-place (`/home/wesd/Projects/clauditor`)
-- **Phase:** `detailing`
-- **PR:** _(filled at publish)_
+- **Phase:** `published`
+- **PR:** https://github.com/wjduenow/clauditor/pull/199
 - **Beads epic:** _(filled at devolve)_
 - **Sessions:** 1
 - **Last session:** 2026-05-25

--- a/plans/super/4-npm-wrapper.md
+++ b/plans/super/4-npm-wrapper.md
@@ -4,9 +4,9 @@
 - **Ticket:** https://github.com/wjduenow/clauditor/issues/4
 - **Branch:** `feature/4-npm-wrapper`
 - **Worktree:** in-place (`/home/wesd/Projects/clauditor`)
-- **Phase:** `published`
+- **Phase:** `devolved`
 - **PR:** https://github.com/wjduenow/clauditor/pull/199
-- **Beads epic:** _(filled at devolve)_
+- **Beads epic:** `clauditor-ovml` (tasks `.1`–`.9`)
 - **Sessions:** 1
 - **Last session:** 2026-05-25
 
@@ -394,4 +394,16 @@ resolved in Discovery scoping questions.
 ---
 
 ## Beads Manifest
-_(filled at devolve)_
+- **Epic:** `clauditor-ovml`
+- **Tasks:**
+  - `clauditor-ovml.1` — US-001 Python `run --json` + `__main__.py` *(ready)*
+  - `clauditor-ovml.2` — US-002 npm/ skeleton + tooling *(ready)*
+  - `clauditor-ovml.3` — US-003 lib core (resolve+exec+errors) — needs .2
+  - `clauditor-ovml.4` — US-004 index.js API — needs .3, .1
+  - `clauditor-ovml.5` — US-005 bin launcher — needs .3
+  - `clauditor-ovml.6` — US-006 jest/vitest matcher — needs .4
+  - `clauditor-ovml.7` — US-007 README + npm-publish CI — needs .5, .6
+  - `clauditor-ovml.8` — US-008 Quality Gate — needs .1–.7
+  - `clauditor-ovml.9` — US-009 Patterns & Memory — needs .8
+- **Dependency graph:** `.1`→`.4`; `.2`→`.3`→{`.4`,`.5`}; `.4`→`.6`;
+  {`.5`,`.6`}→`.7`; `.1`–`.7`→`.8`→`.9`.

--- a/src/clauditor/__main__.py
+++ b/src/clauditor/__main__.py
@@ -1,0 +1,5 @@
+"""Enable ``python -m clauditor`` to dispatch to the CLI entry point."""
+
+from clauditor.cli import main
+
+raise SystemExit(main())

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -159,7 +159,15 @@ def cmd_run(args: argparse.Namespace) -> int:
         # Deliberately excludes secret-bearing fields (api_key_source,
         # raw_messages, stream_events, harness_metadata).
         print(json.dumps(_result_to_json(result), indent=2))
-    elif result.output:
+        # In --json mode the run result is DATA: the skill's own exit
+        # code (which can be -1 on spawn failure, 124 on timeout, or any
+        # other subprocess code) is carried inside the payload as
+        # ``exit_code``/``error``/``error_category``. Return 0 so a
+        # JSON-consuming wrapper (the npm ``clauditor-eval`` bridge)
+        # receives the parsed object instead of mapping an arbitrary
+        # child exit code to a thrown error per the CLI exit taxonomy.
+        return 0
+    if result.output:
         print(result.output)
 
     return result.exit_code

--- a/src/clauditor/cli/run.py
+++ b/src/clauditor/cli/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from clauditor._providers import (
     check_codex_auth,
 )
 from clauditor.runner import (
+    SkillResult,
     SkillRunner,
     env_with_sync_tasks,
 )
@@ -28,6 +30,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     p_run.add_argument("skill", help="Skill name (e.g., find-kid-activities)")
     p_run.add_argument("--args", help="Arguments to pass to the skill")
     p_run.add_argument("--project-dir", help="Project directory (default: cwd)")
+    p_run.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Print the run result as a JSON object to stdout instead of "
+            "the rendered output. No secrets are included."
+        ),
+    )
     # DEC-014: default shifts from 180 to None so the precedence chain
     # (CLI > spec > runner's 300s default) can kick in. ``_positive_int``
     # rejects <= 0 at parse time with exit 2.
@@ -143,7 +153,35 @@ def cmd_run(args: argparse.Namespace) -> int:
     if not result.succeeded_cleanly:
         print(f"ERROR: {_render_skill_error(result)}", file=sys.stderr)
 
-    if result.output:
+    if getattr(args, "json", False):
+        # Structured stdout (no schema_version — that is reserved for
+        # persisted sidecars; stdout --json mirrors validate/extract).
+        # Deliberately excludes secret-bearing fields (api_key_source,
+        # raw_messages, stream_events, harness_metadata).
+        print(json.dumps(_result_to_json(result), indent=2))
+    elif result.output:
         print(result.output)
 
     return result.exit_code
+
+
+def _result_to_json(result: SkillResult) -> dict:
+    """Project a :class:`SkillResult` into the ``run --json`` payload.
+
+    Pure: no I/O, no secrets. The shape is the documented stable
+    surface for ``clauditor run --json`` (no ``schema_version`` — that
+    convention is reserved for persisted sidecars).
+    """
+    return {
+        "output": result.output,
+        "exit_code": result.exit_code,
+        "duration_seconds": result.duration_seconds,
+        "error": result.error,
+        "error_category": result.error_category,
+        "warnings": result.warnings,
+        "input_tokens": result.input_tokens,
+        "output_tokens": result.output_tokens,
+        "harness": result.harness,
+        "skill": result.skill_name,
+        "args": result.args,
+    }

--- a/src/clauditor/cli/validate.py
+++ b/src/clauditor/cli/validate.py
@@ -207,7 +207,12 @@ def cmd_validate(args: argparse.Namespace) -> int:
             return 2
 
         try:
-            print(f"Running /{spec.skill_name} {spec.eval_spec.test_args}...")
+            # Progress goes to stderr under --json so stdout stays pure
+            # JSON (the npm clauditor-eval bridge parses all of stdout).
+            print(
+                f"Running /{spec.skill_name} {spec.eval_spec.test_args}...",
+                file=sys.stderr if args.json else sys.stdout,
+            )
             # DEC-001, DEC-006, DEC-014: thread CLI auth/timeout flags
             # through to the spec. ``--no-api-key`` strips both auth env
             # vars via ``env_without_api_key``; ``--timeout`` wins over
@@ -239,6 +244,26 @@ def cmd_validate(args: argparse.Namespace) -> int:
                     f"{_render_skill_error(skill_result)}",
                     file=sys.stderr,
                 )
+                if args.json:
+                    # Emit a JSON eval result so the --json contract holds
+                    # even when the skill never ran. Consumers (the npm
+                    # ``clauditor-eval`` validate() / toPassClauditor
+                    # matcher) parse exit-1 stdout as JSON; empty stdout
+                    # would surface as an opaque non-JSON error instead of
+                    # a clean {passed: false} result.
+                    print(
+                        json.dumps(
+                            {
+                                "skill": spec.skill_name,
+                                "pass_rate": 0.0,
+                                "passed": False,
+                                "results": [],
+                                "error": _render_skill_error(skill_result),
+                                "error_category": skill_result.error_category,
+                            },
+                            indent=2,
+                        )
+                    )
                 workspace.abort()
                 # Still record history so failed live-validates remain
                 # visible in trend/audit tooling. No iteration is
@@ -253,7 +278,10 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 )
                 return 1
             output = skill_result.output
-            print(f"Skill completed in {skill_result.duration_seconds:.1f}s")
+            print(
+                f"Skill completed in {skill_result.duration_seconds:.1f}s",
+                file=sys.stderr if args.json else sys.stdout,
+            )
 
             results = run_assertions(output, spec.eval_spec.assertions)
 

--- a/src/clauditor/spec.py
+++ b/src/clauditor/spec.py
@@ -163,7 +163,14 @@ class SkillSpec:
             sources = [Path(p) for p in self.eval_spec.input_files]
             stage_inputs(run_dir, sources)
             effective_cwd = run_dir / "inputs"
-            print(f"Staged {len(sources)} input file(s) into {effective_cwd}")
+            # Progress breadcrumb → stderr, never stdout: callers such as
+            # ``clauditor validate --json`` / ``run --json`` emit a pure-JSON
+            # payload on stdout that the npm clauditor-eval bridge parses
+            # wholesale; a stray "Staged ..." line would break JSON.parse.
+            print(
+                f"Staged {len(sources)} input file(s) into {effective_cwd}",
+                file=sys.stderr,
+            )
 
         # DEC-005: thread the per-eval escape hatch into the runner. When
         # no eval_spec is attached, default to True (back-compat).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -349,6 +349,29 @@ class TestPythonDashM:
         assert result.returncode == 0
         assert "usage" in result.stdout.lower()
 
+    def test_main_module_dispatches_to_cli_main(self, monkeypatch):
+        """``__main__`` executes in-process: dispatches to cli.main and
+        raises SystemExit with its return code.
+
+        Runs the module body via ``runpy`` (rather than a subprocess) so
+        coverage instruments ``__main__.py`` — the subprocess smoke test
+        above cannot. ``clauditor.cli.main`` is patched to a sentinel so
+        no real CLI runs.
+        """
+        import runpy
+
+        called = {}
+
+        def _fake_main(argv=None):
+            called["argv"] = argv
+            return 0
+
+        monkeypatch.setattr("clauditor.cli.main", _fake_main)
+        with pytest.raises(SystemExit) as excinfo:
+            runpy.run_module("clauditor", run_name="__main__", alter_sys=True)
+        assert excinfo.value.code == 0
+        assert "argv" in called
+
 
 class TestCmdGrade:
     """Tests for the grade subcommand."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,6 +158,29 @@ class TestCmdValidate:
         assert rc == 1
         assert "Skill failed" in capsys.readouterr().err
 
+    def test_validate_json_emits_json_when_skill_fails_to_run(
+        self, capsys, tmp_path, monkeypatch
+    ):
+        """--json emits a parseable {passed: false} object even when the
+        skill never runs, so the npm bridge's validate() does not choke on
+        empty stdout. Returns 1, but stdout carries valid JSON."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        spec = _make_spec(eval_spec=_make_eval_spec())
+        spec.run.return_value = make_skill_result(
+            output="", exit_code=1, duration_seconds=0.5, error="timeout",
+        )
+
+        with patch("clauditor.cli.SkillSpec.from_file", return_value=spec):
+            rc = main(["validate", "skill.md", "--json"])
+
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is False
+        assert payload["pass_rate"] == 0.0
+        assert payload["results"] == []
+        assert "error" in payload
+
     def test_validate_output_file_missing_exits_2(self, capsys, tmp_path):
         """--output pointing at a non-existent path exits 2 with clean error."""
         missing = tmp_path / "no-such-file.txt"
@@ -282,6 +305,32 @@ class TestCmdRun:
         # not as a bare rendered line.
         assert not out.startswith("PLAIN RENDER LINE")
         assert json.loads(out)["output"] == "PLAIN RENDER LINE"
+
+    def test_run_json_returns_zero_even_on_nonzero_skill_exit(self, capsys):
+        """--json returns 0 so a JSON consumer gets the payload as data.
+
+        The skill's own exit code (e.g. -1 on spawn failure, 124 on
+        timeout) is carried inside the payload as ``exit_code``; the
+        process return code stays 0 in --json mode so the npm bridge
+        does not map an arbitrary child code to a thrown error.
+        """
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="",
+            skill_name="my-skill",
+            exit_code=-1,
+            error="spawn failed",
+        )
+
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill", "--json"])
+
+        # Process exit is 0 (data delivered) ...
+        assert rc == 0
+        # ... but the skill's real exit code is preserved in the payload.
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["exit_code"] == -1
+        assert payload["error"] == "spawn failed"
 
 
 class TestPythonDashM:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,6 +203,103 @@ class TestCmdRun:
         assert rc == 1
         assert "command not found" in capsys.readouterr().err
 
+    def test_run_json_emits_all_documented_keys(self, capsys):
+        """--json prints a parseable object with every documented key."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="skill output here",
+            skill_name="my-skill",
+            args="--depth deep",
+            duration_seconds=2.5,
+            input_tokens=10,
+            output_tokens=20,
+        )
+
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill", "--args", "--depth deep", "--json"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert set(payload.keys()) == {
+            "output",
+            "exit_code",
+            "duration_seconds",
+            "error",
+            "error_category",
+            "warnings",
+            "input_tokens",
+            "output_tokens",
+            "harness",
+            "skill",
+            "args",
+        }
+        assert payload["output"] == "skill output here"
+        assert payload["exit_code"] == 0
+        assert payload["duration_seconds"] == 2.5
+        assert payload["input_tokens"] == 10
+        assert payload["output_tokens"] == 20
+        assert payload["skill"] == "my-skill"
+        assert payload["args"] == "--depth deep"
+        assert payload["harness"] == "claude-code"
+        # No schema_version on stdout --json (sidecar-only convention).
+        assert "schema_version" not in payload
+        # No secret-bearing fields leak into the payload.
+        assert "api_key_source" not in payload
+        assert "raw_messages" not in payload
+        assert "stream_events" not in payload
+        assert "harness_metadata" not in payload
+
+    def test_run_json_handles_empty_optional_fields(self, capsys):
+        """--json does not crash when error is None and warnings == []."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="ok", skill_name="my-skill",
+        )
+
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill", "--json"])
+
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"] is None
+        assert payload["error_category"] is None
+        assert payload["warnings"] == []
+
+    def test_run_json_prints_object_not_rendered_output(self, capsys):
+        """--json replaces the plain stdout render with the JSON object."""
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = make_skill_result(
+            output="PLAIN RENDER LINE", skill_name="my-skill",
+        )
+
+        with patch("clauditor.cli.run.SkillRunner", return_value=mock_runner):
+            rc = main(["run", "my-skill", "--json"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        # The raw output appears only inside the JSON "output" field,
+        # not as a bare rendered line.
+        assert not out.startswith("PLAIN RENDER LINE")
+        assert json.loads(out)["output"] == "PLAIN RENDER LINE"
+
+
+class TestPythonDashM:
+    """Tests for the ``python -m clauditor`` entry point."""
+
+    def test_python_m_clauditor_help_exits_zero(self):
+        """``python -m clauditor --help`` exits 0 (smoke)."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "clauditor", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "usage" in result.stdout.lower()
+
 
 class TestCmdGrade:
     """Tests for the grade subcommand."""

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -788,7 +788,10 @@ class TestSkillSpecRunWithInputFiles:
         spec.run(run_dir=run_dir)
 
         captured = capsys.readouterr()
-        assert "Staged 2 input file(s)" in captured.out
+        # Progress breadcrumb goes to stderr (keeps stdout pure JSON for
+        # `validate --json` / `run --json` consumers like the npm bridge).
+        assert "Staged 2 input file(s)" in captured.err
+        assert "Staged 2 input file(s)" not in captured.out
 
 
 class TestFailedRunResult:


### PR DESCRIPTION
## Summary
Super plan for #4 — npm-installable Node.js wrapper for clauditor.

**Phase:** detailing (awaiting approval)
**Approach:** v1 subprocess-bridge (`clauditor-eval` shells out to the Python engine); PyInstaller binary distribution deferred to a follow-up epic.
**Stories:** 7 implementation + Quality Gate + Patterns & Memory
**Decisions:** 13 captured (DEC-001 … DEC-013)

## Key corrections to the original issue
- npm `clauditor` is taken (v1.0.0) → package named **`clauditor-eval`** (matches PyPI)
- `run`/`capture` lack `--json` → add **`run --json`** + `python -m clauditor`
- `runSkill()` returns the SkillResult shape (no `entries` in v1 — those require an eval spec + L2)
- Distribution = subprocess bridge, not bundled binaries (clauditor needs API keys + network, so "no runtime needed" buys little)

## Plan document
See `plans/super/4-npm-wrapper.md` for the full plan.

## Next steps
- Review the plan in this PR
- Approve in Claude Code to proceed to devolve (beads creation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Released `clauditor-eval` npm package with JavaScript API (`runSkill`, `validate`, `loadSpec`) for Node.js.
  * Added Jest/Vitest custom matcher `toPassClauditor` for testing validation results.
  * Python CLI now supports `--json` output mode for `run` and `validate` commands, enabling machine-readable results.
  * Added support for invoking clauditor via `python -m clauditor`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->