### PR TITLE
chore: release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-26
+
 ### Added
 
+- **npm wrapper package `clauditor-eval` (#4).** A Node.js subprocess
+  bridge that shells out to the Python `clauditor` CLI: a `bin/clauditor.js`
+  launcher, a JS API (`runSkill` / `validate` / `loadSpec`) with
+  TypeScript types, a `toPassClauditor` jest/vitest matcher, and an
+  npm-publish CI workflow. Lets JS/TS projects run clauditor evals
+  without a Python entry point of their own.
+- **`clauditor run --json` structured output and `python -m clauditor`
+  entry point (#4).** `run --json` emits a single pure-JSON document on
+  stdout (skill exit code carried in the payload, all progress routed to
+  stderr) so external wrappers can `JSON.parse` it; `python -m clauditor`
+  invokes the CLI as a module. Both back the npm bridge.
 - **`parallel-research` example skill demonstrating the background-task
   refactor (#103).** Added `examples/.claude/skills/parallel-research/`
   — a runnable companion to "Recipe A" (drop `run_in_background: true`,
@@ -483,7 +496,8 @@ First stable release on PyPI: <https://pypi.org/project/clauditor-eval/0.1.0/>.
 - Bundled `/clauditor` Claude Code slash command installable via
   `clauditor setup`.
 
-[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/wjduenow/clauditor/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.3
 [0.1.2]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.2
 [0.1.1]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.1
 [0.1.0]: https://github.com/wjduenow/clauditor/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clauditor-eval"
-version = "0.1.3.dev0"
+version = "0.1.3"
 description = "Auditor for Claude Code skills and slash commands. Validates structured output against schemas using layered evaluation."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "clauditor-eval"
-version = "0.1.3.dev0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Cuts v0.1.3 to PyPI. Pre-flight tests pass (3815 passed, 2 skipped, 86.09% coverage); `uv build` + `uvx twine check` PASSED on both wheel and sdist. CHANGELOG promoted from `[Unreleased]` to `[0.1.3]` (dated 2026-05-26), with #4 npm-wrapper entries added.

Headline changes since v0.1.2: npm wrapper package (#4), `run --json` + `python -m clauditor` (#4), background-task non-completion eval coverage (#103), Codex harness discovery docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `clauditor-eval` npm wrapper for JavaScript/TypeScript integration.
  * Added `--json` flag for structured JSON output with progress routed separately.
  * Added Python module invocation support via `python -m clauditor`.

* **Chores**
  * Version bumped to 0.1.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->