### PR TITLE
feat(release-manager): add npm publish track + npm test-release path

### DIFF
--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release-manager
-description: Cut a clauditor-eval release. Test releases run from dev (→ TestPyPI, npm dist-tag `next`); full releases run from main (→ PyPI, npm `latest`). Python and npm version independently — release either or both.
+description: Cut a clauditor-eval release. Test releases run from dev (→ TestPyPI, npm dist-tag `next`); full releases run from main (→ PyPI, npm `latest`). Python and npm version independently of each other — release either or both.
 compatibility: "Requires: uv, gh CLI, git, node/npm. Must be run from the clauditor repo root."
 metadata:
   clauditor-version: "0.1.0"
 disable-model-invocation: true
-allowed-tools: Bash(git *), Bash(gh *), Bash(uv *), Bash(uvx *), Bash(npm *), Bash(node *), Bash(grep *), Bash(cat *), Bash(sleep *), Bash(pip *), Bash(curl *), Bash(awk *), Bash(rm *), Bash(date *), Read, Edit, Write
+allowed-tools: Bash(git *), Bash(gh *), Bash(uv *), Bash(uvx *), Bash(npm *), Bash(node *), Bash(cd *), Bash(grep *), Bash(cat *), Bash(sleep *), Bash(pip *), Bash(curl *), Bash(awk *), Bash(rm *), Bash(date *), Read, Edit, Write
 ---
 
 # /release-manager — Cut a clauditor-eval release
@@ -28,9 +28,9 @@ Branch model is shared:
 Ask the user **two** questions:
 
 > **1. Release type?**
-> - `test` — pre-release (Python version must have a dev/alpha/rc suffix; npm version must be a semver prerelease like `0.1.1-rc.0`)
+> - `test` — pre-release (Python version must have a dev/alpha/rc suffix; npm version must be a semver pre-release like `0.1.1-rc.0`)
 > - `full` — stable release (clean versions, e.g. `0.1.0`)
-
+>
 > **2. Which components?**
 > - `pypi` — Python engine only
 > - `npm` — npm wrapper only
@@ -129,10 +129,10 @@ Ask the user to confirm before proceeding.
 
 Read `npm/package.json` and extract the current version
 (`node -p "require('./npm/package.json').version"`). npm uses **semver
-prerelease** syntax (hyphen), NOT Python's `.devN` — `0.1.1-rc.0`,
+pre-release** syntax (hyphen), NOT Python's `.devN` — `0.1.1-rc.0`,
 `0.1.1-beta.2`, etc.
 
-**For a test release:** the version must be a semver prerelease (contains a
+**For a test release:** the version must be a semver pre-release (contains a
 `-`). The publish workflow auto-detects the `-` and publishes under the `next`
 dist-tag (testers run `npm install clauditor-eval@next`; plain installs keep
 resolving `latest`). If `npm/package.json` is a clean version, stop and ask the
@@ -143,7 +143,7 @@ user to bump it to a `-rc.N` / `-beta.N` first.
 
 In both cases the pre-flight registry probe already confirmed the version is
 unpublished. Show the user:
-```
+```text
 npm current version : {npm_current}
 npm release version : {npm_release}   (dist-tag: next | latest)
 ```
@@ -206,7 +206,7 @@ Report: TestPyPI URL `https://test.pypi.org/project/clauditor-eval/{release_vers
 ### npm track (dist-tag `next`)
 
 Run only when `npm`/`both` is selected. The npm version must be a semver
-prerelease (`-rc.N` / `-beta.N`); the publish workflow auto-detects the `-` and
+pre-release (`-rc.N` / `-beta.N`); the publish workflow auto-detects the `-` and
 publishes under the `next` dist-tag via OIDC trusted publishing (no token).
 
 #### Step N1 — Commit if `npm/package.json` changed
@@ -249,12 +249,26 @@ Report: `npm install clauditor-eval@next` → `{npm_release_version}`.
 
 ## Full release workflow
 
+> **Component gating (read first):**
+> - **PyPI track = Steps 1–9.** Run them only when `pypi`/`both` is selected.
+>   For an **`npm`-only** full release, **skip Steps 1–9 entirely** (no
+>   `pyproject.toml` bump, no release PR, no `v` tag, no GitHub Release, no
+>   next-dev bump, no backmerge) and run only the **npm track** below.
+> - **npm track** (after Step 7) runs only when `npm`/`both` is selected.
+> - For **`both`**, run the PyPI track first, then the npm track.
+>
 > **Note:** `main` has GitHub branch protection — direct pushes are rejected. The release-version commit and the next-dev bump both ship via PR.
 >
 > When `npm`/`both` is selected, the `npm/package.json` bump rides the **same
 > release PR** (Step 3) so main carries both version bumps atomically; the
 > `npm-v` tag is then pushed alongside the `v` tag after the merge (npm track
-> below, after Step 7). When `pypi`-only, skip every npm-flavored note here.
+> below, after Step 7).
+>
+> For an **`npm`-only** full release there is no release PR (Steps 1–9 are
+> skipped), so bump `npm/package.json` on its own branch → PR to `main` → merge,
+> then run the npm track to tag and publish.
+
+### PyPI track (Steps 1–9 — skip entirely for an `npm`-only release)
 
 ### Step 1 — Bump to release version
 Edit `pyproject.toml`: set `version = "{release_version}"`. Then refresh the lock file so `uv.lock` matches:

--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -1,27 +1,45 @@
 ---
 name: release-manager
-description: Cut a clauditor-eval release. Test releases run from dev (→ TestPyPI); full releases run from main (→ PyPI).
-compatibility: "Requires: uv, gh CLI, git. Must be run from the clauditor repo root."
+description: Cut a clauditor-eval release. Test releases run from dev (→ TestPyPI, npm dist-tag `next`); full releases run from main (→ PyPI, npm `latest`). Python and npm version independently — release either or both.
+compatibility: "Requires: uv, gh CLI, git, node/npm. Must be run from the clauditor repo root."
 metadata:
   clauditor-version: "0.1.0"
 disable-model-invocation: true
-allowed-tools: Bash(git *), Bash(gh *), Bash(uv *), Bash(uvx *), Bash(grep *), Bash(cat *), Bash(sleep *), Bash(pip *), Bash(curl *), Bash(awk *), Bash(rm *), Bash(date *), Read, Edit, Write
+allowed-tools: Bash(git *), Bash(gh *), Bash(uv *), Bash(uvx *), Bash(npm *), Bash(node *), Bash(grep *), Bash(cat *), Bash(sleep *), Bash(pip *), Bash(curl *), Bash(awk *), Bash(rm *), Bash(date *), Read, Edit, Write
 ---
 
 # /release-manager — Cut a clauditor-eval release
 
-You help the maintainer cut a release of `clauditor-eval`.
-- **Test releases** run from the `dev` branch and publish to TestPyPI.
-- **Full releases** run from the `main` branch and publish to PyPI. The merge from `dev` → `main` is already done before a full release.
+You help the maintainer cut a release of `clauditor-eval`. There are **two
+independently-versioned artifacts**:
 
-## Step 0 — Choose release type
+- **Python engine** → PyPI (test: TestPyPI). Version lives in `pyproject.toml`.
+- **npm wrapper** → npm registry. Version lives in `npm/package.json`. The npm
+  package versions **independently** of the Python engine (they are not kept in
+  lockstep — `npm/package.json` may be `0.1.0` while `pyproject.toml` is
+  `0.1.4.dev0`), so it is released only when the wrapper itself changed.
 
-Ask the user:
-> **Release type?**
-> - `test` — publish to TestPyPI as a pre-release (version must have a dev/alpha/rc suffix)
-> - `full` — publish to real PyPI as a stable release (clean version, e.g. `0.1.0`)
+Branch model is shared:
+- **Test releases** run from the `dev` branch (→ TestPyPI, and/or npm dist-tag `next`).
+- **Full releases** run from the `main` branch (→ PyPI, and/or npm `latest`). The merge from `dev` → `main` is already done before a full release.
 
-Record the choice and follow the matching workflow below.
+## Step 0 — Choose release type and components
+
+Ask the user **two** questions:
+
+> **1. Release type?**
+> - `test` — pre-release (Python version must have a dev/alpha/rc suffix; npm version must be a semver prerelease like `0.1.1-rc.0`)
+> - `full` — stable release (clean versions, e.g. `0.1.0`)
+
+> **2. Which components?**
+> - `pypi` — Python engine only
+> - `npm` — npm wrapper only
+> - `both` — release both this cycle
+
+Record both choices. The release **type** selects the branch (test → `dev`,
+full → `main`); the **components** select which of the PyPI / npm tracks below
+to run. Skip any track the user did not select. When `both` is chosen, run the
+PyPI track first, then the npm track within the same workflow.
 
 ---
 
@@ -43,7 +61,19 @@ Run these checks and STOP if any fail — report the problem clearly and do not 
 3. **Tests pass**: `uv run pytest --cov=clauditor --cov-report=term-missing -q`
 4. **CHANGELOG `[Unreleased]` is current**. Read `CHANGELOG.md` and show the user the current `[Unreleased]` section. Ask: "Does this cover everything shipping in this release?" Pause for confirmation before continuing — `[Unreleased]` becomes the GitHub Release body via `--notes-file` (full release Step 5), so empty / stale content there means an empty / stale release page. If the user wants to update it, stop here, let them edit, then re-run pre-flight.
 
-**Report a pre-flight summary** — always, even when every check passes. Render it as:
+**Additional checks when the `npm` component is selected** (skip entirely for `pypi`-only):
+
+5. **npm package tests pass**: `cd npm && npm install && npm test && npm run test:vitest && npm run lint` — the publish workflow runs these too, but failing fast here avoids a tagged-but-broken release.
+6. **npm version not already published** (the failure that bit us before). Read `npm/package.json` and probe the registry — npm **permanently** rejects re-publishing an existing version, so catch it *before* tagging:
+
+   ```bash
+   nver=$(node -p "require('./npm/package.json').version")
+   if npm view "clauditor-eval@${nver}" version >/dev/null 2>&1; then
+     echo "npm clauditor-eval@${nver} already published — bump npm/package.json"
+   fi
+   ```
+
+**Report a pre-flight summary** — always, even when every check passes. Render it as (include the npm rows only when the `npm` component is selected):
 
 ```
 Pre-flight checks:
@@ -52,11 +82,19 @@ Pre-flight checks:
 - Up to date with origin: PASS|FAIL
 - Tests pass: PASS|FAIL
 - CHANGELOG [Unreleased] reviewed: PASS|FAIL
+- npm package tests (npm only): PASS|FAIL
+- npm version not yet published (npm only): PASS|FAIL
 ```
 
 Then continue to "Determine version" (on all-PASS) or STOP with the failing check highlighted.
 
 ## Determine version
+
+> Run the **PyPI version** block below only when the `pypi` or `both` component
+> is selected; run the **npm version** block only when `npm` or `both`. The two
+> versions are independent — do not derive one from the other.
+
+### PyPI version
 
 Read `pyproject.toml` and extract the current version.
 
@@ -87,9 +125,39 @@ Next dev version: {next}   ← only shown for full release; ask user to confirm
 
 Ask the user to confirm before proceeding.
 
+### npm version
+
+Read `npm/package.json` and extract the current version
+(`node -p "require('./npm/package.json').version"`). npm uses **semver
+prerelease** syntax (hyphen), NOT Python's `.devN` — `0.1.1-rc.0`,
+`0.1.1-beta.2`, etc.
+
+**For a test release:** the version must be a semver prerelease (contains a
+`-`). The publish workflow auto-detects the `-` and publishes under the `next`
+dist-tag (testers run `npm install clauditor-eval@next`; plain installs keep
+resolving `latest`). If `npm/package.json` is a clean version, stop and ask the
+user to bump it to a `-rc.N` / `-beta.N` first.
+
+**For a full release:** the version must be clean (no `-`). It publishes to the
+`latest` dist-tag.
+
+In both cases the pre-flight registry probe already confirmed the version is
+unpublished. Show the user:
+```
+npm current version : {npm_current}
+npm release version : {npm_release}   (dist-tag: next | latest)
+```
+
+Ask the user to confirm before proceeding.
+
 ---
 
 ## Test release workflow
+
+> Run the **PyPI track** (Steps 1–5) when `pypi`/`both` is selected, then the
+> **npm track** when `npm`/`both` is selected. Skip a track that was not chosen.
+
+### PyPI track (TestPyPI)
 
 ### Step 1 — Build and verify
 ```bash
@@ -135,17 +203,67 @@ Confirm `{release_version}` appears.
 
 Report: TestPyPI URL `https://test.pypi.org/project/clauditor-eval/{release_version}/`
 
+### npm track (dist-tag `next`)
+
+Run only when `npm`/`both` is selected. The npm version must be a semver
+prerelease (`-rc.N` / `-beta.N`); the publish workflow auto-detects the `-` and
+publishes under the `next` dist-tag via OIDC trusted publishing (no token).
+
+#### Step N1 — Commit if `npm/package.json` changed
+If the npm version was edited during "Determine version", commit it to `dev`:
+```bash
+git add npm/package.json
+git commit -m "chore(npm): bump to {npm_release_version} for test release"
+git push origin dev
+```
+If it was used as-is, skip.
+
+#### Step N2 — Tag and trigger the npm publish workflow
+```bash
+git tag npm-v{npm_release_version}
+git push origin npm-v{npm_release_version}
+```
+This fires `.github/workflows/npm-publish.yml`. There is **no GitHub Release**
+for npm tags — the tag push alone is the trigger (unlike PyPI, which publishes
+on a GitHub Release).
+
+#### Step N3 — Monitor
+```bash
+gh run watch --repo wjduenow/clauditor
+```
+Wait for the `publish-npm` job. Report any failures. (A 403 "you may not perform
+that action" means the Trusted Publisher / OIDC config regressed; a 403 "cannot
+publish over previously published versions" means the version wasn't bumped.)
+
+#### Step N4 — Verify
+```bash
+sleep 10
+npm view clauditor-eval@next version
+```
+Confirm `{npm_release_version}` appears under the `next` tag, and that
+`npm view clauditor-eval version` (the `latest` tag) is unchanged.
+
+Report: `npm install clauditor-eval@next` → `{npm_release_version}`.
+
 ---
 
 ## Full release workflow
 
 > **Note:** `main` has GitHub branch protection — direct pushes are rejected. The release-version commit and the next-dev bump both ship via PR.
+>
+> When `npm`/`both` is selected, the `npm/package.json` bump rides the **same
+> release PR** (Step 3) so main carries both version bumps atomically; the
+> `npm-v` tag is then pushed alongside the `v` tag after the merge (npm track
+> below, after Step 7). When `pypi`-only, skip every npm-flavored note here.
 
 ### Step 1 — Bump to release version
 Edit `pyproject.toml`: set `version = "{release_version}"`. Then refresh the lock file so `uv.lock` matches:
 ```bash
 uv sync
 ```
+
+**If `npm`/`both`:** also edit `npm/package.json` to set the clean
+`{npm_release_version}` (no `-` suffix) determined earlier.
 
 ### Step 1b — Promote CHANGELOG `[Unreleased]` to `[{release_version}]`
 Edit `CHANGELOG.md` so this release has its own dated section that the GitHub Release body can quote verbatim:
@@ -171,9 +289,12 @@ Both artifacts must show `PASSED`. Stop and report if either fails.
 
 ### Step 3 — Open release PR
 Push the version bump and the CHANGELOG promotion together on a release branch, then open a PR — direct push to `main` is blocked by branch protection.
+When `npm`/`both`, add `npm/package.json` to the same commit so both bumps land atomically on main.
 ```bash
 git checkout -b release/{release_version}
 git add pyproject.toml uv.lock CHANGELOG.md
+# If npm/both: also stage the npm bump
+git add npm/package.json            # npm/both only
 git commit -m "chore: release {release_version}"
 git push -u origin release/{release_version}
 gh pr create --base main --head release/{release_version} \
@@ -221,6 +342,35 @@ curl -sf "https://pypi.org/pypi/clauditor-eval/{release_version}/json" \
 ```
 Confirm `{release_version}` appears.
 
+### npm track (dist-tag `latest`)
+
+Run only when `npm`/`both` is selected. The `npm/package.json` bump already
+landed on `main` via the release PR (Step 3) and was pulled in Step 4, so the
+tag push below publishes the clean version to `latest` via OIDC (no token, no
+GitHub Release — the `npm-v` tag push alone triggers the workflow).
+
+#### Step 7-npm-a — Tag and trigger
+```bash
+git checkout main && git pull origin main      # ensure the npm bump is present
+git tag npm-v{npm_release_version}
+git push origin npm-v{npm_release_version}
+```
+
+#### Step 7-npm-b — Monitor and verify
+```bash
+gh run watch --repo wjduenow/clauditor
+sleep 10
+npm view clauditor-eval version
+```
+Wait for the `publish-npm` job. Confirm `npm view clauditor-eval version`
+(the `latest` tag) now reports `{npm_release_version}`.
+
+Report: `npm install clauditor-eval` → `{npm_release_version}`.
+
+> npm has no next-dev bump or backmerge equivalent (Steps 8–9 are PyPI-only).
+> The next npm release simply edits `npm/package.json` again when the wrapper
+> next changes.
+
 ### Step 8 — Open next-dev bump PR
 Edit `pyproject.toml`: set `version = "{next_dev_version}"`. Refresh the lock, then push via PR:
 ```bash
@@ -254,7 +404,9 @@ If `dev` allows direct push and the merge fast-forwards cleanly, you may instead
 ## Done
 
 Report a summary including:
-- Release type and version
-- PyPI or TestPyPI URL
+- Release type and components released (PyPI / npm / both)
+- PyPI or TestPyPI URL (when the PyPI track ran)
+- npm install hint (when the npm track ran): `clauditor-eval@{npm_version}` for a
+  test release (`next` tag) or `clauditor-eval` for a full release (`latest` tag)
 - For full releases: confirm the next-dev bump PR (Step 8) and the backmerge PR (Step 9) are open or merged
 - If a stash was created during pre-flight, run `git stash pop` and confirm the file came back cleanly

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,7 +56,7 @@ jobs:
       # is npm's analog of TestPyPI (npm has no separate test registry).
       - name: Publish to npm (dist-tag derived from version)
         run: |
-          version="$(node -p "require('./package.json').version")"
+          version="$(node -p 'require("./package.json").version')"
           if [[ "$version" == *-* ]]; then
             echo "Prerelease $version → dist-tag 'next'"
             npm publish --tag next

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,4 +49,18 @@ jobs:
       # config. Provenance attestation is generated automatically for
       # trusted-publisher releases. Unscoped packages publish public by
       # default; no --access flag needed.
-      - run: npm publish
+      #
+      # Dist-tag is derived from the version: a semver prerelease (contains a
+      # '-', e.g. 0.1.1-rc.0) publishes under 'next' so it does not become the
+      # default 'latest' install; a clean version publishes to 'latest'. This
+      # is npm's analog of TestPyPI (npm has no separate test registry).
+      - name: Publish to npm (dist-tag derived from version)
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$version" == *-* ]]; then
+            echo "Prerelease $version → dist-tag 'next'"
+            npm publish --tag next
+          else
+            echo "Stable $version → dist-tag 'latest'"
+            npm publish
+          fi


### PR DESCRIPTION
## Summary

Teaches the `/release-manager` skill to release the **npm wrapper** alongside the Python engine, and completes the npm-side OIDC/dist-tag plumbing. Follow-on to the OIDC migration on `dev` (#205).

- **Component axis in Step 0** — `pypi` / `npm` / `both`. The two artifacts version independently (`pyproject.toml` vs `npm/package.json`), so npm releases only when the wrapper changed.
- **npm pre-flight guard** — probes the registry for the target version before tagging, so "cannot publish over previously published version" is caught early (the failure that surfaced during the manual 0.1.0 publish).
- **Independent npm version determination** — semver prerelease syntax (`0.1.1-rc.0`), not Python's `.devN`.
- **npm tracks in both workflows** — test (dist-tag `next`) and full (dist-tag `latest`). Tag `npm-v{version}` triggers `npm-publish.yml` via OIDC; there is no GitHub Release for npm tags.
- **npm test-release path** — npm has no TestPyPI equivalent, so test releases publish a prerelease under the `next` dist-tag. `npm-publish.yml` now derives the dist-tag from the version: a `-` prerelease → `next`, a clean version → `latest`.

## Test plan

- [x] `npm-publish.yml` YAML validates; dist-tag block is the only diff vs `dev`'s OIDC version.
- [x] `SKILL.eval.json` still valid; existing assertions (pre-flight, "test release", version regex, no traceback) unaffected.
- [x] `clauditor lint` passes (only the pre-existing experimental-`allowed-tools` warning).
- [ ] End-to-end OIDC + dist-tag validation on the next npm version bump (`npm-v0.1.1` → publishes to `latest`; a `-rc.N` tag → `next`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release workflows now support selecting specific components to release (PyPI, npm, or both) with flexible release types (test or full).
  * npm publishing automatically applies appropriate dist-tags: prerelease versions publish under `next`, stable versions under `latest`.
  * Expanded pre-flight checks including npm verification and duplicate prevention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/clauditor/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->