### PR TITLE
ci: bump checkout & setup-uv to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
       - run: uv run ruff check src/ tests/
 
   validate-skill:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -46,8 +46,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
@@ -93,7 +93,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
       - run: uv sync --dev
       - run: uv run mkdocs gh-deploy --force --no-history

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -26,7 +26,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Clears the Node.js 20 action-runtime deprecation on `ci.yml` and `publish.yml` (the remaining workflows after #206 handled `npm-publish.yml`). Closes the action-bump checkboxes in #205.

## Changes
- `actions/checkout@v4 → v5` (ci.yml ×4, publish.yml ×2)
- `astral-sh/setup-uv@v4 → v5` (ci.yml ×3, publish.yml ×2)
- Left as-is: `actions/setup-python@v5` and `codecov/codecov-action@v5` (already current); `pypa/gh-action-pypi-publish@release/v1` (Docker action, Node-independent).

## Note
`astral-sh/setup-uv` latest is **v7**; I pinned **v5** to match the requested bump and the repo's checkout/setup-node line. v5 clears the Node 20 deprecation. Happy to bump setup-uv to v7 if you'd prefer latest.

## Test plan
- [x] All three workflow YAMLs validate.
- [x] No `@v4` action refs remain in `.github/workflows/`.
- [ ] This PR's own CI run is green on the bumped `checkout@v5` / `setup-uv@v5` (lint, validate-skill, test 3.11–3.13).