### PR TITLE
ci: bump setup-uv to v7 (latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
       - run: uv run ruff check src/ tests/
 
   validate-skill:
@@ -47,7 +47,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --dev
@@ -94,6 +94,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --dev
       - run: uv run mkdocs gh-deploy --force --no-history

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -27,6 +27,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
Bumps `astral-sh/setup-uv@v5 → v7` (latest major) across `ci.yml` (×3) and `publish.yml` (×2). Follow-up to #207, which moved it to v5; this takes it to latest. Refs #205.

## Test plan
- [x] Both workflow YAMLs validate; no `setup-uv@v5` refs remain.
- [ ] This PR's CI run is green on `setup-uv@v7` (lint, validate-skill, test 3.11–3.13).